### PR TITLE
Block explorer handling based on network

### DIFF
--- a/app/components/AccountDetails/index.js
+++ b/app/components/AccountDetails/index.js
@@ -22,6 +22,7 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import StyledButton from '../StyledButton';
 import Engine from '../../core/Engine';
 import Logger from '../../util/Logger';
+import { hasBlockExplorer } from '../../util/networks';
 import { getNavigationOptionsTitle } from '../Navbar';
 import { getEtherscanAddressUrl } from '../../util/etherscan';
 import { renderAccountName } from '../../util/address';
@@ -187,7 +188,7 @@ class AccountDetails extends Component {
 	};
 
 	render = () => {
-		const { selectedAddress } = this.props;
+		const { selectedAddress, network } = this.props;
 		const { accountLabelEditable, accountLabel } = this.state;
 		return (
 			<ScrollView style={styles.wrapper} testID={'account-details-screen'}>
@@ -251,14 +252,16 @@ class AccountDetails extends Component {
 					>
 						{strings('account_details.share_account')}
 					</StyledButton>
-					<StyledButton
-						containerStyle={styles.button}
-						type={'normal'}
-						onPress={this.goToEtherscan}
-						testID={'view-account-button'}
-					>
-						{strings('account_details.view_account')}
-					</StyledButton>
+					{hasBlockExplorer(network.provider.type) && (
+						<StyledButton
+							containerStyle={styles.button}
+							type={'normal'}
+							onPress={this.goToEtherscan}
+							testID={'view-account-button'}
+						>
+							{strings('account_details.view_account')}
+						</StyledButton>
+					)}
 					<StyledButton
 						containerStyle={styles.button}
 						type={'warning'}

--- a/app/components/AccountDetails/index.test.js
+++ b/app/components/AccountDetails/index.test.js
@@ -14,7 +14,11 @@ describe('Account Details', () => {
 						selectedAddress: '0xe7E125654064EEa56229f273dA586F10DF96B0a1',
 						identities: { '0xe7E125654064EEa56229f273dA586F10DF96B0a1': { name: 'Account 1' } }
 					},
-					NetworkController: {}
+					NetworkController: {
+						provider: {
+							type: 'mainnet'
+						}
+					}
 				}
 			}
 		};

--- a/app/components/Asset/index.js
+++ b/app/components/Asset/index.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { colors } from '../../styles/common';
 import AssetOverview from '../AssetOverview';
 import Transactions from '../Transactions';
-import Networks from '../../util/networks';
 import { getNavigationOptionsTitle } from '../Navbar';
 import Engine from '../../core/Engine';
 
@@ -119,7 +118,7 @@ class Asset extends Component {
 							conversionRate={conversionRate}
 							currentCurrency={currentCurrency}
 							adjustScroll={this.adjustScroll}
-							networkId={Networks[networkType].networkId}
+							networkType={networkType}
 						/>
 					</View>
 				</View>

--- a/app/components/Collectibles/__snapshots__/index.test.js.snap
+++ b/app/components/Collectibles/__snapshots__/index.test.js.snap
@@ -15,9 +15,9 @@ exports[`Collectibles should render correctly 1`] = `
       Object {
         "alignItems": "center",
         "backgroundColor": "#FFFFFF",
-        "flex": 1,
         "justifyContent": "center",
-        "marginTop": 80,
+        "marginTop": 110,
+        "minHeight": 250,
       }
     }
   >
@@ -33,6 +33,47 @@ exports[`Collectibles should render correctly 1`] = `
     >
       You don't have any collectibles!
     </Text>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingBottom": 30,
+        }
+      }
+    >
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "margin": 20,
+          }
+        }
+        testID="add-collectible-button"
+      >
+        <Icon
+          allowFontScaling={false}
+          color="#008edf"
+          name="plus"
+          size={16}
+        />
+        <Text
+          style={
+            Object {
+              "color": "#008edf",
+              "fontFamily": "Roboto",
+              "fontSize": 15,
+              "fontWeight": "400",
+            }
+          }
+        >
+          ADD COLLECTIBLES
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <ActionSheet
     cancelButtonIndex={1}

