### PR TITLE
dont use cache on pre-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,4 @@
 aliases:
-  - &restore-cache
-    keys:
-      - v1.0.7-{{ .Branch }}-{{ checksum "package.json" }}
-      - v1.0.7-{{ .Branch }}
-
-  - &save-cache
-    key: v1.0.7-{{ .Branch }}-{{ checksum "package.json" }}
-    paths:
-      - node_modules
   - &restore-node-cache
     keys:
       - v1.0.7-node-{{ .Branch }}-{{ checksum "package.json" }}
@@ -37,7 +28,6 @@ jobs:
           root: .
           paths:
           - node_modules
-      - save_cache: *save-cache
   prep-node-deps:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
       xcode: 10.2.0
     steps:
       - checkout
-      - restore_cache: *restore-cache
       - run: *install-node-dependencies
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
This is causing some problems where all the pre-release builds are using cache from previous builds without considering the fact that there could be major changes in between pre-releases.