### PR TITLE
Feature: Allow to import a PK via QR Code &  Allow to remove an imported account

### DIFF
--- a/app/components/UI/AccountList/index.js
+++ b/app/components/UI/AccountList/index.js
@@ -4,6 +4,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import Identicon from '../Identicon';
 import PropTypes from 'prop-types';
 import {
+	Alert,
 	ActivityIndicator,
 	InteractionManager,
 	FlatList,
@@ -258,6 +259,30 @@ export default class AccountList extends Component {
 		return ret;
 	}
 
+	onLongPress = (address, imported, index) => {
+		if (!imported) return;
+		Alert.alert(
+			strings('accounts.remove_account_title'),
+			strings('accounts.remove_account_message'),
+			[
+				{
+					text: strings('accounts.no'),
+					onPress: () => false,
+					style: 'cancel'
+				},
+				{
+					text: strings('accounts.yes_remove_it'),
+					onPress: async () => {
+						await Engine.context.KeyringController.removeAccount(address);
+						// Default to the previous account in the list
+						this.onAccountChange(index - 1);
+					}
+				}
+			],
+			{ cancelable: false }
+		);
+	};
+
 	renderItem = ({ item }) => {
 		const { ticker } = this.props;
 		const { index, name, address, balance, isSelected, isImported } = item;
@@ -276,6 +301,7 @@ export default class AccountList extends Component {
 				style={styles.account}
 				key={`account-${address}`}
 				onPress={() => this.onAccountChange(index)} // eslint-disable-line
+				onLongPress={() => this.onLongPress(address, imported, index)} // eslint-disable-line
 			>
 				<Identicon address={address} diameter={38} />
 				<View style={styles.accountInfo}>

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -4,7 +4,17 @@ import ModalNavbarTitle from '../ModalNavbarTitle';
 import AccountRightButton from '../AccountRightButton';
 import NavbarBrowserTitle from '../NavbarBrowserTitle';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import { Text, Platform, TouchableOpacity, View, StyleSheet, Image, Keyboard, InteractionManager } from 'react-native';
+import {
+	Alert,
+	Text,
+	Platform,
+	TouchableOpacity,
+	View,
+	StyleSheet,
+	Image,
+	Keyboard,
+	InteractionManager
+} from 'react-native';
 import { fontStyles, colors } from '../../../styles/common';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
 import AntIcon from 'react-native-vector-icons/AntDesign';
@@ -17,6 +27,7 @@ import TabCountIcon from '../../UI/Tabs/TabCountIcon';
 import DeeplinkManager from '../../../core/DeeplinkManager';
 import Analytics from '../../../core/Analytics';
 import ANALYTICS_EVENT_OPTS from '../../../util/analytics';
+import { importAccountFromPrivateKey } from '../../../util/address';
 const HOMEPAGE_URL = 'about:blank';
 
 const trackEvent = event => {
@@ -455,6 +466,33 @@ export function getWalletNavbarOptions(title, navigation) {
 	const onScanSuccess = data => {
 		if (data.target_address) {
 			navigation.navigate('SendView', { txMeta: data });
+		} else if (data.private_key) {
+			Alert.alert(
+				strings('wallet.private_key_detected'),
+				strings('wallet.do_you_want_to_import_this_account'),
+				[
+					{
+						text: strings('wallet.cancel'),
+						onPress: () => false,
+						style: 'cancel'
+					},
+					{
+						text: strings('wallet.yes'),
+						onPress: async () => {
+							try {
+								await importAccountFromPrivateKey(data.private_key);
+								navigation.navigate('ImportPrivateKeySuccess');
+							} catch (e) {
+								Alert.alert(
+									strings('import_private_key.error_title'),
+									strings('import_private_key.error_message')
+								);
+							}
+						}
+					}
+				],
+				{ cancelable: false }
+			);
 		} else if (data.walletConnectURI) {
 			setTimeout(() => {
 				DeeplinkManager.parse(data.walletConnectURI);

--- a/app/components/Views/ImportPrivateKey/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportPrivateKey/__snapshots__/index.test.js.snap
@@ -215,6 +215,31 @@ exports[`ImportPrivateKey should render correctly 1`] = `
           underlineColorAndroid="transparent"
           value=""
         />
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "marginTop": 20,
+            }
+          }
+        >
+          <TouchableOpacity
+            activeOpacity={0.2}
+            onPress={[Function]}
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#037dd6",
+                  "fontSize": 14,
+                }
+              }
+            >
+              or Scan a QR Code
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
     <View

--- a/app/components/Views/ImportPrivateKey/index.js
+++ b/app/components/Views/ImportPrivateKey/index.js
@@ -9,7 +9,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { strings } from '../../../../locales/i18n';
 import DeviceSize from '../../../util/DeviceSize';
-import Engine from '../../../core/Engine';
+import { importAccountFromPrivateKey } from '../../../util/address';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -145,13 +145,7 @@ export default class ImportPrivateKey extends Component {
 		this.setState({ loading: true });
 		// Import private key
 		try {
-			let pkey = this.state.privateKey;
-			// Handle PKeys with 0x
-			if (pkey.length === 66 && pkey.substr(0, 2) === '0x') {
-				pkey = pkey.substr(2);
-			}
-			const { KeyringController } = Engine.context;
-			await KeyringController.importAccountWithStrategy('privateKey', [pkey]);
+			await importAccountFromPrivateKey(this.state.privateKey);
 			this.props.navigation.navigate('ImportPrivateKeySuccess');
 			this.setState({ loading: false, privateKey: '' });
 		} catch (e) {

--- a/app/components/Views/ImportPrivateKeySuccess/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportPrivateKeySuccess/__snapshots__/index.test.js.snap
@@ -1,122 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ImportPrivateKeySuccess should render correctly 1`] = `
-<View
-  style={
+<Connect(ImportPrivateKeySuccess)
+  navigation={
     Object {
-      "backgroundColor": "#FFFFFF",
-      "flex": 1,
+      "getParam": [Function],
+      "state": Object {
+        "params": Object {},
+      },
     }
   }
->
-  <ScrollViewMock
-    contentContainerStyle={
-      Object {
-        "flex": 1,
-      }
-    }
-    style={
-      Object {
-        "backgroundColor": "#FFFFFF",
-        "flex": 1,
-      }
-    }
-    testID="first-incoming-transaction-screen"
-  >
-    <View
-      style={
-        Object {
-          "alignItems": "flex-start",
-        }
-      }
-    >
-      <TouchableOpacity
-        activeOpacity={0.2}
-        onPress={[Function]}
-        style={
-          Object {
-            "alignSelf": "flex-end",
-            "marginTop": 40,
-            "paddingBottom": 10,
-            "paddingHorizontal": 22,
-            "paddingTop": 20,
-          }
-        }
-      >
-        <Icon
-          allowFontScaling={false}
-          name="close"
-          size={15}
-          style={
-            Object {
-              "color": "#999999",
-              "fontSize": 28,
-            }
-          }
-        />
-      </TouchableOpacity>
-      <View
-        style={
-          Object {
-            "padding": 30,
-            "paddingTop": 0,
-          }
-        }
-      >
-        <Icon
-          allowFontScaling={false}
-          color="#28a745"
-          name="ios-checkmark-circle-outline"
-          size={12}
-          style={
-            Object {
-              "fontSize": 90,
-              "marginLeft": 0,
-              "marginTop": 0,
-              "textAlign": "left",
-            }
-          }
-        />
-        <Text
-          style={
-            Object {
-              "color": "#000000",
-              "fontFamily": "Roboto",
-              "fontSize": 32,
-              "fontWeight": "400",
-              "justifyContent": "center",
-              "marginBottom": 20,
-              "marginTop": 10,
-              "textAlign": "left",
-            }
-          }
-        >
-          Account succesfully imported!
-        </Text>
-        <View
-          style={
-            Object {
-              "marginBottom": 10,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#000000",
-                "fontFamily": "Roboto",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "lineHeight": 23,
-                "textAlign": "left",
-              }
-            }
-          >
-            You'll be now able to view your account in MetaMask.
-          </Text>
-        </View>
-      </View>
-    </View>
-  </ScrollViewMock>
-</View>
+/>
 `;

--- a/app/components/Views/ImportPrivateKeySuccess/index.test.js
+++ b/app/components/Views/ImportPrivateKeySuccess/index.test.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ImportPrivateKeySuccess from './';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('ImportPrivateKeySuccess', () => {
 	it('should render correctly', () => {
 		const wrapper = shallow(
-			<ImportPrivateKeySuccess navigation={{ getParam: () => null, state: { params: {} } }} />
+			<Provider store={store}>
+				<ImportPrivateKeySuccess navigation={{ getParam: () => null, state: { params: {} } }} />
+			</Provider>
 		);
 		expect(wrapper).toMatchSnapshot();
 	});

--- a/app/components/Views/QRScanner/index.js
+++ b/app/components/Views/QRScanner/index.js
@@ -94,9 +94,15 @@ export default class QrScanner extends Component {
 					action = 'send-token';
 				}
 				data = { ...data, action };
+			} else if (
+				content.length === 64 ||
+				(content.substring(0, 2).toLowerCase() === '0x' && content.length === 66)
+			) {
+				this.shouldReadBarCode = false;
+				data = { private_key: content.length === 64 ? content : content.substr(2) };
 			} else if (content.substring(0, 2).toLowerCase() === '0x') {
 				this.shouldReadBarCode = false;
-				data = { target_address: content };
+				data = { target_address: content, action: 'send-eth' };
 			} else if (content.split('wc:').length > 1) {
 				this.shouldReadBarCode = false;
 				data = { walletConnectURI: content };

--- a/app/util/address.js
+++ b/app/util/address.js
@@ -1,5 +1,5 @@
 import { toChecksumAddress } from 'ethereumjs-util';
-
+import Engine from '../core/Engine';
 /**
  * Returns full checksummed address
  *
@@ -37,4 +37,26 @@ export function renderAccountName(address, identities) {
 		return identities[address].name;
 	}
 	return renderShortAddress(address);
+}
+
+/**
+ * Imports a an account from a private key
+ *
+ * @param {String} private_key - String corresponding to a private key
+ * @returns {Promise} - Returns a promise
+ */
+
+export async function importAccountFromPrivateKey(private_key) {
+	// Import private key
+	try {
+		let pkey = private_key;
+		// Handle PKeys with 0x
+		if (pkey.length === 66 && pkey.substr(0, 2) === '0x') {
+			pkey = pkey.substr(2);
+		}
+		const { KeyringController } = Engine.context;
+		return KeyringController.importAccountWithStrategy('privateKey', [pkey]);
+	} catch (e) {
+		throw e;
+	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -171,7 +171,10 @@
 		"collectible_removed_title": "Collectible removed!",
 		"collectible_removed_desc": "If you change your mind, you can add it back by tapping on \"+ ADD COLLECTIBLES\"",
 		"remove": "Remove",
-		"cancel": "Cancel"
+		"cancel": "Cancel",
+		"yes": "Yes",
+		"private_key_detected": "Private key detected",
+		"do_you_want_to_import_this_account": "Do you want to import this account?"
 	},
 	"transactions_view": {
 		"title": "Transactions"
@@ -245,7 +248,11 @@
 	"accounts": {
 		"create_new_account": "Create New Account",
 		"import_account": "Import an Account",
-		"imported": "IMPORTED"
+		"imported": "IMPORTED",
+		"remove_account_title": "Account removal",
+		"remove_account_message": "Do you really want to remove this account?",
+		"no": "No",
+		"yes_remove_it": "Yes, remove it"
 	},
 	"app_settings": {
 		"title": "Settings",

--- a/locales/en.json
+++ b/locales/en.json
@@ -626,7 +626,8 @@
 		"example": "e.g. 3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
 		"error_title": "Ooops! something went wrong...",
 		"error_message": "We couldn't import that private key. Please make sure you entered it correctly.",
-		"error_empty_message": "You need to enter your private key."
+		"error_empty_message": "You need to enter your private key.",
+		"or_scan_a_qr_code": "or Scan a QR Code"
 	},
 	"import_private_key_success": {
 		"title": "Account succesfully imported!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -615,7 +615,8 @@
 		"example": "ej. 3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
 		"error_title": "Ooops! algo ha salido mal...",
 		"error_message": "No pudimos importar esa llave secreta. Asegúrate de que la hayas ingresado correctamente.",
-		"error_empty_message": "Debes ingresar tu llave privada."
+		"error_empty_message": "Debes ingresar tu llave privada.",
+		"or_scan_a_qr_code": "o escanea un codigo QR"
 	},
 	"import_private_key_success": {
 		"title": "Cuenta importada correctamente!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -171,7 +171,10 @@
 		"collectible_removed_title": "Coleccionable eliminado!",
 		"collectible_removed_desc": "Si cambias de opinión, puedes agregarlo nuevamente presionando en \"Agregar Coleccionable\"",
 		"remove": "Eliminar",
-		"cancel": "Cancelar"
+		"cancel": "Cancelar",
+		"yes": "Sí",
+		"private_key_detected": "Llave privada detectada",
+		"do_you_want_to_import_this_account": "Deseas importar esta cuenta?"
 	},
 	"transactions_view": {
 		"title": "Transacciones"
@@ -245,7 +248,11 @@
 	"accounts": {
 		"create_new_account": "Crear cuenta nueva",
 		"import_account": "Import una cuenta",
-		"imported": "IMPORTAR"
+		"imported": "IMPORTAR",
+		"remove_account_title": "Eliminar cuenta",
+		"remove_account_message": "Realmente deseas liminar esta cuenta?",
+		"no": "No",
+		"yes_remove_it": "Si, deseo eliminarla"
 	},
 	"app_settings": {
 		"title": "Ajustes",


### PR DESCRIPTION
This PR introduces two new features:

- Ability to import a private key by scanning a QR code.  
There's two ways to do that:
a) Account list => Import account => Scan QR code
b) Wallet => Scanner icon

- Ability to remove an imported account.   Long pressing in an imported account will prompt the user to delete it.

Fixes #730 
Fixes #736 

DEMO:

http://recordit.co/FG6yp95PuY