--- a/app/components/Collectibles/index.js
+++ b/app/components/Collectibles/index.js
@@ -14,11 +14,11 @@ const styles = StyleSheet.create({
 		flex: 1
 	},
 	emptyView: {
-		marginTop: 80,
-		alignItems: 'center',
+		marginTop: 110,
+		minHeight: 250,
 		backgroundColor: colors.white,
-		flex: 1,
-		justifyContent: 'center'
+		justifyContent: 'center',
+		alignItems: 'center'
 	},
 	text: {
 		fontSize: 20,
@@ -74,6 +74,7 @@ export default class Collectibles extends Component {
 	renderEmpty = () => (
 		<View style={styles.emptyView}>
 			<Text style={styles.text}>{strings('wallet.no_collectibles')}</Text>
+			{this.renderFooter()}
 		</View>
 	);
 

--- a/app/components/DrawerView/index.js
+++ b/app/components/DrawerView/index.js
@@ -18,7 +18,7 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import FoundationIcon from 'react-native-vector-icons/Foundation';
 import { colors, fontStyles } from '../../styles/common';
-import Networks from '../../util/networks';
+import Networks, { hasBlockExplorer } from '../../util/networks';
 import Identicon from '../Identicon';
 import StyledButton from '../StyledButton';
 import AccountList from '../AccountList';
@@ -289,7 +289,7 @@ class DrawerView extends Component {
 	};
 
 	showAssets = () => {
-		this.goToWalletTab(2);
+		this.goToWalletTab(0);
 	};
 
 	copyAddressToClipboard = async () => {
@@ -496,16 +496,23 @@ class DrawerView extends Component {
 					<View style={styles.menu}>
 						{this.sections.map((section, i) => (
 							<View key={`section_${i}`} style={styles.menuSection}>
-								{section.map((item, j) => (
-									<TouchableOpacity
-										key={`item_${i}_${j}`}
-										style={styles.menuItem}
-										onPress={() => item.action()} // eslint-disable-line
-									>
-										{item.icon}
-										<Text style={styles.menuItemName}>{item.name}</Text>
-									</TouchableOpacity>
-								))}
+								{section
+									.filter(item => {
+										if (item.name.toLowerCase().indexOf('etherscan') !== -1) {
+											return hasBlockExplorer(network.provider.type);
+										}
+										return true;
+									})
+									.map((item, j) => (
+										<TouchableOpacity
+											key={`item_${i}_${j}`}
+											style={styles.menuItem}
+											onPress={() => item.action()} // eslint-disable-line
+										>
+											{item.icon}
+											<Text style={styles.menuItemName}>{item.name}</Text>
+										</TouchableOpacity>
+									))}
 							</View>
 						))}
 					</View>

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -188,7 +188,11 @@ class TransactionElement extends PureComponent {
 		/**
 		 * Callback to render transaction details view
 		 */
-		toggleDetailsView: PropTypes.func
+		toggleDetailsView: PropTypes.func,
+		/**
+		 * Boolean to determine if this network supports a block explorer
+		 */
+		blockExplorer: PropTypes.bool
 	};
 
 	state = {
@@ -265,7 +269,7 @@ class TransactionElement extends PureComponent {
 		}
 	};
 
-	renderTxDetails = tx => {
+	renderTxDetails = (tx, blockExplorer) => {
 		const {
 			transaction: { gas, gasPrice, value, to, from },
 			transactionHash
@@ -318,19 +322,20 @@ class TransactionElement extends PureComponent {
 						</Text>
 					</View>
 				</View>
-				{tx.transactionHash && (
-					<TouchableOpacity
-						onPress={this.viewOnEtherscan} // eslint-disable-line react/jsx-no-bind
-					>
-						<Text style={styles.viewOnEtherscan}>{strings('transactions.view_on_etherscan')}</Text>
-					</TouchableOpacity>
-				)}
+				{tx.transactionHash &&
+					blockExplorer && (
+						<TouchableOpacity
+							onPress={this.viewOnEtherscan} // eslint-disable-line react/jsx-no-bind
+						>
+							<Text style={styles.viewOnEtherscan}>{strings('transactions.view_on_etherscan')}</Text>
+						</TouchableOpacity>
+					)}
 			</View>
 		);
 	};
 
 	render = () => {
-		const { tx, selected, selectedAddress, conversionRate, currentCurrency } = this.props;
+		const { tx, selected, selectedAddress, conversionRate, currentCurrency, blockExplorer } = this.props;
 		const incoming = toChecksumAddress(tx.transaction.to) === selectedAddress;
 		const selfSent = incoming && toChecksumAddress(tx.transaction.from) === selectedAddress;
 		const { actionKey } = this.state;
@@ -373,7 +378,7 @@ class TransactionElement extends PureComponent {
 						</View>
 					</View>
 				</View>
-				{selected ? this.renderTxDetails(tx) : null}
+				{selected ? this.renderTxDetails(tx, blockExplorer) : null}
 			</TouchableOpacity>
 		);
 	};

--- a/app/components/TransactionSubmitted/index.js
+++ b/app/components/TransactionSubmitted/index.js
@@ -21,6 +21,7 @@ import { colors, fontStyles } from '../../styles/common';
 import { getNavigationOptionsTitle } from '../Navbar';
 import StyledButton from '../StyledButton';
 import { getEtherscanTransactionUrl } from '../../util/etherscan';
+import { hasBlockExplorer } from '../../util/networks';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -140,9 +141,11 @@ class TransactionSubmitted extends Component {
 				>
 					<Icon name="check-circle" size={150} style={styles.icon} />
 				</Animated.View>
-				<StyledButton type={'normal'} onPress={this.goToEtherscan} containerStyle={styles.button}>
-					{strings('transaction_submitted.view_on_etherscan')}
-				</StyledButton>
+				{hasBlockExplorer(this.props.network) && (
+					<StyledButton type={'normal'} onPress={this.goToEtherscan} containerStyle={styles.button}>
+						{strings('transaction_submitted.view_on_etherscan')}
+					</StyledButton>
+				)}
 			</View>
 		);
 	}

--- a/app/components/Transactions/index.js
+++ b/app/components/Transactions/index.js
@@ -5,29 +5,24 @@ import { colors, fontStyles } from '../../styles/common';
 import { strings } from '../../../locales/i18n';
 import TransactionElement from '../TransactionElement';
 import Engine from '../../core/Engine';
+import { hasBlockExplorer } from '../../util/networks';
 
 const styles = StyleSheet.create({
 	wrapper: {
 		backgroundColor: colors.white,
 		flex: 1
 	},
-	emptyView: {
-		paddingTop: 80,
-		alignItems: 'center',
-		backgroundColor: colors.white,
-		flex: 1
-	},
-	text: {
-		fontSize: 20,
-		color: colors.fontTertiary,
-		...fontStyles.normal
-	},
-	loader: {
+	emptyContainer: {
 		minHeight: 250,
 		backgroundColor: colors.white,
 		flex: 1,
 		justifyContent: 'center',
 		alignItems: 'center'
+	},
+	text: {
+		fontSize: 20,
+		color: colors.fontTertiary,
+		...fontStyles.normal
 	}
 });
 
@@ -52,7 +47,11 @@ export default class Transactions extends Component {
 		/**
 		 * A string that represents the selected address
 		 */
-		selectedAddress: PropTypes.string
+		selectedAddress: PropTypes.string,
+		/**
+		 * String representing the selected the selected network
+		 */
+		networkType: PropTypes.string.isRequired
 	};
 
 	state = {
@@ -88,13 +87,13 @@ export default class Transactions extends Component {
 	};
 
 	renderLoader = () => (
-		<View style={styles.loader}>
+		<View style={styles.emptyContainer}>
 			<ActivityIndicator size="small" />
 		</View>
 	);
 
 	renderEmpty = () => (
-		<View style={styles.emptyView}>
+		<View style={styles.emptyContainer}>
 			<Text style={styles.text}>{strings('wallet.no_transactions')}</Text>
 		</View>
 	);
@@ -111,6 +110,9 @@ export default class Transactions extends Component {
 		if (!transactions.length) {
 			return this.renderEmpty();
 		}
+
+		const blockExplorer = hasBlockExplorer(this.props.networkType);
+
 		return (
 			<FlatList
 				data={transactions}
@@ -126,6 +128,7 @@ export default class Transactions extends Component {
 						selected={this.state.selectedTx === item.transactionHash}
 						toggleDetailsView={this.toggleDetailsView}
 						navigation={navigation}
+						blockExplorer={blockExplorer}
 					/>
 				)}
 			/>

--- a/app/components/Wallet/index.js
+++ b/app/components/Wallet/index.js
@@ -19,7 +19,7 @@ import DeeplinkManager from '../../core/DeeplinkManager';
 import { fromWei, weiToFiat, hexToBN } from '../../util/number';
 import Collectible from '../Collectible';
 import Engine from '../../core/Engine';
-import Networks from '../../util/networks';
+import Networks, { isKnownNetwork } from '../../util/networks';
 import AppConstants from '../../core/AppConstants';
 import Feedback from '../../core/Feedback';
 // eslint-disable-next-line import/no-unresolved
@@ -229,7 +229,8 @@ class Wallet extends Component {
 				tx =>
 					((tx.transaction.from && toChecksumAddress(tx.transaction.from) === selectedAddress) ||
 						(tx.transaction.to && toChecksumAddress(tx.transaction.to) === selectedAddress)) &&
-					networkId.toString() === tx.networkID &&
+					((networkId && networkId.toString() === tx.networkID) ||
+						(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
 					tx.status !== 'unapproved'
 			);
 
@@ -306,7 +307,7 @@ class Wallet extends Component {
 						conversionRate={conversionRate}
 						currentCurrency={currentCurrency}
 						selectedAddress={selectedAddress}
-						networkId={Networks[networkType].networkId}
+						networkType={networkType}
 					/>
 				</ScrollableTabView>
 				{this.renderAssetModal()}

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -43,3 +43,14 @@ export function getNetworkTypeById(id) {
 
 	throw new Error(`Unknown network with id ${id}`);
 }
+
+export function hasBlockExplorer(key) {
+	return key.toLowerCase() !== 'rpc';
+}
+
+export function isKnownNetwork(id) {
+	const knownNetworks = Object.keys(NetworkList)
+		.map(key => NetworkList[key].networkId)
+		.filter(id => id !== undefined);
+	return knownNetworks.includes(parseInt(id, 10));
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

- Hide all etherscan links if not known public network selected
- Fixed some tx filtering issues for custom RPCs
- Fixed some style for empty state on collectibles and txs tabs

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #243 
