### PR TITLE
Add zxcvbn for password strength estimation

### DIFF
--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.js.snap
@@ -161,6 +161,7 @@ exports[`ChoosePassword should render correctly 1`] = `
             style={
               Object {
                 "alignSelf": "flex-end",
+                "backgroundColor": "#FFFFFF",
                 "marginTop": 8,
                 "position": "absolute",
               }

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -285,6 +285,9 @@ class ChoosePassword extends Component {
 	};
 
 	getPasswordStrengthWord() {
+		// this.state.passwordStrength is calculated by zxcvbn
+		// which returns a score based on "entropy to crack time"
+		// 0 is the weakest, 4 the strongest
 		switch (this.state.passwordStrength) {
 			case 0:
 				return 'weak';

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -27,6 +27,7 @@ import { getOnboardingNavbarOptions } from '../../UI/Navbar';
 import SecureKeychain from '../../../core/SecureKeychain';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import AppConstants from '../../../core/AppConstants';
+import zxcvbn from 'zxcvbn';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -127,6 +128,7 @@ const styles = StyleSheet.create({
 		color: colors.brightGreen
 	},
 	showHideToggle: {
+		backgroundColor: colors.white,
 		position: 'absolute',
 		marginTop: 8,
 		alignSelf: 'flex-end'
@@ -284,11 +286,15 @@ class ChoosePassword extends Component {
 
 	getPasswordStrengthWord() {
 		switch (this.state.passwordStrength) {
+			case 0:
+				return 'weak';
 			case 1:
 				return 'weak';
 			case 2:
-				return 'good';
+				return 'weak';
 			case 3:
+				return 'good';
+			case 4:
 				return 'strong';
 		}
 	}
@@ -330,22 +336,9 @@ class ChoosePassword extends Component {
 	};
 
 	onPasswordChange = val => {
-		let strength = 1;
+		const passInfo = zxcvbn(val);
 
-		// If the password length is greater than 6 and contain alphabet,number,special character respectively
-		if (
-			val.length > 6 &&
-			((val.match(/[a-z]/) && val.match(/\d+/)) ||
-				(val.match(/\d+/) && val.match(/.[!,@,#,$,%,^,&,*,?,_,~,-,(,)]/)) ||
-				(val.match(/[a-z]/) && val.match(/.[!,@,#,$,%,^,&,*,?,_,~,-,(,)]/)))
-		)
-			strength = 2;
-
-		// If the password length is greater than 6 and must contain alphabets,numbers and special characters
-		if (val.length > 6 && val.match(/[a-z]/) && val.match(/\d+/) && val.match(/.[!,@,#,$,%,^,&,*,?,_,~,-,(,)]/))
-			strength = 3;
-
-		this.setState({ password: val, passwordStrength: strength });
+		this.setState({ password: val, passwordStrength: passInfo.score });
 	};
 
 	toggleShowHide = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18365,6 +18365,11 @@
           "dev": true
         }
       }
+    },
+    "zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "url": "0.11.0",
     "url-parse": "1.4.4",
     "valid-url": "1.0.9",
-    "vm-browserify": "0.0.4"
+    "vm-browserify": "0.0.4",
+    "zxcvbn": "4.4.2"
   },
   "devDependencies": {
     "@babel/core": "7.3.4",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We were using a very poor password estimation approach, where passwords like `abc123!` or `passw0rd!` would receive a high score.   After using https://www.npmjs.com/package/zxcvbn to calculate the password strength, those are considered weak and other "harder to crack" passwords like `correcthorsebatterystaple` are ranked with higher strength. 

DEMO:

![demo](https://user-images.githubusercontent.com/1247834/54955290-45805a00-4f23-11e9-9f30-dca9058cce62.gif)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #494 
