### PR TITLE
Two step  push notification prompt

### DIFF
--- a/app/core/AppConstants.js
+++ b/app/core/AppConstants.js
@@ -5,5 +5,6 @@ export default {
 	TX_CHECK_NORMAL_FREQUENCY: 10000,
 	TX_CHECK_BACKGROUND_FREQUENCY: 30000,
 	IPFS_OVERRIDE_PARAM: 'mm_override',
-	supportedTLDs: ['eth', 'xyz', 'test']
+	supportedTLDs: ['eth', 'xyz', 'test'],
+	MAX_PUSH_NOTIFICATION_PROMPT_TIMES: 2
 };

--- a/app/core/TransactionsNotificationManager.js
+++ b/app/core/TransactionsNotificationManager.js
@@ -112,16 +112,11 @@ class TransactionsNotificationManager {
 	 * Handles the push notification prompt
 	 * with a custom set of rules, like max. number of attempts
 	 */
-	requestPushNotificationsPermission = () => {
-		const promptCount = AsyncStorage.getItem('@MetaMask:pushNotificationsPromptCount');
-		if (!promptCount && Number(promptCount) < AppConstants.MAX_PUSH_NOTIFICATION_PROMPT_TIMES) {
+	requestPushNotificationsPermission = async () => {
+		const promptCount = await AsyncStorage.getItem('@MetaMask:pushNotificationsPromptCount');
+		if (!promptCount || Number(promptCount) < AppConstants.MAX_PUSH_NOTIFICATION_PROMPT_TIMES) {
 			PushNotification.checkPermissions(permissions => {
 				if (!permissions || !permissions.alert) {
-					const times = (promptCount && promptCount + 1) || 1;
-					AsyncStorage.setItem('@MetaMask:pushNotificationsPromptCount', times.toString());
-					// In case we want to prompt again after certain time.
-					AsyncStorage.setItem('@MetaMask:pushNotificationsPromptTime', Date.now());
-
 					Alert.alert(
 						strings('notifications.prompt_title'),
 						strings('notifications.prompt_desc'),
@@ -129,7 +124,7 @@ class TransactionsNotificationManager {
 							{
 								text: strings('notifications.prompt_cancel'),
 								onPress: () => false,
-								style: 'cancel'
+								style: 'default'
 							},
 							{
 								text: strings('notifications.prompt_ok'),
@@ -138,6 +133,11 @@ class TransactionsNotificationManager {
 						],
 						{ cancelable: false }
 					);
+
+					const times = (promptCount && Number(promptCount) + 1) || 1;
+					AsyncStorage.setItem('@MetaMask:pushNotificationsPromptCount', times.toString());
+					// In case we want to prompt again after certain time.
+					AsyncStorage.setItem('@MetaMask:pushNotificationsPromptTime', Date.now().toString());
 				}
 			});
 		}
@@ -308,5 +308,8 @@ export default {
 	},
 	gotIncomingTransaction(lastBlock) {
 		return instance.gotIncomingTransaction(lastBlock);
+	},
+	requestPushNotificationsPermission() {
+		return instance.requestPushNotificationsPermission();
 	}
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -628,7 +628,11 @@
 		"pending_message": "Waiting for confirmation...",
 		"error_message": "Tap to view this transaction",
 		"success_message": "Tap to view this transaction",
-		"received_message": "Tap to view this transaction"
+		"received_message": "Tap to view this transaction",
+		"prompt_title": "Enable Push Notifications",
+		"prompt_desc": "Enable notifications so MetaMask can let you know when you've received ETH or when your transactions have been confirmed.",
+		"prompt_ok": "YES",
+		"prompt_cancel": "No, thanks"
 	},
 	"secure_your_wallet_modal": {
 		"title": "Secure your wallet",

--- a/locales/en.json
+++ b/locales/en.json
@@ -631,7 +631,7 @@
 		"received_message": "Tap to view this transaction",
 		"prompt_title": "Enable Push Notifications",
 		"prompt_desc": "Enable notifications so MetaMask can let you know when you've received ETH or when your transactions have been confirmed.",
-		"prompt_ok": "YES",
+		"prompt_ok": "Yes",
 		"prompt_cancel": "No, thanks"
 	},
 	"secure_your_wallet_modal": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -624,7 +624,11 @@
 		"pending_message": "Tu transacción esta en proceso",
 		"error_message": "Presiona para ver esta transacción",
 		"success_message": "Presiona para ver esta transacción",
-		"received_message": "Presiona para ver esta transacción"
+		"received_message": "Presiona para ver esta transacción",
+		"prompt_title": "Habilitar Notifications",
+		"prompt_desc": "Habilita las notifications asi MetaMask puede avisarte cuando recibes ETH o cuando tus transacciones fueron confirmadas.",
+		"prompt_ok": "SI",
+		"prompt_cancel": "No, gracias"
 	},
 	"secure_your_wallet_modal": {
 		"title": "Protege tu billetera",

--- a/locales/es.json
+++ b/locales/es.json
@@ -627,7 +627,7 @@
 		"received_message": "Presiona para ver esta transacción",
 		"prompt_title": "Habilitar Notifications",
 		"prompt_desc": "Habilita las notifications asi MetaMask puede avisarte cuando recibes ETH o cuando tus transacciones fueron confirmadas.",
-		"prompt_ok": "SI",
+		"prompt_ok": "Si",
 		"prompt_cancel": "No, gracias"
 	},
 	"secure_your_wallet_modal": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -627,8 +627,8 @@
 		"error_message": "Presiona para ver esta transacción",
 		"success_message": "Presiona para ver esta transacción",
 		"received_message": "Presiona para ver esta transacción",
-		"prompt_title": "Habilitar Notifications",
-		"prompt_desc": "Habilita las notifications asi MetaMask puede avisarte cuando recibes ETH o cuando tus transacciones fueron confirmadas.",
+		"prompt_title": "Habilitar Notificationes",
+		"prompt_desc": "Habilita las notificationes asi MetaMask puede avisarte cuando recibes ETH o cuando tus transacciones fueron confirmadas.",
 		"prompt_ok": "Si",
 		"prompt_cancel": "No, gracias"
 	},


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Added a two step prompt for push notifications. Benefits are:
- To give more context to the user (increases engagement)
- To prevent getting a "NO" on the OS prompt, which prevent us from prompting again in the future

For now it will prompt once after sending a TX and if the user said now it will prompt again one more time on the next TX submitted.  The number of attempts is configurable and I'm also storing the timestamp of the last prompt so we can in the future re prompt if last time we did it was 1 week or 1 month ago.

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #536 


**DEMO**

![demo](https://user-images.githubusercontent.com/1247834/55771470-3be40f80-5a56-11e9-940e-eb167af99273.gif)

Note: The demo was recording by forcing the prompt to show up during app launch to prevent having to send transactions to test it.