### PR TITLE
Remove aes-js-postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2598,11 +2598,6 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.34.tgz",
       "integrity": "sha512-+w6B0Uo0ZvTSzDkXjoBCTNK0oe+aVL+yPi7kwGZm8hd8+Nj1AFPoxoq1Bl/mEu/G/ivOkUc1LRqVR0XeWFUzuA=="
     },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-      "dev": true
-    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
@@ -14690,11 +14685,16 @@
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
         "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        }
       }
     },
     "web3-provider-engine": {

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -12,16 +12,9 @@ echo "2. React Native nodeify..."
 node_modules/.bin/rn-nodeify --install 'crypto,buffer,react-native-randombytes,vm,stream' --hack
 sed -i '' -e '143s/WKUserScriptInjectionTimeAtDocumentEnd/WKUserScriptInjectionTimeAtDocumentStart/' $WKWEBVIEW_FILE;
 
-# This pkg has been updated but no release in the last 2 years
-# Tried it with the current master but it breaks (and it looks really different)
-# Keeping it for now until we have time to investigate deeper
-echo "3. Fixing ethereumjs-wallet dependency (aes-js)..."
-TARGET="node_modules/ethereumjs-wallet/node_modules/aes-js/index.js"
-sed -i '' -e 's/var previous_mymodule/\/\/var previous_mymodule/' $TARGET;
-echo "Done"
 
 # We need to submit a PR for this one.
-echo "4. Fix react-native-os buildTools version..."
+echo "3. Fix react-native-os buildTools version..."
 TARGET="node_modules/react-native-os/android/build.gradle"
 sed -i '' -e 's/compileSdkVersion 23/compileSdkVersion 26/' $TARGET;
 sed -i '' -e 's/23.0.1/26.0.1/' $TARGET;
@@ -30,7 +23,7 @@ echo "Done"
 
 # This one has been fixed on master
 # we can remove once they release a new version
-echo "5. Fix react-native-fs buildTools version..."
+echo "4. Fix react-native-fs buildTools version..."
 TARGET="node_modules/react-native-fs/android/build.gradle"
 sed -i '' -e 's/compileSdkVersion 25/compileSdkVersion 26/' $TARGET;
 sed -i '' -e 's/25.0.0/26.0.1/' $TARGET;
@@ -38,18 +31,18 @@ echo "Done"
 
 # The build output from aes-js breaks the metro bundler. Until we safely upgrade
 # to a new version of aes-js, we patch it by removing the erroneous line.
-echo "6. Fix aes-js build ouput..."
+echo "5. Fix aes-js build ouput..."
 AES_OUTPUT_FILE="node_modules/aes-js/index.js";
 sed -i '' -e 's/var previous_mymodule = root.mymodule;//g' $AES_OUTPUT_FILE;
 
 # Reported here https://github.com/skv-headless/react-native-scrollable-tab-view/issues/910
-echo "7. Fix react-native-scrollable-tab-view"
+echo "6. Fix react-native-scrollable-tab-view"
 TARGET="node_modules/react-native-scrollable-tab-view/SceneComponent.js"
 sed -i '' -e 's/...props,/...props/' $TARGET;
 echo "Done"
 
 # Waiting for PR to get merged: https://github.com/seekshiva/react-native-remote-svg/pull/18
-echo "8. Fix react-native-remove-svg"
+echo "7. Fix react-native-remove-svg"
 TARGET="node_modules/react-native-remote-svg/SvgImage.js"
 sed -i '' 's/<WebView/<WebView originWhitelist={["*"]}/' $TARGET;
 echo "Done"


### PR DESCRIPTION
Fixes #20  (we're not depending on the aes-js library anymore)