### PR TITLE
Bugfix: remove collectible while sending

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -8,7 +8,7 @@ import Button from '../../Button';
 import ActionModal from '../../../UI/ActionModal';
 import Engine from '../../../../core/Engine';
 import { renderFromWei } from '../../../../util/number';
-import { CANCEL_RATE } from 'gaba/TransactionController';
+import { CANCEL_RATE } from 'gaba/transaction/TransactionController';
 import { getNetworkTypeById, findBlockExplorerForRpc, getBlockExplorerName } from '../../../../util/networks';
 import { getEtherscanTransactionUrl, getEtherscanBaseUrl } from '../../../../util/etherscan';
 import Logger from '../../../../util/Logger';

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -102,17 +102,6 @@ class Send extends Component {
 	}
 
 	/**
-	 * Removes collectible in case an ERC721 asset is being sent
-	 */
-	removeCollectible = () => {
-		const { selectedAsset, assetType } = this.props.transaction;
-		if (assetType === 'ERC721') {
-			const { AssetsController } = Engine.context;
-			AssetsController.removeCollectible(selectedAsset.address, selectedAsset.tokenId);
-		}
-	};
-
-	/**
 	 * Transaction state is erased, ready to create a new clean transaction
 	 */
 	clear = () => {
@@ -392,7 +381,6 @@ class Send extends Component {
 			if (transactionMeta.error) {
 				throw transactionMeta.error;
 			}
-			this.removeCollectible();
 			this.setState({ transactionConfirmed: false, transactionSubmitted: true });
 			this.props.navigation.pop();
 			InteractionManager.runAfterInteractions(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7664,9 +7664,9 @@
       }
     },
     "eth-sig-util": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.1.2.tgz",
-      "integrity": "sha512-bNgt7txkEmaNlLf+PrbwYIdp4KRkB3E7hW0/QwlBpgv920pVVyQnF0evoovfiRveNKM4OrtPYZTojjmsfuCUOw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.2.0.tgz",
+      "integrity": "sha512-bAxW35bL4U2lrtjjV8rFGJ8B27z4Sn5v9eIaNdpPUnPfUAtrvx5j8atfyV+k+JOnbppcvKhWCO1rQSBk4kkAhw==",
       "requires": {
         "buffer": "^5.2.1",
         "elliptic": "^6.4.0",
@@ -7893,9 +7893,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.1.0.tgz",
-      "integrity": "sha512-LUmYkKV/HcZbWRyu3OU9YOevsH3VJDXtI6kEd8VZweQec+JjDGKCmAVKUyzhYUHqxRJu7JNALZ3A/b3NXOP6tA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.2.1.tgz",
+      "integrity": "sha512-VNr8MBdKHHuWgpYhRUhkp05P0mTcTH8Udb8wXcnnxUmwOWl388Sk/Lw2KL1rQNsV3gid2BB2auHT4vcfs9PFbw=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -9580,12 +9580,12 @@
       }
     },
     "gaba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.2.0.tgz",
-      "integrity": "sha512-d0MhQaXSCjFgZc3LC0XheMKReKTBaSFghf9Ps4Tkel/QQtox0+7Knvg70UINJJzHGFvbRFT854kXMrOkJnML/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.4.0.tgz",
+      "integrity": "sha512-kQguvQ+YrhnAK2wEzLAKt7O1A6dvPcg2aho2HQVoPTMVG3nnJUv0O+tx64+sp5hTlJRjyQMLY0WR6n2NyDAC3w==",
       "requires": {
         "await-semaphore": "^0.1.3",
-        "eth-contract-metadata": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31",
+        "eth-contract-metadata": "^1.9.1",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-method-registry": "1.1.0",
@@ -9607,8 +9607,9 @@
       },
       "dependencies": {
         "eth-contract-metadata": {
-          "version": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31",
-          "from": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31"
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/eth-contract-metadata/-/eth-contract-metadata-1.9.1.tgz",
+          "integrity": "sha512-eF02fIKf/8iGL/6SwhEQbmZIzNsQcJloA4r+QrxG/TfwqJAD/ECYxshpaU7hjO0ATPQPpMaNhNvL/p/Rc/B83A=="
         },
         "eth-json-rpc-infura": {
           "version": "3.2.0",
@@ -14850,9 +14851,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ethjs-unit": "0.1.6",
     "events": "3.0.0",
     "fuse.js": "3.4.4",
-    "gaba": "1.2.0",
+    "gaba": "1.4.0",
     "https-browserify": "0.0.1",
     "jsc-android": "236355.1.1",
     "lottie-react-native": "2.6.1",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This pr removes the `removeCollectible` call from `Send` when a collectible is sent. Instead with https://github.com/MetaMask/gaba/pull/114 a sent collectible is going to be removed when assets detection says so.


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #719
