### PR TITLE
Remove collectible if is being sent

### DIFF
--- a/app/components/Send/index.js
+++ b/app/components/Send/index.js
@@ -79,8 +79,8 @@ class Send extends Component {
 	 */
 	removeCollectible = () => {
 		const { selectedAsset, assetType } = this.props.transaction;
-		const { AssetsController } = Engine.context;
 		if (assetType === 'ERC721') {
+			const { AssetsController } = Engine.context;
 			AssetsController.removeCollectible(selectedAsset.address, selectedAsset.tokenId);
 		}
 	};

--- a/app/components/Send/index.js
+++ b/app/components/Send/index.js
@@ -75,6 +75,17 @@ class Send extends Component {
 	}
 
 	/**
+	 * Removes collectible in case an ERC721 asset is being sent
+	 */
+	deleteCollectible = () => {
+		const { selectedAsset, assetType } = this.props.transaction;
+		const { AssetsController } = Engine.context;
+		if (assetType === 'ERC721') {
+			AssetsController.removeCollectible(selectedAsset.address, selectedAsset.tokenId);
+		}
+	};
+
+	/**
 	 * Transaction state is erased, ready to create a new clean transaction
 	 */
 	clear = async () => {
@@ -231,6 +242,7 @@ class Send extends Component {
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
 			this.clear();
+			this.deleteCollectible();
 			this.setState({ transactionConfirmed: false, transactionSubmitted: true });
 		} catch (error) {
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);

--- a/app/components/Send/index.js
+++ b/app/components/Send/index.js
@@ -77,7 +77,7 @@ class Send extends Component {
 	/**
 	 * Removes collectible in case an ERC721 asset is being sent
 	 */
-	deleteCollectible = () => {
+	removeCollectible = () => {
 		const { selectedAsset, assetType } = this.props.transaction;
 		const { AssetsController } = Engine.context;
 		if (assetType === 'ERC721') {
@@ -241,8 +241,8 @@ class Send extends Component {
 			await TransactionController.approveTransaction(transactionMeta.id);
 			const hash = await result;
 			this.props.navigation.push('TransactionSubmitted', { hash });
+			this.removeCollectible();
 			this.clear();
-			this.deleteCollectible();
 			this.setState({ transactionConfirmed: false, transactionSubmitted: true });
 		} catch (error) {
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

When sending a collectible, if tx is sent the collectible is deleted from the state. If tx fails, auto-detection will add it again.

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #383
