### PR TITLE
Feature: token deeplinks support

### DIFF
--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -370,9 +370,12 @@ class TransactionEditor extends Component {
 			if (!value || !gas || !gasPrice || !from) {
 				return strings('transaction.invalid_amount');
 			}
-			const contractBalanceForAddress = hexToBN(contractBalances[selectedAsset.address].toString(16));
+			// If user trying to send a token that doesn't own, don't validate balance
+			const contractBalanceForAddress =
+				contractBalances[selectedAsset.address] &&
+				hexToBN(contractBalances[selectedAsset.address].toString(16));
 			if (value && !isBN(value)) return strings('transaction.invalid_amount');
-			const validateAssetAmount = contractBalanceForAddress.lt(value);
+			const validateAssetAmount = contractBalanceForAddress && contractBalanceForAddress.lt(value);
 			const ethTotalAmount = gas.mul(gasPrice);
 			if (
 				value &&

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -379,8 +379,8 @@ class TransactionEditor extends Component {
 				const { AssetsContractController } = Engine.context;
 				try {
 					contractBalanceForAddress = await AssetsContractController.getBalanceOf(
-						checksummedFrom,
-						selectedAsset.address
+						selectedAsset.address,
+						checksummedFrom
 					);
 				} catch (e) {
 					// Don't validate balance if error

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -241,7 +241,7 @@ class Send extends Component {
 				isVisible: true,
 				autodismiss: 5000,
 				content: 'clipboard-alert',
-				data: { msg: strings('send.warn_network_hange') + NetworkList[newNetworkType].name }
+				data: { msg: strings('send.warn_network_change') + NetworkList[newNetworkType].name }
 			});
 		}
 	};

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -237,7 +237,7 @@ class Send extends Component {
 				isVisible: true,
 				autodismiss: 5000,
 				content: 'clipboard-alert',
-				data: { msg: `Network is being changed to ${NetworkList[newNetworkType].name}` }
+				data: { msg: strings('send.warn_network_hange') + NetworkList[newNetworkType].name }
 			});
 		}
 	};
