### PR TITLE
Render loader when transaction is confirmed

### DIFF
--- a/app/components/AccountApproval/__snapshots__/index.test.js.snap
+++ b/app/components/AccountApproval/__snapshots__/index.test.js.snap
@@ -36,6 +36,7 @@ exports[`AccountApproval should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID=""
     confirmText="CONNECT"
+    confirmed={false}
     showCancelButton={true}
     showConfirmButton={true}
   >

--- a/app/components/ActionView/__snapshots__/index.test.js.snap
+++ b/app/components/ActionView/__snapshots__/index.test.js.snap
@@ -50,6 +50,7 @@ exports[`ActionView should render correctly 1`] = `
           },
         ]
       }
+      disabled={false}
       disabledContainerStyle={
         Object {
           "opacity": 0.6,
@@ -76,6 +77,7 @@ exports[`ActionView should render correctly 1`] = `
           },
         ]
       }
+      disabled={false}
       disabledContainerStyle={
         Object {
           "opacity": 0.6,

--- a/app/components/ActionView/index.js
+++ b/app/components/ActionView/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import StyledButton from '../StyledButton';
 import PropTypes from 'prop-types';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, ActivityIndicator } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { baseStyles, colors } from '../../styles/common';
 import { strings } from '../../../locales/i18n';
@@ -38,7 +38,8 @@ export default function ActionView({
 	onCancelPress,
 	onConfirmPress,
 	showCancelButton,
-	showConfirmButton
+	showConfirmButton,
+	confirmed
 }) {
 	return (
 		<View style={baseStyles.flexGrow}>
@@ -52,6 +53,7 @@ export default function ActionView({
 						type={'cancel'}
 						onPress={onCancelPress}
 						containerStyle={[styles.button, styles.cancel]}
+						disabled={confirmed}
 					>
 						{cancelText.toUpperCase()}
 					</StyledButton>
@@ -62,8 +64,9 @@ export default function ActionView({
 						type={confirmButtonMode}
 						onPress={onConfirmPress}
 						containerStyle={[styles.button, styles.confirm]}
+						disabled={confirmed}
 					>
-						{confirmText.toUpperCase()}
+						{confirmed ? <ActivityIndicator size="small" color="white" /> : confirmText.toUpperCase()}
 					</StyledButton>
 				)}
 			</View>
@@ -76,6 +79,7 @@ ActionView.defaultProps = {
 	confirmButtonMode: 'normal',
 	confirmText: strings('action_view.confirm'),
 	confirmTestID: '',
+	confirmed: false,
 	cancelTestID: '',
 	showCancelButton: true,
 	showConfirmButton: true
@@ -106,6 +110,10 @@ ActionView.propTypes = {
 	 * Text to show in the confirm button
 	 */
 	confirmText: PropTypes.string,
+	/**
+	 * Whether action view was confirmed in order to block any other interaction
+	 */
+	confirmed: PropTypes.bool,
 	/**
 	 * Called when the cancel button is clicked
 	 */

--- a/app/components/AddBookmark/__snapshots__/index.test.js.snap
+++ b/app/components/AddBookmark/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`AddBookmark should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID="add-bookmark-confirm-button"
     confirmText="Add"
+    confirmed={false}
     onCancelPress={[Function]}
     onConfirmPress={[Function]}
     showCancelButton={true}

--- a/app/components/AddCustomCollectible/__snapshots__/index.test.js.snap
+++ b/app/components/AddCustomCollectible/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`AddCustomCollectible should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID="add-custom-asset-confirm-button"
     confirmText="ADD"
+    confirmed={false}
     onCancelPress={[Function]}
     onConfirmPress={[Function]}
     showCancelButton={true}

--- a/app/components/AddCustomToken/__snapshots__/index.test.js.snap
+++ b/app/components/AddCustomToken/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`AddCustomToken should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID="add-custom-asset-confirm-button"
     confirmText="ADD TOKEN"
+    confirmed={false}
     onCancelPress={[Function]}
     onConfirmPress={[Function]}
     showCancelButton={true}

--- a/app/components/RevealPrivateCredential/__snapshots__/index.test.js.snap
+++ b/app/components/RevealPrivateCredential/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`RevealPrivateCredential should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID=""
     confirmText="Next"
+    confirmed={false}
     onCancelPress={[Function]}
     onConfirmPress={[Function]}
     showCancelButton={true}

--- a/app/components/SearchTokenAutocomplete/__snapshots__/index.test.js.snap
+++ b/app/components/SearchTokenAutocomplete/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`SearchTokenAutocomplete should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID=""
     confirmText="ADD TOKEN"
+    confirmed={false}
     onCancelPress={[Function]}
     onConfirmPress={[Function]}
     showCancelButton={true}

--- a/app/components/SendScreen/index.js
+++ b/app/components/SendScreen/index.js
@@ -177,8 +177,9 @@ class SendScreen extends Component {
 			this.reset();
 			this.setState({ transactionConfirmed: false });
 		} catch (error) {
-			this.setState({ transactionConfirmed: false });
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
+			this.setState({ transactionConfirmed: false });
+			this.reset();
 		}
 	};
 

--- a/app/components/SendScreen/index.js
+++ b/app/components/SendScreen/index.js
@@ -49,7 +49,8 @@ class SendScreen extends Component {
 		transaction: undefined,
 		transactionKey: undefined,
 		ready: false,
-		transactionConfirmed: false
+		transactionConfirmed: false,
+		transactionSubmitted: false
 	};
 
 	mounted = false;
@@ -82,7 +83,11 @@ class SendScreen extends Component {
 		this.checkForDeeplinks();
 	}
 
-	componentWillUnmount() {
+	async componentWillUnmount() {
+		const { transaction, transactionSubmitted } = this.state;
+		if (!transactionSubmitted) {
+			transaction && (await this.onCancel(transaction.id));
+		}
 		this.mounted = false;
 	}
 
@@ -175,7 +180,7 @@ class SendScreen extends Component {
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
 			this.reset();
-			this.setState({ transactionConfirmed: false });
+			this.setState({ transactionConfirmed: false, transactionSubmitted: true });
 		} catch (error) {
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
 			this.setState({ transactionConfirmed: false });

--- a/app/components/SendScreen/index.js
+++ b/app/components/SendScreen/index.js
@@ -163,7 +163,6 @@ class SendScreen extends Component {
 		const { navigation } = this.props;
 		const asset = navigation.state && navigation.state && navigation.state.params;
 		try {
-			this.setState({ ready: false });
 			if (!asset) {
 				transaction = this.prepareTransaction(transaction);
 			} else {
@@ -173,10 +172,8 @@ class SendScreen extends Component {
 			await TransactionController.approveTransaction(transactionMeta.id);
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
-			this.setState({ ready: true });
 			this.reset();
 		} catch (error) {
-			this.setState({ ready: true });
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
 		}
 	};

--- a/app/components/SendScreen/index.js
+++ b/app/components/SendScreen/index.js
@@ -163,6 +163,7 @@ class SendScreen extends Component {
 		const { navigation } = this.props;
 		const asset = navigation.state && navigation.state && navigation.state.params;
 		try {
+			this.setState({ ready: false });
 			if (!asset) {
 				transaction = this.prepareTransaction(transaction);
 			} else {
@@ -172,8 +173,10 @@ class SendScreen extends Component {
 			await TransactionController.approveTransaction(transactionMeta.id);
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
+			this.setState({ ready: true });
 			this.reset();
 		} catch (error) {
+			this.setState({ ready: true });
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
 		}
 	};

--- a/app/components/SendScreen/index.js
+++ b/app/components/SendScreen/index.js
@@ -48,7 +48,8 @@ class SendScreen extends Component {
 		mode: 'edit',
 		transaction: undefined,
 		transactionKey: undefined,
-		ready: false
+		ready: false,
+		transactionConfirmed: false
 	};
 
 	mounted = false;
@@ -162,6 +163,7 @@ class SendScreen extends Component {
 		const { TransactionController } = Engine.context;
 		const { navigation } = this.props;
 		const asset = navigation.state && navigation.state && navigation.state.params;
+		this.setState({ transactionConfirmed: true });
 		try {
 			if (!asset) {
 				transaction = this.prepareTransaction(transaction);
@@ -173,7 +175,9 @@ class SendScreen extends Component {
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
 			this.reset();
+			this.setState({ transactionConfirmed: false });
 		} catch (error) {
+			this.setState({ transactionConfirmed: false });
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
 		}
 	};
@@ -200,6 +204,7 @@ class SendScreen extends Component {
 					onConfirm={this.onConfirm}
 					onModeChange={this.onModeChange}
 					transaction={this.state.transaction}
+					transactionConfirmed={this.state.transactionConfirmed}
 				/>
 			) : (
 				this.renderLoader()

--- a/app/components/SignatureRequest/__snapshots__/index.test.js.snap
+++ b/app/components/SignatureRequest/__snapshots__/index.test.js.snap
@@ -192,6 +192,7 @@ exports[`SignatureRequest should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID="request-signature-confirm-button"
     confirmText="SIGN"
+    confirmed={false}
     showCancelButton={true}
     showConfirmButton={true}
   >

--- a/app/components/TransactionEdit/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionEdit/__snapshots__/index.test.js.snap
@@ -15,6 +15,7 @@ exports[`TransactionEdit should render correctly 1`] = `
     confirmButtonMode="normal"
     confirmTestID=""
     confirmText="Next"
+    confirmed={false}
     onConfirmPress={[Function]}
     showCancelButton={true}
     showConfirmButton={true}

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -53,6 +53,10 @@ class TransactionEditor extends Component {
 		 */
 		transaction: PropTypes.object,
 		/**
+		 * Whether the transaction was confirmed or not
+		 */
+		transactionConfirmed: PropTypes.bool,
+		/**
 		 * Object containing accounts balances
 		 */
 		contractBalances: PropTypes.object
@@ -246,7 +250,8 @@ class TransactionEditor extends Component {
 		const { amount, gas, gasPrice, from, to, data } = this.state;
 		const {
 			mode,
-			transaction: { asset }
+			transaction: { asset },
+			transactionConfirmed
 		} = this.props;
 		const transactionData = { amount, gas, gasPrice, from, to, data, asset };
 
@@ -278,6 +283,7 @@ class TransactionEditor extends Component {
 						onModeChange={this.props.onModeChange}
 						transactionData={transactionData}
 						validateAmount={this.validateAmount}
+						transactionConfirmed={transactionConfirmed}
 					/>
 				)}
 			</View>

--- a/app/components/TransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionReview/__snapshots__/index.test.js.snap
@@ -124,7 +124,6 @@ exports[`TransactionReview should render correctly 1`] = `
     confirmTestID=""
     confirmText="Confirm"
     confirmed={false}
-    onConfirmPress={[Function]}
     showCancelButton={true}
     showConfirmButton={true}
   >

--- a/app/components/TransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionReview/__snapshots__/index.test.js.snap
@@ -123,6 +123,8 @@ exports[`TransactionReview should render correctly 1`] = `
     confirmButtonMode="confirm"
     confirmTestID=""
     confirmText="Confirm"
+    confirmed={false}
+    onConfirmPress={[Function]}
     showCancelButton={true}
     showConfirmButton={true}
   >

--- a/app/components/TransactionReview/index.js
+++ b/app/components/TransactionReview/index.js
@@ -134,7 +134,8 @@ class TransactionReview extends Component {
 		toFocused: false,
 		amountError: '',
 		actionKey: strings('transactions.tx_review_confirm'),
-		showHexData: false
+		showHexData: false,
+		transactionConfirmed: false
 	};
 
 	componentDidMount = async () => {
@@ -148,6 +149,12 @@ class TransactionReview extends Component {
 		const amountError = validateAmount && validateAmount();
 		const actionKey = await getTransactionReviewActionKey(transactionData);
 		this.setState({ amountError, actionKey, showHexData });
+	};
+
+	onConfirm = () => {
+		const { onConfirm } = this.props;
+		this.setState({ transactionConfirmed: true });
+		onConfirm && onConfirm();
 	};
 
 	edit = () => {
@@ -221,7 +228,7 @@ class TransactionReview extends Component {
 
 	render = () => {
 		const { transactionData } = this.props;
-		const { actionKey } = this.state;
+		const { actionKey, transactionConfirmed } = this.state;
 		return (
 			<View style={styles.root}>
 				{this.renderTransactionDirection()}
@@ -229,7 +236,8 @@ class TransactionReview extends Component {
 					confirmButtonMode="confirm"
 					cancelText={strings('transaction.reject')}
 					onCancelPress={this.props.onCancel}
-					onConfirmPress={this.props.onConfirm}
+					onConfirmPress={this.onConfirm}
+					confirmed={transactionConfirmed}
 				>
 					<TransactionReviewSummary
 						edit={this.edit}

--- a/app/components/TransactionReview/index.js
+++ b/app/components/TransactionReview/index.js
@@ -121,6 +121,10 @@ class TransactionReview extends Component {
 		 */
 		showHexData: PropTypes.bool,
 		/**
+		 * Whether the transaction was confirmed or not
+		 */
+		transactionConfirmed: PropTypes.bool,
+		/**
 		 * Transaction object associated with this transaction
 		 */
 		transactionData: PropTypes.object,
@@ -134,8 +138,7 @@ class TransactionReview extends Component {
 		toFocused: false,
 		amountError: '',
 		actionKey: strings('transactions.tx_review_confirm'),
-		showHexData: false,
-		transactionConfirmed: false
+		showHexData: false
 	};
 
 	componentDidMount = async () => {
@@ -149,12 +152,6 @@ class TransactionReview extends Component {
 		const amountError = validateAmount && validateAmount();
 		const actionKey = await getTransactionReviewActionKey(transactionData);
 		this.setState({ amountError, actionKey, showHexData });
-	};
-
-	onConfirm = () => {
-		const { onConfirm } = this.props;
-		this.setState({ transactionConfirmed: true });
-		onConfirm && onConfirm();
 	};
 
 	edit = () => {
@@ -227,8 +224,8 @@ class TransactionReview extends Component {
 	};
 
 	render = () => {
-		const { transactionData } = this.props;
-		const { actionKey, transactionConfirmed } = this.state;
+		const { transactionData, transactionConfirmed } = this.props;
+		const { actionKey } = this.state;
 		return (
 			<View style={styles.root}>
 				{this.renderTransactionDirection()}
@@ -236,7 +233,7 @@ class TransactionReview extends Component {
 					confirmButtonMode="confirm"
 					cancelText={strings('transaction.reject')}
 					onCancelPress={this.props.onCancel}
-					onConfirmPress={this.onConfirm}
+					onConfirmPress={this.props.onConfirm}
 					confirmed={transactionConfirmed}
 				>
 					<TransactionReviewSummary

--- a/package-lock.json
+++ b/package-lock.json
@@ -6054,12 +6054,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6074,17 +6076,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6201,7 +6206,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6213,6 +6219,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6227,6 +6234,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6234,12 +6242,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6258,6 +6268,7 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6338,7 +6349,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6350,6 +6362,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6471,6 +6484,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6584,7 +6598,6 @@
       "requires": {
         "await-semaphore": "^0.1.3",
         "eth-block-tracker": "^4.1.0",
-        "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-phishing-detect": "^1.1.13",
@@ -6605,7 +6618,7 @@
       "dependencies": {
         "eth-contract-metadata": {
           "version": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
-          "from": "github:estebanmino/eth-contract-metadata#master"
+          "from": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a"
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

1. Render loader when a transaction being reviewed is confirmed, this block the user clicking more than one time the button `CONFIRM`.

2. If TX fails, SendScreen goes to Edit mode for a new TX.

3. If the user for some reason goes out of SendScreen view, the tx is going to be canceled by default.

![ready](https://user-images.githubusercontent.com/12115171/50930170-01121180-143e-11e9-8a3e-351607c4783f.gif)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #292
