### PR TITLE
Bugfix: disable add asset buttons

### DIFF
--- a/app/components/UI/AddCustomCollectible/__snapshots__/index.test.js.snap
+++ b/app/components/UI/AddCustomCollectible/__snapshots__/index.test.js.snap
@@ -14,6 +14,7 @@ exports[`AddCustomCollectible should render correctly 1`] = `
     cancelTestID="add-custom-asset-cancel-button"
     cancelText="CANCEL"
     confirmButtonMode="normal"
+    confirmDisabled={true}
     confirmTestID="add-custom-asset-confirm-button"
     confirmText="ADD"
     confirmed={false}

--- a/app/components/UI/AddCustomCollectible/index.js
+++ b/app/components/UI/AddCustomCollectible/index.js
@@ -157,50 +157,61 @@ class AddCustomCollectible extends Component {
 		}
 	};
 
-	render = () => (
-		<View style={styles.wrapper} testID={'add-custom-token-screen'}>
-			<ActionView
-				cancelTestID={'add-custom-asset-cancel-button'}
-				confirmTestID={'add-custom-asset-confirm-button'}
-				cancelText={strings('add_asset.collectibles.cancel_add_collectible')}
-				confirmText={strings('add_asset.collectibles.add_collectible')}
-				onCancelPress={this.cancelAddCollectible}
-				onConfirmPress={this.addCollectible}
-			>
-				<View>
-					<View style={styles.rowWrapper}>
-						<Text style={fontStyles.normal}>{strings('collectible.collectible_address')}</Text>
-						<TextInput
-							style={[styles.textInput, this.state.inputWidth ? { width: this.state.inputWidth } : {}]}
-							placeholder={'0x...'}
-							value={this.state.address}
-							onChangeText={this.onAddressChange}
-							onBlur={this.validateCustomCollectibleAddress}
-							testID={'input-collectible-address'}
-							onSubmitEditing={this.jumpToAssetTokenId}
-						/>
-						<Text style={styles.warningText}>{this.state.warningAddress}</Text>
+	render = () => {
+		const { address, tokenId } = this.state;
+
+		return (
+			<View style={styles.wrapper} testID={'add-custom-token-screen'}>
+				<ActionView
+					cancelTestID={'add-custom-asset-cancel-button'}
+					confirmTestID={'add-custom-asset-confirm-button'}
+					cancelText={strings('add_asset.collectibles.cancel_add_collectible')}
+					confirmText={strings('add_asset.collectibles.add_collectible')}
+					onCancelPress={this.cancelAddCollectible}
+					onConfirmPress={this.addCollectible}
+					confirmDisabled={!address && !tokenId}
+				>
+					<View>
+						<View style={styles.rowWrapper}>
+							<Text style={fontStyles.normal}>{strings('collectible.collectible_address')}</Text>
+							<TextInput
+								style={[
+									styles.textInput,
+									this.state.inputWidth ? { width: this.state.inputWidth } : {}
+								]}
+								placeholder={'0x...'}
+								value={this.state.address}
+								onChangeText={this.onAddressChange}
+								onBlur={this.validateCustomCollectibleAddress}
+								testID={'input-collectible-address'}
+								onSubmitEditing={this.jumpToAssetTokenId}
+							/>
+							<Text style={styles.warningText}>{this.state.warningAddress}</Text>
+						</View>
+						<View style={styles.rowWrapper}>
+							<Text style={fontStyles.normal}>{strings('collectible.collectible_token_id')}</Text>
+							<TextInput
+								style={[
+									styles.textInput,
+									this.state.inputWidth ? { width: this.state.inputWidth } : {}
+								]}
+								value={this.state.tokenId}
+								keyboardType="numeric"
+								onChangeText={this.onTokenIdChange}
+								onBlur={this.validateCustomCollectibleTokenId}
+								testID={'input-token-decimals'}
+								ref={this.assetTokenIdInput}
+								onSubmitEditing={this.addCollectible}
+								returnKeyType={'done'}
+								placeholder={strings('collectible.id_placeholder')}
+							/>
+							<Text style={styles.warningText}>{this.state.warningTokenId}</Text>
+						</View>
 					</View>
-					<View style={styles.rowWrapper}>
-						<Text style={fontStyles.normal}>{strings('collectible.collectible_token_id')}</Text>
-						<TextInput
-							style={[styles.textInput, this.state.inputWidth ? { width: this.state.inputWidth } : {}]}
-							value={this.state.tokenId}
-							keyboardType="numeric"
-							onChangeText={this.onTokenIdChange}
-							onBlur={this.validateCustomCollectibleTokenId}
-							testID={'input-token-decimals'}
-							ref={this.assetTokenIdInput}
-							onSubmitEditing={this.addCollectible}
-							returnKeyType={'done'}
-							placeholder={strings('collectible.id_placeholder')}
-						/>
-						<Text style={styles.warningText}>{this.state.warningTokenId}</Text>
-					</View>
-				</View>
-			</ActionView>
-		</View>
-	);
+				</ActionView>
+			</View>
+		);
+	};
 }
 
 const mapStateToProps = state => ({

--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.js.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.js.snap
@@ -14,6 +14,7 @@ exports[`AddCustomToken should render correctly 1`] = `
     cancelTestID="add-custom-asset-cancel-button"
     cancelText="CANCEL"
     confirmButtonMode="normal"
