### PR TITLE
Fix approval closed

### DIFF
--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -42,13 +42,13 @@ class Approval extends Component {
 
 	state = {
 		mode: 'review',
-		transactionConfirmed: false
+		transactionHandled: false
 	};
 
 	componentWillUnmount = () => {
-		const { transactionConfirmed } = this.state;
+		const { transactionHandled } = this.state;
 		const { transaction } = this.props;
-		if (!transactionConfirmed) {
+		if (!transactionHandled) {
 			Engine.context.TransactionController.cancelTransaction(transaction.id);
 		}
 		this.clear();
@@ -64,6 +64,7 @@ class Approval extends Component {
 	onCancel = () => {
 		const { transaction } = this.props;
 		Engine.context.TransactionController.cancelTransaction(transaction.id);
+		this.setState({ transactionHandled: true });
 		this.props.navigation.goBack();
 	};
 
@@ -78,7 +79,7 @@ class Approval extends Component {
 			transaction = this.prepareTransaction(transaction);
 			TransactionController.hub.once(`${transaction.id}:finished`, transactionMeta => {
 				if (transactionMeta.status === 'submitted') {
-					this.setState({ transactionConfirmed: true });
+					this.setState({ transactionHandled: true });
 					this.props.navigation.goBack();
 				} else {
 					throw transactionMeta.error;
@@ -91,7 +92,7 @@ class Approval extends Component {
 			await TransactionController.approveTransaction(transaction.id);
 		} catch (error) {
 			Alert.alert('Transaction error', JSON.stringify(error), [{ text: 'OK' }]);
-			this.setState({ transactionConfirmed: false });
+			this.setState({ transactionHandled: false });
 		}
 	};
 

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -62,9 +62,6 @@ class Approval extends Component {
 	};
 
 	onCancel = () => {
-		const { transaction } = this.props;
-		Engine.context.TransactionController.cancelTransaction(transaction.id);
-		this.setState({ transactionHandled: true });
 		this.props.navigation.goBack();
 	};
 

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -41,10 +41,16 @@ class Approval extends Component {
 	};
 
 	state = {
-		mode: 'review'
+		mode: 'review',
+		transactionConfirmed: false
 	};
 
 	componentWillUnmount = () => {
+		const { transactionConfirmed } = this.state;
+		const { transaction } = this.props;
+		if (!transactionConfirmed) {
+			Engine.context.TransactionController.cancelTransaction(transaction.id);
+		}
 		this.clear();
 	};
 
@@ -72,6 +78,7 @@ class Approval extends Component {
 			transaction = this.prepareTransaction(transaction);
 			TransactionController.hub.once(`${transaction.id}:finished`, transactionMeta => {
 				if (transactionMeta.status === 'submitted') {
+					this.setState({ transactionConfirmed: true });
 					this.props.navigation.goBack();
 				} else {
 					throw transactionMeta.error;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

With https://github.com/MetaMask/MetaMask/pull/434 Approval screen wasn't cancelling transactions when the view was closed with Confirm or Reject. This could produce that many transactions could be maintained as unapproved state for ever. 

This PR fixes that, cancelling the transaction when approval screen is closed (for example when android user press .back). If Confirm or Rejected are not pressed txs are not being handled (transactionHandled) so we should cancel it.

![dh7rw3g0ck](https://user-images.githubusercontent.com/12115171/53305332-355f5700-385f-11e9-9600-b60e4862b3de.gif)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
