### PR TITLE
fix android build on MacOS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,20 @@ allprojects {
     }
 }
 
+subprojects {project ->
+    if (project.name.contains('react-native-fabric')) {
+        buildscript {
+            repositories {
+				google()
+				jcenter()
+                maven {
+					   url = 'https://dl.bintray.com/android/android-tools/'
+				}
+            }
+        }
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'
     distributionUrl = distributionUrl.replace("bin", "all")

--- a/package-lock.json
+++ b/package-lock.json
@@ -6584,7 +6584,6 @@
       "requires": {
         "await-semaphore": "^0.1.3",
         "eth-block-tracker": "^4.1.0",
-        "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-phishing-detect": "^1.1.13",
@@ -6605,7 +6604,7 @@
       "dependencies": {
         "eth-contract-metadata": {
           "version": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
-          "from": "github:estebanmino/eth-contract-metadata#master"
+          "from": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a"
         }
       }
     },
@@ -12685,12 +12684,12 @@
       }
     },
     "react-native-vector-icons": {
-      "version": "4.6.0",
-      "resolved": "http://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz",
-      "integrity": "sha512-rpfhfPiXCK2PX1nrNhdxSMrEGB/Gw/SvKoPM0G2wAkSoqynnes19K0VYI+Up7DqR1rFIpE4hP2erpT1tNx2tfg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-6.1.0.tgz",
+      "integrity": "sha512-1GF5I4VWgwnzBtVfAKNgEiR5ziHi5QaKL381wwApMzuiFgIJMNt5XIChuKwKoaiB86s+P5iMcYWxYCyENL96lA==",
       "requires": {
         "lodash": "^4.0.0",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "yargs": "^8.0.2"
       },
       "dependencies": {
@@ -12719,7 +12718,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-native-settings-list": "^1.8.0",
     "react-native-shake": "^3.2.4",
     "react-native-share": "^1.1.1",
-    "react-native-vector-icons": "^4.6.0",
+    "react-native-vector-icons": "^6.1.0",
     "react-native-web3-webview": "^1.2.8",
     "react-navigation": "^3.0.9",
     "react-redux": "^5.0.7",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -96,25 +96,3 @@ sed -i'' -e 's/ 23/ 27/' $TARGET;
 sed -i'' -e 's/ 22/ 27/' $TARGET;
 sed -i'' -e 's/ 16/ 19/' $TARGET;
 sed -i'' -e 's/compile /api /' $TARGET;
-
-# This one has been fixed on master
-# we can remove once they release a new version
-echo "10. Fix eth-name-hash to be compatible with android"
-TARGET="node_modules/idna-uts46-hx/node_modules/punycode/punycode.js"
-sed -i'' -e 's/fromCodePoint/fromCharCode/' $TARGET;
-echo "Done"
-
-# Fix old gradle
-echo "11. Fix modules with old gradle versions"
-TARGET="node_modules/react-native-vector-icons/android/build.gradle"
-sed -i'' -e 's/com.android.tools.build:gradle:2.3./com.android.tools.build:gradle:3.2.1/' $TARGET;
-sed -i'' -e  '/jcenter()/a \
-google() \
-' $TARGET;
-
-# Fix old gradle
-echo "12. Fix modules with old gradle versions"
-TARGET="node_modules/react-native-fabric/android/build.gradle"
-sed -i'' -e  '/jcenter()/a \
-google() \
-' $TARGET;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Currently you can't build Android from iOS for several npm package incompatibilities:
- old version of react-native-vector-icons
- missing dep on the java repository for react-native-fabric

This PR solves both issues and you can build succesfully.

