### PR TITLE
Improvement: update corresponding balances

### DIFF
--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -466,6 +466,9 @@ class TransactionEditor extends Component {
 			transaction: { to },
 			networkType
 		} = this.props;
+		if (!to) {
+			return undefined;
+		}
 		const address = toChecksumAddress(to);
 		if (networkType === 'mainnet') {
 			const contractMapToken = contractMap[address];

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -91,7 +91,9 @@ class Approval extends Component {
 			TransactionController.hub.once(`${transaction.id}:finished`, transactionMeta => {
 				// Add to the AddressBook if it's an unkonwn address
 				const checksummedAddress = toChecksumAddress(transactionMeta.transaction.to);
-				const existingContact = addressBook.find(address => toChecksumAddress(address) === checksummedAddress);
+				const existingContact = addressBook.find(
+					({ address }) => toChecksumAddress(address) === checksummedAddress
+				);
 				if (!existingContact) {
 					AddressBookController.set(checksummedAddress, '');
 				}
@@ -99,7 +101,10 @@ class Approval extends Component {
 				if (transactionMeta.status === 'submitted') {
 					this.setState({ transactionHandled: true });
 					this.props.navigation.pop();
-					TransactionsNotificationManager.watchSubmittedTransaction(transactionMeta);
+					TransactionsNotificationManager.watchSubmittedTransaction({
+						...transactionMeta,
+						assetType: transaction.assetType
+					});
 				} else {
 					throw transactionMeta.error;
 				}

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -386,7 +386,10 @@ class Send extends Component {
 			this.setState({ transactionConfirmed: false, transactionSubmitted: true });
 			this.props.navigation.pop();
 			InteractionManager.runAfterInteractions(() => {
-				TransactionsNotificationManager.watchSubmittedTransaction(transactionMeta);
+				TransactionsNotificationManager.watchSubmittedTransaction({
+					...transactionMeta,
+					assetType: transaction.assetType
+				});
 			});
 		} catch (error) {
 			Alert.alert('Transaction error', error && error.message, [{ text: 'OK' }]);

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -84,12 +84,13 @@ class Send extends Component {
 	 * Resets gas and gasPrice of transaction, passing state to 'edit'
 	 */
 	async reset() {
-		const { transaction } = this.props;
+		const { transaction, navigation } = this.props;
 		const { gas, gasPrice } = await Engine.context.TransactionController.estimateGas(transaction);
 		this.props.setTransactionObject({
 			gas: hexToBN(gas),
 			gasPrice: hexToBN(gasPrice)
 		});
+		navigation && navigation.setParams({ mode: 'edit' });
 		return this.mounted && this.setState({ mode: 'edit', transactionKey: Date.now() });
 	}
 

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -369,7 +369,9 @@ class Send extends Component {
 
 			// Add to the AddressBook if it's an unkonwn address
 			const checksummedAddress = toChecksumAddress(transactionMeta.transaction.to);
-			const existingContact = addressBook.find(address => toChecksumAddress(address) === checksummedAddress);
+			const existingContact = addressBook.find(
+				({ address }) => toChecksumAddress(address) === checksummedAddress
+			);
 			if (!existingContact) {
 				AddressBookController.set(checksummedAddress, '');
 			}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR changes polling for token balances, account tracker and asset detection for all transactions confirmed to only poll for token balances and asset detection for ERC20 txs and only assets detection for ERC721 txs, for all cases it polls for account tracker because of gas.

Also fixes:

1. Last recent addresses PR was using toChecksumAddress with an object, making txs fail. This was fixed for send and approval screens.
2. When a tx failed in tx screen, navbar left button (Cancel or Edit) depending the case wasn't updating.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #569
