### PR TITLE
Temp fix for build #29

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -46,7 +46,7 @@ platform :ios do
 		setup_circle_ci
 
 		increment_build_number({
-  			build_number: latest_testflight_build_number + 1
+  			build_number: latest_testflight_build_number + 2
 		})
 
 		match(type: "appstore")


### PR DESCRIPTION
There's a bug with the fastlane `latest_testflight_build_number` that doesn't register expired builds (I did that with the build #28) so now it's using the number 28 and the build gets rejected by Apple servers.

Bumping the build number + 2 will do the trick and then I'll revert this PR.