### PR TITLE
Add missing build steps to iOS release command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:android:release": "./scripts/build.sh android release",
     "build:ios:release": "./scripts/build.sh ios release",
     "release:android": "./scripts/build.sh android release && open android/app/build/outputs/apk/release/",
-    "release:ios": "cd ios && fastlane beta",
+    "release:ios": "./scripts/build.sh ios release",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest ./app/ --forceExit",
     "test:unit:update": "time jest -u ./app/ --forceExit",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -126,6 +126,11 @@ buildIosDevice(){
 	react-native run-ios  --device
 }
 
+buildIosRelease(){
+	prebuild_ios
+	cd ios && fastlane beta
+}
+
 buildAndroidRelease(){
 	adb uninstall io.metamask || true
 	prebuild_android
@@ -143,8 +148,7 @@ if [ "$PLATFORM" == "ios" ]
   	then
 
 	if [ "$MODE" == "release" ] ; then
-		echo "Release mode is not suppported on iOS"
-		exit 1;
+		buildIosRelease
     else
 		if [ "$RUN_DEVICE" = true ] ; then
 			buildIosDevice


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We were missing to build our web3 + provider bundle and source the JS environment variables.
I believe this is the cause why sync with the extension is not working in Testflight builds but it works on dev mode.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