+    confirmDisabled={true}
     confirmTestID="add-custom-asset-confirm-button"
     confirmText="ADD TOKEN"
     confirmed={false}

--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -149,65 +149,69 @@ export default class AddCustomToken extends Component {
 		current && current.focus();
 	};
 
-	render = () => (
-		<View style={styles.wrapper} testID={'add-custom-token-screen'}>
-			<ActionView
-				cancelTestID={'add-custom-asset-cancel-button'}
-				confirmTestID={'add-custom-asset-confirm-button'}
-				cancelText={strings('add_asset.tokens.cancel_add_token')}
-				confirmText={strings('add_asset.tokens.add_token')}
-				onCancelPress={this.cancelAddToken}
-				onConfirmPress={this.addToken}
-			>
-				<View>
-					<View style={styles.rowWrapper}>
-						<Text style={fontStyles.normal}>{strings('token.token_address')}</Text>
-						<TextInput
-							style={styles.textInput}
-							placeholder={'0x...'}
-							value={this.state.address}
-							onChangeText={this.onAddressChange}
-							onBlur={this.onAddressBlur}
-							testID={'input-token-address'}
-							onSubmitEditing={this.jumpToAssetSymbol}
-							returnKeyType={'next'}
-						/>
-						<Text style={styles.warningText}>{this.state.warningAddress}</Text>
+	render = () => {
+		const { address, symbol, decimals } = this.state;
+		return (
+			<View style={styles.wrapper} testID={'add-custom-token-screen'}>
+				<ActionView
+					cancelTestID={'add-custom-asset-cancel-button'}
+					confirmTestID={'add-custom-asset-confirm-button'}
+					cancelText={strings('add_asset.tokens.cancel_add_token')}
+					confirmText={strings('add_asset.tokens.add_token')}
+					onCancelPress={this.cancelAddToken}
+					onConfirmPress={this.addToken}
+					confirmDisabled={!(address && symbol && decimals)}
+				>
+					<View>
+						<View style={styles.rowWrapper}>
+							<Text style={fontStyles.normal}>{strings('token.token_address')}</Text>
+							<TextInput
+								style={styles.textInput}
+								placeholder={'0x...'}
+								value={this.state.address}
+								onChangeText={this.onAddressChange}
+								onBlur={this.onAddressBlur}
+								testID={'input-token-address'}
+								onSubmitEditing={this.jumpToAssetSymbol}
+								returnKeyType={'next'}
+							/>
+							<Text style={styles.warningText}>{this.state.warningAddress}</Text>
+						</View>
+						<View style={styles.rowWrapper}>
+							<Text style={fontStyles.normal}>{strings('token.token_symbol')}</Text>
+							<TextInput
+								style={styles.textInput}
+								placeholder={'GNO'}
+								value={this.state.symbol}
+								onChangeText={this.onSymbolChange}
+								onBlur={this.validateCustomTokenSymbol}
+								testID={'input-token-symbol'}
+								ref={this.assetSymbolInput}
+								onSubmitEditing={this.jumpToAssetPrecision}
+								returnKeyType={'next'}
+							/>
+							<Text style={styles.warningText}>{this.state.warningSymbol}</Text>
+						</View>
+						<View style={styles.rowWrapper}>
+							<Text style={fontStyles.normal}>{strings('token.token_precision')}</Text>
+							<TextInput
+								style={styles.textInput}
+								value={this.state.decimals}
+								keyboardType="numeric"
+								maxLength={2}
+								placeholder={'18'}
+								onChangeText={this.onDecimalsChange}
+								onBlur={this.validateCustomTokenDecimals}
+								testID={'input-token-decimals'}
+								ref={this.assetPrecisionInput}
+								onSubmitEditing={this.addToken}
+								returnKeyType={'done'}
+							/>
+							<Text style={styles.warningText}>{this.state.warningDecimals}</Text>
+						</View>
 					</View>
-					<View style={styles.rowWrapper}>
-						<Text style={fontStyles.normal}>{strings('token.token_symbol')}</Text>
-						<TextInput
-							style={styles.textInput}
-							placeholder={'GNO'}
-							value={this.state.symbol}
-							onChangeText={this.onSymbolChange}
-							onBlur={this.validateCustomTokenSymbol}
-							testID={'input-token-symbol'}
-							ref={this.assetSymbolInput}
-							onSubmitEditing={this.jumpToAssetPrecision}
-							returnKeyType={'next'}
-						/>
-						<Text style={styles.warningText}>{this.state.warningSymbol}</Text>
-					</View>
-					<View style={styles.rowWrapper}>
-						<Text style={fontStyles.normal}>{strings('token.token_precision')}</Text>
-						<TextInput
-							style={styles.textInput}
-							value={this.state.decimals}
-							keyboardType="numeric"
-							maxLength={2}
-							placeholder={'18'}
-							onChangeText={this.onDecimalsChange}
-							onBlur={this.validateCustomTokenDecimals}
-							testID={'input-token-decimals'}
-							ref={this.assetPrecisionInput}
-							onSubmitEditing={this.addToken}
-							returnKeyType={'done'}
-						/>
-						<Text style={styles.warningText}>{this.state.warningDecimals}</Text>
-					</View>
-				</View>
-			</ActionView>
-		</View>
-	);
+				</ActionView>
+			</View>
+		);
+	};
 }

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.js.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.js.snap
@@ -14,6 +14,7 @@ exports[`SearchTokenAutocomplete should render correctly 1`] = `
     cancelTestID=""
     cancelText="CANCEL"
     confirmButtonMode="normal"
+    confirmDisabled={true}
     confirmTestID=""
     confirmText="ADD TOKEN"
     confirmed={false}

--- a/app/components/UI/SearchTokenAutocomplete/index.js
+++ b/app/components/UI/SearchTokenAutocomplete/index.js
@@ -53,6 +53,7 @@ export default class SearchTokenAutocomplete extends Component {
 
 	render = () => {
 		const { searchResults, selectedAsset, searchQuery } = this.state;
+		const { address, symbol, decimals } = selectedAsset;
 
 		return (
 			<View style={styles.wrapper} testID={'search-token-screen'}>
@@ -61,6 +62,7 @@ export default class SearchTokenAutocomplete extends Component {
 					confirmText={strings('add_asset.tokens.add_token')}
 					onCancelPress={this.cancelAddToken}
 					onConfirmPress={this.addToken}
+					confirmDisabled={!(address && symbol && decimals)}
 				>
 					<View>
 						<AssetSearch onSearch={this.handleSearch} />


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This pr disables add asset buttons on `AddCustomToken`, `SearchToken` and `AddcustomCollectible` if no data selected or typed.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #717
