### PR TITLE
Use new GABA version that does not break ios minification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6397,11 +6397,12 @@
       }
     },
     "gaba": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.0.0-beta.31.tgz",
-      "integrity": "sha512-A85jRFSUlk+3ietJE4j7NdWFir1Ehb9SePCshbmJTITnuISgAWUQ7fnSfyEs0zGQz+TNtdg38itVZU7M90BY9A==",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.0.0-beta.33.tgz",
+      "integrity": "sha512-185M7VkdUrF98QvSz3lIo5XnUcfgnpZKhf/N/h83VTGS+brTRQouLnN2C1pqnjWThwz2qlp69UarcgtiL9/sgg==",
       "requires": {
         "await-semaphore": "^0.1.3",
+        "eth-block-tracker": "git://github.com/metamask/eth-block-tracker.git#f3a6ad253829fbd5f9a5666084af7bce97c6a260",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-phishing-detect": "^1.1.13",
@@ -6415,7 +6416,7 @@
       "dependencies": {
         "eth-block-tracker": {
           "version": "git://github.com/metamask/eth-block-tracker.git#f3a6ad253829fbd5f9a5666084af7bce97c6a260",
-          "from": "git://github.com/metamask/eth-block-tracker.git#f3a6ad253829fbd5f9a5666084af7bce97c6a260",
+          "from": "git://github.com/metamask/eth-block-tracker.git#3.0.1-subscription-fix",
           "requires": {
             "eth-query": "^2.1.0",
             "ethereumjs-tx": "^1.3.3",
@@ -10928,7 +10929,7 @@
     },
     "node-fetch": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
       "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-int64": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ethereumjs-util": "^5.2.0",
     "ethjs-unit": "^0.1.6",
     "events": "^3.0.0",
-    "gaba": "^1.0.0-beta.31",
+    "gaba": "^1.0.0-beta.33",
     "prop-types": "^15.6.2",
     "react": "16.4.1",
     "react-native": "0.56.0",


### PR DESCRIPTION
**Description**

This PR bumps GABA to a version that doesn't rely on `constructor.name`.

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #90 
