### PR TITLE
Account names

### DIFF
--- a/app/components/AccountApproval/index.js
+++ b/app/components/AccountApproval/index.js
@@ -161,6 +161,10 @@ class AccountApproval extends Component {
 		 */
 		onCancel: PropTypes.func,
 		/**
+		/* Identities object required to get account name
+		*/
+		identities: PropTypes.object,
+		/**
 		 * A string that represents the selected address
 		 */
 		selectedAddress: PropTypes.string
@@ -171,7 +175,8 @@ class AccountApproval extends Component {
 			currentPageInformation: { title, url },
 			onConfirm,
 			onCancel,
-			selectedAddress
+			selectedAddress,
+			identities
 		} = this.props;
 		return (
 			<View style={styles.root}>
@@ -207,7 +212,9 @@ class AccountApproval extends Component {
 							</View>
 							<View style={styles.dapp}>
 								<Identicon address={selectedAddress} diameter={54} />
-								<Text style={styles.selectedAddress}>{renderAccountName(selectedAddress)}</Text>
+								<Text style={styles.selectedAddress}>
+									{renderAccountName(selectedAddress, identities)}
+								</Text>
 							</View>
 						</View>
 						<Text style={styles.intro}>
@@ -230,7 +237,8 @@ class AccountApproval extends Component {
 }
 
 const mapStateToProps = state => ({
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
+	identities: state.engine.backgroundState.PreferencesController.identities
 });
 
 export default connect(mapStateToProps)(AccountApproval);

--- a/app/components/AccountApproval/index.js
+++ b/app/components/AccountApproval/index.js
@@ -9,6 +9,7 @@ import { strings } from '../../../locales/i18n';
 import { colors, fontStyles } from '../../styles/common';
 import DeviceSize from '../../util/DeviceSize';
 import WebsiteIcon from '../WebsiteIcon';
+import { renderAccountName } from '../../util/address';
 
 const styles = StyleSheet.create({
 	root: {
@@ -152,10 +153,6 @@ class AccountApproval extends Component {
 		 */
 		currentPageInformation: PropTypes.object,
 		/**
-		 * List of accounts from the PreferencesController
-		 */
-		identities: PropTypes.object,
-		/**
 		 * Callback triggered on account access approval
 		 */
 		onConfirm: PropTypes.func,
@@ -174,8 +171,7 @@ class AccountApproval extends Component {
 			currentPageInformation: { title, url },
 			onConfirm,
 			onCancel,
-			selectedAddress,
-			identities
+			selectedAddress
 		} = this.props;
 		return (
 			<View style={styles.root}>
@@ -211,7 +207,7 @@ class AccountApproval extends Component {
 							</View>
 							<View style={styles.dapp}>
 								<Identicon address={selectedAddress} diameter={54} />
-								<Text style={styles.selectedAddress}>{identities[selectedAddress].name}</Text>
+								<Text style={styles.selectedAddress}>{renderAccountName(selectedAddress)}</Text>
 							</View>
 						</View>
 						<Text style={styles.intro}>
@@ -234,8 +230,7 @@ class AccountApproval extends Component {
 }
 
 const mapStateToProps = state => ({
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
-	identities: state.engine.backgroundState.PreferencesController.identities
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
 });
 
 export default connect(mapStateToProps)(AccountApproval);

--- a/app/components/AccountDetails/index.js
+++ b/app/components/AccountDetails/index.js
@@ -24,6 +24,7 @@ import Engine from '../../core/Engine';
 import Logger from '../../util/Logger';
 import { getNavigationOptionsTitle } from '../Navbar';
 import { getEtherscanAddressUrl } from '../../util/etherscan';
+import { renderAccountName } from '../../util/address';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -118,18 +119,14 @@ class AccountDetails extends Component {
 		*/
 		navigation: PropTypes.object,
 		/**
-		/* identities object required to get account name
-		*/
-		identities: PropTypes.object,
-		/**
 		 * Object representing the selected network
 		 */
 		network: PropTypes.object.isRequired
 	};
 
 	componentDidMount = () => {
-		const { identities, selectedAddress } = this.props;
-		const accountLabel = identities[selectedAddress].name;
+		const { selectedAddress } = this.props;
+		const accountLabel = renderAccountName(selectedAddress);
 		this.setState({ accountLabel });
 	};
 
@@ -180,8 +177,8 @@ class AccountDetails extends Component {
 	};
 
 	cancelAccountLabelEdition = () => {
-		const { identities, selectedAddress } = this.props;
-		const accountLabel = identities[selectedAddress].name;
+		const { selectedAddress } = this.props;
+		const accountLabel = renderAccountName(selectedAddress);
 		this.setState({ accountLabelEditable: false, accountLabel });
 	};
 
@@ -274,8 +271,7 @@ class AccountDetails extends Component {
 
 const mapStateToProps = state => ({
 	network: state.engine.backgroundState.NetworkController,
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
-	identities: state.engine.backgroundState.PreferencesController.identities
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
 });
 
 export default connect(mapStateToProps)(AccountDetails);

--- a/app/components/AccountDetails/index.js
+++ b/app/components/AccountDetails/index.js
@@ -119,14 +119,18 @@ class AccountDetails extends Component {
 		*/
 		navigation: PropTypes.object,
 		/**
+		/* Identities object required to get account name
+		*/
+		identities: PropTypes.object,
+		/**
 		 * Object representing the selected network
 		 */
 		network: PropTypes.object.isRequired
 	};
 
 	componentDidMount = () => {
-		const { selectedAddress } = this.props;
-		const accountLabel = renderAccountName(selectedAddress);
+		const { identities, selectedAddress } = this.props;
+		const accountLabel = renderAccountName(selectedAddress, identities);
 		this.setState({ accountLabel });
 	};
 
@@ -177,8 +181,8 @@ class AccountDetails extends Component {
 	};
 
 	cancelAccountLabelEdition = () => {
-		const { selectedAddress } = this.props;
-		const accountLabel = renderAccountName(selectedAddress);
+		const { identities, selectedAddress } = this.props;
+		const accountLabel = renderAccountName(selectedAddress, identities);
 		this.setState({ accountLabelEditable: false, accountLabel });
 	};
 
@@ -271,7 +275,8 @@ class AccountDetails extends Component {
 
 const mapStateToProps = state => ({
 	network: state.engine.backgroundState.NetworkController,
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
+	identities: state.engine.backgroundState.PreferencesController.identities
 });
 
 export default connect(mapStateToProps)(AccountDetails);

--- a/app/components/SignatureRequest/index.js
+++ b/app/components/SignatureRequest/index.js
@@ -109,6 +109,10 @@ class SignatureRequest extends Component {
 		 */
 		accounts: PropTypes.object,
 		/**
+		 * List of accounts from the PreferencesController
+		 */
+		identities: PropTypes.object,
+		/**
 		 * Callback triggered when this message signature is rejected
 		 */
 		onCancel: PropTypes.func,
@@ -154,9 +158,9 @@ class SignatureRequest extends Component {
 	};
 
 	render() {
-		const { children, message, accounts, selectedAddress } = this.props;
+		const { children, message, accounts, selectedAddress, identities } = this.props;
 		const balance = fromWei(accounts[selectedAddress].balance, 'ether');
-		const accountLabel = renderAccountName(selectedAddress);
+		const accountLabel = renderAccountName(selectedAddress, identities);
 		return (
 			<View style={styles.wrapper}>
 				<View style={styles.header}>
@@ -208,7 +212,8 @@ class SignatureRequest extends Component {
 
 const mapStateToProps = state => ({
 	accounts: state.engine.backgroundState.AccountTrackerController.accounts,
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
+	identities: state.engine.backgroundState.PreferencesController.identities
 });
 
 export default connect(mapStateToProps)(SignatureRequest);

--- a/app/components/SignatureRequest/index.js
+++ b/app/components/SignatureRequest/index.js
@@ -9,6 +9,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { fromWei } from '../../util/number';
 import Identicon from '../Identicon';
 import WebsiteIcon from '../WebsiteIcon';
+import { renderAccountName } from '../../util/address';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -108,10 +109,6 @@ class SignatureRequest extends Component {
 		 */
 		accounts: PropTypes.object,
 		/**
-		 * List of accounts from the PreferencesController
-		 */
-		identities: PropTypes.object,
-		/**
 		 * Callback triggered when this message signature is rejected
 		 */
 		onCancel: PropTypes.func,
@@ -157,9 +154,9 @@ class SignatureRequest extends Component {
 	};
 
 	render() {
-		const { children, message, accounts, selectedAddress, identities } = this.props;
+		const { children, message, accounts, selectedAddress } = this.props;
 		const balance = fromWei(accounts[selectedAddress].balance, 'ether');
-		const accountLabel = identities[selectedAddress].name;
+		const accountLabel = renderAccountName(selectedAddress);
 		return (
 			<View style={styles.wrapper}>
 				<View style={styles.header}>
@@ -211,8 +208,7 @@ class SignatureRequest extends Component {
 
 const mapStateToProps = state => ({
 	accounts: state.engine.backgroundState.AccountTrackerController.accounts,
-	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
-	identities: state.engine.backgroundState.PreferencesController.identities
+	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress
 });
 
 export default connect(mapStateToProps)(SignatureRequest);

--- a/app/components/TransactionReview/index.js
+++ b/app/components/TransactionReview/index.js
@@ -97,6 +97,10 @@ const styles = StyleSheet.create({
 class TransactionReview extends Component {
 	static propTypes = {
 		/**
+		/* Identities object required to get account name
+		*/
+		identities: PropTypes.object,
+		/**
 		 * Callback triggered when this transaction is cancelled
 		 */
 		onCancel: PropTypes.func,
@@ -153,14 +157,15 @@ class TransactionReview extends Component {
 
 	renderTransactionDirection = () => {
 		const {
-			transactionData: { from = this.props.selectedAddress, to }
+			transactionData: { from = this.props.selectedAddress, to },
+			identities
 		} = this.props;
 		return (
 			<View style={styles.graphic}>
 				<View style={{ ...styles.addressGraphic, ...styles.fromGraphic }}>
 					<Identicon address={from} diameter={18} />
 					<Text style={styles.addressText} numberOfLines={1}>
-						{renderAccountName(from)}
+						{renderAccountName(from, identities)}
 					</Text>
 				</View>
 				<View style={styles.arrow}>
@@ -169,7 +174,7 @@ class TransactionReview extends Component {
 				<View style={{ ...styles.addressGraphic, ...styles.toGraphic }}>
 					<Identicon address={to} diameter={18} />
 					<Text style={styles.addressText} numberOfLines={1}>
-						{renderAccountName(to)}
+						{renderAccountName(to, identities)}
 					</Text>
 				</View>
 			</View>
@@ -240,6 +245,7 @@ class TransactionReview extends Component {
 
 const mapStateToProps = state => ({
 	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
+	identities: state.engine.backgroundState.PreferencesController.identities,
 	showHexData: state.settings.showHexData
 });
 

--- a/app/components/TransactionReview/index.js
+++ b/app/components/TransactionReview/index.js
@@ -13,6 +13,7 @@ import DefaultTabBar from 'react-native-scrollable-tab-view/DefaultTabBar';
 import TransactionReviewInformation from './TransactionReviewInformation';
 import TransactionReviewData from './TransactionReviewData';
 import TransactionReviewSummary from './TransactionReviewSummary';
+import { renderAccountName } from '../../util/address';
 
 const styles = StyleSheet.create({
 	root: {
@@ -159,7 +160,7 @@ class TransactionReview extends Component {
 				<View style={{ ...styles.addressGraphic, ...styles.fromGraphic }}>
 					<Identicon address={from} diameter={18} />
 					<Text style={styles.addressText} numberOfLines={1}>
-						{from}
+						{renderAccountName(from)}
 					</Text>
 				</View>
 				<View style={styles.arrow}>
@@ -168,7 +169,7 @@ class TransactionReview extends Component {
 				<View style={{ ...styles.addressGraphic, ...styles.toGraphic }}>
 					<Identicon address={to} diameter={18} />
 					<Text style={styles.addressText} numberOfLines={1}>
-						{to}
+						{renderAccountName(to)}
 					</Text>
 				</View>
 			</View>

--- a/app/util/address.js
+++ b/app/util/address.js
@@ -1,5 +1,4 @@
 import { toChecksumAddress } from 'ethereumjs-util';
-import Engine from '../core/Engine';
 
 /**
  * Returns full checksummed address
@@ -28,14 +27,10 @@ export function renderShortAddress(address, chars = 4) {
  * Returns address name if it's in known identities
  *
  * @param {String} address - String corresponding to an address
+ * @param {Object} identities - Identities object
  * @returns {String} - String corresponding to account name. If there is no name, returns the original address
  */
-export function renderAccountName(address) {
-	const {
-		PreferencesController: {
-			state: { identities }
-		}
-	} = Engine.context;
+export function renderAccountName(address, identities) {
 	if (identities && address && address in identities) {
 		return identities[address].name;
 	}

--- a/app/util/address.js
+++ b/app/util/address.js
@@ -1,10 +1,43 @@
 import { toChecksumAddress } from 'ethereumjs-util';
+import Engine from '../core/Engine';
 
+/**
+ * Returns full checksummed address
+ *
+ * @param {String} address - String corresponding to an address
+ * @returns {String} - String corresponding to full checksummed address
+ */
 export function renderFullAddress(address) {
 	return toChecksumAddress(address);
 }
 
+/**
+ * Returns short address format
+ *
+ * @param {String} address - String corresponding to an address
+ * @param {Number} chars - Number of characters to show at the end and beginning.
+ * Defaults to 4.
+ * @returns {String} - String corresponding to short address format
+ */
 export function renderShortAddress(address, chars = 4) {
 	const checksummedAddress = toChecksumAddress(address);
 	return `${checksummedAddress.substr(0, chars)}...${checksummedAddress.substr(0, chars)}`;
+}
+
+/**
+ * Returns address name if it's in known identities
+ *
+ * @param {String} address - String corresponding to an address
+ * @returns {String} - String corresponding to account name. If there is no name, returns the original address
+ */
+export function renderAccountName(address) {
+	const {
+		PreferencesController: {
+			state: { identities }
+		}
+	} = Engine.context;
+	if (identities && address && address in identities) {
+		return identities[address].name;
+	}
+	return address;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

THis PR adds a new `renderAccountName` util method to be used to get account names where is necessary.
It also adds documentation for `address` utils.

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #278