### PR TITLE
Fix blank screen browser issue

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -66,7 +66,11 @@ class Browser extends PureComponent {
 
 	componentDidMount() {
 		const activeTab = this.props.tabs.find(tab => tab.id === this.props.activeTab);
-		activeTab && this.switchToTab(activeTab);
+		if (activeTab) {
+			activeTab && this.switchToTab(activeTab);
+		} else {
+			this.props.tabs.length > 0 && this.switchToTab(this.props.tabs[0]);
+		}
 	}
 
 	createBrowserTabs(tabs) {

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -67,7 +67,7 @@ class Browser extends PureComponent {
 	componentDidMount() {
 		const activeTab = this.props.tabs.find(tab => tab.id === this.props.activeTab);
 		if (activeTab) {
-			activeTab && this.switchToTab(activeTab);
+			this.switchToTab(activeTab);
 		} else {
 			this.props.tabs.length > 0 && this.switchToTab(this.props.tabs[0]);
 		}


### PR DESCRIPTION
The active tab wasn't set so there's nothing displayed in the screen.
This bugfix is not ideal but at least we're defaulting to the first tab in that scenario