### PR TITLE
Fix xcconfig files

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,6 +106,11 @@ prebuild(){
 
 prebuild_ios(){
 	prebuild
+	# Generate xcconfig files for CircleCI
+	if [ "$PRE_RELEASE" = true ] ; then
+		echo "" > ios/debug.xcconfig
+		echo "" > ios/release.xcconfig
+	fi
 }
 
 prebuild_android(){


### PR DESCRIPTION
Locally those files are generated via postinstall script but CircleCI lose those files after switching jobs since we're caching only the node_modules folder.
