### PR TITLE
Enable android app bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,10 @@ jobs:
           name: build:pre-release
           command:
             |
-              npm run build:android:pre-release
+              npm run build:android:pre-release:bundle
+      - store_artifacts:
+          path: android/app/build/outputs/bundle/release
+          destination: bundle
       - store_artifacts:
           path: android/app/build/outputs/apk/release
           destination: builds

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:announce": "node ./scripts/metamask-bot-build-announce.js",
     "build:android:release": "./scripts/build.sh android release",
     "build:android:pre-release": "./scripts/build.sh android release --pre",
+    "build:android:pre-release:bundle": "GENERATE_BUNDLE=true ./scripts/build.sh android release --pre",
     "build:ios:release": "./scripts/build.sh ios release",
     "build:ios:pre-release": "./scripts/build.sh ios release --pre",
     "release:android": "./scripts/build.sh android release && open android/app/build/outputs/apk/release/",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -178,8 +178,13 @@ buildAndroidRelease(){
 
 	node_modules/.bin/react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res
 
-	cd android &&
-	./gradlew assembleRelease -x bundleReleaseJsAndAssets
+	# GENERATE APK
+	cd android && ./gradlew assembleRelease -x bundleReleaseJsAndAssets
+
+	# GENERATE BUNDLE
+	if [ "$GENERATE_BUNDLE" = true ] ; then
+		./gradlew bundleRelease
+	fi
 
 	if [ "$PRE_RELEASE" = true ] ; then
 		# Generate sourcemaps

--- a/scripts/metamask-bot-build-announce.js
+++ b/scripts/metamask-bot-build-announce.js
@@ -37,6 +37,7 @@ async function start() {
 	const APK_BUILD_LINK_BASE = `https://${CIRCLE_BUILD_NUM}-141427485-gh.circle-artifacts.com/0`;
 
 	const APK_LINK = `${APK_BUILD_LINK_BASE}/builds/app-release.apk`;
+	const AAP_LINK = `${APK_BUILD_LINK_BASE}/bundle/app.aab`;
 
 
 	const content = {
@@ -52,6 +53,12 @@ async function start() {
 				"title_link": APK_LINK,
 				"title" : "Android",
 				"text": "Download APK",
+				"thumb_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Android_robot.svg/511px-Android_robot.svg.png"
+			},
+			{
+				"title_link": AAP_LINK,
+				"title" : "Android App Bundle",
+				"text": "Download AAP",
 				"thumb_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Android_robot.svg/511px-Android_robot.svg.png"
 			}
 		]


### PR DESCRIPTION
This should make the app size considerably small since the APK will only contain the code for the arch supported by the downloading device.

We will get a new link with the metamask bot that contains the AAP

Fixes #812