### PR TITLE
Feature: EIP-945 support

### DIFF
--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -297,7 +297,17 @@ export class Browser extends Component {
 				return promise;
 			},
 			web3_clientVersion: payload =>
-				Promise.resolve({ result: 'MetaMask/0.1.0/Alpha/Mobile', jsonrpc: payload.jsonrpc, id: payload.id })
+				Promise.resolve({ result: 'MetaMask/0.1.0/Alpha/Mobile', jsonrpc: payload.jsonrpc, id: payload.id }),
+			wallet_scanQRCode: () => {
+				this.props.navigation.navigate('QRScanner', {
+					onScanSuccess: data => {
+						Promise.resolve(data);
+					},
+					onScanError: e => {
+						Promise.reject(e.toString());
+					}
+				});
+			}
 		});
 
 		const entryScriptWeb3 =

--- a/app/components/Browser/index.js
+++ b/app/components/Browser/index.js
@@ -298,15 +298,24 @@ export class Browser extends Component {
 			},
 			web3_clientVersion: payload =>
 				Promise.resolve({ result: 'MetaMask/0.1.0/Alpha/Mobile', jsonrpc: payload.jsonrpc, id: payload.id }),
-			wallet_scanQRCode: () => {
-				this.props.navigation.navigate('QRScanner', {
-					onScanSuccess: data => {
-						Promise.resolve(data);
-					},
-					onScanError: e => {
-						Promise.reject(e.toString());
-					}
+			wallet_scanQRCode: payload => {
+				const promise = new Promise((resolve, reject) => {
+					this.props.navigation.navigate('QRScanner', {
+						onScanSuccess: data => {
+							let result = data;
+							if (data.target_address) {
+								result = data.target_address;
+							} else if (data.scheme) {
+								result = JSON.stringify(data);
+							}
+							resolve({ result, jsonrpc: payload.jsonrpc, id: payload.id });
+						},
+						onScanError: e => {
+							reject({ errir: e.toString(), jsonrpc: payload.jsonrpc, id: payload.id });
+						}
+					});
 				});
+				return promise;
 			}
 		});
 

--- a/app/components/QRScanner/__snapshots__/index.test.js.snap
+++ b/app/components/QRScanner/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ exports[`QrScanner should render correctly 1`] = `
   <View
     flashMode="auto"
     onBarCodeRead={[Function]}
+    onMountError={[Function]}
     permissionDialogMessage="We need your permission to scan QR codes"
     permissionDialogTitle="Allow camera access"
     style={

--- a/app/components/QRScanner/index.js
+++ b/app/components/QRScanner/index.js
@@ -1,6 +1,6 @@
 'use strict';
 import React, { Component } from 'react';
-import { InteractionManager, SafeAreaView, Alert, Image, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { InteractionManager, SafeAreaView, Image, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import { RNCamera } from 'react-native-camera';
 import { colors } from '../../styles/common';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -65,6 +65,9 @@ export default class QrScanner extends Component {
 
 	goBack = () => {
 		this.props.navigation.goBack();
+		if (this.props.navigation.state.params.onScanError) {
+			this.props.navigation.state.params.onScanError('USER_CANCELLED');
+		}
 	};
 
 	onBarCodeRead = response => {
@@ -83,8 +86,8 @@ export default class QrScanner extends Component {
 			this.shouldReadBarCode = false;
 			data = { content };
 		} else {
-			Alert.alert(strings('qr_scanner.invalid_qr_code_title'), strings('qr_scanner.invalid_qr_code_message'));
-			return false;
+			// EIP-945 allows scanning arbitrary data
+			data = content;
 		}
 		this.mounted = false;
 		this.props.navigation.goBack();
@@ -93,9 +96,19 @@ export default class QrScanner extends Component {
 		});
 	};
 
+	onError = error => {
+		this.props.navigation.goBack();
+		InteractionManager.runAfterInteractions(() => {
+			if (this.props.navigation.state.params.onScanError && error) {
+				this.props.navigation.state.params.onScanError(error.message);
+			}
+		});
+	};
+
 	render = () => (
 		<View style={styles.container}>
 			<RNCamera
+				onMountError={this.onError}
 				style={styles.preview}
 				type={'back'}
 				onBarCodeRead={this.shouldReadBarCode ? this.onBarCodeRead : null}

--- a/app/components/QRScanner/index.js
+++ b/app/components/QRScanner/index.js
@@ -91,9 +91,7 @@ export default class QrScanner extends Component {
 		}
 		this.mounted = false;
 		this.props.navigation.goBack();
-		InteractionManager.runAfterInteractions(() => {
-			this.props.navigation.state.params.onScanSuccess(data);
-		});
+		this.props.navigation.state.params.onScanSuccess(data);
 	};
 
 	onError = error => {

--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -156,6 +156,22 @@ class InpageBridge {
 			});
 		});
 	}
+
+	/**
+	 * Called by dapps to use the QR scanner
+	 *
+	 */
+	scanQRCode() {
+		return new Promise((resolve, reject) => {
+			this.sendAsync({ method: 'wallet_scanQRCode' }, (error, result) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(result);
+			});
+		});
+	}
 }
 
 window.ethereum = new InpageBridge();

--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -161,14 +161,19 @@ class InpageBridge {
 	 * Called by dapps to use the QR scanner
 	 *
 	 */
-	scanQRCode() {
+	scanQRCode(regex = null) {
 		return new Promise((resolve, reject) => {
-			this.sendAsync({ method: 'wallet_scanQRCode' }, (error, result) => {
+			this.sendAsync({ method: 'wallet_scanQRCode' }, (error, response) => {
 				if (error) {
 					reject(error);
 					return;
 				}
-				resolve(result);
+				if (regex && !regex.exec(response.result)) {
+					reject({ message: 'NO_REGEX_MATCH', data: response.result });
+				} else if (!regex && !/^(0x){1}[0-9a-fA-F]{40}$/i.exec(response.result)) {
+					reject({ message: 'INVALID_ETHEREUM_ADDRESS', data: response.result });
+				}
+				resolve(response.result);
 			});
 		});
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR exposes a new provider method `scanQRCode` as specified on [EIP-945](https://github.com/ethereum/EIPs/issues/945), which allows dApps to scan QR codes.

Potential use cases:
 - A DApp that can needs to scan Ethereum addresses
 - An event-ticketing DApp that lets people check in by scanning tickets
 - An airdrop DApp that allows people to redeem tokens by scanning vouchers

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented


Can be tested via: https://cipher-qr-scan.netlify.com/