### PR TITLE
Fix walletconnect when instapay is ON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## Current Develop Branch
-
 ## v0.2.4 - Aug 28 2019
+- [#1037](https://github.com/MetaMask/metamask-mobile/pull/1037) - Fix walletconnect
 - [#1036](https://github.com/MetaMask/metamask-mobile/pull/1036): Bugfix: browser crash (#1036)
+- [#1034](https://github.com/MetaMask/metamask-mobile/pull/1034): Bump 0.2.4 (#1034)
+- [#1027](https://github.com/MetaMask/metamask-mobile/pull/1027): Improvement: approval token transfer data (#1027)
+- [#1028](https://github.com/MetaMask/metamask-mobile/pull/1028): fix no password logged out scenario (#1028)
+- [#1030](https://github.com/MetaMask/metamask-mobile/pull/1030): Allow to import / export Pkey & seed phrase via QR Codes (#1030)
+- [#1021](https://github.com/MetaMask/metamask-mobile/pull/1021): bugfix: fix dapp compat issues (#1021)
 - [#1007](https://github.com/MetaMask/metamask-mobile/pull/1007): Bugfix: phishing alerts (#1007)
 - [#1023](https://github.com/MetaMask/metamask-mobile/pull/1023): Fix forkdelta.app (#1023)
 - [#1017](https://github.com/MetaMask/metamask-mobile/pull/1017): Allow ENS available TLDs that are not ENS names (#1017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current Develop Branch
 
 ## v0.2.4 - Aug 28 2019
-- [#1037](https://github.com/MetaMask/metamask-mobile/pull/1037) - Fix walletconnect
+- [#1037](https://github.com/MetaMask/metamask-mobile/pull/1037) - Fix walletconnect (#1037)
 - [#1036](https://github.com/MetaMask/metamask-mobile/pull/1036): Bugfix: browser crash (#1036)
 - [#1034](https://github.com/MetaMask/metamask-mobile/pull/1034): Bump 0.2.4 (#1034)
 - [#1027](https://github.com/MetaMask/metamask-mobile/pull/1027): Improvement: approval token transfer data (#1027)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Current Develop Branch
+
 ## v0.2.4 - Aug 28 2019
 - [#1037](https://github.com/MetaMask/metamask-mobile/pull/1037) - Fix walletconnect
 - [#1036](https://github.com/MetaMask/metamask-mobile/pull/1036): Bugfix: browser crash (#1036)

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -644,6 +644,7 @@ class Main extends PureComponent {
 		if (
 			this.props.paymentChannelsEnabled &&
 			AppConstants.CONNEXT.SUPPORTED_NETWORKS.includes(this.props.providerType) &&
+			transactionMeta.transaction.data &&
 			transactionMeta.transaction.data.substr(0, 10) === CONNEXT_DEPOSIT &&
 			to === AppConstants.CONNEXT.CONTRACTS[networkId]
 		) {


### PR DESCRIPTION
We were breaking all the transactions of the approval screen if the TX didn't have any data attached and InstaPay was ON.  This affected WalletConnect too.