### PR TITLE
Bugfix: Fix browser tabs

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -292,7 +292,7 @@ export function getBrowserViewNavbarOptions(navigation) {
 	let hostname = null;
 	let isHttps = false;
 	if (url && url !== HOMEPAGE_URL) {
-		isHttps = url.toLowerCase().substr(0, 6) === 'https:';
+		isHttps = url && url.toLowerCase().substr(0, 6) === 'https:';
 		const urlObj = new URL(url);
 		hostname = urlObj.hostname.toLowerCase().replace('www.', '');
 		if (hostname === 'ipfs.io' && url.search(`${AppConstants.IPFS_OVERRIDE_PARAM}=false`) === -1) {

--- a/app/components/UI/Tabs/__snapshots__/index.test.js.snap
+++ b/app/components/UI/Tabs/__snapshots__/index.test.js.snap
@@ -102,6 +102,7 @@ exports[`Tabs should render correctly 1`] = `
     >
       <TouchableOpacity
         activeOpacity={0.2}
+        onPress={[Function]}
         style={
           Object {
             "alignContent": "flex-start",

--- a/app/components/UI/Tabs/index.js
+++ b/app/components/UI/Tabs/index.js
@@ -234,8 +234,12 @@ export default class Tabs extends PureComponent {
 		);
 	}
 
+	onNewTabPress = () => {
+		this.props.newTab();
+	};
+
 	renderTabActions() {
-		const { tabs, closeAllTabs, newTab, closeTabsView } = this.props;
+		const { tabs, closeAllTabs, closeTabsView } = this.props;
 		return (
 			<View style={styles.tabActions}>
 				<TouchableOpacity style={[styles.tabAction, styles.tabActionleft]} onPress={closeAllTabs}>
@@ -244,7 +248,7 @@ export default class Tabs extends PureComponent {
 					</Text>
 				</TouchableOpacity>
 				<View style={styles.tabAction}>
-					<TouchableOpacity style={styles.newTabIconButton} onPress={newTab}>
+					<TouchableOpacity style={styles.newTabIconButton} onPress={this.onNewTabPress}>
 						<MaterialCommunityIcon name="plus" size={15} style={styles.newTabIcon} />
 					</TouchableOpacity>
 				</View>

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1054,6 +1054,9 @@ export class BrowserTab extends PureComponent {
 		}, 300);
 	};
 
+	onNewTabPress = () => {
+		this.openNewTab();
+	};
 	openNewTab = url => {
 		this.toggleOptionsIfNeeded();
 		setTimeout(() => {
@@ -1268,7 +1271,7 @@ export class BrowserTab extends PureComponent {
 								Platform.OS === 'android' ? styles.optionsWrapperAndroid : styles.optionsWrapperIos
 							]}
 						>
-							<Button onPress={this.openNewTab} style={styles.option}>
+							<Button onPress={this.onNewTabPress} style={styles.option}>
 								<View style={styles.optionIconWrapper}>
 									<MaterialCommunityIcon name="plus" size={18} style={styles.optionIcon} />
 								</View>


### PR DESCRIPTION
With #725 and #715  I've introduced the ability of opening a new tab on a certain url (required for deeplinks) but I forgot to update the calls to "newTab" which by default is passing an event as parameter and was breaking pretty much the entire browser.

This PR fixes that issue.