### PR TITLE
Consistent decimals

### DIFF
--- a/app/components/AccountList/index.js
+++ b/app/components/AccountList/index.js
@@ -14,7 +14,7 @@ import {
 	SafeAreaView
 } from 'react-native';
 import { colors, fontStyles } from '../../styles/common';
-import { fromWei } from '../../util/number';
+import { renderFromWei } from '../../util/number';
 import { strings } from '../../../locales/i18n';
 import { toChecksumAddress } from 'ethereumjs-util';
 
@@ -234,7 +234,7 @@ export default class AccountList extends Component {
 					<View style={styles.accountInfo}>
 						<Text style={styles.accountLabel}>{name}</Text>
 						<Text style={styles.accountBalance}>
-							{fromWei(balance, 'ether')} {strings('unit.eth')}
+							{renderFromWei(balance)} {strings('unit.eth')}
 						</Text>
 					</View>
 					<View style={styles.selected}>{selected}</View>

--- a/app/components/AccountSelect/index.js
+++ b/app/components/AccountSelect/index.js
@@ -7,7 +7,7 @@ import { colors, fontStyles } from '../../styles/common';
 import { connect } from 'react-redux';
 import { hexToBN } from 'gaba/util';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { weiToFiat, fromWei } from '../../util/number';
+import { weiToFiat, renderFromWei } from '../../util/number';
 import { strings } from '../../../locales/i18n';
 
 const styles = StyleSheet.create({
@@ -138,7 +138,7 @@ class AccountSelect extends Component {
 					</View>
 					<View>
 						<Text style={styles.info}>
-							{fromWei(balance).toString()} {strings('unit.eth')}
+							{renderFromWei(balance)} {strings('unit.eth')}
 						</Text>
 					</View>
 					<View>

--- a/app/components/CustomGas/index.js
+++ b/app/components/CustomGas/index.js
@@ -292,7 +292,7 @@ class CustomGas extends Component {
 		return (
 			<View>
 				<Text style={styles.textTotalGas}>
-					{fromWei(totalGas.toString())} {strings('unit.eth')}
+					{fromWei(totalGas)} {strings('unit.eth')}
 				</Text>
 				<Text style={styles.text}>{strings('custom_gas.gas_limit')}</Text>
 				<TextInput

--- a/app/components/DrawerView/index.js
+++ b/app/components/DrawerView/index.js
@@ -23,7 +23,7 @@ import Identicon from '../Identicon';
 import StyledButton from '../StyledButton';
 import AccountList from '../AccountList';
 import NetworkList from '../NetworkList';
-import { fromWei } from '../../util/number';
+import { renderFromWei } from '../../util/number';
 import { strings } from '../../../locales/i18n';
 import { DrawerActions } from 'react-navigation-drawer'; // eslint-disable-line
 import Modal from 'react-native-modal';
@@ -408,7 +408,7 @@ class DrawerView extends Component {
 	render = () => {
 		const { network, accounts, identities, selectedAddress, keyrings } = this.props;
 		const account = { address: selectedAddress, ...identities[selectedAddress], ...accounts[selectedAddress] };
-		account.balance = (accounts[selectedAddress] && fromWei(accounts[selectedAddress].balance, 'ether')) || 0;
+		account.balance = (accounts[selectedAddress] && renderFromWei(accounts[selectedAddress].balance)) || 0;
 		const { color, name } = Networks[network.provider.type] || { ...Networks.rpc, color: null };
 
 		return (

--- a/app/components/SignatureRequest/index.js
+++ b/app/components/SignatureRequest/index.js
@@ -6,7 +6,7 @@ import { strings } from '../../../locales/i18n';
 import { connect } from 'react-redux';
 import ActionView from '../ActionView';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import { fromWei } from '../../util/number';
+import { renderFromWei } from '../../util/number';
 import Identicon from '../Identicon';
 import WebsiteIcon from '../WebsiteIcon';
 import { renderAccountName } from '../../util/address';
@@ -159,7 +159,7 @@ class SignatureRequest extends Component {
 
 	render() {
 		const { children, message, accounts, selectedAddress, identities } = this.props;
-		const balance = fromWei(accounts[selectedAddress].balance, 'ether');
+		const balance = renderFromWei(accounts[selectedAddress].balance);
 		const accountLabel = renderAccountName(selectedAddress, identities);
 		return (
 			<View style={styles.wrapper}>

--- a/app/components/Tokens/index.js
+++ b/app/components/Tokens/index.js
@@ -7,7 +7,7 @@ import { strings } from '../../../locales/i18n';
 import contractMap from 'eth-contract-metadata';
 import TokenElement from '../TokenElement';
 import ActionSheet from 'react-native-actionsheet';
-import { fromTokenMinimalUnit, balanceToFiat } from '../../util/number';
+import { renderFromTokenMinimalUnit, balanceToFiat } from '../../util/number';
 import Engine from '../../core/Engine';
 
 const styles = StyleSheet.create({
@@ -135,7 +135,7 @@ export default class Tokens extends Component {
 					const balance =
 						item.balance ||
 						(item.address in tokenBalances
-							? fromTokenMinimalUnit(tokenBalances[item.address], item.decimals)
+							? renderFromTokenMinimalUnit(tokenBalances[item.address], item.decimals)
 							: undefined);
 					const balanceFiat =
 						item.balanceFiat || balanceToFiat(balance, conversionRate, exchangeRate, currentCurrency);

--- a/app/components/TransactionElement/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionElement/__snapshots__/index.test.js.snap
@@ -121,7 +121,7 @@ exports[`TransactionElement should render correctly 1`] = `
         >
           -
            
-          0.00 USD
+          0 USD
         </Text>
       </View>
     </View>

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -4,7 +4,7 @@ import { Clipboard, TouchableOpacity, StyleSheet, Text, View, Image } from 'reac
 import { colors, fontStyles } from '../../styles/common';
 import { strings } from '../../../locales/i18n';
 import { toLocaleDateTime } from '../../util/date';
-import { fromWei, weiToFiat, hexToBN, isBN, toBN, toGwei } from '../../util/number';
+import { renderFromWei, weiToFiat, hexToBN, isBN, toBN, toGwei } from '../../util/number';
 import { toChecksumAddress } from 'ethereumjs-util';
 import Identicon from '../Identicon';
 import { connect } from 'react-redux';
@@ -297,7 +297,7 @@ class TransactionElement extends PureComponent {
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>{strings('transactions.amount')}</Text>
 						<Text style={[styles.detailRowText, styles.alignRight]}>
-							{fromWei(value, 'ether')} {strings('unit.eth')}
+							{renderFromWei(value)} {strings('unit.eth')}
 						</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
@@ -313,7 +313,7 @@ class TransactionElement extends PureComponent {
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>{strings('transactions.total')}</Text>
 						<Text style={[styles.detailRowText, styles.alignRight]}>
-							{fromWei(total, 'ether')} {strings('unit.eth')}
+							{renderFromWei(total)} {strings('unit.eth')}
 						</Text>
 					</View>
 					<View style={[styles.detailRowInfoItem, styles.noBorderBottom]}>
@@ -365,7 +365,7 @@ class TransactionElement extends PureComponent {
 						</View>
 						<View style={styles.amounts}>
 							<Text style={styles.amount}>
-								- {fromWei(tx.transaction.value, 'ether')} {strings('unit.eth')}
+								- {renderFromWei(tx.transaction.value)} {strings('unit.eth')}
 							</Text>
 							<Text style={styles.amountFiat}>
 								-{' '}

--- a/app/components/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
@@ -65,7 +65,7 @@ exports[`TransactionReviewInformation should render correctly 1`] = `
           }
         }
       >
-        0.00 USD
+        0 USD
       </Text>
       <Text
         style={

--- a/app/components/Wallet/index.js
+++ b/app/components/Wallet/index.js
@@ -16,7 +16,7 @@ import { strings } from '../../../locales/i18n';
 import Branch from 'react-native-branch';
 import Logger from '../../util/Logger';
 import DeeplinkManager from '../../core/DeeplinkManager';
-import { fromWei, weiToFiat, hexToBN } from '../../util/number';
+import { renderFromWei, weiToFiat, hexToBN } from '../../util/number';
 import Collectible from '../Collectible';
 import Engine from '../../core/Engine';
 import Networks, { isKnownNetwork } from '../../util/networks';
@@ -256,7 +256,7 @@ class Wallet extends Component {
 		let balance = 0;
 		let assets = tokens;
 		if (accounts[selectedAddress]) {
-			balance = fromWei(accounts[selectedAddress].balance, 'ether');
+			balance = renderFromWei(accounts[selectedAddress].balance);
 			assets = [
 				{
 					name: 'Ether',

--- a/app/util/custom-gas.js
+++ b/app/util/custom-gas.js
@@ -1,5 +1,5 @@
 import { BN } from 'ethereumjs-util';
-import { fromWei, weiToFiat } from './number';
+import { renderFromWei, weiToFiat } from './number';
 
 /**
  * Calculates wei value of estimate gas price in gwei
@@ -34,7 +34,7 @@ export function getWeiGasFee(estimate, gasLimit = 21000) {
  */
 export function getRenderableEthGasFee(estimate, gasLimit = 21000) {
 	const gasFee = getWeiGasFee(estimate, gasLimit);
-	return fromWei(gasFee);
+	return renderFromWei(gasFee);
 }
 
 /**

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -108,7 +108,7 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
  *
  * @param {Number|String|BN} tokenValue - Token value to convert
  * @param {Number} decimals - Token decimals to convert
- * @param {Number} decimalsToShow - Decimals to
+ * @param {Number} decimalsToShow - Decimals to 5
  * @returns {String} - String of token minimal unit, in render format
  */
 export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow = 5) {
@@ -122,6 +122,7 @@ export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow 
  * Converts wei to render format string, showing 5 decimals
  *
  * @param {Number|String|BN} value - Wei to convert
+ * @param {Number} decimalsToShow - Decimals to 5
  * @returns {String} - String of token minimal unit, in render format
  */
 export function renderFromWei(value, decimalsToShow = 5) {
@@ -225,11 +226,13 @@ export function weiToFiat(wei, conversionRate, currencyCode) {
  *
  * @param {number} wei - BN corresponding to an amount of wei
  * @param {number} conversionRate - ETH to current currency conversion rate
+ * @param {Number} decimalsToShow - Decimals to 5
  * @returns {Number} - The converted balance
  */
-export function weiToFiatNumber(wei, conversionRate) {
+export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
+	const base = Math.pow(10, decimalsToShow);
 	const eth = fromWei(wei).toString();
-	let value = parseFloat(Math.round(eth * conversionRate * 100) / 100).toFixed(2);
+	let value = parseFloat(Math.round(eth * conversionRate * base) / base);
 	value = isNaN(value) ? 0.0 : value;
 	return value;
 }
@@ -257,10 +260,12 @@ export function balanceToFiat(balance, conversionRate, exchangeRate, currencyCod
  * @param {number} balance - Number corresponding to a balance of an asset
  * @param {number} conversionRate - ETH to current currency conversion rate
  * @param {number} exchangeRate - Asset to ETH conversion rate
+ * @param {Number} decimalsToShow - Decimals to 5
  * @returns {Number} - The converted balance
  */
-export function balanceToFiatNumber(balance, conversionRate, exchangeRate) {
-	let fiatFixed = parseFloat(Math.round(balance * conversionRate * exchangeRate * 100) / 100).toFixed(2);
+export function balanceToFiatNumber(balance, conversionRate, exchangeRate, decimalsToShow = 5) {
+	const base = Math.pow(10, decimalsToShow);
+	let fiatFixed = parseFloat(Math.round(balance * conversionRate * exchangeRate * base) / base);
 	fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
 	return fiatFixed;
 }

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -58,7 +58,7 @@ export function fromTokenMinimalUnit(minimalInput, decimals) {
  * Converts some unit to token minimal unit
  *
  * @param {number|string|BN} tokenValue - Value to convert
- * @param {string} unit - Unit to convert from, ether by default
+ * @param {string} decimals - Unit to convert from, ether by default
  * @returns {Object} - BN instance containing the new number
  */
 export function toTokenMinimalUnit(tokenValue, decimals) {
@@ -101,6 +101,36 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
 		tokenMinimal = tokenMinimal.mul(negative);
 	}
 	return new BN(tokenMinimal.toString(10), 10);
+}
+
+/**
+ * Converts some token minimal unit to render format string, showing 5 decimals
+ *
+ * @param {Number|String|BN} tokenValue - Token value to convert
+ * @param {Number} decimals - Token decimals to convert
+ * @param {Number} decimalsToShow - Decimals to
+ * @returns {String} - String of token minimal unit, in render format
+ */
+export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow = 5) {
+	const minimalUnit = fromTokenMinimalUnit(tokenValue, decimals);
+	const renderMinimalUnit = parseFloat(minimalUnit)
+		.toFixed(decimalsToShow)
+		.toString();
+	return renderMinimalUnit;
+}
+
+/**
+ * Converts wei to render format string, showing 5 decimals
+ *
+ * @param {Number|String|BN} value - Wei to convert
+ * @returns {String} - String of token minimal unit, in render format
+ */
+export function renderFromWei(value, decimalsToShow = 5) {
+	const wei = fromWei(value);
+	const renderWei = parseFloat(wei)
+		.toFixed(decimalsToShow)
+		.toString();
+	return renderWei;
 }
 
 /**

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -113,9 +113,8 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
  */
 export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow = 5) {
 	const minimalUnit = fromTokenMinimalUnit(tokenValue, decimals);
-	const renderMinimalUnit = parseFloat(minimalUnit)
-		.toFixed(decimalsToShow)
-		.toString();
+	const base = Math.pow(10, decimalsToShow);
+	const renderMinimalUnit = Math.round(parseFloat(minimalUnit) * base) / base;
 	return renderMinimalUnit;
 }
 
@@ -127,9 +126,8 @@ export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow 
  */
 export function renderFromWei(value, decimalsToShow = 5) {
 	const wei = fromWei(value);
-	const renderWei = parseFloat(wei)
-		.toFixed(decimalsToShow)
-		.toString();
+	const base = Math.pow(10, decimalsToShow);
+	const renderWei = Math.round(parseFloat(wei) * base) / base;
 	return renderWei;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR adds two new methods and modifies two:

1. `renderFromTokenMinimalUnit` and `renderFromWei` to render "crypto" values, the first one is for tokens with variable decimals and the second one for ETH.
2. `balanceToFiatNumber` and `weiToFiatNumber` to do the same with fiat values for ETH and Tokens.

GIF of the app that is being changed 

![consistentdecimals](https://user-images.githubusercontent.com/12115171/51003963-7e5d8500-1517-11e9-945e-0deebb79016d.gif)

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #270
