### PR TITLE
Bugfix: gas api returning same price

### DIFF
--- a/app/components/UI/CustomGas/index.js
+++ b/app/components/UI/CustomGas/index.js
@@ -224,7 +224,15 @@ class CustomGas extends Component {
 			Logger.log('Error while trying to get gas limit estimates', error);
 			basicGasEstimates = { average: AVERAGE_GAS, safeLow: LOW_GAS, fast: FAST_GAS };
 		}
-		const { average, fast, safeLow } = basicGasEstimates;
+
+		// Handle api failure returning same gas prices
+		let { average, fast, safeLow } = basicGasEstimates;
+		if (average === fast && average === safeLow) {
+			average = AVERAGE_GAS;
+			safeLow = LOW_GAS;
+			fast = FAST_GAS;
+		}
+
 		this.setState({
 			averageGwei: convertApiValueToGWEI(average),
 			fastGwei: convertApiValueToGWEI(fast),


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Sometimes gas api returns 2 Gwei as default for SLOW AVERAGE and FAST gas options, this pr set these to 1, 2 and 4 Gwei,  as we do when the api is down.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
