### PR TITLE
Bugfix: Fix android login error msg

### DIFF
--- a/app/components/Views/AccountBackupStep4/index.js
+++ b/app/components/Views/AccountBackupStep4/index.js
@@ -197,7 +197,7 @@ export default class AccountBackupStep4 extends Component {
 			this.setState({ view: SEED_PHRASE, ready: true });
 		} catch (e) {
 			let msg = strings('reveal_credential.warning_incorrect_password');
-			if (e.toString() !== WRONG_PASSWORD_ERROR) {
+			if (e.toString().toLowerCase() !== WRONG_PASSWORD_ERROR.toLowerCase()) {
 				msg = strings('reveal_credential.unknown_error');
 			}
 			this.setState({

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -210,7 +210,7 @@ class Login extends Component {
 			}
 		} catch (error) {
 			// Should we force people to enable passcode / biometrics?
-			if (error.toString() === WRONG_PASSWORD_ERROR) {
+			if (error.toString().toLowerCase() === WRONG_PASSWORD_ERROR.toLowerCase()) {
 				this.setState({ loading: false, error: strings('login.invalid_password') });
 			} else if (error.toString() === PASSCODE_NOT_SET_ERROR) {
 				Alert.alert(

--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -173,7 +173,7 @@ class RevealPrivateCredential extends Component {
 			}
 		} catch (e) {
 			let msg = strings('reveal_credential.warning_incorrect_password');
-			if (e.toString() !== WRONG_PASSWORD_ERROR) {
+			if (e.toString().toLowerCase() !== WRONG_PASSWORD_ERROR.toLowerCase()) {
 				msg = strings('reveal_credential.unknown_error');
 			}
 


### PR DESCRIPTION
The error coming from the native libs had different case. So a lower case string comparison made the trick.

![Screen Shot 2019-06-12 at 12 04 17 AM](https://user-images.githubusercontent.com/1247834/59322812-07830e80-8ca6-11e9-93e5-acc54050ae60.png)

Fixes #716