### PR TITLE
Fix account list

### DIFF
--- a/app/components/UI/AccountList/index.js
+++ b/app/components/UI/AccountList/index.js
@@ -51,11 +51,13 @@ const styles = StyleSheet.create({
 		borderColor: colors.borderColor,
 		flexDirection: 'row',
 		paddingHorizontal: 20,
-		paddingVertical: 20
+		paddingVertical: 20,
+		height: 80
 	},
 	accountInfo: {
-		marginLeft: 15,
-		flex: 1
+		marginHorizontal: 15,
+		flex: 1,
+		flexDirection: 'row'
 	},
 	accountLabel: {
 		fontSize: 18,
@@ -67,10 +69,6 @@ const styles = StyleSheet.create({
 		fontSize: 12,
 		color: colors.fontSecondary,
 		...fontStyles.normal
-	},
-	selected: {
-		marginRight: 15,
-		alignContent: 'flex-end'
 	},
 	footer: {
 		height: DeviceSize.isIphoneX() ? 120 : 100,
@@ -99,13 +97,24 @@ const styles = StyleSheet.create({
 	},
 	importedWrapper: {
 		width: Platform.OS === 'android' ? 73 : 70,
-		flex: 1,
-		marginTop: 5,
 		paddingHorizontal: 10,
 		paddingVertical: 3,
 		borderRadius: 10,
 		borderWidth: StyleSheet.hairlineWidth,
 		borderColor: colors.another50ShadesOfGrey
+	},
+	importedView: {
+		flex: 0.5,
+		alignItems: 'center',
+		marginTop: 2
+	},
+	accountMain: {
+		flex: 1,
+		flexDirection: 'column'
+	},
+	selectedWrapper: {
+		flex: 0.2,
+		alignItems: 'flex-end'
 	}
 });
 
@@ -256,13 +265,17 @@ export default class AccountList extends Component {
 			>
 				<Identicon address={address} diameter={38} />
 				<View style={styles.accountInfo}>
-					<Text style={styles.accountLabel}>{name}</Text>
-					<Text style={styles.accountBalance}>
-						{renderFromWei(balance)} {strings('unit.eth')}
-					</Text>
-					<View style={styles.imported}>{imported}</View>
+					<View style={styles.accountMain}>
+						<Text numberOfLines={1} style={[styles.accountLabel]}>
+							{name}
+						</Text>
+						<Text style={styles.accountBalance}>
+							{renderFromWei(balance)} {strings('unit.eth')}
+						</Text>
+					</View>
+					{imported && <View style={styles.importedView}>{imported}</View>}
+					<View style={styles.selectedWrapper}>{selected}</View>
 				</View>
-				<View style={styles.selected}>{selected}</View>
 			</TouchableOpacity>
 		);
 	};
@@ -290,7 +303,7 @@ export default class AccountList extends Component {
 
 	keyExtractor = item => item.address;
 
-	render = () => {
+	render() {
 		const accounts = this.getAccounts();
 
 		return (
@@ -304,6 +317,7 @@ export default class AccountList extends Component {
 					renderItem={this.renderItem}
 					ref={this.flatList}
 					style={styles.accountsWrapper}
+					getItemLayout={(data, index) => ({ length: 80, offset: 80 * (index - 2), index })} // eslint-disable-line
 				/>
 				<View style={styles.footer}>
 					<TouchableOpacity style={styles.footerButton} onPress={this.addAccount}>
@@ -319,5 +333,5 @@ export default class AccountList extends Component {
 				</View>
 			</SafeAreaView>
 		);
-	};
+	}
 }

--- a/app/components/UI/AccountList/index.js
+++ b/app/components/UI/AccountList/index.js
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
 		...fontStyles.normal
 	},
 	footer: {
-		height: DeviceSize.isIphoneX() ? 120 : 100,
+		height: DeviceSize.isIphoneX() ? 140 : 110,
 		paddingBottom: DeviceSize.isIphoneX() ? 30 : 0,
 		justifyContent: 'center',
 		flexDirection: 'column',
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 	},
 	footerButton: {
 		width: '100%',
-		height: 43,
+		height: 55,
 		alignItems: 'center',
 		justifyContent: 'center',
 		borderTopWidth: StyleSheet.hairlineWidth,

--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -126,7 +126,9 @@ class AccountOverview extends Component {
 	};
 
 	setAccountLabelEditable = () => {
-		this.setState({ accountLabelEditable: true });
+		const { identities, selectedAddress } = this.props;
+		const accountLabel = renderAccountName(selectedAddress, identities);
+		this.setState({ accountLabelEditable: true, accountLabel });
 		setTimeout(() => {
 			this.input && this.input.current && this.input.current.focus();
 		}, 100);

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -96,7 +96,8 @@ const styles = StyleSheet.create({
 		marginBottom: 12
 	},
 	accountNameWrapper: {
-		flexDirection: 'row'
+		flexDirection: 'row',
+		paddingRight: 17
 	},
 	accountName: {
 		fontSize: 20,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR

- Fixes a bug making crush the app if more than 10 accounts because we're using `flatList`s `scrollToIndex`. Changed account element UI to use `getItemLayout`, now the scroll is smoother and doesn't crAsh the app.
- On drawer if name is too long breaks the UI, fixed that.
- There was a bug editing the name. If you're in account `Account 1` then changed to `Whatever` then changed account and tried to edit you'll get `Whatever` automatically.
- Change accountlist footer buttons to height 55 according to figma (not in the gif)

![dd6wednma2](https://user-images.githubusercontent.com/12115171/54043285-f5776880-41aa-11e9-88e2-4246e512df73.gif)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
