### PR TITLE
bugfix: collectibles empty details

### DIFF
--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -65,8 +65,13 @@ export default class CollectibleOverview extends PureComponent {
 
 	render = () => {
 		const {
-			collectible: { name, tokenId, description }
+			collectible: { name, tokenId },
+			collectible
 		} = this.props;
+		let description;
+		if (collectible.description) {
+			description = collectible.description;
+		}
 		return (
 			<View style={styles.wrapper}>
 				<View style={styles.basicsWrapper}>
@@ -79,14 +84,14 @@ export default class CollectibleOverview extends PureComponent {
 						{strings('unit.token_id')}
 						{tokenId}
 					</Text>
-					<View style={styles.information}>
-						{description && (
+					{description && (
+						<View style={styles.information}>
 							<View style={styles.row}>
 								<Text style={styles.label}>{strings('collectible.collectible_description')}</Text>
 								<Text style={styles.content}>{description}</Text>
 							</View>
-						)}
-					</View>
+						</View>
+					)}
 				</View>
 			</View>
 		);

--- a/app/components/UI/Collectibles/index.js
+++ b/app/components/UI/Collectibles/index.js
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
 	tokenId: {
 		fontSize: 12,
 		marginTop: 4,
+		marginRight: 8,
 		color: colors.grey400,
 		...fontStyles.normal
 	}
@@ -125,7 +126,7 @@ export default class Collectibles extends PureComponent {
 				<CollectibleImage collectible={item} />
 				<View style={styles.rows}>
 					<Text style={styles.name}>{item.name}</Text>
-					<Text style={styles.tokenId}>
+					<Text style={styles.tokenId} numberOfLines={1}>
 						{strings('unit.token_id')}
 						{item.tokenId}
 					</Text>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This was happening because for some collectibles the API response of description was an empty string and we're checking it on render method. Change that check and now it works.


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #867 
