### PR TITLE
More provider compatibility fixes

### DIFF
--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -532,8 +532,15 @@ export class Browser extends Component {
 			});
 	};
 
-	onMessage = ({ nativeEvent: { data } }) => {
+	onMessage = msg => {
+		let {
+			nativeEvent: { data }
+		} = msg;
 		try {
+			// Check if it's a MM request
+			if (!data || (typeof data === 'string' && data.toString().indexOf('__mmID') === -1)) {
+				return;
+			}
 			data = typeof data === 'string' ? JSON.parse(data) : data;
 			// Android workaround
 			data = typeof data === 'string' && data.includes('GET_TITLE_FOR_BOOKMARK') ? JSON.parse(data) : data;
@@ -614,6 +621,7 @@ export class Browser extends Component {
 
 				window.postMessage(
 					JSON.stringify({
+						__mmID: 0,
 						type: 'GET_TITLE_FOR_BOOKMARK',
 						title: title ? title.content : document.title,
 						url: location.href,

--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -532,10 +532,7 @@ export class Browser extends Component {
 			});
 	};
 
-	onMessage = msg => {
-		let {
-			nativeEvent: { data }
-		} = msg;
+	onMessage = ({ nativeEvent: { data } }) => {
 		try {
 			// Check if it's a MM request
 			if (!data || (typeof data === 'string' && data.toString().indexOf('__mmID') === -1)) {

--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -619,12 +619,13 @@ export class Browser extends Component {
 
 				window.postMessage(
 					JSON.stringify({
-						__mmID: 0,
+						__mmID: 1,
 						type: 'GET_TITLE_FOR_BOOKMARK',
 						title: title ? title.content : document.title,
 						url: location.href,
 						icon: icon && icon.href
-					})
+					}),
+					'*'
 				)
 			})();
 		`;

--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -279,20 +279,21 @@ export class Browser extends Component {
 
 	async componentDidMount() {
 		this.backgroundBridge = new BackgroundBridge(Engine, this.webview, {
-			eth_requestAccounts: ({ hostname, params }) => {
+			eth_requestAccounts: payload => {
+				const { hostname, params } = payload;
 				const { approvedHosts, privacyMode, selectedAddress } = this.props;
 				const promise = new Promise((resolve, reject) => {
 					this.approvalRequest = { resolve, reject };
 				});
 				if (!privacyMode || ((!params || !params.force) && approvedHosts[hostname])) {
-					this.approvalRequest.resolve([selectedAddress]);
+					this.approvalRequest.resolve({ ...payload, result: [selectedAddress] });
 					this.backgroundBridge.enableAccounts();
 				} else {
 					this.setState({ showApprovalDialog: true });
 				}
 				return promise;
 			},
-			web3_clientVersion: () => Promise.resolve('MetaMask/0.1.0/Alpha/Mobile')
+			web3_clientVersion: payload => Promise.resolve({ ...payload, result: 'MetaMask/0.1.0/Alpha/Mobile' })
 		});
 
 		const entryScriptWeb3 =

--- a/app/core/BackgroundBridge.js
+++ b/app/core/BackgroundBridge.js
@@ -20,10 +20,11 @@ export class BackgroundBridge {
 					})
 				);
 		};
+
 		if (override) {
 			override(payload)
 				.then(response => {
-					done(undefined, { ...payload, result: response });
+					done(undefined, response);
 				})
 				.catch(error => {
 					done(error);

--- a/app/core/BackgroundBridge.js
+++ b/app/core/BackgroundBridge.js
@@ -23,7 +23,7 @@ export class BackgroundBridge {
 		if (override) {
 			override(payload)
 				.then(response => {
-					done(undefined, response);
+					done(undefined, { ...payload, result: response });
 				})
 				.catch(error => {
 					done(error);
@@ -72,6 +72,7 @@ export class BackgroundBridge {
 		if (this._accounts) {
 			payload.selectedAddress = selectedAddress;
 		}
+
 		current &&
 			current.postMessage(
 				JSON.stringify({

--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -21,7 +21,7 @@ class InpageBridge {
 	}
 
 	_onBackgroundResponse({ __mmID, error, response }) {
-		const { callback } = this._pending[`${__mmID}`];
+		const callback = this._pending[`${__mmID}`];
 		if (!error && response.error) {
 			error = response.error;
 		}
@@ -124,10 +124,7 @@ class InpageBridge {
 				hostname: window.location.hostname
 			}));
 		}
-		this._pending[`${payload.__mmID}`] = {
-			callback,
-			payload
-		};
+		this._pending[`${payload.__mmID}`] = callback;
 
 		window.postMessage(
 			{
@@ -146,7 +143,7 @@ class InpageBridge {
 	 */
 	enable(params) {
 		return new Promise((resolve, reject) => {
-			this.sendAsync({ method: 'eth_requestAccounts', params }, (error, response) => {
+			this.sendAsync({ id: 1, jsonrpc: '2.0', method: 'eth_requestAccounts', params }, (error, response) => {
 				if (error) {
 					reject(error);
 					return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12761,9 +12761,9 @@
       }
     },
     "react-native-web3-webview": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-1.2.2.tgz",
-      "integrity": "sha512-s6C+xa4dswHgqAYy3NkLYKnGU6AJ21762Uc805Lvg7QoWIhQibQuD0LWx5r6WR0q2wNCjlwkrvq8NAHju+7Aww==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-1.2.3.tgz",
+      "integrity": "sha512-WfIIozZv767ZH50exStZqe3rPXXvX4XQeO0IFT7L9PoaLXyEWO2MSunew04d0N+TmS+GYJfS1YnHdSyHxb4qVw==",
       "requires": {
         "fbjs": "^0.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-native-shake": "^3.2.4",
     "react-native-share": "^1.1.1",
     "react-native-vector-icons": "^4.6.0",
-    "react-native-web3-webview": "^1.2.2",
+    "react-native-web3-webview": "^1.2.3",
     "react-navigation": "^2.6.2",
     "react-redux": "^5.0.7",
     "readable-stream": "^1.0.33",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

- Avoid parsing external messages
- Add payload to response on methods that we override
- Bump `react-native-web3-webview` which includes a fix for postMessage (we were overriding the event and breaking all apps that use postMessage by redirecting all the msgs to react-native)

After this fix all this dApps are working:
- dai.makerdao.com
- godsunchained.com
- 3box.io
- votest.democracy.earth

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #236 
