### PR TITLE
Collectible transaction details

### DIFF
--- a/app/components/TransactionElement/TransactionDetails/index.js
+++ b/app/components/TransactionElement/TransactionDetails/index.js
@@ -95,6 +95,9 @@ export default class TransactionDetails extends PureComponent {
 		 * Action that shows the global alert
 		 */
 		viewOnEtherscan: PropTypes.func.isRequired,
+		/**
+		 * Object with information to render
+		 */
 		transactionDetails: PropTypes.object
 	};
 

--- a/app/components/TransactionElement/TransactionDetails/index.js
+++ b/app/components/TransactionElement/TransactionDetails/index.js
@@ -95,15 +95,7 @@ export default class TransactionDetails extends PureComponent {
 		 * Action that shows the global alert
 		 */
 		viewOnEtherscan: PropTypes.func.isRequired,
-		renderFrom: PropTypes.string,
-		renderTo: PropTypes.string,
-		transactionHash: PropTypes.string,
-		valueLabel: PropTypes.string,
-		renderValue: PropTypes.string,
-		renderGas: PropTypes.string,
-		renderGasPrice: PropTypes.string,
-		renderTotalValue: PropTypes.string,
-		renderTotalValueFiat: PropTypes.string
+		transactionDetails: PropTypes.object
 	};
 
 	renderTxHash = transactionHash => {
@@ -123,7 +115,7 @@ export default class TransactionDetails extends PureComponent {
 	};
 
 	copy = async () => {
-		await Clipboard.setString(this.props.transactionHash);
+		await Clipboard.setString(this.props.transactionDetails.transactionHash);
 		this.props.showAlert({
 			isVisible: true,
 			autodismiss: 2000,
@@ -142,7 +134,7 @@ export default class TransactionDetails extends PureComponent {
 		const {
 			transactionObject: { networkID }
 		} = this.props;
-		this.props.viewOnEtherscan(networkID, this.props.transactionHash);
+		this.props.viewOnEtherscan(networkID, this.props.transactionDetails.transactionHash);
 	};
 
 	render = () => {
@@ -150,48 +142,56 @@ export default class TransactionDetails extends PureComponent {
 
 		return (
 			<View style={styles.detailRowWrapper}>
-				{this.renderTxHash(this.props.transactionHash)}
+				{this.renderTxHash(this.props.transactionDetails.transactionHash)}
 				<Text style={styles.detailRowTitle}>{strings('transactions.from')}</Text>
 				<View style={[styles.detailRowInfo, styles.singleRow]}>
-					<Text style={styles.detailRowText}>{this.props.renderFrom}</Text>
+					<Text style={styles.detailRowText}>{this.props.transactionDetails.renderFrom}</Text>
 				</View>
 				<Text style={styles.detailRowTitle}>{strings('transactions.to')}</Text>
 				<View style={[styles.detailRowInfo, styles.singleRow]}>
-					<Text style={styles.detailRowText}>{this.props.renderTo}</Text>
+					<Text style={styles.detailRowText}>{this.props.transactionDetails.renderTo}</Text>
 				</View>
 				<Text style={styles.detailRowTitle}>{strings('transactions.details')}</Text>
 				<View style={styles.detailRowInfo}>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>
-							{this.props.valueLabel || strings('transactions.amount')}
+							{this.props.transactionDetails.valueLabel || strings('transactions.amount')}
 						</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderValue}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>
+							{this.props.transactionDetails.renderValue}
+						</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>
 							{strings('transactions.gas_limit')}
 						</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderGas}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>
+							{this.props.transactionDetails.renderGas}
+						</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>
 							{strings('transactions.gas_price')}
 						</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderGasPrice}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>
+							{this.props.transactionDetails.renderGasPrice}
+						</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>{strings('transactions.total')}</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderTotalValue}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>
+							{this.props.transactionDetails.renderTotalValue}
+						</Text>
 					</View>
-					{this.props.renderTotalValueFiat && (
+					{this.props.transactionDetails.renderTotalValueFiat && (
 						<View style={[styles.detailRowInfoItem, styles.noBorderBottom]}>
 							<Text style={[styles.detailRowText, styles.alignRight]}>
-								{this.props.renderTotalValueFiat}
+								{this.props.transactionDetails.renderTotalValueFiat}
 							</Text>
 						</View>
 					)}
 				</View>
-				{this.props.transactionHash &&
+				{this.props.transactionDetails.transactionHash &&
 					blockExplorer && (
 						<TouchableOpacity
 							onPress={this.viewOnEtherscan} // eslint-disable-line react/jsx-no-bind

--- a/app/components/TransactionElement/TransactionDetails/index.js
+++ b/app/components/TransactionElement/TransactionDetails/index.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { Clipboard, TouchableOpacity, StyleSheet, Text, View } from 'react-native';
 import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
-import { renderFromWei, weiToFiat, hexToBN, isBN, toBN, toGwei, weiToFiatNumber } from '../../../util/number';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { renderFullAddress } from '../../../util/address';
 
 const styles = StyleSheet.create({
 	detailRowWrapper: {
@@ -82,14 +80,6 @@ const styles = StyleSheet.create({
 export default class TransactionDetails extends PureComponent {
 	static propTypes = {
 		/**
-		 * ETH to current currency conversion rate
-		 */
-		conversionRate: PropTypes.number,
-		/**
-		 * Currency code of the currently-active currency
-		 */
-		currentCurrency: PropTypes.string,
-		/**
 		 * Object corresponding to a transaction, containing transaction object, networkId and transaction hash string
 		 */
 		transactionObject: PropTypes.object,
@@ -104,7 +94,16 @@ export default class TransactionDetails extends PureComponent {
 		/**
 		 * Action that shows the global alert
 		 */
-		viewOnEtherscan: PropTypes.func.isRequired
+		viewOnEtherscan: PropTypes.func.isRequired,
+		renderFrom: PropTypes.string,
+		renderTo: PropTypes.string,
+		transactionHash: PropTypes.string,
+		valueLabel: PropTypes.string,
+		renderValue: PropTypes.string,
+		renderGas: PropTypes.string,
+		renderGasPrice: PropTypes.string,
+		renderTotalValue: PropTypes.string,
+		renderTotalValueFiat: PropTypes.string
 	};
 
 	renderTxHash = transactionHash => {
@@ -124,10 +123,7 @@ export default class TransactionDetails extends PureComponent {
 	};
 
 	copy = async () => {
-		const {
-			transactionObject: { transactionHash }
-		} = this.props;
-		await Clipboard.setString(transactionHash);
+		await Clipboard.setString(this.props.transactionHash);
 		this.props.showAlert({
 			isVisible: true,
 			autodismiss: 2000,
@@ -144,87 +140,58 @@ export default class TransactionDetails extends PureComponent {
 
 	viewOnEtherscan = () => {
 		const {
-			transactionObject: { transactionHash, networkID }
+			transactionObject: { networkID }
 		} = this.props;
-		this.props.viewOnEtherscan(networkID, transactionHash);
+		this.props.viewOnEtherscan(networkID, this.props.transactionHash);
 	};
 
 	render = () => {
-		const {
-			transactionObject: {
-				transaction: { gas, gasPrice, value, to, from },
-				transactionHash,
-				transfer
-			},
-			blockExplorer
-		} = this.props;
-		const gasBN = hexToBN(gas);
-		const gasPriceBN = hexToBN(gasPrice);
-		const amount = hexToBN(value);
-		const { conversionRate, currentCurrency } = this.props;
-		const totalGas = isBN(gasBN) && isBN(gasPriceBN) ? gasBN.mul(gasPriceBN) : toBN('0x0');
-		const totalEth = isBN(amount) ? amount.add(totalGas) : totalGas;
-		const renderAmount = transfer
-			? !transfer.amount
-				? strings('transaction.value_not_available')
-				: transfer.amount
-			: renderFromWei(value) + ' ' + strings('unit.eth');
-		const renderTotalEth = renderFromWei(totalEth) + ' ' + strings('unit.eth');
-		const renderTotal = transfer
-			? transfer.amount
-				? transfer.amount + ' ' + strings('unit.divisor') + ' ' + renderTotalEth
-				: strings('transaction.value_not_available')
-			: renderTotalEth;
-
-		const renderTotalEthFiat = weiToFiat(totalEth, conversionRate, currentCurrency).toUpperCase();
-		const totalEthFiatAmount = weiToFiatNumber(totalEth, conversionRate);
-		const renderTotalFiat = transfer
-			? transfer.amountFiat
-				? totalEthFiatAmount + transfer.amountFiat + ' ' + currentCurrency.toUpperCase()
-				: undefined
-			: renderTotalEthFiat;
-		const renderTo = transfer ? transfer.to : !to ? strings('transactions.to_contract') : renderFullAddress(to);
+		const { blockExplorer } = this.props;
 
 		return (
 			<View style={styles.detailRowWrapper}>
-				{this.renderTxHash(transactionHash)}
+				{this.renderTxHash(this.props.transactionHash)}
 				<Text style={styles.detailRowTitle}>{strings('transactions.from')}</Text>
 				<View style={[styles.detailRowInfo, styles.singleRow]}>
-					<Text style={styles.detailRowText}>{renderFullAddress(from)}</Text>
+					<Text style={styles.detailRowText}>{this.props.renderFrom}</Text>
 				</View>
 				<Text style={styles.detailRowTitle}>{strings('transactions.to')}</Text>
 				<View style={[styles.detailRowInfo, styles.singleRow]}>
-					<Text style={styles.detailRowText}>{renderTo}</Text>
+					<Text style={styles.detailRowText}>{this.props.renderTo}</Text>
 				</View>
 				<Text style={styles.detailRowTitle}>{strings('transactions.details')}</Text>
 				<View style={styles.detailRowInfo}>
 					<View style={styles.detailRowInfoItem}>
-						<Text style={[styles.detailRowText, styles.alignLeft]}>{strings('transactions.amount')}</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{renderAmount}</Text>
+						<Text style={[styles.detailRowText, styles.alignLeft]}>
+							{this.props.valueLabel || strings('transactions.amount')}
+						</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderValue}</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>
 							{strings('transactions.gas_limit')}
 						</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{hexToBN(gas).toNumber()}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderGas}</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>
 							{strings('transactions.gas_price')}
 						</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{toGwei(gasPrice)}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderGasPrice}</Text>
 					</View>
 					<View style={styles.detailRowInfoItem}>
 						<Text style={[styles.detailRowText, styles.alignLeft]}>{strings('transactions.total')}</Text>
-						<Text style={[styles.detailRowText, styles.alignRight]}>{renderTotal}</Text>
+						<Text style={[styles.detailRowText, styles.alignRight]}>{this.props.renderTotalValue}</Text>
 					</View>
-					{renderTotalFiat && (
+					{this.props.renderTotalValueFiat && (
 						<View style={[styles.detailRowInfoItem, styles.noBorderBottom]}>
-							<Text style={[styles.detailRowText, styles.alignRight]}>{renderTotalFiat}</Text>
+							<Text style={[styles.detailRowText, styles.alignRight]}>
+								{this.props.renderTotalValueFiat}
+							</Text>
 						</View>
 					)}
 				</View>
-				{transactionHash &&
+				{this.props.transactionHash &&
 					blockExplorer && (
 						<TouchableOpacity
 							onPress={this.viewOnEtherscan} // eslint-disable-line react/jsx-no-bind

--- a/app/components/TransactionElement/TransactionDetails/index.test.js
+++ b/app/components/TransactionElement/TransactionDetails/index.test.js
@@ -21,8 +21,17 @@ describe('TransactionDetails', () => {
 		const wrapper = shallow(
 			<TransactionDetails
 				transactionObject={{
-					transaction: { transactionHash: '0x1', gas: '', gasPrice: '', value: '', to: '', from: '' },
 					networkID: '1'
+				}}
+				transactionDetails={{
+					renderFrom: '0x0',
+					renderTo: '0x1',
+					transactionHash: '0x2',
+					renderValue: '2 TKN',
+					renderGas: '21000',
+					renderGasPrice: '2',
+					renderTotalValue: '2 TKN / 0.001 ETH',
+					renderTotalValueFiat: ''
 				}}
 			/>,
 			{

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -253,7 +253,8 @@ export default class TransactionElement extends PureComponent {
 	renderTransferElement = () => {
 		const {
 			tx: {
-				transaction: { gas, gasPrice, to, data, hash, from }
+				transaction: { gas, gasPrice, to, data, from },
+				transactionHash
 			},
 			conversionRate,
 			currentCurrency,
@@ -298,7 +299,7 @@ export default class TransactionElement extends PureComponent {
 		const transactionDetails = {
 			renderFrom: renderFullAddress(from),
 			renderTo: renderFullAddress(addressTo),
-			transactionHash: hash,
+			transactionHash,
 			renderValue: renderToken,
 			renderGas: parseInt(gas, 16).toString(),
 			renderGasPrice: renderToGwei(gasPrice),
@@ -320,7 +321,8 @@ export default class TransactionElement extends PureComponent {
 	renderTransferFromElement = () => {
 		const {
 			tx: {
-				transaction: { gas, gasPrice, data, to, hash }
+				transaction: { gas, gasPrice, data, to },
+				transactionHash
 			},
 			collectibleContracts
 		} = this.props;
@@ -336,12 +338,13 @@ export default class TransactionElement extends PureComponent {
 		const gasBN = hexToBN(gas);
 		const gasPriceBN = hexToBN(gasPrice);
 		const totalGas = isBN(gasBN) && isBN(gasPriceBN) ? gasBN.mul(gasPriceBN) : toBN('0x0');
-		const renderCollectible = '#' + tokenId + ' ' + (collectible ? collectible.symbol : undefined);
+		const renderCollectible =
+			strings('unit.token_id') + tokenId + ' ' + (collectible ? collectible.symbol : undefined);
 
 		const transactionDetails = {
 			renderFrom: renderFullAddress(addressFrom),
 			renderTo: renderFullAddress(addressTo),
-			transactionHash: hash,
+			transactionHash,
 			renderValue: renderCollectible,
 			renderGas: parseInt(gas, 16).toString(),
 			renderGasPrice: renderToGwei(gasPrice),
@@ -359,7 +362,7 @@ export default class TransactionElement extends PureComponent {
 		const transactionElement = {
 			addressTo,
 			actionKey,
-			value: `#${tokenId}`,
+			value: `${strings('unit.token_id')}${tokenId}`,
 			fiatValue: collectible ? collectible.symbol : undefined
 		};
 
@@ -369,7 +372,8 @@ export default class TransactionElement extends PureComponent {
 	renderConfirmElement = () => {
 		const {
 			tx: {
-				transaction: { value, gas, gasPrice, from, to, hash }
+				transaction: { value, gas, gasPrice, from, to },
+				transactionHash
 			},
 			conversionRate,
 			currentCurrency
@@ -387,7 +391,7 @@ export default class TransactionElement extends PureComponent {
 		const transactionDetails = {
 			renderFrom: renderFullAddress(from),
 			renderTo: renderFullAddress(to),
-			transactionHash: hash,
+			transactionHash,
 			renderValue: renderFromWei(value) + ' ' + strings('unit.eth'),
 			renderGas: parseInt(gas, 16).toString(),
 			renderGasPrice: renderToGwei(gasPrice),
@@ -408,7 +412,8 @@ export default class TransactionElement extends PureComponent {
 	renderDeploymentElement = () => {
 		const {
 			tx: {
-				transaction: { value, gas, gasPrice, to, from, hash }
+				transaction: { value, gas, gasPrice, to, from },
+				transactionHash
 			},
 			conversionRate,
 			currentCurrency
@@ -432,7 +437,7 @@ export default class TransactionElement extends PureComponent {
 		const transactionDetails = {
 			renderFrom: renderFullAddress(from),
 			renderTo: strings('transactions.to_contract'),
-			transactionHash: hash,
+			transactionHash,
 			renderValue: renderFromWei(value) + ' ' + strings('unit.eth'),
 			renderGas: parseInt(gas, 16).toString(),
 			renderGasPrice: renderToGwei(gasPrice),
@@ -469,7 +474,6 @@ export default class TransactionElement extends PureComponent {
 			default:
 				[transactionElement, transactionDetails] = this.renderConfirmElement(totalGas);
 		}
-
 		return (
 			<TouchableOpacity
 				style={styles.row}

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, StyleSheet, Text, View, Image } from 'react-native';
+import { TouchableOpacity, StyleSheet, Text, View } from 'react-native';
 import { colors, fontStyles } from '../../styles/common';
 import { strings } from '../../../locales/i18n';
 import { toLocaleDateTime } from '../../util/date';
@@ -88,14 +88,8 @@ const styles = StyleSheet.create({
 	statusFailed: {
 		backgroundColor: colors.lightRed,
 		color: colors.error
-	},
-	ethLogo: {
-		width: 24,
-		height: 24
 	}
 });
-
-const ethLogo = require('../../images/eth-logo.png'); // eslint-disable-line
 
 /**
  * View that renders a transaction item part of transactions list
@@ -210,6 +204,32 @@ export default class TransactionElement extends PureComponent {
 			/>
 		) : null;
 
+	/**
+	 * Renders an horizontal bar with basic tx information
+	 *
+	 * @param {string} addressTo - Transaction to address
+	 * @param {string} actionKey - Transaction action key
+	 * @param {string} status - Transaction status
+	 * @param {string} value - Transaction crypto value (ETH, assets ERC20 and ERC721)
+	 * @param {string} fiatValue - transaction fiat crypto value, if available
+	 */
+	renderTxElement = (addressTo, actionKey, status, value, fiatValue) => (
+		<View style={styles.rowOnly}>
+			{this.renderTxTime()}
+			<View style={styles.subRow}>
+				<Identicon address={addressTo} diameter={24} />
+				<View style={styles.info}>
+					<Text style={styles.address}>{actionKey}</Text>
+					<Text style={[styles.status, this.getStatusStyle(status)]}>{status.toUpperCase()}</Text>
+				</View>
+				<View style={styles.amounts}>
+					<Text style={styles.amount}>{value}</Text>
+					<Text style={styles.amountFiat}>{fiatValue}</Text>
+				</View>
+			</View>
+		</View>
+	);
+
 	renderTransferElement = () => {
 		const {
 			tx,
@@ -253,24 +273,13 @@ export default class TransactionElement extends PureComponent {
 		};
 		return (
 			<View style={styles.rowContent}>
-				<View style={styles.rowOnly}>
-					{this.renderTxTime()}
-					<View style={styles.subRow}>
-						<Identicon address={addressTo} diameter={24} />
-						<View style={styles.info}>
-							<Text style={styles.address}>{renderActionKey}</Text>
-							<Text style={[styles.status, this.getStatusStyle(tx.status)]}>
-								{tx.status.toUpperCase()}
-							</Text>
-						</View>
-						<View style={styles.amounts}>
-							<Text style={styles.amount}>
-								{!renderTokenAmount ? strings('transaction.value_not_available') : renderTokenAmount}
-							</Text>
-							<Text style={styles.amountFiat}>{renderTokenFiatAmount}</Text>
-						</View>
-					</View>
-				</View>
+				{this.renderTxElement(
+					addressTo,
+					renderActionKey,
+					tx.status,
+					!renderTokenAmount ? strings('transaction.value_not_available') : renderTokenAmount,
+					renderTokenFiatAmount
+				)}
 				{this.renderTxDetails(
 					selected,
 					{ ...tx, ...{ transfer } },
@@ -301,22 +310,7 @@ export default class TransactionElement extends PureComponent {
 		const renderTotalEthFiat = weiToFiat(totalETh, conversionRate, currentCurrency).toUpperCase();
 		return (
 			<View style={styles.rowContent}>
-				<View style={styles.rowOnly}>
-					{this.renderTxTime()}
-					<View style={styles.subRow}>
-						<Identicon address={tx.transaction.to} diameter={24} />
-						<View style={styles.info}>
-							<Text style={styles.address}>{actionKey}</Text>
-							<Text style={[styles.status, this.getStatusStyle(tx.status)]}>
-								{tx.status.toUpperCase()}
-							</Text>
-						</View>
-						<View style={styles.amounts}>
-							<Text style={styles.amount}>{renderTotalEth}</Text>
-							<Text style={styles.amountFiat}>{renderTotalEthFiat}</Text>
-						</View>
-					</View>
-				</View>
+				{this.renderTxElement(tx.transaction.to, actionKey, tx.status, renderTotalEth, renderTotalEthFiat)}
 				{this.renderTxDetails(selected, tx, blockExplorer, showAlert, currentCurrency, conversionRate)}
 			</View>
 		);
@@ -329,22 +323,7 @@ export default class TransactionElement extends PureComponent {
 		const renderTotalEthFiat = weiToFiat(totalGas, conversionRate, currentCurrency).toUpperCase();
 		return (
 			<View style={styles.rowContent}>
-				<View style={styles.rowOnly}>
-					{this.renderTxTime()}
-					<View style={styles.subRow}>
-						<Image source={ethLogo} style={styles.ethLogo} />
-						<View style={styles.info}>
-							<Text style={styles.address}>{actionKey}</Text>
-							<Text style={[styles.status, this.getStatusStyle(tx.status)]}>
-								{tx.status.toUpperCase()}
-							</Text>
-						</View>
-						<View style={styles.amounts}>
-							<Text style={styles.amount}>{renderTotalEth}</Text>
-							<Text style={styles.amountFiat}>{renderTotalEthFiat}</Text>
-						</View>
-					</View>
-				</View>
+				{this.renderTxElement(tx.transaction.to, actionKey, tx.status, renderTotalEth, renderTotalEthFiat)}
 				{this.renderTxDetails(selected, tx, blockExplorer, showAlert, currentCurrency, conversionRate)}
 			</View>
 		);

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -22,6 +22,7 @@ import Identicon from '../Identicon';
 import { getActionKey, decodeTransferData } from '../../util/transactions';
 import TransactionDetails from './TransactionDetails';
 import { renderFullAddress } from '../../util/address';
+import FadeIn from 'react-native-fade-in-image';
 
 const styles = StyleSheet.create({
 	row: {
@@ -233,7 +234,9 @@ export default class TransactionElement extends PureComponent {
 				{this.renderTxTime()}
 				<View style={styles.subRow}>
 					{contractDeployment ? (
-						<Image source={ethLogo} style={styles.ethLogo} />
+						<FadeIn>
+							<Image source={ethLogo} style={styles.ethLogo} />
+						</FadeIn>
 					) : (
 						<Identicon address={addressTo} diameter={24} />
 					)}

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -14,7 +14,7 @@ import {
 	toBN,
 	isBN,
 	balanceToFiatNumber,
-	toGwei,
+	renderToGwei,
 	weiToFiatNumber
 } from '../../util/number';
 import { toChecksumAddress } from 'ethereumjs-util';
@@ -301,7 +301,7 @@ export default class TransactionElement extends PureComponent {
 			transactionHash: hash,
 			renderValue: renderToken,
 			renderGas: parseInt(gas, 16).toString(),
-			renderGasPrice: toGwei(gasPrice),
+			renderGasPrice: renderToGwei(gasPrice),
 			renderTotalValue:
 				renderToken + ' ' + strings('unit.divisor') + ' ' + renderFromWei(totalGas) + ' ' + strings('unit.eth'),
 			renderTotalValueFiat: totalFiatNumber ? totalFiatNumber + ' ' + currentCurrency.toUpperCase() : undefined
@@ -344,7 +344,7 @@ export default class TransactionElement extends PureComponent {
 			transactionHash: hash,
 			renderValue: renderCollectible,
 			renderGas: parseInt(gas, 16).toString(),
-			renderGasPrice: toGwei(gasPrice),
+			renderGasPrice: renderToGwei(gasPrice),
 			renderTotalValue:
 				renderCollectible +
 				' ' +
@@ -390,7 +390,7 @@ export default class TransactionElement extends PureComponent {
 			transactionHash: hash,
 			renderValue: renderFromWei(value) + ' ' + strings('unit.eth'),
 			renderGas: parseInt(gas, 16).toString(),
-			renderGasPrice: toGwei(gasPrice),
+			renderGasPrice: renderToGwei(gasPrice),
 			renderTotalValue: renderFromWei(totalValue) + ' ' + strings('unit.eth'),
 			renderTotalValueFiat: weiToFiat(totalValue, conversionRate, currentCurrency).toUpperCase()
 		};
@@ -435,7 +435,7 @@ export default class TransactionElement extends PureComponent {
 			transactionHash: hash,
 			renderValue: renderFromWei(value) + ' ' + strings('unit.eth'),
 			renderGas: parseInt(gas, 16).toString(),
-			renderGasPrice: toGwei(gasPrice),
+			renderGasPrice: renderToGwei(gasPrice),
 			renderTotalValue: renderFromWei(totalEth) + ' ' + strings('unit.eth'),
 			renderTotalValueFiat: weiToFiat(totalEth, conversionRate, currentCurrency).toUpperCase()
 		};

--- a/app/components/TransactionElement/index.js
+++ b/app/components/TransactionElement/index.js
@@ -338,8 +338,9 @@ export default class TransactionElement extends PureComponent {
 		const gasBN = hexToBN(gas);
 		const gasPriceBN = hexToBN(gasPrice);
 		const totalGas = isBN(gasBN) && isBN(gasPriceBN) ? gasBN.mul(gasPriceBN) : toBN('0x0');
-		const renderCollectible =
-			strings('unit.token_id') + tokenId + ' ' + (collectible ? collectible.symbol : undefined);
+		const renderCollectible = collectible
+			? strings('unit.token_id') + tokenId + ' ' + collectible.symbol
+			: strings('unit.token_id') + tokenId;
 
 		const transactionDetails = {
 			renderFrom: renderFullAddress(addressFrom),

--- a/app/components/Transactions/index.js
+++ b/app/components/Transactions/index.js
@@ -55,6 +55,10 @@ class Transactions extends PureComponent {
 		*/
 		navigation: PropTypes.object,
 		/**
+		 * An array that represents the user collectible contracts
+		 */
+		collectibleContracts: PropTypes.object,
+		/**
 		 * An array that represents the user tokens
 		 */
 		tokens: PropTypes.object,
@@ -186,6 +190,7 @@ class Transactions extends PureComponent {
 			onPressItem={this.toggleDetailsView}
 			blockExplorer
 			tokens={this.props.tokens}
+			collectibleContracts={this.props.collectibleContracts}
 			contractExchangeRates={this.props.contractExchangeRates}
 			conversionRate={this.props.conversionRate}
 			currentCurrency={this.props.currentCurrency}
@@ -230,6 +235,7 @@ const mapStateToProps = state => ({
 		tokens[token.address] = token;
 		return tokens;
 	}, {}),
+	collectibleContracts: state.engine.backgroundState.AssetsController.collectibleContracts,
 	contractExchangeRates: state.engine.backgroundState.TokenRatesController.contractExchangeRates,
 	conversionRate: state.engine.backgroundState.CurrencyRateController.conversionRate,
 	currentCurrency: state.engine.backgroundState.CurrencyRateController.currentCurrency

--- a/app/components/Transactions/index.js
+++ b/app/components/Transactions/index.js
@@ -57,7 +57,7 @@ class Transactions extends PureComponent {
 		/**
 		 * An array that represents the user collectible contracts
 		 */
-		collectibleContracts: PropTypes.object,
+		collectibleContracts: PropTypes.array,
 		/**
 		 * An array that represents the user tokens
 		 */

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -206,6 +206,20 @@ export function toGwei(value, unit = 'ether') {
 }
 
 /**
+ * Converts some unit to Gwei and return it in render format
+ *
+ * @param {number|string|BN} value - Value to convert
+ * @param {string} unit - Unit to convert from, ether by default
+ * @returns {string} - String instance containing the renderable number
+ */
+export function renderToGwei(value, unit = 'ether') {
+	const gwei = fromWei(value, unit) * 1000000000;
+	let gweiFixed = parseFloat(Math.round(gwei));
+	gweiFixed = isNaN(gweiFixed) ? 0 : gweiFixed;
+	return gweiFixed;
+}
+
+/**
  * Converts wei expressed as a BN instance into a human-readable fiat string
  *
  * @param {number} wei - BN corresponding to an amount of wei

--- a/app/util/transactions.js
+++ b/app/util/transactions.js
@@ -210,6 +210,8 @@ export async function getActionKey(tx, selectedAddress) {
 	switch (actionKey) {
 		case SEND_TOKEN_ACTION_KEY:
 			return strings('transactions.sent_tokens');
+		case TRANSFER_FROM_ACTION_KEY:
+			return strings('transactions.sent_collectible');
 		case SEND_ETHER_ACTION_KEY:
 			return incoming
 				? selfSent

--- a/app/util/transactions.js
+++ b/app/util/transactions.js
@@ -85,13 +85,25 @@ export function generateTransferData(assetType, opts) {
  * @returns {Object} - Object containing the decoded transfer data
  */
 export function decodeTransferData(assetType, data) {
-	let encodedAddress, encodedAmount, bufferEncodedAddress;
 	switch (assetType) {
-		case 'ERC20':
-			encodedAddress = data.substr(10, 64);
-			encodedAmount = data.substr(74, 138);
-			bufferEncodedAddress = rawEncode(['address'], [addHexPrefix(encodedAddress)]);
+		case 'ERC20': {
+			const encodedAddress = data.substr(10, 64);
+			const encodedAmount = data.substr(74, 138);
+			const bufferEncodedAddress = rawEncode(['address'], [addHexPrefix(encodedAddress)]);
 			return [addHexPrefix(rawDecode(['address'], bufferEncodedAddress)[0]), hexToBN(encodedAmount)];
+		}
+		case 'ERC721': {
+			const encodedFromAddress = data.substr(10, 64);
+			const encodedToAddress = data.substr(74, 64);
+			const encodedTokenId = data.substr(138, 64);
+			const bufferEncodedFromAddress = rawEncode(['address'], [addHexPrefix(encodedFromAddress)]);
+			const bufferEncodedToAddress = rawEncode(['address'], [addHexPrefix(encodedToAddress)]);
+			return [
+				addHexPrefix(rawDecode(['address'], bufferEncodedFromAddress)[0]),
+				addHexPrefix(rawDecode(['address'], bufferEncodedToAddress)[0]),
+				parseInt(encodedTokenId, 16).toString()
+			];
+		}
 	}
 }
 

--- a/app/util/transactions.test.js
+++ b/app/util/transactions.test.js
@@ -48,13 +48,23 @@ describe('Transactions utils :: generateTransferData', () => {
 });
 
 describe('Transactions utils :: decodeTransferData', () => {
-	it('decodeTransferData', () => {
+	it('decodeTransferData ERC20', () => {
 		const [address, amount] = decodeTransferData(
 			'ERC20',
 			'0xa9059cbb00000000000000000000000056ced0d816c668d7c0bcc3fbf0ab2c6896f589a00000000000000000000000000000000000000000000000000000000000000001'
 		);
 		expect(address).toEqual('0x56ced0d816c668d7c0bcc3fbf0ab2c6896f589a0');
 		expect(amount.toNumber()).toEqual(1);
+	});
+
+	it('decodeTransferData ERC721', () => {
+		const [fromAddress, toAddress, tokenId] = decodeTransferData(
+			'ERC721',
+			'0x23b872dd00000000000000000000000056ced0d816c668d7c0bcc3fbf0ab2c6896f589c900000000000000000000000056ced0d816c668d7c0bcc3fbf0ab2c6896f589b400000000000000000000000000000000000000000000000000000000000004f1'
+		);
+		expect(fromAddress).toEqual('0x56ced0d816c668d7c0bcc3fbf0ab2c6896f589c9');
+		expect(toAddress).toEqual('0x56ced0d816c668d7c0bcc3fbf0ab2c6896f589b4');
+		expect(tokenId).toEqual('1265');
 	});
 });
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -358,6 +358,7 @@
 		"self_sent_ether": "Sent Yourself Ether",
 		"received_ether": "Received Ether",
 		"sent_tokens": "Sent Tokens",
+		"sent_collectible": "Sent Collectible",
 		"sent": "Sent",
 		"contract_deploy": "Contract Deployment",
 		"to_contract": "New Contract",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,14 +2408,6 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
-    "backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-      "requires": {
-        "precond": "0.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -5108,8 +5100,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereumjs-abi": {
@@ -5237,8 +5238,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereumjs-abi": {
@@ -6074,7 +6084,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6092,11 +6103,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6109,15 +6122,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6220,7 +6236,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6230,6 +6247,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6242,17 +6260,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6269,6 +6290,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6341,7 +6363,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6351,6 +6374,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6426,7 +6450,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6456,6 +6481,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6473,6 +6499,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6511,11 +6538,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6561,7 +6590,6 @@
       "requires": {
         "await-semaphore": "^0.1.3",
         "eth-block-tracker": "^4.1.0",
-        "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-phishing-detect": "^1.1.13",
@@ -6577,8 +6605,86 @@
         "percentile": "^1.2.1",
         "single-call-balance-checker-abi": "^1.0.0",
         "uuid": "^3.3.2",
-        "web3": "^0.20.7",
-        "web3-provider-engine": "github:metamask/provider-engine#e91367bc2c2535fbf7add06244d9d4ec98620042"
+        "web3": "^0.20.7"
+      },
+      "dependencies": {
+        "eth-contract-metadata": {
+          "version": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
+          "from": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a"
+        },
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "github:metamask/provider-engine#e91367bc2c2535fbf7add06244d9d4ec98620042",
+          "from": "github:metamask/provider-engine#e91367bc2c2535fbf7add06244d9d4ec98620042",
+          "requires": {
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.85.0",
+            "semaphore": "^1.0.3",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "eth-block-tracker": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+              "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
+              "requires": {
+                "eth-query": "^2.1.0",
+                "ethereumjs-tx": "^1.3.3",
+                "ethereumjs-util": "^5.1.3",
+                "ethjs-util": "^0.1.3",
+                "json-rpc-engine": "^3.6.0",
+                "pify": "^2.3.0",
+                "tape": "^4.6.3"
+              }
+            },
+            "eth-sig-util": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+              "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+              "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-util": "^5.1.1"
+              }
+            }
+          }
+        }
       }
     },
     "gauge": {
@@ -11869,11 +11975,6 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
-    "precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -15582,7 +15683,6 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -15591,80 +15691,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-        }
-      }
-    },
-    "web3-provider-engine": {
-      "version": "github:metamask/provider-engine#e91367bc2c2535fbf7add06244d9d4ec98620042",
-      "from": "github:metamask/provider-engine#feature/getaccounts-payload",
-      "requires": {
-        "async": "^2.5.0",
-        "backoff": "^2.5.0",
-        "clone": "^2.0.0",
-        "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^3.0.0",
-        "eth-json-rpc-infura": "^3.1.0",
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-block": "^1.2.2",
-        "ethereumjs-tx": "^1.2.0",
-        "ethereumjs-util": "^5.1.5",
-        "ethereumjs-vm": "^2.3.4",
-        "json-rpc-error": "^2.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "promise-to-callback": "^1.0.0",
-        "readable-stream": "^2.2.9",
-        "request": "^2.85.0",
-        "semaphore": "^1.0.3",
-        "ws": "^5.1.1",
-        "xhr": "^2.2.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "eth-block-tracker": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
-          "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
-          "requires": {
-            "eth-query": "^2.1.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.3",
-            "ethjs-util": "^0.1.3",
-            "json-rpc-engine": "^3.6.0",
-            "pify": "^2.3.0",
-            "tape": "^4.6.3"
-          }
-        },
-        "eth-sig-util": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-          "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-          "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-            "ethereumjs-util": "^5.1.1"
-          }
-        },
-        "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Now that we have collectibles support we can display respective data on transactions detail.

The GIF starts without the collectible information in state, that's why the transaction is shown without specific collectible information at the beginning.

![txdetails](https://user-images.githubusercontent.com/12115171/52891242-92c11d00-3168-11e9-82ec-14f2079c5bbe.gif)

It also adds code refactor to maintain logic in `TransactionElement` leaving to `TransactionDetails` the responsibility to render information.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #366