### PR TITLE
feature: add EIP-1102 convenience methods

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -461,7 +461,10 @@ export class Browser extends Component {
 				const { AssetsController } = Engine.context;
 				const suggestionResult = await AssetsController.watchAsset({ address, symbol, decimals, image }, type);
 				return suggestionResult.result;
-			}
+			},
+			metamask_isApproved: async ({ hostname }) => ({
+				isApproved: !!this.props.approvedHosts[hostname]
+			})
 		});
 
 		const entryScriptWeb3 =

--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -296,4 +296,54 @@ class InpageBridge {
 }
 
 window.ethereum = new InpageBridge();
+
+/**
+ * Expose nonstandard convenience methods at an application-specific namespace.
+ * A Proxy is used so developers can be warned about the use of these methods.
+ */
+window.ethereum._metamask = new Proxy(
+	{
+		/**
+		 * Determines if user accounts are enabled for this domain
+		 *
+		 * @returns {boolean} - true if accounts are enabled for this domain
+		 */
+		isEnabled: () => !!window.ethereum._selectedAddress,
+
+		/**
+		 * Determines if user accounts have been previously enabled for this
+		 * domain in the past. This is useful for determining if a user has
+		 * previously whitelisted a given dapp.
+		 *
+		 * @returns {Promise<boolean>} - Promise resolving to true if accounts have been previously enabled for this domain
+		 */
+		isApproved: async () => {
+			const { isApproved } = await window.ethereum.send('metamask_isApproved');
+			return isApproved;
+		},
+
+		/**
+		 * Determines if MetaMask is unlocked by the user. The mobile application
+		 * is always unlocked, so this method exists only for symmetry with the
+		 * browser extension.
+		 *
+		 * @returns {Promise<boolean>} - Promise resolving to true
+		 */
+		isUnlocked: () => Promise.resolve(true)
+	},
+	{
+		get: (obj, prop) => {
+			!window.ethereum._warned &&
+				// eslint-disable-next-line no-console
+				console.warn(
+					'Heads up! ethereum._metamask exposes methods that have ' +
+						'not been standardized yet. This means that these methods may not be implemented ' +
+						'in other dapp browsers and may be removed from MetaMask in the future.'
+				);
+			window.ethereum._warned = true;
+			return obj[prop];
+		}
+	}
+);
+
 window.postMessage({ type: 'ETHEREUM_PROVIDER_SUCCESS' }, '*');

--- a/app/core/InpageBridge.test.js
+++ b/app/core/InpageBridge.test.js
@@ -19,7 +19,8 @@ describe('InpageBridge', () => {
 			set(instance) {
 				expect(instance).toBeDefined();
 				INSTANCE = instance;
-			}
+			},
+			get: () => ({})
 		});
 		require('./InpageBridge');
 	});


### PR DESCRIPTION
**Description**

This pull request updates the `InpageProvider` and its associated RPC method overrides in the `Browser` view to handle MetaMask-specific convenience methods.

Resolves 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #256 
