### PR TITLE
move submodules init to prebuild_ios

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,6 +111,8 @@ prebuild_ios(){
 		echo "" > ios/debug.xcconfig
 		echo "" > ios/release.xcconfig
 	fi
+	# Required to install mixpanel dep
+	git submodule update --init --recursive
 }
 
 prebuild_android(){

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -138,5 +138,3 @@ else
 	}' $TARGET;
 fi
 
-echo "14. Pull git submodules"
-git submodule update --init --recursive


### PR DESCRIPTION
Earlier we added it to the postinstall but the problem with it is that CircleCI runs two different vms for installing deps and building iOS.

Since it's an iOS only step I've moved it into the build script on the prebuild_ios fn.