### PR TITLE
Retry ethereum.enable after 1 sec if bridge not ready

### DIFF
--- a/app/components/UI/AccountApproval/index.js
+++ b/app/components/UI/AccountApproval/index.js
@@ -241,6 +241,7 @@ class AccountApproval extends PureComponent {
 			selectedAddress,
 			identities
 		} = this.props;
+		const host = getHost(url);
 		return (
 			<View style={styles.root}>
 				<View style={styles.titleWrapper}>
@@ -258,9 +259,9 @@ class AccountApproval extends PureComponent {
 					<View style={styles.wrapper}>
 						<View style={styles.header}>
 							<View style={styles.dapp}>
-								<WebsiteIcon style={styles.icon} title={title} url={url} />
+								<WebsiteIcon style={styles.icon} title={title || host} url={url} />
 								<Text style={styles.headerTitle} numberOfLines={1}>
-									{title || getHost(url)}
+									{title || host}
 								</Text>
 								<Text style={styles.headerUrl} numberOfLines={1}>
 									{url}

--- a/app/components/Views/BrowserTab/__snapshots__/index.test.js.snap
+++ b/app/components/Views/BrowserTab/__snapshots__/index.test.js.snap
@@ -190,7 +190,7 @@ exports[`Browser should render correctly 1`] = `
         Object {
           "icon": undefined,
           "title": "",
-          "url": "",
+          "url": "https://metamask.io",
         }
       }
       onCancel={[Function]}

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1536,7 +1536,10 @@ export class BrowserTab extends PureComponent {
 	};
 
 	renderApprovalModal = () => {
-		const { showApprovalDialog, currentPageTitle, currentPageUrl, currentPageIcon } = this.state;
+		const { showApprovalDialog, currentPageTitle, currentPageUrl, currentPageIcon, inputValue } = this.state;
+		const url =
+			currentPageUrl && currentPageUrl.length && currentPageUrl !== 'localhost' ? currentPageUrl : inputValue;
+
 		return (
 			<Modal
 				isVisible={showApprovalDialog}
@@ -1553,7 +1556,7 @@ export class BrowserTab extends PureComponent {
 				<AccountApproval
 					onCancel={this.onAccountsReject}
 					onConfirm={this.onAccountsConfirm}
-					currentPageInformation={{ title: currentPageTitle, url: currentPageUrl, icon: currentPageIcon }}
+					currentPageInformation={{ title: currentPageTitle, url, icon: currentPageIcon }}
 				/>
 			</Modal>
 		);


### PR DESCRIPTION
For light pages that were calling ethereum.enable right after the onload event was triggered, they might get an error if the react native bridge is not ready.

This PR simply retries that request.

The reproduction site that was failing is now working: https://brunobar79.github.io/dapp-issues-repro/

 