### PR TITLE
bugfix: reveal credential ui

### DIFF
--- a/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.js.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.js.snap
@@ -93,7 +93,7 @@ exports[`RevealPrivateCredential should render correctly 1`] = `
       <View
         style={
           Object {
-            "paddingVertical": 20,
+            "padding": 20,
           }
         }
       >

--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -53,9 +53,6 @@ const styles = StyleSheet.create({
 	rowWrapper: {
 		padding: 20
 	},
-	contentWrapper: {
-		paddingVertical: 20
-	},
 	warningWrapper: {
 		backgroundColor: colors.red000
 	},
@@ -284,7 +281,7 @@ class RevealPrivateCredential extends PureComponent {
 							</View>
 						</View>
 
-						<View style={styles.contentWrapper}>
+						<View style={styles.rowWrapper}>
 							{unlocked ? (
 								<ScrollableTabView renderTabBar={this.renderTabBar}>
 									<View tabLabel={strings(`reveal_credential.text`)} style={styles.tabContent}>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Small ui bug introduced here https://github.com/MetaMask/metamask-mobile/pull/1030/files#diff-9a4519f8dc3bf65e7b7f59c5a891b523R286

before

![image](https://user-images.githubusercontent.com/12115171/64809079-e5cc4880-d56e-11e9-9525-8e6914e910d6.png)

after
![image](https://user-images.githubusercontent.com/12115171/64809056-dbaa4a00-d56e-11e9-9618-64fd95a6fa56.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
