### PR TITLE
Fix custom gas price

### DIFF
--- a/app/components/UI/CustomGas/index.js
+++ b/app/components/UI/CustomGas/index.js
@@ -8,6 +8,7 @@ import {
 	getRenderableEthGasFee,
 	getRenderableFiatGasFee,
 	apiEstimateModifiedToWEI,
+	apiEstimateModifiedToGWEI,
 	fetchBasicGasEstimates
 } from '../../../util/custom-gas';
 import { BN } from 'ethereumjs-util';
@@ -120,7 +121,7 @@ class CustomGas extends Component {
 		selected: 'average',
 		ready: false,
 		advancedCustomGas: false,
-		customGasPrice: '20',
+		customGasPrice: '10',
 		customGasLimit: this.props.gas.toNumber().toString(),
 		warningGasLimit: '',
 		warningGasPrice: ''
@@ -306,7 +307,7 @@ class CustomGas extends Component {
 					keyboardType="numeric"
 					style={styles.gasInput}
 					onChangeText={this.onGasPriceChange}
-					value={customGasPrice}
+					value={apiEstimateModifiedToGWEI(customGasPrice).toString()}
 				/>
 				<Text style={styles.text}>{warningGasPrice}</Text>
 			</View>

--- a/app/components/UI/CustomGas/index.js
+++ b/app/components/UI/CustomGas/index.js
@@ -8,8 +8,8 @@ import {
 	getRenderableEthGasFee,
 	getRenderableFiatGasFee,
 	apiEstimateModifiedToWEI,
-	apiEstimateModifiedToGWEI,
-	fetchBasicGasEstimates
+	fetchBasicGasEstimates,
+	convertApiValueToGWEI
 } from '../../../util/custom-gas';
 import { BN } from 'ethereumjs-util';
 import { fromWei } from '../../../util/number';
@@ -135,7 +135,7 @@ class CustomGas extends Component {
 			gasAverageSelected: false,
 			gasSlowSelected: false,
 			selected: 'fast',
-			customGasPrice: fastGwei.toString()
+			customGasPrice: fastGwei
 		});
 		this.props.handleGasFeeSelection(gas, apiEstimateModifiedToWEI(fastGwei));
 	};
@@ -148,7 +148,7 @@ class CustomGas extends Component {
 			gasAverageSelected: true,
 			gasSlowSelected: false,
 			selected: 'average',
-			customGasPrice: averageGwei.toString()
+			customGasPrice: averageGwei
 		});
 		this.props.handleGasFeeSelection(gas, apiEstimateModifiedToWEI(averageGwei));
 	};
@@ -161,7 +161,7 @@ class CustomGas extends Component {
 			gasAverageSelected: false,
 			gasSlowSelected: true,
 			selected: 'slow',
-			customGasPrice: safeLowGwei.toString()
+			customGasPrice: safeLowGwei
 		});
 		this.props.handleGasFeeSelection(gas, apiEstimateModifiedToWEI(safeLowGwei));
 	};
@@ -198,9 +198,9 @@ class CustomGas extends Component {
 		const basicGasEstimates = await fetchBasicGasEstimates();
 		const { average, fast, safeLow } = basicGasEstimates;
 		this.setState({
-			averageGwei: average,
-			fastGwei: fast,
-			safeLowGwei: safeLow,
+			averageGwei: convertApiValueToGWEI(average),
+			fastGwei: convertApiValueToGWEI(fast),
+			safeLowGwei: convertApiValueToGWEI(safeLow),
 			ready: true
 		});
 	};
@@ -307,7 +307,7 @@ class CustomGas extends Component {
 					keyboardType="numeric"
 					style={styles.gasInput}
 					onChangeText={this.onGasPriceChange}
-					value={apiEstimateModifiedToGWEI(customGasPrice).toString()}
+					value={customGasPrice.toString()}
 				/>
 				<Text style={styles.text}>{warningGasPrice}</Text>
 			</View>

--- a/app/util/custom-gas.js
+++ b/app/util/custom-gas.js
@@ -13,6 +13,16 @@ export function apiEstimateModifiedToWEI(estimate) {
 }
 
 /**
+ * Calculates value of estimate gas price in gwei
+ *
+ * @param {number} estimate - Number corresponding to api gas price estimation
+ * @returns {Object} - BN instance containing gas price in gwei
+ */
+export function apiEstimateModifiedToGWEI(estimate) {
+	return new BN((estimate / 10).toString(), 10);
+}
+
+/**
  * Calculates gas fee in wei
  *
  * @param {number} estimate - Number corresponding to api gas price estimation

--- a/app/util/custom-gas.js
+++ b/app/util/custom-gas.js
@@ -9,17 +9,17 @@ import { renderFromWei, weiToFiat } from './number';
  */
 export function apiEstimateModifiedToWEI(estimate) {
 	const GWEIRate = 1000000000;
-	return new BN(((estimate * GWEIRate) / 10).toString(), 10);
+	return new BN((estimate * GWEIRate).toString(), 10);
 }
 
 /**
- * Calculates value of estimate gas price in gwei
+ * Calculates GWEI value of estimate gas price from ethgasstation.info
  *
  * @param {number} estimate - Number corresponding to api gas price estimation
- * @returns {Object} - BN instance containing gas price in gwei
+ * @returns {Object} - BN instance containing gas price in wei
  */
-export function apiEstimateModifiedToGWEI(estimate) {
-	return new BN((estimate / 10).toString(), 10);
+export function convertApiValueToGWEI(val) {
+	return (parseInt(val, 10) / 10).toString();
 }
 
 /**

--- a/app/util/custom-gas.js
+++ b/app/util/custom-gas.js
@@ -15,8 +15,8 @@ export function apiEstimateModifiedToWEI(estimate) {
 /**
  * Calculates GWEI value of estimate gas price from ethgasstation.info
  *
- * @param {number} estimate - Number corresponding to api gas price estimation
- * @returns {Object} - BN instance containing gas price in wei
+ * @param {number} val - Number corresponding to api gas price estimation
+ * @returns {string} - The GWEI value as a string
  */
 export function convertApiValueToGWEI(val) {
 	return (parseInt(val, 10) / 10).toString();


### PR DESCRIPTION
We were showing the wrong custom gas price in the advanced options of the send screen:

<img width="720" alt="Screen Shot 2019-03-28 at 6 31 31 PM" src="https://user-images.githubusercontent.com/1247834/55198814-fe49d180-518d-11e9-8a7f-174b699e27c0.png">
<img width="361" alt="Screen Shot 2019-03-28 at 6 34 22 PM" src="https://user-images.githubusercontent.com/1247834/55198815-fe49d180-518d-11e9-9828-b55b813194b3.png">


After the fix: http://recordit.co/C1pQuhGsiw

CC: @omnat 

