### PR TITLE
Bugfix: browser crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Develop Branch
 
 ## v0.2.4 - Aug 28 2019
+- [#1036](https://github.com/MetaMask/metamask-mobile/pull/1036): Bugfix: browser crash (#1036)
 - [#1007](https://github.com/MetaMask/metamask-mobile/pull/1007): Bugfix: phishing alerts (#1007)
 - [#1023](https://github.com/MetaMask/metamask-mobile/pull/1023): Fix forkdelta.app (#1023)
 - [#1017](https://github.com/MetaMask/metamask-mobile/pull/1017): Allow ENS available TLDs that are not ENS names (#1017)

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1161,7 +1161,6 @@ export class BrowserTab extends PureComponent {
 	};
 
 	onMessage = ({ nativeEvent: { data } }) => {
-		if (!this.webview.current) return;
 		try {
 			data = typeof data === 'string' ? JSON.parse(data) : data;
 			if (!data || !data.type) {

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1019,11 +1019,8 @@ export class BrowserTab extends PureComponent {
 		current && current.reload();
 	};
 
-	forceReload = (isInitialReload = false) => {
+	forceReload = () => {
 		this.toggleOptionsIfNeeded();
-		if (!isInitialReload) {
-			this.isReloading = true;
-		}
 		// As we're reloading to other url we should remove this callback
 		this.approvalRequest = undefined;
 		const url2Reload = this.state.inputValue;
@@ -1037,11 +1034,6 @@ export class BrowserTab extends PureComponent {
 				});
 			}, 300);
 		});
-		if (!isInitialReload) {
-			setTimeout(() => {
-				this.isReloading = false;
-			}, 1500);
-		}
 	};
 
 	initialReload = () => {

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1161,6 +1161,7 @@ export class BrowserTab extends PureComponent {
 	};
 
 	onMessage = ({ nativeEvent: { data } }) => {
+		if (!this.webview.current) return;
 		try {
 			data = typeof data === 'string' ? JSON.parse(data) : data;
 			if (!data || !data.type) {

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -413,9 +413,10 @@ export class BrowserTab extends PureComponent {
 		if (!currentPageTitle || currentPageTitle !== {}) {
 			// We need to get the title to add bookmark
 			const { current } = this.webview;
-			Platform.OS === 'ios'
-				? current && current.evaluateJavaScript(JS_WINDOW_INFORMATION)
-				: current && current.injectJavaScript(JS_WINDOW_INFORMATION);
+			current &&
+				(Platform.OS === 'ios'
+					? current.evaluateJavaScript(JS_WINDOW_INFORMATION)
+					: current.injectJavaScript(JS_WINDOW_INFORMATION));
 		}
 		setTimeout(() => {
 			callback();
@@ -435,13 +436,9 @@ export class BrowserTab extends PureComponent {
 		});
 	}
 
-	reloadFromError = () => {
-		this.reload(true);
-	};
-
 	async componentDidMount() {
 		if (this.isTabActive()) {
-			this.reload(true, true);
+			this.initialReload();
 		} else if (this.isTabActive() && this.isENSUrl(this.state.url)) {
 			this.go(this.state.url);
 		}
@@ -989,7 +986,7 @@ export class BrowserTab extends PureComponent {
 		if (lastUrlBeforeHome === HOMEPAGE_URL) {
 			this.reload();
 		} else {
-			this.reload(true);
+			this.forceReload();
 		}
 		setTimeout(() => {
 			this.props.navigation.setParams({
@@ -1016,34 +1013,43 @@ export class BrowserTab extends PureComponent {
 		this.setState({ forwardEnabled });
 	};
 
-	reload = (force = false, isInitialReload = false) => {
+	reload = () => {
 		this.toggleOptionsIfNeeded();
-		if (!force) {
-			const { current } = this.webview;
-			current && current.reload();
-		} else {
-			if (!isInitialReload) {
-				this.isReloading = true;
-			}
-			// As we're reloading to other url we should remove this callback
-			this.approvalRequest = undefined;
-			const url2Reload = this.state.inputValue;
-			// Force unmount the webview to avoid caching problems
-			this.setState({ forceReload: true }, () => {
-				// Make sure we're not calling last mounted webview during this time threshold
-				this.webview.current = null;
-				setTimeout(() => {
-					this.setState({ forceReload: false }, () => {
-						this.go(url2Reload);
-					});
-				}, 300);
-			});
-			if (!isInitialReload) {
-				setTimeout(() => {
-					this.isReloading = false;
-				}, 1500);
-			}
+		const { current } = this.webview;
+		current && current.reload();
+	};
+
+	forceReload = (isInitialReload = false) => {
+		this.toggleOptionsIfNeeded();
+		if (!isInitialReload) {
+			this.isReloading = true;
 		}
+		// As we're reloading to other url we should remove this callback
+		this.approvalRequest = undefined;
+		const url2Reload = this.state.inputValue;
+		// Force unmount the webview to avoid caching problems
+		this.setState({ forceReload: true }, () => {
+			// Make sure we're not calling last mounted webview during this time threshold
+			this.webview.current = null;
+			setTimeout(() => {
+				this.setState({ forceReload: false }, () => {
+					this.go(url2Reload);
+				});
+			}, 300);
+		});
+		if (!isInitialReload) {
+			setTimeout(() => {
+				this.isReloading = false;
+			}, 1500);
+		}
+	};
+
+	initialReload = () => {
+		this.isReloading = true;
+		this.forceReload();
+		setTimeout(() => {
+			this.isReloading = false;
+		}, 1500);
 	};
 
 	addBookmark = () => {
@@ -1352,7 +1358,7 @@ export class BrowserTab extends PureComponent {
 
 		return (
 			<React.Fragment>
-				<Button onPress={() => this.reload()} style={styles.option}>
+				<Button onPress={this.reload} style={styles.option}>
 					<View style={styles.optionIconWrapper}>
 						<Icon name="refresh" size={15} style={styles.optionIcon} />
 					</View>
@@ -1438,9 +1444,7 @@ export class BrowserTab extends PureComponent {
 		if (this.isHomepage()) {
 			const { current } = this.webview;
 			const blur = `document.getElementsByClassName('autocomplete-input')[0].blur();`;
-			Platform.OS === 'ios'
-				? current && current.evaluateJavaScript(blur)
-				: current && current.injectJavaScript(blur);
+			current && (Platform.OS === 'ios' ? current.evaluateJavaScript(blur) : current.injectJavaScript(blur));
 		}
 	};
 
@@ -1675,7 +1679,7 @@ export class BrowserTab extends PureComponent {
 		if ([6].includes(wizardStep)) {
 			if (!this.wizardScrollAdjusted) {
 				setTimeout(() => {
-					this.reload(true);
+					this.forceReload();
 				}, 1);
 				this.wizardScrollAdjusted = true;
 			}
@@ -1702,7 +1706,7 @@ export class BrowserTab extends PureComponent {
 						<Web3Webview
 							// eslint-disable-next-line react/jsx-no-bind
 							renderError={() => (
-								<WebviewError error={this.state.lastError} onReload={this.reloadFromError} />
+								<WebviewError error={this.state.lastError} onReload={this.forceReload} />
 							)}
 							injectedOnStartLoadingJavaScript={entryScriptWeb3}
 							onProgress={this.onLoadProgress}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19116,9 +19116,9 @@
       "from": "github:brunobar79/react-native-view-shot#androidx"
     },
     "react-native-web3-webview": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.2.tgz",
-      "integrity": "sha512-qIB4OQGRoc4E69VDmGWvYd+zpOdGcZht3kETsXlpUkBY42uCukuoZ7bNOlPe6XjbOq1KPHJvepKUaDmZ2sKcPw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-native-web3-webview/-/react-native-web3-webview-2.1.3.tgz",
+      "integrity": "sha512-drCLDbfHpgKQXFAG5bXCK7WO2NjlsjiChn8XAls9p10/b8Z9fhB6q1luTYC1C6eO7YGmvY2HHPg/TtGDrqU5pg==",
       "requires": {
         "fbjs": "^0.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-view-shot": "github:brunobar79/react-native-view-shot#androidx",
-    "react-native-web3-webview": "2.1.2",
+    "react-native-web3-webview": "2.1.3",
     "react-navigation": "3.11.1",
     "react-redux": "5.1.1",
     "readable-stream": "1.0.33",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR updates `react-native-web3-webview` to a new version that fixes a crash caused because it was receiving `onMessage` calls when `BrowserTab` was unmounted. This was happening in both Android and IOS.
Added some modifications to the way we were interacting with reload methods too.
 
**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #1029
