### PR TITLE
Remove info icon from drawer menu

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -16,7 +16,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import FeatherIcon from 'react-native-vector-icons/Feather';
-import IonicIcon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { colors, fontStyles } from '../../../styles/common';
 import { hasBlockExplorer } from '../../../util/networks';
@@ -118,14 +117,6 @@ const styles = StyleSheet.create({
 		lineHeight: 16,
 		color: colors.white,
 		...fontStyles.normal
-	},
-	qrCodeWrapper: {
-		position: 'absolute',
-		right: 17,
-		top: 17
-	},
-	infoIcon: {
-		color: colors.white
 	},
 	buttons: {
 		flexDirection: 'row',
@@ -602,18 +593,6 @@ class DrawerView extends Component {
 									<Text style={styles.accountAddress}>{renderShortAddress(account.address)}</Text>
 								</TouchableOpacity>
 							</View>
-							<TouchableOpacity
-								style={styles.qrCodeWrapper}
-								onPress={this.onAccountPress}
-								testID={'navbar-account-button'}
-							>
-								<IonicIcon
-									name="ios-information-circle-outline"
-									onPress={this.showAccountDetails}
-									size={24}
-									style={styles.infoIcon}
-								/>
-							</TouchableOpacity>
 						</ImageBackground>
 					</View>
 					<View style={styles.buttons}>


### PR DESCRIPTION
As simple as that.
![screen shot 2019-03-06 at 3 33 55 pm](https://user-images.githubusercontent.com/1247834/53911731-45c4be00-4025-11e9-8fde-a7e355d9a62c.png)
