### PR TITLE
bugfix: tx details

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -332,7 +332,7 @@ class TransactionDetails extends PureComponent {
 						<Text style={styles.gasTitle}>{strings('transaction.gasCancelFee')}</Text>
 						<View style={styles.cancelFeeWrapper}>
 							<Text style={styles.cancelFee}>
-								{renderFromWei(existingGasPriceDecimal * CANCEL_RATE)} {strings('unit.eth')}
+								{renderFromWei(Math.floor(existingGasPriceDecimal * CANCEL_RATE))} {strings('unit.eth')}
 							</Text>
 						</View>
 						<Text style={styles.modalText}>{strings('transaction.cancel_tx_message')}</Text>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I had some crashes on tx history when clicking details. Caused because we were transforming a decimal number to numberToBN 

This only happens with some txs, not all

Maybe fixes https://github.com/MetaMask/metamask-mobile/issues/851

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
