### PR TITLE
Improvement: Transaction Edit

### DIFF
--- a/app/components/UI/AccountInput/index.js
+++ b/app/components/UI/AccountInput/index.js
@@ -154,7 +154,13 @@ class AccountInput extends Component {
 		 * Network id
 		 */
 		updateToAddressError: PropTypes.func,
+		/**
+		 * Callback to open accounts dropdown
+		 */
 		openAccountSelect: PropTypes.func,
+		/**
+		 * Whether accounts dropdown is opened
+		 */
 		isOpen: PropTypes.bool
 	};
 

--- a/app/components/UI/AccountInput/index.js
+++ b/app/components/UI/AccountInput/index.js
@@ -153,11 +153,12 @@ class AccountInput extends Component {
 		/**
 		 * Network id
 		 */
-		updateToAddressError: PropTypes.func
+		updateToAddressError: PropTypes.func,
+		openAccountSelect: PropTypes.func,
+		isOpen: PropTypes.bool
 	};
 
 	state = {
-		isOpen: false,
 		address: undefined,
 		ensRecipient: undefined,
 		value: undefined
@@ -204,9 +205,8 @@ class AccountInput extends Component {
 	};
 
 	onFocus = () => {
-		const { onFocus } = this.props;
-		const { isOpen } = this.state;
-		this.setState({ isOpen: !isOpen });
+		const { onFocus, isOpen, openAccountSelect } = this.props;
+		openAccountSelect && openAccountSelect(!isOpen);
 		onFocus && onFocus();
 	};
 
@@ -271,22 +271,25 @@ class AccountInput extends Component {
 	}
 
 	onChange = async value => {
-		const { accounts, onChange } = this.props;
+		const { accounts, onChange, openAccountSelect } = this.props;
 		const addresses = Object.keys(accounts).filter(address => address.toLowerCase().match(value.toLowerCase()));
 		const visibleOptions = value.length === 0 ? accounts : addresses.map(address => accounts[address]);
 		const match = visibleOptions.length === 1 && visibleOptions[0].address.toLowerCase() === value.toLowerCase();
 		this.setState({
-			isOpen: (value.length === 0 || visibleOptions.length) > 0 && !match,
 			value
 		});
+		openAccountSelect && openAccountSelect((value.length === 0 || visibleOptions.length) > 0 && !match);
 		onChange && onChange(value);
 	};
 
 	onInputFocus = () => {
-		this.setState({ isOpen: false });
+		const { openAccountSelect } = this.props;
+		openAccountSelect && openAccountSelect(true);
 	};
 
 	scan = () => {
+		const { openAccountSelect } = this.props;
+		openAccountSelect && openAccountSelect(false);
 		this.setState({ isOpen: false });
 		this.props.navigation.navigate('QRScanner', {
 			onScanSuccess: meta => {
@@ -298,8 +301,8 @@ class AccountInput extends Component {
 	};
 
 	render = () => {
-		const { isOpen, value, ensRecipient, address } = this.state;
-		const { placeholder } = this.props;
+		const { value, ensRecipient, address } = this.state;
+		const { placeholder, isOpen } = this.props;
 		return (
 			<View style={styles.root}>
 				<View style={styles.accountContainer}>

--- a/app/components/UI/AccountSelect/index.js
+++ b/app/components/UI/AccountSelect/index.js
@@ -114,14 +114,20 @@ class AccountSelect extends Component {
 		/**
 		 * Address of the currently-selected account
 		 */
-		value: PropTypes.string
+		value: PropTypes.string,
+		/**
+		 * Callback to open accounts dropdown
+		 */
+		openAccountSelect: PropTypes.func,
+		/**
+		 * Whether accounts dropdown is opened
+		 */
+		isOpen: PropTypes.bool
 	};
 
 	static defaultProps = {
 		enabled: true
 	};
-
-	state = { isOpen: false };
 
 	componentDidMount() {
 		const { onChange, selectedAddress } = this.props;
@@ -129,14 +135,14 @@ class AccountSelect extends Component {
 	}
 
 	renderActiveOption() {
-		const { selectedAddress, accounts, identities, value } = this.props;
+		const { selectedAddress, accounts, identities, value, isOpen, openAccountSelect } = this.props;
 		const targetAddress = toChecksumAddress(value || selectedAddress);
 		const account = { ...identities[targetAddress], ...accounts[targetAddress] };
 		return (
 			<View style={styles.activeOption}>
 				{this.props.enabled && <MaterialIcon name={'arrow-drop-down'} size={24} style={styles.arrow} />}
 				{this.renderOption(account, () => {
-					this.setState({ isOpen: !this.state.isOpen });
+					openAccountSelect && openAccountSelect(!isOpen);
 				})}
 			</View>
 		);
@@ -169,13 +175,14 @@ class AccountSelect extends Component {
 	}
 
 	renderOptionList() {
-		const { accounts, identities, onChange } = this.props;
+		const { accounts, identities, onChange, openAccountSelect } = this.props;
 		return (
 			<ScrollView style={styles.componentContainer}>
 				<View style={styles.optionList}>
 					{Object.keys(identities).map(address =>
 						this.renderOption({ ...identities[address], ...accounts[address] }, () => {
-							this.setState({ isOpen: false, value: address });
+							this.setState({ value: address });
+							openAccountSelect && openAccountSelect(true);
 							onChange && onChange(address);
 						})
 					)}
@@ -187,7 +194,7 @@ class AccountSelect extends Component {
 	render = () => (
 		<View style={styles.root}>
 			{this.renderActiveOption()}
-			{this.state.isOpen && this.props.enabled && this.renderOptionList()}
+			{this.props.isOpen && this.props.enabled && this.renderOptionList()}
 		</View>
 	);
 }

--- a/app/components/UI/ActionView/index.js
+++ b/app/components/UI/ActionView/index.js
@@ -37,6 +37,7 @@ export default function ActionView({
 	confirmButtonMode,
 	onCancelPress,
 	onConfirmPress,
+	onTouchablePress,
 	showCancelButton,
 	showConfirmButton,
 	confirmed,
@@ -45,7 +46,9 @@ export default function ActionView({
 	return (
 		<View style={baseStyles.flexGrow}>
 			<KeyboardAwareScrollView style={baseStyles.flexGrow} resetScrollToCoords={{ x: 0, y: 0 }}>
-				<TouchableWithoutFeedback style={baseStyles.flexGrow}>{children}</TouchableWithoutFeedback>
+				<TouchableWithoutFeedback style={baseStyles.flexGrow} onPress={onTouchablePress}>
+					{children}
+				</TouchableWithoutFeedback>
 			</KeyboardAwareScrollView>
 			<View style={styles.actionContainer}>
 				{showCancelButton && (
@@ -127,6 +130,11 @@ ActionView.propTypes = {
 	 * Called when the confirm button is clicked
 	 */
 	onConfirmPress: PropTypes.func,
+	/**
+	 * Called when the touchable without feedback is clicked
+	 */
+	onTouchablePress: PropTypes.func,
+
 	/**
 	 * Whether cancel button is shown
 	 */

--- a/app/components/UI/CustomGas/index.js
+++ b/app/components/UI/CustomGas/index.js
@@ -107,7 +107,11 @@ class CustomGas extends Component {
 		/**
 		 * Object BN containing estimated gas limit
 		 */
-		gas: PropTypes.object
+		gas: PropTypes.object,
+		/**
+		 * Callback to modify state in parent state
+		 */
+		onPress: PropTypes.func
 	};
 
 	state = {
@@ -129,7 +133,8 @@ class CustomGas extends Component {
 
 	onPressGasFast = () => {
 		const { fastGwei } = this.state;
-		const { gas } = this.props;
+		const { gas, onPress } = this.props;
+		onPress && onPress();
 		this.setState({
 			gasFastSelected: true,
 			gasAverageSelected: false,
@@ -142,7 +147,8 @@ class CustomGas extends Component {
 
 	onPressGasAverage = () => {
 		const { averageGwei } = this.state;
-		const { gas } = this.props;
+		const { gas, onPress } = this.props;
+		onPress && onPress();
 		this.setState({
 			gasFastSelected: false,
 			gasAverageSelected: true,
@@ -155,7 +161,8 @@ class CustomGas extends Component {
 
 	onPressGasSlow = () => {
 		const { safeLowGwei } = this.state;
-		const { gas } = this.props;
+		const { gas, onPress } = this.props;
+		onPress && onPress();
 		this.setState({
 			gasFastSelected: false,
 			gasAverageSelected: false,
@@ -168,7 +175,8 @@ class CustomGas extends Component {
 
 	onAdvancedOptions = () => {
 		const { advancedCustomGas, selected, fastGwei, averageGwei, safeLowGwei, customGasPrice } = this.state;
-		const { gas } = this.props;
+		const { gas, onPress } = this.props;
+		onPress && onPress();
 		if (advancedCustomGas) {
 			switch (selected) {
 				case 'slow':

--- a/app/components/UI/EthInput/index.js
+++ b/app/components/UI/EthInput/index.js
@@ -166,10 +166,18 @@ class EthInput extends Component {
 		/**
 		 * Transaction object associated with this transaction
 		 */
-		transaction: PropTypes.object
+		transaction: PropTypes.object,
+		/**
+		 * Callback to open assets dropdown
+		 */
+		openEthInput: PropTypes.func,
+		/**
+		 * Whether assets dropdown is opened
+		 */
+		isOpen: PropTypes.bool
 	};
 
-	state = { isOpen: false, readableValue: undefined, assets: undefined };
+	state = { readableValue: undefined, assets: undefined };
 
 	componentDidUpdate = () => {
 		const { fillMax, readableValue } = this.props;
@@ -231,13 +239,13 @@ class EthInput extends Component {
 	};
 
 	onFocus = () => {
-		const { isOpen } = this.state;
-		this.setState({ isOpen: !isOpen });
+		const { isOpen, openEthInput } = this.props;
+		openEthInput && openEthInput(!isOpen);
 	};
 
 	selectAsset = async asset => {
-		this.setState({ isOpen: false });
-		const { handleUpdateAsset, onChange } = this.props;
+		const { handleUpdateAsset, onChange, openEthInput } = this.props;
+		openEthInput && openEthInput(false);
 		handleUpdateAsset && (await handleUpdateAsset(asset));
 		onChange && onChange(undefined);
 		this.setState({ readableValue: undefined });
@@ -412,7 +420,8 @@ class EthInput extends Component {
 	};
 
 	render = () => {
-		const { isOpen, assets } = this.state;
+		const { assets } = this.state;
+		const { isOpen } = this.props;
 		const selectAssets = assets && assets.length > 1;
 		return (
 			<View style={styles.root}>

--- a/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
@@ -17,6 +17,7 @@ exports[`TransactionEdit should render correctly 1`] = `
     confirmText="Next"
     confirmed={false}
     onConfirmPress={[Function]}
+    onTouchablePress={[Function]}
     showCancelButton={true}
     showConfirmButton={true}
   >
@@ -25,6 +26,7 @@ exports[`TransactionEdit should render correctly 1`] = `
         Object {
           "flex": 1,
           "flexDirection": "column",
+          "minHeight": "100%",
           "padding": 16,
         }
       }
@@ -138,7 +140,9 @@ exports[`TransactionEdit should render correctly 1`] = `
         </View>
         <Connect(EthInput)
           fillMax={false}
+          isOpen={false}
           onChange={[Function]}
+          openEthInput={[Function]}
           updateFillMax={[Function]}
           value=""
         />
@@ -184,6 +188,7 @@ exports[`TransactionEdit should render correctly 1`] = `
         </View>
         <Connect(AccountInput)
           address="0x2"
+          isOpen={false}
           navigation={
             Object {
               "state": Object {
@@ -194,6 +199,7 @@ exports[`TransactionEdit should render correctly 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          openAccountSelect={[Function]}
           placeholder="Recipient Address"
           updateToAddressError={[Function]}
         />
@@ -241,6 +247,7 @@ exports[`TransactionEdit should render correctly 1`] = `
           gas=""
           gasPrice=""
           handleGasFeeSelection={[Function]}
+          onPress={[Function]}
           totalGas={"14a"}
         />
       </View>

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -84,7 +84,8 @@ const styles = StyleSheet.create({
 	form: {
 		flex: 1,
 		padding: 16,
-		flexDirection: 'column'
+		flexDirection: 'column',
+		minHeight: '100%'
 	},
 	hexData: {
 		...fontStyles.bold,
@@ -183,7 +184,21 @@ class TransactionEdit extends Component {
 		gasError: '',
 		fillMax: false,
 		ensRecipient: undefined,
-		data: undefined
+		data: undefined,
+		accountSelectIsOpen: false,
+		ethInputIsOpen: false
+	};
+
+	openAccountSelect = isOpen => {
+		this.setState({ accountSelectIsOpen: isOpen, ethInputIsOpen: false });
+	};
+
+	openEthInputIsOpen = isOpen => {
+		this.setState({ ethInputIsOpen: isOpen, accountSelectIsOpen: false });
+	};
+
+	closeAccountSelect = () => {
+		this.setState({ accountSelectIsOpen: false, ethInputIsOpen: false });
 	};
 
 	componentDidMount = () => {
@@ -333,11 +348,16 @@ class TransactionEdit extends Component {
 			transaction: { value, gas, gasPrice, from, to, selectedAsset, readableValue, ensRecipient },
 			showHexData
 		} = this.props;
-		const { gasError, toAddressError, data } = this.state;
+		const { gasError, toAddressError, data, accountSelectIsOpen, ethInputIsOpen } = this.state;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		return (
 			<View style={styles.root}>
-				<ActionView confirmText="Next" onCancelPress={this.props.onCancel} onConfirmPress={this.review}>
+				<ActionView
+					confirmText={strings('transaction.next')}
+					onCancelPress={this.props.onCancel}
+					onConfirmPress={this.review}
+					onTouchablePress={this.closeAccountSelect}
+				>
 					<View style={styles.form}>
 						<View style={[styles.formRow, styles.fromRow]}>
 							<View style={styles.label}>
@@ -355,6 +375,8 @@ class TransactionEdit extends Component {
 								readableValue={readableValue}
 								fillMax={this.state.fillMax}
 								updateFillMax={this.updateFillMax}
+								openEthInput={this.openEthInputIsOpen}
+								isOpen={ethInputIsOpen}
 							/>
 						</View>
 						<View style={[styles.formRow, styles.toRow]}>
@@ -372,6 +394,8 @@ class TransactionEdit extends Component {
 								updateToAddressError={this.updateToAddressError}
 								ensRecipient={ensRecipient}
 								navigation={navigation}
+								openAccountSelect={this.openAccountSelect}
+								isOpen={accountSelectIsOpen}
 							/>
 						</View>
 						<View style={[styles.formRow, styles.row, styles.notAbsolute]}>
@@ -384,6 +408,7 @@ class TransactionEdit extends Component {
 								totalGas={totalGas}
 								gas={gas}
 								gasPrice={gasPrice}
+								onPress={this.closeAccountSelect}
 							/>
 						</View>
 						<View style={[styles.formRow, styles.row]}>

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -197,7 +197,7 @@ class TransactionEdit extends Component {
 		this.setState({ ethInputIsOpen: isOpen, accountSelectIsOpen: false });
 	};
 
-	closeAccountSelect = () => {
+	closeDropdowns = () => {
 		this.setState({ accountSelectIsOpen: false, ethInputIsOpen: false });
 	};
 
@@ -356,7 +356,7 @@ class TransactionEdit extends Component {
 					confirmText={strings('transaction.next')}
 					onCancelPress={this.props.onCancel}
 					onConfirmPress={this.review}
-					onTouchablePress={this.closeAccountSelect}
+					onTouchablePress={this.closeDropdowns}
 				>
 					<View style={styles.form}>
 						<View style={[styles.formRow, styles.fromRow]}>
@@ -408,7 +408,7 @@ class TransactionEdit extends Component {
 								totalGas={totalGas}
 								gas={gas}
 								gasPrice={gasPrice}
-								onPress={this.closeAccountSelect}
+								onPress={this.closeDropdowns}
 							/>
 						</View>
 						<View style={[styles.formRow, styles.row]}>

--- a/locales/en.json
+++ b/locales/en.json
@@ -298,6 +298,7 @@
 	"transaction": {
 		"alert": "ALERT",
 		"amount": "Amount",
+		"next": "Next",
 		"confirm": "Confirm",
 		"reject": "Reject",
 		"edit": "Edit",

--- a/locales/es.json
+++ b/locales/es.json
@@ -296,6 +296,7 @@
 	"transaction": {
 		"alert": "ALERTA",
 		"amount": "Cantidad",
+		"next": "Siguiente",
 		"confirm": "Confirmar",
 		"reject": "Rechazar",
 		"edit": "Editar",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR adds small UX changes to TransactionEdit component.

- Clicking "outside" of dropdown components will close all dropdowns.
- Combine to tappable areas
- Pressing in account dropdown will close eth input dropdown (assets) and vice versa.

![O0T1ZqgGag](https://user-images.githubusercontent.com/12115171/55576824-8da03900-56e8-11e9-8816-19881fea66e2.gif)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #543 

cc @bdresser 