### PR TITLE
Fix e2e tests

### DIFF
--- a/app/components/App/index.js
+++ b/app/components/App/index.js
@@ -21,7 +21,7 @@ const LOCK_TIMEOUT = 30000;
 
 const MainNav = createStackNavigator(
 	{
-		Home: {
+		Root: {
 			screen: createDrawerNavigator(
 				{
 					Main: {

--- a/package.json
+++ b/package.json
@@ -142,13 +142,13 @@
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/MetaMask.app",
         "build": "npm run start:ios",
         "type": "ios.simulator",
-        "name": "iPhone 7"
+        "name": "iPhone X"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/MetaMask.app",
         "build": "npm run start:ios -- --configuration Release",
         "type": "ios.simulator",
-        "name": "iPhone 7"
+        "name": "iPhone X"
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -16,7 +16,7 @@ sed -i '' -e '143s/WKUserScriptInjectionTimeAtDocumentEnd/WKUserScriptInjectionT
 echo "3. Fix react-native-os buildTools version..."
 TARGET="node_modules/react-native-os/android/build.gradle"
 sed -i '' -e 's/compileSdkVersion 23/compileSdkVersion 26/' $TARGET;
-sed -i '' -e 's/23.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/23.0.1/27.0.3/' $TARGET;
 echo "Done"
 
 # This one has been fixed on master
@@ -24,7 +24,7 @@ echo "Done"
 echo "4. Fix react-native-fs buildTools version..."
 TARGET="node_modules/react-native-fs/android/build.gradle"
 sed -i '' -e 's/compileSdkVersion 25/compileSdkVersion 26/' $TARGET;
-sed -i '' -e 's/25.0.0/26.0.2/' $TARGET;
+sed -i '' -e 's/25.0.0/27.0.3/' $TARGET;
 echo "Done"
 
 # The build output from aes-js breaks the metro bundler. Until we safely upgrade
@@ -50,24 +50,24 @@ echo "Done"
 echo "8. Fix react-native-fabric buildTools version..."
 TARGET="node_modules/react-native-fabric/android/build.gradle"
 sed -i '' -e 's/compileSdkVersion 23/compileSdkVersion 26/' $TARGET;
-sed -i '' -e 's/23.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/23.0.1/27.0.3/' $TARGET;
 echo "Done"
 
-echo "9. Update all the modules to BuildTools 26.0.2..."
+echo "9. Update all the modules to BuildTools 27.0.3..."
 TARGET="node_modules/react-native-aes-crypto/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-fabric/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-fs/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-keychain/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-linear-gradient/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-os/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-randombytes/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 TARGET="node_modules/react-native-vector-icons/android/build.gradle"
-sed -i '' -e 's/26.0.1/26.0.2/' $TARGET;
+sed -i '' -e 's/26.0.1/27.0.3/' $TARGET;
 echo "Done"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I accidentally named 2 routes as HOME, and that was making the Browser screen to be the default view instead of the Wallet view. That was breaking e2e tests.

- Other 2 e2e fixes related:
  - Run iOS tests on iPhone X instead of 7
  - Upgrade buildTools version to 27.0.3 (to remove android warnings)

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
