### PR TITLE
Fix balanceToFiat

### DIFF
--- a/app/util/number.js
+++ b/app/util/number.js
@@ -128,7 +128,7 @@ export function weiToFiat(wei, conversionRate, currencyCode) {
  * @returns {string} - Currency-formatted string
  */
 export function balanceToFiat(balance, conversionRate, exchangeRate, currencyCode) {
-	if (!balance || !exchangeRate) {
+	if (balance === undefined || balance === null || exchangeRate === undefined || exchangeRate === null) {
 		return undefined;
 	}
 	let fiatFixed = parseFloat(Math.round(balance * conversionRate * exchangeRate * 100) / 100).toFixed(2);


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Fix `balanceToFiat` in `number.js` that was making the app don't render fiat value for tokens with no balance (for  example `0.00 USD`).

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
