### PR TITLE
Fix forkdelta.app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ aliases:
       |
         npm install
 
+  - &clear-bad-deps
+      |
+        rm -rf node_modules/websocket/.git
+
 defaults: &defaults
   working_directory: ~/MetaMask
 
@@ -33,6 +37,7 @@ jobs:
     steps:
       - checkout
       - restore_cache: *restore-cache
+      - run: *clear-bad-deps
       - run: *install-node-dependencies
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,7 @@ aliases:
 
   - &install-node-dependencies
       |
-        npm install
-
-  - &clear-bad-deps
-      |
-        rm -rf node_modules/websocket/.git
+        rm -rf node_modules/websocket/.git && npm install
 
 defaults: &defaults
   working_directory: ~/MetaMask
@@ -37,7 +33,6 @@ jobs:
     steps:
       - checkout
       - restore_cache: *restore-cache
-      - run: *clear-bad-deps
       - run: *install-node-dependencies
       - persist_to_workspace:
           root: .

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1190,7 +1190,7 @@ export class BrowserTab extends PureComponent {
 		const { ipfsGateway } = this.props;
 		const data = {};
 		const urlObj = new URL(url);
-		if (urlObj.protocol.indexOf('http')) {
+		if (urlObj.protocol.indexOf('http') === -1) {
 			return;
 		}
 		this.lastUrlBeforeHome = null;

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1190,6 +1190,9 @@ export class BrowserTab extends PureComponent {
 		const { ipfsGateway } = this.props;
 		const data = {};
 		const urlObj = new URL(url);
+		if (urlObj.protocol.indexOf('http')) {
+			return;
+		}
 		this.lastUrlBeforeHome = null;
 
 		data.fullHostname = urlObj.hostname;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19142,9 +19142,9 @@
       "from": "github:brunobar79/react-native-view-shot#androidx"
     },
     "react-native-web3-webview": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.1.tgz",
-      "integrity": "sha512-GNuLl7rJhUFoSdVnBs+9MqJLE3PTsD+GCb/ZCU9JoWyWci44sBbM0rEj7RICyukjgdqK3j2186/a2u5LrQBQtQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.2.tgz",
+      "integrity": "sha512-qIB4OQGRoc4E69VDmGWvYd+zpOdGcZht3kETsXlpUkBY42uCukuoZ7bNOlPe6XjbOq1KPHJvepKUaDmZ2sKcPw==",
       "requires": {
         "fbjs": "^0.8.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19142,9 +19142,9 @@
       "from": "github:brunobar79/react-native-view-shot#androidx"
     },
     "react-native-web3-webview": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.0.tgz",
-      "integrity": "sha512-YTJI5mtJUxzUFlzSFYeBaMbDA/794is8W85KEfk2UR4CinpAgKz29QAN00/DqNHlRhSjsca/vy8b2a44EwTIkw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.1.tgz",
+      "integrity": "sha512-GNuLl7rJhUFoSdVnBs+9MqJLE3PTsD+GCb/ZCU9JoWyWci44sBbM0rEj7RICyukjgdqK3j2186/a2u5LrQBQtQ==",
       "requires": {
         "fbjs": "^0.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-view-shot": "github:brunobar79/react-native-view-shot#androidx",
-    "react-native-web3-webview": "2.1.1",
+    "react-native-web3-webview": "2.1.2",
     "react-navigation": "3.11.1",
     "react-redux": "5.1.1",
     "readable-stream": "1.0.33",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-view-shot": "github:brunobar79/react-native-view-shot#androidx",
-    "react-native-web3-webview": "2.1.0",
+    "react-native-web3-webview": "2.1.1",
     "react-navigation": "3.11.1",
     "react-redux": "5.1.1",
     "readable-stream": "1.0.33",


### PR DESCRIPTION
Forkdelta was crashing the browser on iOS & Android because of a request to a non standard protocol. That fix was included in the latest version of `react-native-web3-webview` and now it works correctly.

Fixes #918 

Android: https://recordit.co/6qjq9jDMSc
iOS: http://recordit.co/lLJ6EGAh4k

