### PR TITLE
Update balances when TX confirmed or incoming

### DIFF
--- a/app/core/TransactionsNotificationManager.js
+++ b/app/core/TransactionsNotificationManager.js
@@ -162,6 +162,15 @@ class TransactionsNotificationManager {
 				// Clean up
 				this._removeListeners(transactionMeta.id);
 
+				const { TokenBalancesController, AssetsDetectionController, AccountTrackerController } = Engine.context;
+				// Detect assets and tokens and account balances
+				// right after a transaction was confirmed
+				Promise.all([
+					AccountTrackerController.poll(),
+					TokenBalancesController.poll(),
+					AssetsDetectionController.poll()
+				]);
+
 				Platform.OS === 'ios' &&
 					setTimeout(() => {
 						PushNotification.requestPermissions();
@@ -236,6 +245,11 @@ class TransactionsNotificationManager {
 				});
 			}
 		}
+
+		// Update balance upon detecting
+		// a new incoming transaction
+		const { AccountTrackerController } = Engine.context;
+		AccountTrackerController.poll();
 	};
 }
 


### PR DESCRIPTION
Every time we receive a new tx or a submitted tx gets confirmed we know that:
- The ETH balance has change
- The Token balance might have change
- New tokens can be received (think of uniswap)
- Token balance can change

This PR makes sure we refresh all the info by using the new polling mechanism in gaba, which won't cause additional request but instead restart polling on demand. 