### PR TITLE
Security audit suggestions

### DIFF
--- a/app/components/Views/AdvancedSettings/index.js
+++ b/app/components/Views/AdvancedSettings/index.js
@@ -198,6 +198,11 @@ class AdvancedSettings extends Component {
 			}
 			return false;
 		}
+		const url = new URL(rpcUrl);
+		if (url.protocol === 'http:') {
+			this.setState({ warningRpcUrl: strings('app_settings.invalid_rpc_prefix') });
+			return false;
+		}
 		return true;
 	};
 

--- a/app/components/Views/AdvancedSettings/index.js
+++ b/app/components/Views/AdvancedSettings/index.js
@@ -27,6 +27,7 @@ import RNFS from 'react-native-fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import { Buffer } from 'buffer';
 import Logger from '../../../util/Logger';
+import { isprivateConnection } from '../../../util/networks';
 import URL from 'url-parse';
 
 const styles = StyleSheet.create({
@@ -174,16 +175,13 @@ class AdvancedSettings extends Component {
 		this.setState({ resetModalVisible: false });
 	};
 
-	isprivateConnection = hostname =>
-		/(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(hostname);
-
 	addRpcUrl = () => {
 		const { PreferencesController, NetworkController } = Engine.context;
 		const { rpcUrl } = this.state;
 		const { navigation } = this.props;
 		if (this.validateRpcUrl()) {
 			const url = new URL(rpcUrl);
-			!this.isprivateConnection(url.hostname) && url.set('protocol', 'https:');
+			!isprivateConnection(url.hostname) && url.set('protocol', 'https:');
 			PreferencesController.addToFrequentRpcList(url.href);
 			NetworkController.setRpcTarget(url.href);
 			navigation.navigate('WalletView');
@@ -202,7 +200,7 @@ class AdvancedSettings extends Component {
 			return false;
 		}
 		const url = new URL(rpcUrl);
-		const privateConnection = this.isprivateConnection(url.hostname);
+		const privateConnection = isprivateConnection(url.hostname);
 		if (!privateConnection && url.protocol === 'http:') {
 			this.setState({ warningRpcUrl: strings('app_settings.invalid_rpc_prefix') });
 			return false;

--- a/app/components/Views/AdvancedSettings/index.js
+++ b/app/components/Views/AdvancedSettings/index.js
@@ -27,7 +27,6 @@ import RNFS from 'react-native-fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import { Buffer } from 'buffer';
 import Logger from '../../../util/Logger';
-import URL from 'url-parse';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -179,10 +178,8 @@ class AdvancedSettings extends Component {
 		const { rpcUrl } = this.state;
 		const { navigation } = this.props;
 		if (this.validateRpcUrl()) {
-			const url = new URL(rpcUrl);
-			url.set('protocol', 'https:');
-			PreferencesController.addToFrequentRpcList(url.href);
-			NetworkController.setRpcTarget(url.href);
+			PreferencesController.addToFrequentRpcList(rpcUrl);
+			NetworkController.setRpcTarget(rpcUrl);
 			navigation.navigate('WalletView');
 		}
 	};

--- a/app/components/Views/AdvancedSettings/index.js
+++ b/app/components/Views/AdvancedSettings/index.js
@@ -27,6 +27,7 @@ import RNFS from 'react-native-fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import { Buffer } from 'buffer';
 import Logger from '../../../util/Logger';
+import URL from 'url-parse';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -178,8 +179,10 @@ class AdvancedSettings extends Component {
 		const { rpcUrl } = this.state;
 		const { navigation } = this.props;
 		if (this.validateRpcUrl()) {
-			PreferencesController.addToFrequentRpcList(rpcUrl);
-			NetworkController.setRpcTarget(rpcUrl);
+			const url = new URL(rpcUrl);
+			url.set('protocol', 'https:');
+			PreferencesController.addToFrequentRpcList(url.href);
+			NetworkController.setRpcTarget(url.href);
 			navigation.navigate('WalletView');
 		}
 	};

--- a/app/components/Views/AdvancedSettings/index.js
+++ b/app/components/Views/AdvancedSettings/index.js
@@ -174,13 +174,16 @@ class AdvancedSettings extends Component {
 		this.setState({ resetModalVisible: false });
 	};
 
+	isprivateConnection = hostname =>
+		/(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(hostname);
+
 	addRpcUrl = () => {
 		const { PreferencesController, NetworkController } = Engine.context;
 		const { rpcUrl } = this.state;
 		const { navigation } = this.props;
 		if (this.validateRpcUrl()) {
 			const url = new URL(rpcUrl);
-			url.set('protocol', 'https:');
+			!this.isprivateConnection(url.hostname) && url.set('protocol', 'https:');
 			PreferencesController.addToFrequentRpcList(url.href);
 			NetworkController.setRpcTarget(url.href);
 			navigation.navigate('WalletView');
@@ -199,7 +202,8 @@ class AdvancedSettings extends Component {
 			return false;
 		}
 		const url = new URL(rpcUrl);
-		if (url.protocol === 'http:') {
+		const privateConnection = this.isprivateConnection(url.hostname);
+		if (!privateConnection && url.protocol === 'http:') {
 			this.setState({ warningRpcUrl: strings('app_settings.invalid_rpc_prefix') });
 			return false;
 		}

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -56,5 +56,8 @@ export function isKnownNetwork(id) {
 }
 
 export function isprivateConnection(hostname) {
-	return /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(hostname);
+	return (
+		hostname === 'localhost' ||
+		/(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(hostname)
+	);
 }

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -54,3 +54,7 @@ export function isKnownNetwork(id) {
 		.filter(id => id !== undefined);
 	return knownNetworks.includes(parseInt(id, 10));
 }
+
+export function isprivateConnection(hostname) {
+	return /(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/.test(hostname);
+}

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -170,7 +170,7 @@ export function isBN(value) {
  * @returns {boolean} - True if the string is a valid decimal
  */
 export function isDecimal(value) {
-	return /^(\d+\.?\d*|\.\d+)$/.test(value);
+	return Number.isFinite(parseFloat(value)) && !Number.isNaN(parseFloat(value)) && !isNaN(+value);
 }
 
 /**

--- a/locales/en.json
+++ b/locales/en.json
@@ -196,7 +196,7 @@
 		"clear_browser_history_modal_message": "We are about to remove all your browser history. Are you sure?",
 		"reset_account_modal_message": "Resetting your account will clear your transaction history.",
 		"save_rpc_url": "SAVE",
-		"invalid_rpc_prefix": "URIs require the appropriate HTTP/HTTPS prefix",
+		"invalid_rpc_prefix": "URIs require the appropriate HTTPS prefix",
 		"invalid_rpc_url": "Invalid RPC URL",
 		"sync_with_extension": "Sync with Metamask Extension",
 		"sync_with_extension_desc": "This will import all extension accounts to this device.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -185,7 +185,7 @@
 		"reset_account_modal_title": "¿Reinciar Cuenta?",
 		"reset_account_modal_message": "Reiniciar tu cuenta borrará tu historial de transacciones.",
 		"save_rpc_url": "GUARDAR",
-		"invalid_rpc_prefix": "URIs requieren el apropiado HTTPS prefijo",
+		"invalid_rpc_prefix": "URIs requieren el prefijo HTTPS",
 		"invalid_rpc_url": "RPC URL inválida",
 		"search_engine": "Motor de Búsqueda",
 		"auto_lock": "Bloqueo automático",

--- a/locales/es.json
+++ b/locales/es.json
@@ -185,7 +185,7 @@
 		"reset_account_modal_title": "¿Reinciar Cuenta?",
 		"reset_account_modal_message": "Reiniciar tu cuenta borrará tu historial de transacciones.",
 		"save_rpc_url": "GUARDAR",
-		"invalid_rpc_prefix": "URIs requieren el apropiado HTTP/HTTPS prefijo",
+		"invalid_rpc_prefix": "URIs requieren el apropiado HTTPS prefijo",
 		"invalid_rpc_url": "RPC URL inválida",
 		"search_engine": "Motor de Búsqueda",
 		"auto_lock": "Bloqueo automático",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
This PR addresses

1. https://github.com/MetaMask/MetaMask/issues/497 with one change. If we were only doing `Number` validation, strings as `1-abc` would pass `isDecimal` because `parseFloat` would convert it to `1`, making the app fail converting values to BN. Added `!isNaN(+value)` to avoid these cases.

2. #496 , now we're only allowing `http` connections from private connections only. Everything else has to be `https` by input validation and also forcing it when adding custom rpc.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #497
Resolves #496
