### PR TITLE
Fix fiat value for tx details

### DIFF
--- a/app/components/TransactionElement/TransactionDetails/index.js
+++ b/app/components/TransactionElement/TransactionDetails/index.js
@@ -178,10 +178,10 @@ class TransactionDetails extends PureComponent {
 			: renderTotalEth;
 
 		const renderTotalEthFiat = weiToFiat(totalEth, conversionRate, currentCurrency).toUpperCase();
-		const totalEthAFiatAmount = weiToFiatNumber(totalEth, conversionRate);
+		const totalEthFiatAmount = weiToFiatNumber(totalEth, conversionRate);
 		const renderTotalFiat = transfer
 			? transfer.amountFiat
-				? totalEthAFiatAmount + transfer.amountFiat + ' ' + currentCurrency.toUpperCase()
+				? totalEthFiatAmount + transfer.amountFiat + ' ' + currentCurrency.toUpperCase()
 				: undefined
 			: renderTotalEthFiat;
 		const renderTo = transfer ? transfer.to : !to ? strings('transactions.to_contract') : renderFullAddress(to);

--- a/app/components/TransactionElement/TransactionDetails/index.js
+++ b/app/components/TransactionElement/TransactionDetails/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Clipboard, TouchableOpacity, StyleSheet, Text, View } from 'react-native';
 import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
-import { renderFromWei, weiToFiat, hexToBN, isBN, toBN, toGwei } from '../../../util/number';
+import { renderFromWei, weiToFiat, hexToBN, isBN, toBN, toGwei, weiToFiatNumber } from '../../../util/number';
 import { connect } from 'react-redux';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { renderFullAddress } from '../../../util/address';
@@ -178,10 +178,10 @@ class TransactionDetails extends PureComponent {
 			: renderTotalEth;
 
 		const renderTotalEthFiat = weiToFiat(totalEth, conversionRate, currentCurrency).toUpperCase();
-
+		const totalEthAFiatAmount = weiToFiatNumber(totalEth, conversionRate);
 		const renderTotalFiat = transfer
 			? transfer.amountFiat
-				? transfer.amountFiat + ' ' + strings('unit.divisor') + ' ' + renderTotalEthFiat
+				? totalEthAFiatAmount + transfer.amountFiat + ' ' + currentCurrency.toUpperCase()
 				: undefined
 			: renderTotalEthFiat;
 		const renderTo = transfer ? transfer.to : !to ? strings('transactions.to_contract') : renderFullAddress(to);

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -12,7 +12,8 @@ import {
 	fromTokenMinimalUnit,
 	balanceToFiat,
 	toBN,
-	isBN
+	isBN,
+	balanceToFiatNumber
 } from '../../util/number';
 import { toChecksumAddress } from 'ethereumjs-util';
 import Identicon from '../Identicon';
@@ -287,21 +288,26 @@ class TransactionElement extends PureComponent {
 			? renderFromTokenMinimalUnit(amount, token.decimals) + ' ' + token.symbol
 			: undefined;
 		const exchangeRate = token ? contractExchangeRates[token.address] : undefined;
-		let renderTokenFiatAmount;
+		let renderTokenFiatAmount, renderTokenFiatNumber;
 		if (exchangeRate) {
 			renderTokenFiatAmount =
 				'- ' +
 				balanceToFiat(
-					fromTokenMinimalUnit(amount) || 0,
+					fromTokenMinimalUnit(amount, token.decimals) || 0,
 					conversionRate,
 					exchangeRate,
 					currentCurrency
 				).toUpperCase();
+			renderTokenFiatNumber = balanceToFiatNumber(
+				fromTokenMinimalUnit(amount, token.decimals) || 0,
+				conversionRate,
+				exchangeRate
+			);
 		}
 		const transfer = {
 			to: addressTo,
 			amount: renderTokenAmount,
-			amountFiat: renderTokenFiatAmount
+			amountFiat: renderTokenFiatNumber
 		};
 		return (
 			<View style={styles.rowContent}>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

For tokens with conversion rate available tx details didn't work as expected. In tx details:

1. Total =  Token Value /  Gas Value (ETH)
2. Fiat Total = Token fiat value + gas fiat value

![image](https://user-images.githubusercontent.com/12115171/51204302-08279c80-18e2-11e9-955d-a7792800b65a.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
