### PR TITLE
Fix send screen

### DIFF
--- a/app/components/AccountInput/index.js
+++ b/app/components/AccountInput/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { renderShortAddress } from '../../util/address';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { ScrollView } from 'react-native-gesture-handler';
+import ElevatedView from 'react-native-elevated-view';
 
 const styles = StyleSheet.create({
 	root: {
@@ -17,18 +18,14 @@ const styles = StyleSheet.create({
 		color: colors.inputBorderColor,
 		position: 'absolute',
 		right: 10,
-		top: 20
+		top: Platform.OS === 'android' ? 20 : 13
 	},
 	componentContainer: {
-		position: 'absolute',
-		zIndex: 6,
-		width: '100%',
-		marginTop: 60,
+		position: 'relative',
 		maxHeight: 200,
 		borderColor: colors.inputBorderColor,
 		borderRadius: 4,
-		borderWidth: 1,
-		elevation: 10
+		borderWidth: 1
 	},
 	input: {
 		...fontStyles.bold,
@@ -74,8 +71,7 @@ const styles = StyleSheet.create({
 		width: '100%',
 		top: 0,
 		left: 0,
-		right: 0,
-		elevation: 10
+		right: 0
 	},
 	content: {
 		flex: 1,
@@ -158,15 +154,17 @@ class AccountInput extends Component {
 	renderOptionList() {
 		const { visibleOptions = this.props.accounts } = this.state;
 		return (
-			<ScrollView style={styles.componentContainer}>
-				<View style={styles.optionList}>
-					{Object.keys(visibleOptions).map(address =>
-						this.renderOption(visibleOptions[address], () => {
-							this.selectAccount(visibleOptions[address]);
-						})
-					)}
-				</View>
-			</ScrollView>
+			<ElevatedView elevation={10} style={styles.root}>
+				<ScrollView style={styles.componentContainer}>
+					<View style={styles.optionList}>
+						{Object.keys(visibleOptions).map(address =>
+							this.renderOption(visibleOptions[address], () => {
+								this.selectAccount(visibleOptions[address]);
+							})
+						)}
+					</View>
+				</ScrollView>
+			</ElevatedView>
 		);
 	}
 

--- a/app/components/EthInput/index.js
+++ b/app/components/EthInput/index.js
@@ -14,6 +14,7 @@ import { strings } from '../../../locales/i18n';
 import TokenImage from '../TokenImage';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { ScrollView } from 'react-native-gesture-handler';
+import ElevatedView from 'react-native-elevated-view';
 
 const styles = StyleSheet.create({
 	root: {
@@ -76,18 +77,14 @@ const styles = StyleSheet.create({
 		color: colors.inputBorderColor,
 		position: 'absolute',
 		right: 10,
-		top: 20
+		top: Platform.OS === 'android' ? 20 : 13
 	},
 	componentContainer: {
-		position: 'absolute',
-		zIndex: 2,
-		width: '100%',
-		marginTop: 55,
+		position: 'relative',
 		maxHeight: 200,
 		borderColor: colors.inputBorderColor,
 		borderRadius: 4,
-		borderWidth: 1,
-		elevation: 9
+		borderWidth: 1
 	},
 	optionList: {
 		backgroundColor: colors.white,
@@ -99,8 +96,7 @@ const styles = StyleSheet.create({
 		width: '100%',
 		top: 0,
 		left: 0,
-		right: 0,
-		elevation: 10
+		right: 0
 	},
 	option: {
 		flexDirection: 'row',
@@ -255,15 +251,17 @@ class EthInput extends Component {
 			...this.props.tokens
 		];
 		return (
-			<ScrollView style={styles.componentContainer}>
-				<View style={styles.optionList}>
-					{tokens.map(token =>
-						this.renderAsset(token, async () => {
-							await this.selectAsset(token);
-						})
-					)}
-				</View>
-			</ScrollView>
+			<ElevatedView elevation={10} style={styles.root}>
+				<ScrollView style={styles.componentContainer}>
+					<View style={styles.optionList}>
+						{tokens.map(token =>
+							this.renderAsset(token, async () => {
+								await this.selectAsset(token);
+							})
+						)}
+					</View>
+				</ScrollView>
+			</ElevatedView>
 		);
 	};
 

--- a/app/components/Send/__snapshots__/index.test.js.snap
+++ b/app/components/Send/__snapshots__/index.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Accounts should render correctly 1`] = `<withNavigation(Send) />`;
+exports[`Accounts should render correctly 1`] = `<Send />`;

--- a/app/components/Send/index.js
+++ b/app/components/Send/index.js
@@ -46,6 +46,7 @@ export default class Send extends Component {
 	};
 
 	mounted = false;
+	unmountHandled = false;
 
 	async reset() {
 		const { navigation } = this.props;
@@ -77,7 +78,7 @@ export default class Send extends Component {
 
 	async componentWillUnmount() {
 		const { transaction, transactionSubmitted } = this.state;
-		if (!transactionSubmitted) {
+		if (!transactionSubmitted && !this.unmountHandled) {
 			transaction && (await this.onCancel(transaction.id));
 		}
 		this.mounted = false;
@@ -154,6 +155,7 @@ export default class Send extends Component {
 		} else {
 			this.props.navigation.pop();
 		}
+		this.unmountHandled = true;
 	};
 
 	onConfirm = async (transaction, asset) => {

--- a/app/components/Send/index.js
+++ b/app/components/Send/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { SafeAreaView, ActivityIndicator, Alert, StyleSheet, View } from 'react-native';
-import { withNavigation } from 'react-navigation';
 import { colors } from '../../styles/common';
 import Engine from '../../core/Engine';
 import TransactionEditor from '../TransactionEditor';
@@ -26,7 +25,7 @@ const styles = StyleSheet.create({
 /**
  * View that wraps the wraps the "Send" screen
  */
-class Send extends Component {
+export default class Send extends Component {
 	static navigationOptions = ({ navigation }) =>
 		getClosableNavigationOptions(strings('send.title'), strings('navigation.cancel'), navigation);
 
@@ -153,7 +152,7 @@ class Send extends Component {
 		if (this.state.mode !== 'edit') {
 			this.props.navigation.pop(2);
 		} else {
-			this.props.navigation.goBack();
+			this.props.navigation.pop();
 		}
 	};
 
@@ -209,5 +208,3 @@ class Send extends Component {
 		</SafeAreaView>
 	);
 }
-
-export default withNavigation(Send);

--- a/app/components/TransactionEdit/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionEdit/__snapshots__/index.test.js.snap
@@ -31,11 +31,19 @@ exports[`TransactionEdit should render correctly 1`] = `
     >
       <View
         style={
-          Object {
-            "flex": 0,
-            "flexDirection": "row",
-            "marginTop": 18,
-          }
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            Object {
+              "left": 15,
+              "marginRight": 0,
+              "marginTop": 30,
+              "position": "absolute",
+              "right": 15,
+              "zIndex": 5,
+            },
+          ]
         }
       >
         <View
@@ -71,51 +79,20 @@ exports[`TransactionEdit should render correctly 1`] = `
         style={
           Array [
             Object {
-              "flex": 0,
               "flexDirection": "row",
-              "marginTop": 18,
             },
-            Object {},
-          ]
-        }
-      >
-        <View
-          style={
             Object {
-              "flex": 0,
-              "paddingRight": 18,
-              "width": 106,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#7c7e84",
-                "fontFamily": "Roboto",
-                "fontSize": 16,
-                "fontWeight": "600",
-              }
-            }
-          >
-            To
-            :
-          </Text>
-        </View>
-        <Connect(AccountInput)
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Recipient Address"
-          showQRScanner={[Function]}
-        />
-      </View>
-      <View
-        style={
-          Object {
-            "flex": 0,
-            "flexDirection": "row",
-            "marginTop": 18,
-          }
+              "marginTop": 18,
+              "zIndex": 3,
+            },
+            Object {
+              "left": 15,
+              "marginTop": 190,
+              "position": "absolute",
+              "right": 15,
+              "zIndex": 4,
+            },
+          ]
         }
       >
         <View
@@ -168,11 +145,64 @@ exports[`TransactionEdit should render correctly 1`] = `
       </View>
       <View
         style={
-          Object {
-            "flex": 0,
-            "flexDirection": "row",
-            "marginTop": 18,
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            Object {
+              "left": 15,
+              "marginTop": 120,
+              "position": "absolute",
+              "right": 15,
+              "zIndex": 4,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 0,
+              "paddingRight": 18,
+              "width": 106,
+            }
           }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#7c7e84",
+                "fontFamily": "Roboto",
+                "fontSize": 16,
+                "fontWeight": "600",
+              }
+            }
+          >
+            To
+            :
+          </Text>
+        </View>
+        <Connect(AccountInput)
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder="Recipient Address"
+          showQRScanner={[Function]}
+        />
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            Object {
+              "marginTop": 18,
+              "zIndex": 3,
+            },
+            Object {
+              "marginTop": 240,
+            },
+          ]
         }
       >
         <View
@@ -209,12 +239,11 @@ exports[`TransactionEdit should render correctly 1`] = `
         style={
           Array [
             Object {
-              "flex": 0,
               "flexDirection": "row",
-              "marginTop": 18,
             },
             Object {
-              "minHeight": 64,
+              "marginTop": 18,
+              "zIndex": 3,
             },
           ]
         }

--- a/app/components/TransactionEdit/index.js
+++ b/app/components/TransactionEdit/index.js
@@ -208,9 +208,9 @@ class TransactionEdit extends Component {
 			.gt(fromWei(0))
 			? hexToBN(balance).sub(totalGas)
 			: fromWei(0);
-		this.props.handleUpdateAmount(asset ? contractBalances[asset.address] : ethMaxAmount);
+		this.props.handleUpdateAmount(asset ? hexToBN(contractBalances[asset.address].toString(16)) : ethMaxAmount);
 		const readableValue = asset
-			? fromTokenMinimalUnit(contractBalances[asset.address], asset.decimals)
+			? fromTokenMinimalUnit(hexToBN(contractBalances[asset.address].toString(16)), asset.decimals)
 			: fromWei(ethMaxAmount);
 		this.props.handleUpdateReadableValue(readableValue);
 		this.setState({ fillMax: true });
@@ -231,7 +231,7 @@ class TransactionEdit extends Component {
 	};
 
 	validate = () => {
-		const amountError = this.props.validateAmount();
+		const amountError = this.props.validateAmount(false);
 		const gasError = this.props.validateGas();
 		const toAddressError = this.props.validateToAddress();
 		this.setState({ amountError, gasError, toAddressError });
@@ -248,7 +248,7 @@ class TransactionEdit extends Component {
 		}
 		await this.props.handleUpdateAmount(processedAmount);
 		this.props.handleUpdateReadableValue(amount);
-		const amountError = this.props.validateAmount();
+		const amountError = this.props.validateAmount(true);
 		this.setState({ amountError });
 	};
 

--- a/app/components/TransactionEdit/index.js
+++ b/app/components/TransactionEdit/index.js
@@ -4,7 +4,7 @@ import AccountSelect from '../AccountSelect';
 import ActionView from '../ActionView';
 import EthInput from '../EthInput';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { colors, fontStyles } from '../../styles/common';
 import { connect } from 'react-redux';
 import {
@@ -26,16 +26,36 @@ const styles = StyleSheet.create({
 		flex: 1
 	},
 	formRow: {
-		flex: 0,
-		flexDirection: 'row',
-		marginTop: 18
+		flexDirection: 'row'
 	},
-	fromRow: {},
-	toRow: {},
-	amountRow: {},
-	gasRow: {},
-	hexDataRow: {
-		minHeight: 64
+	fromRow: {
+		marginRight: 0,
+		position: 'absolute',
+		zIndex: 5,
+		right: 15,
+		left: 15,
+		marginTop: 30
+	},
+	toRow: {
+		right: 15,
+		left: 15,
+		marginTop: Platform.OS === 'android' ? 125 : 120,
+		position: 'absolute',
+		zIndex: 4
+	},
+	row: {
+		marginTop: 18,
+		zIndex: 3
+	},
+	amountRow: {
+		right: 15,
+		left: 15,
+		marginTop: Platform.OS === 'android' ? 205 : 190,
+		position: 'absolute',
+		zIndex: 4
+	},
+	notAbsolute: {
+		marginTop: Platform.OS === 'android' ? 270 : 240
 	},
 	label: {
 		flex: 0,
@@ -270,26 +290,13 @@ class TransactionEdit extends Component {
 			<View style={styles.root}>
 				<ActionView confirmText="Next" onCancelPress={this.props.onCancel} onConfirmPress={this.review}>
 					<View style={styles.form}>
-						<View style={{ ...styles.formRow, ...styles.fromRow }}>
+						<View style={[styles.formRow, styles.fromRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.from')}:</Text>
 							</View>
 							<AccountSelect value={from} onChange={this.updateFromAddress} enabled={false} />
 						</View>
-						<View style={[styles.formRow, styles.toRow]}>
-							<View style={styles.label}>
-								<Text style={styles.labelText}>{strings('transaction.to')}:</Text>
-								{toAddressError ? <Text style={styles.error}>{toAddressError}</Text> : null}
-							</View>
-							<AccountInput
-								onChange={this.updateToAddress}
-								onFocus={this.onFocusToAddress}
-								placeholder={strings('transaction.recipient_address')}
-								showQRScanner={this.onScanSuccess}
-								value={to}
-							/>
-						</View>
-						<View style={{ ...styles.formRow, ...styles.amountRow, ...styles.notAbsolute }}>
+						<View style={[styles.formRow, styles.row, styles.amountRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.amount')}:</Text>
 								{amountError ? (
@@ -310,7 +317,20 @@ class TransactionEdit extends Component {
 								updateFillMax={this.updateFillMax}
 							/>
 						</View>
-						<View style={{ ...styles.formRow, ...styles.gasRow }}>
+						<View style={[styles.formRow, styles.toRow]}>
+							<View style={styles.label}>
+								<Text style={styles.labelText}>{strings('transaction.to')}:</Text>
+								{toAddressError ? <Text style={styles.error}>{toAddressError}</Text> : null}
+							</View>
+							<AccountInput
+								onChange={this.updateToAddress}
+								onFocus={this.onFocusToAddress}
+								placeholder={strings('transaction.recipient_address')}
+								showQRScanner={this.onScanSuccess}
+								value={to}
+							/>
+						</View>
+						<View style={[styles.formRow, styles.row, styles.notAbsolute]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.gas_fee')}:</Text>
 								{gasError ? <Text style={styles.error}>{gasError}</Text> : null}
@@ -322,7 +342,7 @@ class TransactionEdit extends Component {
 								gasPrice={gasPrice}
 							/>
 						</View>
-						<View style={[styles.formRow, styles.hexDataRow]}>
+						<View style={[styles.formRow, styles.row]}>
 							{showHexData && (
 								<View style={styles.label}>
 									<Text style={styles.labelText}>{strings('transaction.hex_data')}:</Text>

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -157,51 +157,56 @@ class TransactionEditor extends Component {
 	};
 
 	validate = () => {
-		if (this.validateAmount() || this.validateGas() || this.validateToAddress()) {
+		if (this.validateAmount(false) || this.validateGas() || this.validateToAddress()) {
 			return true;
 		}
 	};
 
-	validateAmount = () => {
+	validateAmount = (allowEmpty = true) => {
 		const { asset } = this.state;
-		return asset ? this.validateTokenAmount() : this.validateEtherAmount();
+		return asset ? this.validateTokenAmount(allowEmpty) : this.validateEtherAmount(allowEmpty);
 	};
 
-	validateEtherAmount = () => {
+	validateEtherAmount = (allowEmpty = true) => {
 		let error;
-		const { amount, gas, gasPrice, from } = this.state;
-		const checksummedFrom = from ? toChecksumAddress(from) : '';
-		const fromAccount = this.props.accounts[checksummedFrom];
-		(!amount || !gas || !gasPrice || !from) && (error = strings('transaction.invalid_amount'));
-		amount && !isBN(amount) && (error = strings('transaction.invalid_amount'));
-		amount &&
-			fromAccount &&
-			isBN(gas) &&
-			isBN(gasPrice) &&
-			isBN(amount) &&
-			hexToBN(fromAccount.balance).lt(amount.add(gas.mul(gasPrice))) &&
-			(error = strings('transaction.insufficient'));
+		if (!allowEmpty) {
+			const { amount, gas, gasPrice, from } = this.state;
+			const checksummedFrom = from ? toChecksumAddress(from) : '';
+			const fromAccount = this.props.accounts[checksummedFrom];
+			(!amount || !gas || !gasPrice || !from) && (error = strings('transaction.invalid_amount'));
+			amount && !isBN(amount) && (error = strings('transaction.invalid_amount'));
+			amount &&
+				fromAccount &&
+				isBN(gas) &&
+				isBN(gasPrice) &&
+				isBN(amount) &&
+				hexToBN(fromAccount.balance).lt(amount.add(gas.mul(gasPrice))) &&
+				(error = strings('transaction.insufficient'));
+		}
 		return error;
 	};
 
-	validateTokenAmount = () => {
+	validateTokenAmount = (allowEmpty = true) => {
 		let error;
-		const { amount, gas, gasPrice, from, asset } = this.state;
-		const { contractBalances } = this.props;
-		const checksummedFrom = from ? toChecksumAddress(from) : '';
-		const fromAccount = this.props.accounts[checksummedFrom];
-		if (!amount || !gas || !gasPrice || !from) {
-			return strings('transaction.invalid_amount');
+		if (!allowEmpty) {
+			const { amount, gas, gasPrice, from, asset } = this.state;
+			const { contractBalances } = this.props;
+			const checksummedFrom = from ? toChecksumAddress(from) : '';
+			const fromAccount = this.props.accounts[checksummedFrom];
+			if (!amount || !gas || !gasPrice || !from) {
+				return strings('transaction.invalid_amount');
+			}
+			const contractBalanceForAddress = hexToBN(contractBalances[asset.address].toString(16));
+			amount && !isBN(amount) && (error = strings('transaction.invalid_amount'));
+			const validateAssetAmount = contractBalanceForAddress.lt(amount);
+			const ethTotalAmount = gas.mul(gasPrice);
+			amount &&
+				fromAccount &&
+				isBN(gas) &&
+				isBN(gasPrice) &&
+				(validateAssetAmount || hexToBN(fromAccount.balance).lt(ethTotalAmount)) &&
+				(error = strings('transaction.insufficient'));
 		}
-		amount && !isBN(amount) && (error = strings('transaction.invalid_amount'));
-		const validateAssetAmount = contractBalances[asset.address].lt(amount);
-		const ethTotalAmount = gas.mul(gasPrice);
-		amount &&
-			fromAccount &&
-			isBN(gas) &&
-			isBN(gasPrice) &&
-			(validateAssetAmount || hexToBN(fromAccount.balance).lt(ethTotalAmount)) &&
-			(error = strings('transaction.insufficient'));
 		return error;
 	};
 

--- a/app/components/TransactionEditor/index.js
+++ b/app/components/TransactionEditor/index.js
@@ -152,7 +152,8 @@ class TransactionEditor extends Component {
 	};
 
 	handleUpdateAsset = async asset => {
-		await this.setState({ amount: undefined, data: undefined, to: undefined, asset, readableValue: undefined });
+		await this.setState({ amount: undefined, data: undefined, asset, readableValue: undefined });
+		await this.handleUpdateToAddress(this.state.to);
 	};
 
 	validate = () => {

--- a/app/components/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
+++ b/app/components/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
@@ -29,6 +29,7 @@ exports[`TransactionReviewInformation should render correctly 1`] = `
           "fontFamily": "Roboto",
           "fontSize": 12,
           "fontWeight": "600",
+          "minWidth": 50,
         }
       }
     >
@@ -101,6 +102,7 @@ exports[`TransactionReviewInformation should render correctly 1`] = `
           "fontFamily": "Roboto",
           "fontSize": 12,
           "fontWeight": "600",
+          "minWidth": 50,
         }
       }
     >

--- a/app/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/TransactionReview/TransactionReviewInformation/index.js
@@ -55,7 +55,8 @@ const styles = StyleSheet.create({
 		...fontStyles.bold,
 		color: colors.gray,
 		flex: 1,
-		fontSize: 12
+		fontSize: 12,
+		minWidth: 50
 	},
 	overviewFiat: {
 		...fontStyles.bold,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

- Fixed issues with dropdowns in iOS
- Added missing elevation in iOS
- Fixed bug that was resetting the TO field while selecting a different asset
- Prevent validation of amount when it's empty unless we try to advance to review screen. This way we avoid showing errors to the user too early.
- Fixed Cancel button (bottom one) which wasn't working
- Fixed MAX amount while sending tokens giving error (contractBalances[asset.address] is an instance of BigNumber instead of BN so I had to do the conversion)


DEMO: 
![send](https://user-images.githubusercontent.com/1247834/51421521-205f1c00-1b6d-11e9-812b-97ce20099151.gif)

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #330 
