### PR TITLE
Fix bottombar animation for pages with not enough height to scroll (iOS)

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import {
+	Dimensions,
 	Text,
 	ActivityIndicator,
 	Platform,
@@ -839,6 +840,10 @@ export class Browser extends Component {
 	};
 
 	handleScroll = e => {
+		if (e.contentSize.height < Dimensions.get('window').height) {
+			return;
+		}
+
 		if (this.state.progress < 1) {
 			return;
 		}


### PR DESCRIPTION
The bottom navbar was trying to hide even if the height of the content was not enough to hide it entirely. This PR makes sure there's enough content to hide it, otherwise it says fixed as it should.

Before the fix:

![before](https://user-images.githubusercontent.com/1247834/53623693-d9346400-3bcb-11e9-9afb-8693f61b5b05.gif)

After:
![after](https://user-images.githubusercontent.com/1247834/53623618-a68a6b80-3bcb-11e9-91b8-7013fc750962.gif)

