### PR TITLE
fix return key type

### DIFF
--- a/app/components/AddCustomAsset/__snapshots__/index.test.js.snap
+++ b/app/components/AddCustomAsset/__snapshots__/index.test.js.snap
@@ -40,6 +40,7 @@ exports[`AddCustomAsset should render correctly 1`] = `
         onChangeText={[Function]}
         onSubmitEditing={[Function]}
         placeholder="0x..."
+        returnKeyType="next"
         style={
           Object {
             "borderColor": "#CCCCCC",
@@ -87,6 +88,7 @@ exports[`AddCustomAsset should render correctly 1`] = `
         onChangeText={[Function]}
         onSubmitEditing={[Function]}
         placeholder="GNO"
+        returnKeyType="next"
         style={
           Object {
             "borderColor": "#CCCCCC",
@@ -136,6 +138,7 @@ exports[`AddCustomAsset should render correctly 1`] = `
         onChangeText={[Function]}
         onSubmitEditing={[Function]}
         placeholder="18"
+        returnKeyType="done"
         style={
           Object {
             "borderColor": "#CCCCCC",

--- a/app/components/AddCustomAsset/index.js
+++ b/app/components/AddCustomAsset/index.js
@@ -150,6 +150,7 @@ export default class AddCustomAsset extends Component {
 							onBlur={this.validateCustomTokenAddress}
 							testID={'input-token-address'}
 							onSubmitEditing={this.jumpToAssetSymbol}
+							returnKeyType={'next'}
 						/>
 						<Text style={styles.warningText}>{this.state.warningAddress}</Text>
 					</View>
@@ -164,6 +165,7 @@ export default class AddCustomAsset extends Component {
 							testID={'input-token-symbol'}
 							ref={this.assetSymbolInput}
 							onSubmitEditing={this.jumpToAssetPrecision}
+							returnKeyType={'next'}
 						/>
 						<Text style={styles.warningText}>{this.state.warningSymbol}</Text>
 					</View>
@@ -180,6 +182,7 @@ export default class AddCustomAsset extends Component {
 							testID={'input-token-decimals'}
 							ref={this.assetPrecisionInput}
 							onSubmitEditing={this.addToken}
+							returnKeyType={'done'}
 						/>
 						<Text style={styles.warningText}>{this.state.warningDecimals}</Text>
 					</View>

--- a/app/components/CreatePassword/__snapshots__/index.test.js.snap
+++ b/app/components/CreatePassword/__snapshots__/index.test.js.snap
@@ -90,6 +90,7 @@ exports[`CreatePassword should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder=""
+          returnKeyType="next"
           secureTextEntry={true}
           style={
             Object {
@@ -130,6 +131,7 @@ exports[`CreatePassword should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder=""
+          returnKeyType="done"
           secureTextEntry={true}
           style={
             Object {

--- a/app/components/CreatePassword/index.js
+++ b/app/components/CreatePassword/index.js
@@ -176,6 +176,7 @@ export default class CreatePassword extends Component {
 								underlineColorAndroid={colors.borderColor}
 								testID={'input-password'}
 								onSubmitEditing={this.jumpToConfirmPassword}
+								returnKeyType={'next'}
 							/>
 						</View>
 						<View style={styles.field}>
@@ -190,6 +191,7 @@ export default class CreatePassword extends Component {
 								underlineColorAndroid={colors.borderColor}
 								testID={'input-password-confirm'}
 								onSubmitEditing={this.onPressCreate}
+								returnKeyType={'done'}
 							/>
 						</View>
 

--- a/app/components/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -75,6 +75,7 @@ exports[`ImportFromSeed should render correctly 1`] = `
         onChangeText={[Function]}
         onSubmitEditing={[Function]}
         placeholder="Enter your seed phrase here"
+        returnKeyType="next"
         style={
           Object {
             "backgroundColor": "#FFFFFF",
@@ -117,6 +118,7 @@ exports[`ImportFromSeed should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder=""
+          returnKeyType="next"
           secureTextEntry={true}
           style={
             Object {
@@ -157,6 +159,7 @@ exports[`ImportFromSeed should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder=""
+          returnKeyType="done"
           secureTextEntry={true}
           style={
             Object {

--- a/app/components/ImportFromSeed/index.js
+++ b/app/components/ImportFromSeed/index.js
@@ -218,6 +218,7 @@ export default class ImportFromSeed extends Component {
 							testID={'input-seed-phrase'}
 							blurOnSubmit
 							onSubmitEditing={this.jumpToPassword}
+							returnKeyType={'next'}
 						/>
 						<View style={styles.field}>
 							<Text style={styles.label}>{strings('importFromSeed.new_password')}</Text>
@@ -231,6 +232,7 @@ export default class ImportFromSeed extends Component {
 								underlineColorAndroid={colors.borderColor}
 								testID={'input-password'}
 								onSubmitEditing={this.jumpToConfirmPassword}
+								returnKeyType={'next'}
 							/>
 						</View>
 						<View style={styles.field}>
@@ -245,6 +247,7 @@ export default class ImportFromSeed extends Component {
 								underlineColorAndroid={colors.borderColor}
 								testID={'input-password-confirm'}
 								onSubmitEditing={this.onPressImport}
+								returnKeyType={'done'}
 							/>
 						</View>
 

--- a/app/components/Login/__snapshots__/index.test.js.snap
+++ b/app/components/Login/__snapshots__/index.test.js.snap
@@ -77,6 +77,7 @@ exports[`Login should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder=""
+          returnKeyType="done"
           secureTextEntry={true}
           style={
             Object {

--- a/app/components/Login/index.js
+++ b/app/components/Login/index.js
@@ -156,6 +156,7 @@ export default class Login extends Component {
 								placeholder={''}
 								underlineColorAndroid={colors.borderColor}
 								onSubmitEditing={this.onLogin}
+								returnKeyType={'done'}
 							/>
 						</View>
 						{this.props.error && <Text style={styles.errorMsg}>{this.props.error}</Text>}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Set the keyboard submit button to 'next' and 'done' on all the forms  except on the transaction editor (@bitpshr  I'll leave this one to you since it doesn't have the "jump to next field" feature and most inputs are custom)

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #121 
