### PR TITLE
Fix duplicate approval screens

### DIFF
--- a/app/components/Approval/index.js
+++ b/app/components/Approval/index.js
@@ -5,6 +5,7 @@ import TransactionEditor from '../TransactionEditor';
 import { BNToHex, hexToBN } from '../../util/number';
 import { getModalNavbarOptions } from '../Navbar';
 import { strings } from '../../../locales/i18n';
+import Screen from '../Screen';
 
 /**
  * Component that manages transaction approval from the dapp browser
@@ -63,13 +64,15 @@ export default class Approval extends Component {
 		} = this.props.navigation.state;
 		const { transaction } = this.sanitizeTransactionMeta(transactionMeta);
 		return (
-			<TransactionEditor
-				mode={this.state.mode}
-				onCancel={this.onCancel}
-				onConfirm={this.onConfirm}
-				onModeChange={this.onModeChange}
-				transaction={transaction}
-			/>
+			<Screen>
+				<TransactionEditor
+					mode={this.state.mode}
+					onCancel={this.onCancel}
+					onConfirm={this.onConfirm}
+					onModeChange={this.onModeChange}
+					transaction={transaction}
+				/>
+			</Screen>
 		);
 	};
 }

--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -356,6 +356,10 @@ export class Browser extends Component {
 	componentWillUnmount() {
 		this.mounted = false;
 		AppState.removeEventListener('change', this.handleAppStateChange);
+		// Remove all Engine listeners
+		Engine.context.TransactionController.hub.removeAllListeners();
+		Engine.context.PersonalMessageManager.hub.removeAllListeners();
+		Engine.context.TypedMessageManager.hub.removeAllListeners();
 	}
 
 	handleAppStateChange = async nextAppState => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We were not removing the listeners for the signing and tx approval screens, so every time you close the browser and open a new one it was keeping the old listeners in memory, which ended up on having one approval screen per each time you opened a tab.

BONUS:  Fixed the buttons on the Approval screen, which were outside of the [SafeArea](https://facebook.github.io/react-native/docs/safeareaview)

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #214