@@ -261,7 +261,14 @@ class Send extends Component {
 			token.decimals = parseInt(String(decimals));
 		} catch (e) {
 			// TODO probably drop tx
-			token.decimals = 18;
+			// Drop tx since we don't have any form to get decimals and send the correct tx
+			this.props.showAlert({
+				isVisible: true,
+				autodismiss: 2000,
+				content: 'clipboard-alert',
+				data: { msg: strings(`send.deeplink_failure`) }
+			});
+			this.onCancel();
 		}
 		try {
 			token.symbol = await AssetsContractController.getAssetSymbol(address);

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -93,6 +93,9 @@ class Send extends Component {
 		this.props.newTransaction();
 	};
 
+	/**
+	 * Check if view is called with txMeta object for a deeplink
+	 */
 	checkForDeeplinks() {
 		const { navigation } = this.props;
 		const txMeta = navigation && navigation.getParam('txMeta', null);
@@ -141,14 +144,38 @@ class Send extends Component {
 		}
 	}
 
+	/**
+	 * Handle txMeta object, setting neccesary state to make a transaction
+	 */
 	handleNewTxMeta = async ({
 		target_address,
+		action,
 		chain_id = null, // eslint-disable-line no-unused-vars
 		function_name = null, // eslint-disable-line no-unused-vars
 		parameters = null
 	}) => {
-		const newTxMeta = { symbol: 'ETH', assetType: 'ETH', type: 'ETHER_TRANSACTION' };
-		newTxMeta.to = toChecksumAddress(target_address);
+		let newTxMeta;
+		switch (action) {
+			case 'send-eth':
+				newTxMeta = { symbol: 'ETH', assetType: 'ETH', type: 'ETHER_TRANSACTION' };
+				newTxMeta.to = toChecksumAddress(target_address);
+				break;
+			case 'send-token':
+				newTxMeta = {
+					assetType: 'ERC20',
+					type: 'INDIVIDUAL_TOKEN_TRANSACTION',
+					selectedAsset: {
+						symbol: 'TKN',
+						address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
+						decimals: 18
+					}
+				};
+				newTxMeta.to = toChecksumAddress(parameters.address);
+				break;
+			default:
+				newTxMeta = { symbol: 'ETH', assetType: 'ETH', type: 'ETHER_TRANSACTION' };
+				newTxMeta.to = toChecksumAddress(target_address);
+		}
 
 		if (parameters) {
 			const { value, gas, gasPrice } = parameters;

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -11,6 +11,7 @@ import { getTransactionOptionsTitle } from '../../UI/Navbar';
 import { connect } from 'react-redux';
 import { newTransaction, setTransactionObject } from '../../../actions/transaction';
 import TransactionsNotificationManager from '../../../core/TransactionsNotificationManager';
+import { getNetworkTypeById } from '../../../util/networks';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -154,6 +155,9 @@ class Send extends Component {
 		function_name = null, // eslint-disable-line no-unused-vars
 		parameters = null
 	}) => {
+		if (chain_id) {
+			this.handleNetworkSwitch(chain_id);
+		}
 		let newTxMeta;
 		switch (action) {
 			case 'send-eth':
@@ -205,6 +209,19 @@ class Send extends Component {
 
 		this.props.setTransactionObject(newTxMeta);
 		this.mounted && this.setState({ ready: true, mode: 'edit', transactionKey: Date.now() });
+	};
+
+	/**
+	 * Method in charge of changing network if is needed
+	 *
+	 * @param chainId - Corresponding id for network
+	 */
+	handleNetworkSwitch = chainId => {
+		const networkType = getNetworkTypeById(chainId);
+		if (networkType) {
+			const { NetworkController } = Engine.context;
+			NetworkController.setProviderType(networkType);
+		}
 	};
 
 	/**

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -255,9 +255,20 @@ class Send extends Component {
 			return contractMap[address];
 		}
 		const { AssetsContractController } = Engine.context;
-		const decimals = await AssetsContractController.getTokenDecimals(address);
-		const symbol = await AssetsContractController.getAssetSymbol(address);
-		return { address, symbol, decimals: parseInt(String(decimals)) };
+		const token = { address };
+		try {
+			const decimals = await AssetsContractController.getTokenDecimals(address);
+			token.decimals = parseInt(String(decimals));
+		} catch (e) {
+			// TODO probably drop tx
+			token.decimals = 18;
+		}
+		try {
+			token.symbol = await AssetsContractController.getAssetSymbol(address);
+		} catch (e) {
+			token.symbol = 'ERC20';
+		}
+		return token;
 	};
 
 	/**

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import { newTransaction, setTransactionObject } from '../../../actions/transaction';
 import TransactionsNotificationManager from '../../../core/TransactionsNotificationManager';
 import { getNetworkTypeById } from '../../../util/networks';
+import contractMap from 'eth-contract-metadata';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -151,7 +152,7 @@ class Send extends Component {
 	handleNewTxMeta = async ({
 		target_address,
 		action,
-		chain_id = null, // eslint-disable-line no-unused-vars
+		chain_id = null,
 		function_name = null, // eslint-disable-line no-unused-vars
 		parameters = null
 	}) => {
@@ -228,11 +229,15 @@ class Send extends Component {
 	/**
 	 * Retrieves ERC20 asset information (symbol and decimals) to be used with deeplinks
 	 *
-	 * @param address- Corresponding ERC20 asset address
+	 * @param address - Corresponding ERC20 asset address
 	 *
 	 * @returns ERC20 asset, containing address, symbol and decimals
 	 */
 	handleTokenDeeplink = async address => {
+		address = toChecksumAddress(address);
+		if (address in contractMap) {
+			return contractMap[address];
+		}
 		const { AssetsContractController } = Engine.context;
 		const decimals = await AssetsContractController.getTokenDecimals(address);
 		const symbol = await AssetsContractController.getAssetSymbol(address);

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -109,7 +109,7 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
  * @param {Number|String|BN} tokenValue - Token value to convert
  * @param {Number} decimals - Token decimals to convert
  * @param {Number} decimalsToShow - Decimals to 5
- * @returns {Number} - String of token minimal unit, in render format
+ * @returns {Number} - Number of token minimal unit, in render format
  */
 export function renderFromTokenMinimalUnit(tokenValue, decimals, decimalsToShow = 5) {
 	const minimalUnit = fromTokenMinimalUnit(tokenValue, decimals);

--- a/locales/en.json
+++ b/locales/en.json
@@ -98,7 +98,7 @@
 	},
 	"send": {
 		"title": "Send",
-		"deeplink_failure": "Ooops! Something happened, please try again with other transaction.",
+		"deeplink_failure": "Ooops! Something went wrong! Please try again",
 		"warn_network_change": "Network changed to "
 	},
 	"receive": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -97,7 +97,9 @@
 		"public_address": "Public Address"
 	},
 	"send": {
-		"title": "Send"
+		"title": "Send",
+		"deeplink_failure": "Ooops! Something happened, please try again with other transaction.",
+		"warn_network_hange": "Network is being changed to "
 	},
 	"receive": {
 		"title": "Receive"

--- a/locales/en.json
+++ b/locales/en.json
@@ -99,7 +99,7 @@
 	"send": {
 		"title": "Send",
 		"deeplink_failure": "Ooops! Something happened, please try again with other transaction.",
-		"warn_network_change": "Network is being changed to "
+		"warn_network_change": "Network changed to "
 	},
 	"receive": {
 		"title": "Receive"

--- a/locales/en.json
+++ b/locales/en.json
@@ -99,7 +99,7 @@
 	"send": {
 		"title": "Send",
 		"deeplink_failure": "Ooops! Something happened, please try again with other transaction.",
-		"warn_network_hange": "Network is being changed to "
+		"warn_network_change": "Network is being changed to "
 	},
 	"receive": {
 		"title": "Receive"

--- a/locales/es.json
+++ b/locales/es.json
@@ -97,7 +97,9 @@
 		"public_address": "Public Address"
 	},
 	"send": {
-		"title": "Enviar"
+		"title": "Enviar",
+		"deeplink_failure": "Ooops! S algo ha salido mal, por favor intenta nuevamente con una nueva transacción.",
+		"warn_network_hange": "La red está siendo cambiada a "
 	},
 	"receive": {
 		"title": "Recibir"

--- a/locales/es.json
+++ b/locales/es.json
@@ -98,8 +98,8 @@
 	},
 	"send": {
 		"title": "Enviar",
-		"deeplink_failure": "Ooops! S algo ha salido mal, por favor intenta nuevamente con una nueva transacción.",
-		"warn_network_change": "La red está siendo cambiada a "
+		"deeplink_failure": "Ooops! Algo ha salido mal, por favor intėntalo de nuevo",
+		"warn_network_change": "La red ha sido cambiada a "
 	},
 	"receive": {
 		"title": "Recibir"

--- a/locales/es.json
+++ b/locales/es.json
@@ -99,7 +99,7 @@
 	"send": {
 		"title": "Enviar",
 		"deeplink_failure": "Ooops! S algo ha salido mal, por favor intenta nuevamente con una nueva transacción.",
-		"warn_network_hange": "La red está siendo cambiada a "
+		"warn_network_change": "La red está siendo cambiada a "
 	},
 	"receive": {
 		"title": "Recibir"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR adds support for deeplinks for ERC20 tokens.

- If `chainid` is defined, the app will change network and show an alert saying what is happening. if there is no `chainId` or `chainId` is the current network, won't show anything.
- Since we need decimals to build the tx object, after being changed to the right network we have two flows.
1. User has the token already or it's in contract metadata, for that case we're using that information without requesting that from the contract.
2. If user doesn't have the token, we'll query the contract for `symbol` and `decimal`. if `symbol` request fails, it defaults to `ERC20` (it's not valuable for the tx object). If `decimals` request fails, we drop the transaction and show a message saying an error happened with that tx.
- Finally, for token balance validation. if the user already has the .token is the same validation we had until now. If that's not the case, we query balance to the contract. if that fails we don't validate it and we let the user decide.

![zTovrREVT5](https://user-images.githubusercontent.com/12115171/55763836-bdc44080-5a36-11e9-869f-9b6a4351db77.gif)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #457 
