### PR TITLE
Bugfix: bowser bottom bar navigation

### DIFF
--- a/app/components/UI/BrowserBottomBar/__snapshots__/index.test.js.snap
+++ b/app/components/UI/BrowserBottomBar/__snapshots__/index.test.js.snap
@@ -33,7 +33,6 @@ exports[`BrowserBottomBar should render correctly 1`] = `
   >
     <Icon
       allowFontScaling={false}
-      disabled={false}
       name="angle-left"
       size={24}
       style={
@@ -51,6 +50,7 @@ exports[`BrowserBottomBar should render correctly 1`] = `
   </TouchableOpacity>
   <TouchableOpacity
     activeOpacity={0.2}
+    disabled={true}
     onPress={[Function]}
     style={
       Object {

--- a/app/components/UI/BrowserBottomBar/index.js
+++ b/app/components/UI/BrowserBottomBar/index.js
@@ -102,14 +102,9 @@ export default class BrowserBottomBar extends PureComponent {
 		return (
 			<ElevatedView elevation={11} style={styles.bottomBar}>
 				<TouchableOpacity onPress={goBack} style={styles.iconButton} disabled={!canGoBack}>
-					<Icon
-						name="angle-left"
-						disabled={!canGoBack}
-						size={24}
-						style={[styles.icon, !canGoBack ? styles.disabledIcon : {}]}
-					/>
+					<Icon name="angle-left" size={24} style={[styles.icon, !canGoBack ? styles.disabledIcon : {}]} />
 				</TouchableOpacity>
-				<TouchableOpacity onPress={goForward} style={styles.iconButton}>
+				<TouchableOpacity onPress={goForward} style={styles.iconButton} disabled={!canGoForward}>
 					<Icon
 						name="angle-right"
 						size={24}

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1012,9 +1012,13 @@ export class BrowserTab extends PureComponent {
 			if (!isInitialReload) {
 				this.isReloading = true;
 			}
+			// As we're reloading to other url we should remove this callback
+			this.approvalRequest = undefined;
 			const url2Reload = this.state.inputValue;
 			// Force unmount the webview to avoid caching problems
 			this.setState({ forceReload: true }, () => {
+				// Make sure we're not calling last mounted webview during this time threshold
+				this.webview.current = null;
 				setTimeout(() => {
 					this.setState({ forceReload: false }, () => {
 						this.go(url2Reload);
@@ -1527,12 +1531,14 @@ export class BrowserTab extends PureComponent {
 		this.setState({ showApprovalDialog: false });
 		approveHost(this.state.fullHostname);
 		this.backgroundBridge.enableAccounts();
-		this.approvalRequest.resolve([selectedAddress]);
+		this.approvalRequest && this.approvalRequest.resolve && this.approvalRequest.resolve([selectedAddress]);
 	};
 
 	onAccountsReject = () => {
 		this.setState({ showApprovalDialog: false });
-		this.approvalRequest.reject('User rejected account access');
+		this.approvalRequest &&
+			this.approvalRequest.reject &&
+			this.approvalRequest.reject('User rejected account access');
 	};
 
 	renderApprovalModal = () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes three bugs I found investigating https://www.fabric.io/metamask/android/apps/io.metamask/issues/5c9561a5f8b88c296331b222/sessions/5D44847E034400015FF94C2A629752E5_DNE_0_v2?build=109182544

- Minor bug with goForward button styles, was enabled even though it wasn't possible.
- `double java.lang.Double.doubleValue()' on a null object reference` crash. Going back and forward very quickly in the browser makes the app crash, in this PR `webview` ref is always defined but when forcing reload `{ current }` will be null, avoiding calling to an unmounted webview ref.
- `double java.lang.Double.doubleValue()' on a null object reference` crash. Reproduction steps: Go to uniswap then go back before connect modal prompts, you'll get to homescreen with a connect modal, if you press cancel the app will crash. This not always happens, but at least one of three times it does. This PR makes `approvalRequest` callbacks object undefined if the webview was reloaded, avoiding calling an undefined object with the user response (reject or connect).

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
