### PR TITLE
Fix sourcemap generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5928,6 +5928,12 @@
         "cssom": "0.3.x"
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
     "d64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
@@ -7552,7 +7558,7 @@
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
@@ -8674,6 +8680,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
     },
     "fake-merkle-patricia-tree": {
       "version": "1.0.1",
@@ -10339,6 +10351,12 @@
           "dev": true
         }
       }
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
     },
     "i18n-js": {
       "version": "3.0.11",
@@ -16647,6 +16665,12 @@
         }
       }
     },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
     "please-upgrade-node": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
@@ -16823,6 +16847,19 @@
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
+      }
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+      "dev": true,
+      "requires": {
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.2.x",
+        "winston": "0.8.x"
       }
     },
     "prompts": {
@@ -17578,6 +17615,26 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-native-cli": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-cli/-/react-native-cli-2.0.1.tgz",
+      "integrity": "sha1-8s08eqG4OCjN+6Yw4t/YF992bVQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "minimist": "^1.2.0",
+        "prompt": "^0.2.14",
+        "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "react-native-crypto": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-native-crypto/-/react-native-crypto-2.1.2.tgz",
@@ -18193,6 +18250,15 @@
         "react-proxy": "^1.1.7"
       }
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -18513,6 +18579,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
     },
     "rimraf": {
@@ -19568,6 +19640,12 @@
           "dev": true
         }
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "stack-utils": {
       "version": "1.0.2",
@@ -20669,6 +20747,34 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "utile": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "dev": true,
+      "requires": {
+        "async": "~0.2.9",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.4.x",
+        "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "ncp": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+          "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
+          "dev": true
+        }
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -21071,7 +21177,7 @@
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
@@ -21261,6 +21367,41 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/window-or-global/-/window-or-global-1.0.1.tgz",
       "integrity": "sha1-2+RboqKRqrxW1iz2bEW3+jIpRt4="
+    },
+    "winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test:e2e:ios": "detox build -c ios.sim.debug && detox test -c ios.sim.debug",
     "test:e2e:android": "detox build -c android.emu.debug && detox test -c android.emu.debug",
     "postinstall": "./scripts/postinstall.sh",
-    "sourcemaps:android": "react-native bundle --platform android --entry-file index.js --dev false --reset-cache --bundle-output /tmp/bundle.android.js --assets-dest /tmp/ --sourcemap-output sourcemaps/android/index.js.map",
-    "sourcemaps:ios": "react-native bundle --platform ios --entry-file index.js --dev false --reset-cache --bundle-output /tmp/bundle.ios.js --assets-dest /tmp/ --sourcemap-output sourcemaps/ios/index.js.map",
+    "sourcemaps:android": "node_modules/.bin/react-native bundle --platform android --entry-file index.js --dev false --reset-cache --bundle-output /tmp/bundle.android.js --assets-dest /tmp/ --sourcemap-output sourcemaps/android/index.js.map",
+    "sourcemaps:ios": "node_modules/.bin/react-native bundle --platform ios --entry-file index.js --dev false --reset-cache --bundle-output /tmp/bundle.ios.js --assets-dest /tmp/ --sourcemap-output sourcemaps/ios/index.js.map",
     "stacktrace:android": "stack-beautifier sourcemaps/android.js.map -t trace.txt",
     "stacktrace:ios": "stack-beautifier sourcemaps/ios.js.map -t trace.txt"
   },
@@ -160,6 +160,7 @@
     "octonode": "0.9.5",
     "prettier": "1.16.4",
     "react-dom": "16.8.4",
+    "react-native-cli": "2.0.1",
     "react-test-renderer": "16.8.4",
     "regenerator-runtime": "0.13.1",
     "request-promise": "4.2.4",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,6 +111,8 @@ prebuild_ios(){
 		echo "" > ios/debug.xcconfig
 		echo "" > ios/release.xcconfig
 	fi
+	# Required to install mixpanel dep
+	git submodule update --init --recursive
 }
 
 prebuild_android(){
@@ -174,7 +176,6 @@ buildAndroidRelease(){
 		echo $ANDROID_KEYSTORE | base64 --decode > android/keystores/release.keystore
 	fi
 
-	npm i react-native-cli --save-dev
 	node_modules/.bin/react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
 
 	cd android &&

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -138,5 +138,3 @@ else
 	}' $TARGET;
 fi
 
-echo "14. Pull git submodules"
-git submodule update --init --recursive


### PR DESCRIPTION
We depend on the react-native-cli to generate the sourcemaps, so we need to install it on the build machines. Including it as a dev-dep saves to save us some time.