### PR TITLE
Attempt to fix android pre-release

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -174,8 +174,11 @@ buildAndroidRelease(){
 		echo $ANDROID_KEYSTORE | base64 --decode > android/keystores/release.keystore
 	fi
 
+	npm i react-native-cli --save-dev
+	node_modules/.bin/react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
+
 	cd android &&
-	./gradlew assembleRelease
+	./gradlew assembleRelease -x bundleReleaseJsAndAssets
 
 	if [ "$PRE_RELEASE" = true ] ; then
 		# Generate sourcemaps


### PR DESCRIPTION
Apparently there's something going on with react native + gradle 5.0.
Splitting the build process in two (bundling first, then building and use the bundle previously generated) seems to solve the issue.

Source: https://github.com/facebook/react-native/issues/24552