### PR TITLE
Bugfix: send screen ui

### DIFF
--- a/app/components/UI/AccountInput/index.js
+++ b/app/components/UI/AccountInput/index.js
@@ -35,7 +35,9 @@ const styles = StyleSheet.create({
 	input: {
 		...fontStyles.bold,
 		backgroundColor: colors.white,
-		marginRight: 24
+		marginRight: 24,
+		paddingLeft: 0,
+		minWidth: 120
 	},
 	qrCodeButton: {
 		minHeight: Platform.OS === 'android' ? 50 : 50,
@@ -46,7 +48,6 @@ const styles = StyleSheet.create({
 		alignItems: 'center'
 	},
 	accountContainer: {
-		flex: 1,
 		flexDirection: 'row',
 		backgroundColor: colors.white,
 		borderColor: colors.grey100,
@@ -322,7 +323,7 @@ class AccountInput extends Component {
 	renderOptionList() {
 		const visibleOptions = this.getVisibleOptions(this.state.value);
 		return (
-			<ElevatedView elevation={10}>
+			<ElevatedView borderRadius={4} elevation={10}>
 				<ScrollView style={styles.componentContainer} keyboardShouldPersistTaps={'handled'}>
 					<View style={styles.optionList}>
 						{Object.keys(visibleOptions).map(address =>

--- a/app/components/UI/EthInput/index.js
+++ b/app/components/UI/EthInput/index.js
@@ -35,7 +35,6 @@ const styles = StyleSheet.create({
 		paddingVertical: 10,
 		paddingLeft: 14,
 		position: 'relative',
-		backgroundColor: colors.white,
 		borderColor: colors.grey100,
 		borderRadius: 4,
 		borderWidth: 1
@@ -108,20 +107,20 @@ const styles = StyleSheet.create({
 	},
 	componentContainer: {
 		position: 'relative',
-		maxHeight: 200,
-		borderRadius: 4
+		maxHeight: 200
 	},
 	optionList: {
 		backgroundColor: colors.white,
 		borderColor: colors.grey100,
 		borderRadius: 4,
 		borderWidth: 1,
-		paddingLeft: 14,
-		paddingBottom: 12,
-		width: '100%'
+		paddingHorizontal: 14,
+		paddingVertical: 6,
+		flexGrow: 1
 	},
 	selectableAsset: {
-		paddingTop: 12
+		flex: 1,
+		paddingVertical: 6
 	}
 });
 
@@ -368,7 +367,7 @@ class EthInput extends Component {
 		};
 		const assetsList = assetsLists[assetType]();
 		return (
-			<ElevatedView elevation={10} style={styles.root}>
+			<ElevatedView borderRadius={4} elevation={10} style={styles.root}>
 				<ScrollView style={styles.componentContainer} keyboardShouldPersistTaps={'handled'}>
 					<View style={styles.optionList}>
 						{assetsList.map(asset => (

--- a/app/components/UI/EthInput/index.js
+++ b/app/components/UI/EthInput/index.js
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
 		marginVertical: 3,
 		marginHorizontal: 3
 	},
-	componentContainer: {
+	scrollContainer: {
 		position: 'relative',
 		maxHeight: 200
 	},
@@ -368,13 +368,10 @@ class EthInput extends Component {
 		const assetsList = assetsLists[assetType]();
 		return (
 			<ElevatedView borderRadius={4} elevation={10} style={styles.root}>
-				<ScrollView style={styles.componentContainer} keyboardShouldPersistTaps={'handled'}>
+				<ScrollView style={styles.scrollContainer} keyboardShouldPersistTaps={'handled'}>
 					<View style={styles.optionList}>
-						{assetsList.map(asset => (
-							<View
-								key={asset.address + asset.tokenId || asset.symbol || undefined}
-								style={styles.selectableAsset}
-							>
+						{assetsList.map((asset, i) => (
+							<View key={i} style={styles.selectableAsset}>
 								{this.renderAsset(asset, async () => {
 									await this.selectAsset(asset);
 								})}

--- a/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
@@ -24,12 +24,15 @@ exports[`TransactionEdit should render correctly 1`] = `
   >
     <View
       style={
-        Object {
-          "flex": 1,
-          "flexDirection": "column",
-          "minHeight": "100%",
-          "padding": 16,
-        }
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "column",
+            "minHeight": "100%",
+            "padding": 16,
+          },
+          Object {},
+        ]
       }
     >
       <View

--- a/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionEdit/__snapshots__/index.test.js.snap
@@ -28,7 +28,6 @@ exports[`TransactionEdit should render correctly 1`] = `
           Object {
             "flex": 1,
             "flexDirection": "column",
-            "minHeight": "100%",
             "padding": 16,
           },
           Object {},

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -83,11 +83,10 @@ const styles = StyleSheet.create({
 	form: {
 		flex: 1,
 		padding: 16,
-		flexDirection: 'column',
-		minHeight: '100%'
+		flexDirection: 'column'
 	},
 	androidForm: {
-		minHeight: 520
+		paddingBottom: 100
 	},
 	hexData: {
 		...fontStyles.bold,
@@ -362,7 +361,7 @@ class TransactionEdit extends Component {
 					onTouchablePress={this.closeDropdowns}
 					keyboardShouldPersistTaps={'handled'}
 				>
-					<View style={[styles.form, Platform.OS === 'android' ? styles.androidForm : {}]}>
+					<View style={[styles.form, Platform.OS === 'android' && !showHexData ? styles.androidForm : {}]}>
 						<View style={[styles.formRow, styles.fromRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.from')}:</Text>

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -369,6 +369,20 @@ class TransactionEdit extends Component {
 							</View>
 							<AccountSelect value={from} onChange={this.updateFromAddress} enabled={false} />
 						</View>
+						<View style={[styles.formRow, styles.row, styles.amountRow]}>
+							{this.renderAmountLabel()}
+							<EthInput
+								onChange={this.updateAmount}
+								value={value}
+								asset={selectedAsset}
+								handleUpdateAsset={this.props.handleUpdateAsset}
+								readableValue={readableValue}
+								fillMax={this.state.fillMax}
+								updateFillMax={this.updateFillMax}
+								openEthInput={this.openEthInputIsOpen}
+								isOpen={ethInputIsOpen}
+							/>
+						</View>
 						<View style={[styles.formRow, styles.toRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.to')}:</Text>
@@ -392,20 +406,7 @@ class TransactionEdit extends Component {
 								isOpen={accountSelectIsOpen}
 							/>
 						</View>
-						<View style={[styles.formRow, styles.row, styles.amountRow]}>
-							{this.renderAmountLabel()}
-							<EthInput
-								onChange={this.updateAmount}
-								value={value}
-								asset={selectedAsset}
-								handleUpdateAsset={this.props.handleUpdateAsset}
-								readableValue={readableValue}
-								fillMax={this.state.fillMax}
-								updateFillMax={this.updateFillMax}
-								openEthInput={this.openEthInputIsOpen}
-								isOpen={ethInputIsOpen}
-							/>
-						</View>
+
 						<View style={[styles.formRow, styles.row, styles.notAbsolute]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.gas_fee')}:</Text>

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 	amountRow: {
 		right: 15,
 		left: 15,
-		marginTop: Platform.OS === 'android' ? 205 : 190,
+		marginTop: Platform.OS === 'android' ? 200 : 190,
 		position: 'absolute',
 		zIndex: 4
 	},

--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -86,6 +86,9 @@ const styles = StyleSheet.create({
 		flexDirection: 'column',
 		minHeight: '100%'
 	},
+	androidForm: {
+		minHeight: 520
+	},
 	hexData: {
 		...fontStyles.bold,
 		backgroundColor: colors.white,
@@ -359,26 +362,12 @@ class TransactionEdit extends Component {
 					onTouchablePress={this.closeDropdowns}
 					keyboardShouldPersistTaps={'handled'}
 				>
-					<View style={styles.form}>
+					<View style={[styles.form, Platform.OS === 'android' ? styles.androidForm : {}]}>
 						<View style={[styles.formRow, styles.fromRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.from')}:</Text>
 							</View>
 							<AccountSelect value={from} onChange={this.updateFromAddress} enabled={false} />
-						</View>
-						<View style={[styles.formRow, styles.row, styles.amountRow]}>
-							{this.renderAmountLabel()}
-							<EthInput
-								onChange={this.updateAmount}
-								value={value}
-								asset={selectedAsset}
-								handleUpdateAsset={this.props.handleUpdateAsset}
-								readableValue={readableValue}
-								fillMax={this.state.fillMax}
-								updateFillMax={this.updateFillMax}
-								openEthInput={this.openEthInputIsOpen}
-								isOpen={ethInputIsOpen}
-							/>
 						</View>
 						<View style={[styles.formRow, styles.toRow]}>
 							<View style={styles.label}>
@@ -401,6 +390,20 @@ class TransactionEdit extends Component {
 								navigation={navigation}
 								openAccountSelect={this.openAccountSelect}
 								isOpen={accountSelectIsOpen}
+							/>
+						</View>
+						<View style={[styles.formRow, styles.row, styles.amountRow]}>
+							{this.renderAmountLabel()}
+							<EthInput
+								onChange={this.updateAmount}
+								value={value}
+								asset={selectedAsset}
+								handleUpdateAsset={this.props.handleUpdateAsset}
+								readableValue={readableValue}
+								fillMax={this.state.fillMax}
+								updateFillMax={this.updateFillMax}
+								openEthInput={this.openEthInputIsOpen}
+								isOpen={ethInputIsOpen}
 							/>
 						</View>
 						<View style={[styles.formRow, styles.row, styles.notAbsolute]}>

--- a/app/components/Views/QRScanner/__snapshots__/index.test.js.snap
+++ b/app/components/Views/QRScanner/__snapshots__/index.test.js.snap
@@ -10,12 +10,18 @@ exports[`QrScanner should render correctly 1`] = `
   }
 >
   <View
+    androidCameraPermissionOptions={
+      Object {
+        "buttonNegative": "Cancel",
+        "buttonPositive": "Ok",
+        "message": "We need your permission to scan QR codes",
+        "title": "Allow camera access",
+      }
+    }
     captureAudio={false}
     flashMode="auto"
     onBarCodeRead={[Function]}
     onMountError={[Function]}
-    permissionDialogMessage="We need your permission to scan QR codes"
-    permissionDialogTitle="Allow camera access"
     style={
       Object {
         "flex": 1,

--- a/app/components/Views/QRScanner/index.js
+++ b/app/components/Views/QRScanner/index.js
@@ -137,8 +137,8 @@ export default class QrScanner extends Component {
 				androidCameraPermissionOptions={{
 					title: strings('qr_scanner.allow_camera_dialog_title'),
 					message: strings('qr_scanner.allow_camera_dialog_message'),
-					buttonPositive: 'Ok',
-					buttonNegative: 'Cancel'
+					buttonPositive: strings('qr_scanner.ok'),
+					buttonNegative: strings('qr_scanner.cancel')
 				}}
 			>
 				<SafeAreaView style={styles.innerView}>

--- a/app/components/Views/QRScanner/index.js
+++ b/app/components/Views/QRScanner/index.js
@@ -134,8 +134,12 @@ export default class QrScanner extends Component {
 				type={'back'}
 				onBarCodeRead={this.shouldReadBarCode ? this.onBarCodeRead : null}
 				flashMode={'auto'}
-				permissionDialogTitle={strings('qr_scanner.allow_camera_dialog_title')}
-				permissionDialogMessage={strings('qr_scanner.allow_camera_dialog_message')}
+				androidCameraPermissionOptions={{
+					title: strings('qr_scanner.allow_camera_dialog_title'),
+					message: strings('qr_scanner.allow_camera_dialog_message'),
+					buttonPositive: 'Ok',
+					buttonNegative: 'Cancel'
+				}}
 			>
 				<SafeAreaView style={styles.innerView}>
 					<TouchableOpacity style={styles.closeIcon} onPress={this.goBack}>

--- a/locales/en.json
+++ b/locales/en.json
@@ -401,7 +401,9 @@
 		"invalid_qr_code_message": "The QR code that you are trying to scan it is not valid.",
 		"allow_camera_dialog_title": "Allow camera access",
 		"allow_camera_dialog_message": "We need your permission to scan QR codes",
-		"scanning": "scanning..."
+		"scanning": "scanning...",
+		"ok": "Ok",
+		"cancel": "Cancel"
 	},
 	"action_view": {
 		"cancel": "Cancel",

--- a/locales/es.json
+++ b/locales/es.json
@@ -401,7 +401,9 @@
 		"outdated_qr_code_desc": "!Este parece ser un código QR expirado! Por favor, intenta escanear uno nuevo",
 		"allow_camera_dialog_title": "Permite acceso a la cámara",
 		"allow_camera_dialog_message": "Necesitamos tu permiso para escanear códigos QR",
-		"scanning": "escaneando..."
+		"scanning": "escaneando...",
+		"ok": "Ok",
+		"cancel": "Cancelar"
 	},
 	"action_view": {
 		"cancel": "Cancelar",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes several bugs on send screen

- Android: When screen was too small assets dropdown was cut.
- Android: Assets and account dropdowns corners didn't look fine.
- Android: Account input placeholder wasn't centered.
- Fixed some style issues

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #755
