### PR TITLE
Fix crash when trying to sync from Wallet scanner

### DIFF
--- a/app/components/Views/QRScanner/index.js
+++ b/app/components/Views/QRScanner/index.js
@@ -8,7 +8,8 @@ import {
 	TouchableOpacity,
 	View,
 	StyleSheet,
-	Platform
+	Platform,
+	Alert
 } from 'react-native';
 import { RNCamera } from 'react-native-camera';
 import { colors } from '../../../styles/common';
@@ -84,16 +85,24 @@ export default class QrScanner extends PureComponent {
 		if (!this.mounted) return false;
 		const content = response.data;
 
+		if (!content) return false;
+
 		let data = {};
 
 		if (content.split('metamask-sync:').length > 1) {
 			this.shouldReadBarCode = false;
 			data = { content };
-			this.props.navigation.state.params.onStartScan(data).then(() => {
-				this.props.navigation.state.params.onScanSuccess(data);
-			});
-			this.mounted = false;
-			this.props.navigation.goBack();
+			if (this.props.navigation.state.params.onStartScan) {
+				this.props.navigation.state.params.onStartScan(data).then(() => {
+					this.props.navigation.state.params.onScanSuccess(data);
+				});
+				this.mounted = false;
+				this.props.navigation.goBack();
+			} else {
+				Alert.alert(strings('qr_scanner.error'), strings('qr_scanner.attempting_sync_from_wallet_error'));
+				this.mounted = false;
+				this.props.navigation.goBack();
+			}
 		} else {
 			if (content.split('ethereum:').length > 1) {
 				this.shouldReadBarCode = false;

--- a/locales/en.json
+++ b/locales/en.json
@@ -407,7 +407,9 @@
 		"allow_camera_dialog_message": "We need your permission to scan QR codes",
 		"scanning": "scanning...",
 		"ok": "Ok",
-		"cancel": "Cancel"
+		"cancel": "Cancel",
+		"error": "Error",
+		"attempting_sync_from_wallet_error": "Looks like you're trying to sync with the extension. In order to do that, Please go to Settings > Advanced > Sync with MetaMask Extension"
 	},
 	"action_view": {
 		"cancel": "Cancel",

--- a/locales/es.json
+++ b/locales/es.json
@@ -403,7 +403,9 @@
 		"allow_camera_dialog_message": "Necesitamos tu permiso para escanear códigos QR",
 		"scanning": "escaneando...",
 		"ok": "Ok",
-		"cancel": "Cancelar"
+		"cancel": "Cancelar",
+		"error": "Error",
+		"attempting_sync_from_wallet_error": "Hemos detectado que quieres sincronizar con la extensión de MetaMask. Para eso ve a Ajustes > Avanzado > Sincronizar con la extensión de MetaMask"
 	},
 	"action_view": {
 		"cancel": "Cancelar",


### PR DESCRIPTION
Apparently there's a bunch of people trying to sync from the wallet scanner and that was crashing the app.

We added an alert indicating where to go in order to do it properly.