### PR TITLE
Bugfix: phishing modal

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1680,14 +1680,6 @@ export class BrowserTab extends PureComponent {
 		);
 	}
 
-	onBrowserHomeGoToUrl = url => {
-		this.props.navigation.setParams({
-			url,
-			silent: false,
-			showUrlModal: false
-		});
-	};
-
 	getUserAgent() {
 		if (Platform.OS === 'android') {
 			return 'Mozilla/5.0 (Linux; Android 8.1.0; Android SDK built for x86 Build/OSM1.180201.023) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36';
@@ -1743,7 +1735,7 @@ export class BrowserTab extends PureComponent {
 				{this.renderProgressBar()}
 				{!isHidden && url === HOMEPAGE_URL ? (
 					<View style={styles.homepage}>
-						<BrowserHome goToUrl={this.onBrowserHomeGoToUrl} navigation={this.props.navigation} />
+						<BrowserHome goToUrl={this.go} navigation={this.props.navigation} />
 					</View>
 				) : null}
 				{!isHidden && this.renderUrlModal()}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes #617 

![QJAMiHWkpW](https://user-images.githubusercontent.com/12115171/57110177-9bf06d80-6d05-11e9-96a9-5f70f48e8178.gif)

We were using other `goToUrl` method from HomePage, setting directly navigation params without checking for phishing sites as the `Browser` method `go` does.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #617
