### PR TITLE
Bump kotlin plugin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 		compileSdkVersion = 28
 		targetSdkVersion = 28
 		supportLibVersion = "28.0.0"
-		kotlinVersion = '1.3.0'
+		kotlinVersion = '1.3.10'
 	}
     repositories {
         google()


### PR DESCRIPTION
#706  introduced an update in gradle which makes it incompatible with the kotlin plugin version and that broke android builds.

This PR fixes the issue