### PR TITLE
Fix webview content inset (iOS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7385,7 +7385,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7403,11 +7404,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7420,15 +7423,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7531,7 +7537,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7541,6 +7548,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7553,17 +7561,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7580,6 +7591,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7652,7 +7664,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7662,6 +7675,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7737,7 +7751,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7767,6 +7782,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7784,6 +7800,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7822,11 +7839,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -15564,9 +15583,9 @@
       }
     },
     "react-native-web3-webview": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-1.3.0.tgz",
-      "integrity": "sha512-W1WoGI2LrrsTWXiRQiaL+QfIdbjAW03zUXLo7p22eMxbEx94khwlnkAH+AUSPbkIlFwxEM0ODVdZiL7h5HWQWw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-1.3.1.tgz",
+      "integrity": "sha512-sGcfdHMl0wSruZDQry7Dz0P42VYLfTX19+Rf9zejsBHUhNxa8YwS2mbtWFKqcuC1IGkj1KqMVR7Olhak2X5P4w==",
       "requires": {
         "fbjs": "^0.8.3"
       },
@@ -17961,7 +17980,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -18005,16 +18024,16 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d8d7fc9cc1fd781186c25676af100d1ec727013e",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d8d7fc9cc1fd781186c25676af100d1ec727013e",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
           },
           "dependencies": {
             "ethereumjs-util": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-native-share": "1.1.3",
     "react-native-svg": "9.3.3",
     "react-native-vector-icons": "6.4.1",
-    "react-native-web3-webview": "1.3.0",
+    "react-native-web3-webview": "1.3.1",
     "react-navigation": "3.3.2",
     "react-redux": "5.1.1",
     "readable-stream": "1.0.33",


### PR DESCRIPTION
Sites where the content <= webview height were not able to display the bottom of the content, causing buttons to be not accesible due to be covered by the bottombar. This PR bumps `react-native-web3-webview` which fixes that issue.

DEMO after the fix: 

![vuH95hJy8t](https://user-images.githubusercontent.com/1247834/54580911-a7e7d080-49e0-11e9-8f4e-5ab7b4792d41.gif)
