### PR TITLE
Token improvements

### DIFF
--- a/app/components/EthInput/index.js
+++ b/app/components/EthInput/index.js
@@ -9,8 +9,8 @@ import {
 	toWei,
 	fromWei,
 	balanceToFiat,
-	toAssetMinimal,
-	fromAssetMinimal
+	toTokenMinimalUnit,
+	fromTokenMinimalUnit
 } from '../../util/number';
 import { strings } from '../../../locales/i18n';
 
@@ -90,7 +90,7 @@ class EthInput extends Component {
 	onChange = value => {
 		const { onChange, asset } = this.props;
 		!asset && onChange && onChange(isDecimal(value) ? toWei(value) : undefined);
-		asset && onChange && onChange(isDecimal(value) ? toAssetMinimal(value, asset.decimals) : undefined);
+		asset && onChange && onChange(isDecimal(value) ? toTokenMinimalUnit(value, asset.decimals) : undefined);
 	};
 
 	render = () => {
@@ -108,7 +108,7 @@ class EthInput extends Component {
 			} else {
 				convertedAmount = strings('transaction.conversion_not_available');
 			}
-			readableValue = value && fromAssetMinimal(value, asset.decimals);
+			readableValue = value && fromTokenMinimalUnit(value, asset.decimals);
 		} else {
 			convertedAmount = weiToFiat(value, this.props.conversionRate, currentCurrency).toUpperCase();
 			readableValue = value && fromWei(value);

--- a/app/components/EthInput/index.js
+++ b/app/components/EthInput/index.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 import { Platform, StyleSheet, Text, TextInput, View } from 'react-native';
 import { colors, fontStyles } from '../../styles/common';
 import { connect } from 'react-redux';
-import { weiToFiat, isDecimal, toWei, fromWei, balanceToFiat } from '../../util/number';
+import {
+	weiToFiat,
+	isDecimal,
+	toWei,
+	fromWei,
+	balanceToFiat,
+	toAssetMinimal,
+	fromAssetMinimal
+} from '../../util/number';
 import { strings } from '../../../locales/i18n';
 
 const styles = StyleSheet.create({
@@ -80,13 +88,14 @@ class EthInput extends Component {
 	};
 
 	onChange = value => {
-		const { onChange } = this.props;
-		onChange && onChange(isDecimal(value) ? toWei(value) : undefined);
+		const { onChange, asset } = this.props;
+		!asset && onChange && onChange(isDecimal(value) ? toWei(value) : undefined);
+		asset && onChange && onChange(isDecimal(value) ? toAssetMinimal(value, asset.decimals) : undefined);
 	};
 
 	render = () => {
 		const { currentCurrency, readonly, value, asset, contractExchangeRates } = this.props;
-		let convertedAmount;
+		let convertedAmount, readableValue;
 		if (asset) {
 			const exchangeRate = contractExchangeRates[asset.address];
 			if (exchangeRate) {
@@ -99,8 +108,10 @@ class EthInput extends Component {
 			} else {
 				convertedAmount = strings('transaction.conversion_not_available');
 			}
+			readableValue = value && fromAssetMinimal(value, asset.decimals);
 		} else {
 			convertedAmount = weiToFiat(value, this.props.conversionRate, currentCurrency).toUpperCase();
+			readableValue = value && fromWei(value);
 		}
 		return (
 			<View style={styles.root}>
@@ -116,7 +127,7 @@ class EthInput extends Component {
 						spellCheck={false}
 						style={styles.input}
 					>
-						{value ? fromWei(value) : value}
+						{readableValue}
 					</TextInput>
 					<Text style={styles.eth} numberOfLines={1}>
 						{(asset && asset.symbol) || strings('unit.eth')}

--- a/app/components/Tokens/index.js
+++ b/app/components/Tokens/index.js
@@ -7,7 +7,7 @@ import { strings } from '../../../locales/i18n';
 import contractMap from 'eth-contract-metadata';
 import TokenElement from '../TokenElement';
 import ActionSheet from 'react-native-actionsheet';
-import { calcTokenValue, balanceToFiat } from '../../util/number';
+import { fromAssetMinimal, balanceToFiat } from '../../util/number';
 import Engine from '../../core/Engine';
 
 const styles = StyleSheet.create({
@@ -135,7 +135,7 @@ export default class Tokens extends Component {
 					const balance =
 						item.balance ||
 						(item.address in tokenBalances
-							? calcTokenValue(tokenBalances[item.address], item.decimals)
+							? fromAssetMinimal(tokenBalances[item.address], item.decimals)
 							: undefined);
 					const balanceFiat =
 						item.balanceFiat || balanceToFiat(balance, conversionRate, exchangeRate, currentCurrency);

--- a/app/components/Tokens/index.js
+++ b/app/components/Tokens/index.js
@@ -7,7 +7,7 @@ import { strings } from '../../../locales/i18n';
 import contractMap from 'eth-contract-metadata';
 import TokenElement from '../TokenElement';
 import ActionSheet from 'react-native-actionsheet';
-import { fromAssetMinimal, balanceToFiat } from '../../util/number';
+import { fromTokenMinimalUnit, balanceToFiat } from '../../util/number';
 import Engine from '../../core/Engine';
 
 const styles = StyleSheet.create({
@@ -135,7 +135,7 @@ export default class Tokens extends Component {
 					const balance =
 						item.balance ||
 						(item.address in tokenBalances
-							? fromAssetMinimal(tokenBalances[item.address], item.decimals)
+							? fromTokenMinimalUnit(tokenBalances[item.address], item.decimals)
 							: undefined);
 					const balanceFiat =
 						item.balanceFiat || balanceToFiat(balance, conversionRate, exchangeRate, currentCurrency);

--- a/app/components/TransactionEdit/index.js
+++ b/app/components/TransactionEdit/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { colors, fontStyles } from '../../styles/common';
 import { connect } from 'react-redux';
-import { toBN, isBN, hexToBN, fromWei, toWei } from '../../util/number';
+import { toBN, isBN, hexToBN, fromWei } from '../../util/number';
 import { strings } from '../../../locales/i18n';
 import CustomGas from '../CustomGas';
 
@@ -178,8 +178,7 @@ class TransactionEdit extends Component {
 			.gt(fromWei(0))
 			? hexToBN(balance).sub(totalGas)
 			: fromWei(0);
-		const tokenMaxAmount = asset && contractBalances[asset.address];
-		this.props.handleUpdateAmount(asset ? toWei(tokenMaxAmount) : ethMaxAmount);
+		this.props.handleUpdateAmount(asset ? contractBalances[asset.address] : ethMaxAmount);
 	};
 
 	onFocusToAddress = () => {

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -119,7 +119,7 @@ class TransactionEditor extends Component {
 			to && asset ? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend }) : data;
 		const amountToSend = asset ? '0x0' : amount;
 		const { gas } = await this.estimateGas({ amount: amountToSend, newData });
-		this.setState({ amount: amountToSend, data: newData, gas: hexToBN(gas) });
+		this.setState({ amount, data: newData, gas: hexToBN(gas) });
 	};
 
 	handleUpdateData = async data => {

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -116,7 +116,9 @@ class TransactionEditor extends Component {
 		} = this.props;
 		const tokenAmountToSend = asset && amount && amount.toString(16);
 		const newData =
-			to && asset ? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend }) : data;
+			to && asset && tokenAmountToSend
+				? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend })
+				: data;
 		const amountToSend = asset ? '0x0' : amount;
 		const { gas } = await this.estimateGas({ amount: amountToSend, newData });
 		this.setState({ amount, data: newData, gas: hexToBN(gas) });
@@ -137,7 +139,10 @@ class TransactionEditor extends Component {
 			transaction: { asset }
 		} = this.props;
 		const tokenAmountToSend = asset && amount && amount.toString(16);
-		const newData = asset ? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend }) : data;
+		const newData =
+			asset && tokenAmountToSend
+				? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend })
+				: data;
 		const { gas } = await this.estimateGas({ data: newData, to: asset ? asset.address : to });
 		this.setState({ to, gas: hexToBN(gas), data: newData });
 	};

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -4,7 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import { colors } from '../../styles/common';
 import TransactionReview from '../TransactionReview';
 import TransactionEdit from '../TransactionEdit';
-import { isBN, hexToBN, toBN, toWei, fromWei, calcTokenValueToSend } from '../../util/number';
+import { isBN, hexToBN, toBN } from '../../util/number';
 import { isValidAddress, toChecksumAddress, BN } from 'ethereumjs-util';
 import { strings } from '../../../locales/i18n';
 import { connect } from 'react-redux';
@@ -114,7 +114,7 @@ class TransactionEditor extends Component {
 		const {
 			transaction: { asset }
 		} = this.props;
-		const tokenAmountToSend = asset && calcTokenValueToSend(fromWei(amount), asset.decimals);
+		const tokenAmountToSend = asset && amount && amount.toString(16);
 		const newData =
 			to && asset ? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend }) : data;
 		const amountToSend = asset ? '0x0' : amount;
@@ -136,7 +136,7 @@ class TransactionEditor extends Component {
 		const {
 			transaction: { asset }
 		} = this.props;
-		const tokenAmountToSend = asset && calcTokenValueToSend(fromWei(amount), asset.decimals);
+		const tokenAmountToSend = asset && amount && amount.toString(16);
 		const newData = asset ? generateTransferData('ERC20', { toAddress: to, amount: tokenAmountToSend }) : data;
 		const { gas } = await this.estimateGas({ data: newData, to: asset ? asset.address : to });
 		this.setState({ to, gas: hexToBN(gas), data: newData });
@@ -184,7 +184,8 @@ class TransactionEditor extends Component {
 		if (!amount || !gas || !gasPrice || !from) {
 			return strings('transaction.invalid_amount');
 		}
-		const validateAssetAmount = toWei(contractBalances[asset.address]).lt(amount);
+		amount && !isBN(amount) && (error = strings('transaction.invalid_amount'));
+		const validateAssetAmount = contractBalances[asset.address].lt(amount);
 		const ethTotalAmount = gas.mul(gasPrice);
 		amount &&
 			fromAccount &&

--- a/app/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/TransactionReview/TransactionReviewInformation/index.js
@@ -11,7 +11,7 @@ import {
 	fromWei,
 	weiToFiatNumber,
 	balanceToFiatNumber,
-	fromAssetMinimal
+	fromTokenMinimalUnit
 } from '../../../util/number';
 import { strings } from '../../../../locales/i18n';
 
@@ -118,13 +118,16 @@ class TransactionReviewInformation extends Component {
 	};
 
 	getTotalAmount = (totalGas, amount, conversionRate, exchangeRate, currentCurrency) => {
+		const {
+			transactionData: { asset }
+		} = this.props;
 		let total = 0;
 		const gasFeeFiat = weiToFiatNumber(totalGas, conversionRate);
 		let balanceFiat;
-		if (exchangeRate) {
+		if (asset) {
 			balanceFiat = balanceToFiatNumber(parseFloat(amount), conversionRate, exchangeRate);
 		} else {
-			balanceFiat = weiToFiatNumber(amount, conversionRate, exchangeRate);
+			balanceFiat = weiToFiatNumber(amount, conversionRate);
 		}
 		total = parseFloat(gasFeeFiat) + parseFloat(balanceFiat);
 		return `${total} ${currentCurrency.toUpperCase()}`;
@@ -146,7 +149,7 @@ class TransactionReviewInformation extends Component {
 		const { amountError } = this.state;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const ethTotal = isBN(amount) && !asset ? amount.add(totalGas) : totalGas;
-		const assetAmount = isBN(amount) && asset ? fromAssetMinimal(amount, asset.decimals) : undefined;
+		const assetAmount = isBN(amount) && asset ? fromTokenMinimalUnit(amount, asset.decimals) : undefined;
 
 		return (
 			<View style={styles.overview}>

--- a/app/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/TransactionReview/TransactionReviewInformation/index.js
@@ -117,17 +117,14 @@ class TransactionReviewInformation extends Component {
 		actionKey: strings('transactions.tx_review_confirm')
 	};
 
-	getTotalAmount = (totalGas, amount, conversionRate, exchangeRate, currentCurrency) => {
-		const {
-			transactionData: { asset }
-		} = this.props;
+	getTotalFiat = (asset, totalGas, conversionRate, exchangeRate, currentCurrency, amountEth, amountToken) => {
 		let total = 0;
 		const gasFeeFiat = weiToFiatNumber(totalGas, conversionRate);
 		let balanceFiat;
-		if (asset) {
-			balanceFiat = balanceToFiatNumber(parseFloat(amount), conversionRate, exchangeRate);
+		if (asset && exchangeRate) {
+			balanceFiat = balanceToFiatNumber(parseFloat(amountToken), conversionRate, exchangeRate);
 		} else {
-			balanceFiat = weiToFiatNumber(amount, conversionRate);
+			balanceFiat = weiToFiatNumber(amountEth, conversionRate);
 		}
 		total = parseFloat(gasFeeFiat) + parseFloat(balanceFiat);
 		return `${total} ${currentCurrency.toUpperCase()}`;
@@ -148,8 +145,9 @@ class TransactionReviewInformation extends Component {
 		const conversionRateAsset = asset ? contractExchangeRates[asset.address] : undefined;
 		const { amountError } = this.state;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
-		const ethTotal = isBN(amount) && !asset ? amount.add(totalGas) : totalGas;
-		const assetAmount = isBN(amount) && asset ? fromTokenMinimalUnit(amount, asset.decimals) : undefined;
+		const totalEth = isBN(amount) && !asset ? amount.add(totalGas) : totalGas;
+		const amountEth = isBN(amount) && !asset ? amount : undefined;
+		const amountToken = asset ? fromTokenMinimalUnit(amount, asset.decimals) : undefined;
 
 		return (
 			<View style={styles.overview}>
@@ -178,17 +176,19 @@ class TransactionReviewInformation extends Component {
 							{strings('transaction.gas_fee').toUpperCase()}
 						</Text>
 						<Text style={{ ...styles.overviewFiat, ...styles.overviewAccent }}>
-							{this.getTotalAmount(
+							{this.getTotalFiat(
+								asset,
 								totalGas,
-								asset ? assetAmount : ethTotal,
 								conversionRate,
 								conversionRateAsset,
-								currentCurrency
+								currentCurrency,
+								amountEth,
+								amountToken
 							)}
 						</Text>
 						<Text style={styles.overviewEth}>
-							{asset && assetAmount} {asset && asset.symbol} {asset && ' + '}
-							{fromWei(ethTotal).toString()} {strings('unit.eth')}
+							{asset && amountToken} {asset && asset.symbol} {asset && ' + '}
+							{fromWei(totalEth).toString()} {strings('unit.eth')}
 						</Text>
 					</View>
 				</View>

--- a/app/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/TransactionReview/TransactionReviewInformation/index.js
@@ -4,7 +4,15 @@ import PropTypes from 'prop-types';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { colors, fontStyles } from '../../../styles/common';
 import { connect } from 'react-redux';
-import { toBN, isBN, weiToFiat, fromWei, weiToFiatNumber, balanceToFiatNumber } from '../../../util/number';
+import {
+	toBN,
+	isBN,
+	weiToFiat,
+	fromWei,
+	weiToFiatNumber,
+	balanceToFiatNumber,
+	fromAssetMinimal
+} from '../../../util/number';
 import { strings } from '../../../../locales/i18n';
 
 const styles = StyleSheet.create({
@@ -138,7 +146,8 @@ class TransactionReviewInformation extends Component {
 		const { amountError } = this.state;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const ethTotal = isBN(amount) && !asset ? amount.add(totalGas) : totalGas;
-		const assetAmount = isBN(amount) && asset ? fromWei(amount) : undefined;
+		const assetAmount = isBN(amount) && asset ? fromAssetMinimal(amount, asset.decimals) : undefined;
+
 		return (
 			<View style={styles.overview}>
 				<View style={{ ...styles.overviewRow, ...styles.topOverviewRow }}>
@@ -174,7 +183,6 @@ class TransactionReviewInformation extends Component {
 								currentCurrency
 							)}
 						</Text>
-
 						<Text style={styles.overviewEth}>
 							{asset && assetAmount} {asset && asset.symbol} {asset && ' + '}
 							{fromWei(ethTotal).toString()} {strings('unit.eth')}

--- a/app/components/TransactionReview/TransactionReviewSummary/index.js
+++ b/app/components/TransactionReview/TransactionReviewSummary/index.js
@@ -85,7 +85,7 @@ class TransactionReviewSummary extends Component {
 		edit: PropTypes.func
 	};
 
-	getAssetConversion(asset, amount, conversionRate, exchangeRate, currentCurrency) {
+	getAssetFiat = (asset, amount, conversionRate, exchangeRate, currentCurrency) => {
 		let convertedAmount;
 		if (asset) {
 			if (exchangeRate) {
@@ -102,7 +102,7 @@ class TransactionReviewSummary extends Component {
 			convertedAmount = weiToFiat(amount, conversionRate, currentCurrency).toUpperCase();
 		}
 		return convertedAmount;
-	}
+	};
 
 	edit = () => {
 		const { edit } = this.props;
@@ -131,7 +131,7 @@ class TransactionReviewSummary extends Component {
 				) : (
 					<View>
 						<Text style={styles.summaryFiat}>
-							{this.getAssetConversion(
+							{this.getAssetFiat(
 								asset,
 								asset ? assetAmount : amount,
 								this.props.conversionRate,

--- a/app/components/TransactionReview/TransactionReviewSummary/index.js
+++ b/app/components/TransactionReview/TransactionReviewSummary/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
-import { fromWei, weiToFiat, balanceToFiat, fromAssetMinimal } from '../../../util/number';
+import { fromWei, weiToFiat, balanceToFiat, fromTokenMinimalUnit } from '../../../util/number';
 import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -116,7 +116,7 @@ class TransactionReviewSummary extends Component {
 			contractExchangeRates,
 			actionKey
 		} = this.props;
-		const assetAmount = asset ? fromAssetMinimal(amount, asset.decimals) : undefined;
+		const assetAmount = asset ? fromTokenMinimalUnit(amount, asset.decimals) : undefined;
 		const conversionRate = asset ? contractExchangeRates[asset.address] : this.props.conversionRate;
 		return (
 			<View style={styles.summary}>

--- a/app/components/TransactionReview/TransactionReviewSummary/index.js
+++ b/app/components/TransactionReview/TransactionReviewSummary/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
-import { isBN, fromWei, weiToFiat, balanceToFiat } from '../../../util/number';
+import { fromWei, weiToFiat, balanceToFiat, fromAssetMinimal } from '../../../util/number';
 import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -116,7 +116,7 @@ class TransactionReviewSummary extends Component {
 			contractExchangeRates,
 			actionKey
 		} = this.props;
-		const assetAmount = isBN(amount) && asset ? fromWei(amount) : undefined;
+		const assetAmount = asset ? fromAssetMinimal(amount, asset.decimals) : undefined;
 		const conversionRate = asset ? contractExchangeRates[asset.address] : this.props.conversionRate;
 		return (
 			<View style={styles.summary}>

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -69,12 +69,14 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
 		value = value.substring(1);
 	}
 	if (value === '.') {
-		throw new Error('[ethjs-unit] while converting number ' + tokenValue + ' to wei, invalid value');
+		throw new Error('[number] while converting number ' + tokenValue + ' to token minimal util, invalid value');
 	}
 	// Split it into a whole and fractional part
 	const comps = value.split('.');
 	if (comps.length > 2) {
-		throw new Error('[ethjs-unit] while converting number ' + tokenValue + ' to wei,  too many decimal points');
+		throw new Error(
+			'[number] while converting number ' + tokenValue + ' to token minimal util,  too many decimal points'
+		);
 	}
 	let whole = comps[0],
 		fraction = comps[1];
@@ -85,7 +87,9 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
 		fraction = '0';
 	}
 	if (fraction.length > decimals) {
-		throw new Error('[ethjs-unit] while converting number ' + tokenValue + ' to wei, too many decimal places');
+		throw new Error(
+			'[number] while converting number ' + tokenValue + ' to token minimal util, too many decimal places'
+		);
 	}
 	while (fraction.length < decimals) {
 		fraction += '0';

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "gaba": "^1.0.0-beta.55",
     "https-browserify": "0.0.1",
     "multihashes": "^0.4.14",
+    "number-to-bn": "^1.7.0",
     "prop-types": "^15.6.2",
     "pubnub": "^4.21.5",
     "react": "^16.6.3",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR adds a structural change of how we handle token balances.

1. As ETH is handled in `wei` using `toWei` to store ETH input values to BN in state, and `fromWei` to render the BN wei value, two methods were implemented for tokens. 
- `toTokenMinimalUnit` used to store token input values to state in a BN object in a minimal token value format.
- `fromTokenMinimalUnit` used to render minimal token value stored in a BN object, using the token decimals.
The idea of this change is to simplify the way that the app is currently handling token balances.

2. Updated some balance to fiat methods on transation review. Soon it should be in their own util to be used from transaction details as well.

3. Fix #277



**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #277
