### PR TITLE
fix webview black flash

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-view-shot": "git+ssh://git@github.com/brunobar79/react-native-view-shot.git#androidx",
-    "react-native-webview": "git+ssh://git@github.com/brunobar79/react-native-webview.git#e56c638e71958612658ac8931b1d1044fdd358ac",
+    "react-native-webview": "git+ssh://git@github.com/brunobar79/react-native-webview.git#29368fb2d6d7314fefc0e4b67206b09952706267",
     "react-navigation": "3.11.1",
     "react-redux": "5.1.1",
     "readable-stream": "1.0.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9123,9 +9123,9 @@ react-native-vector-icons@6.4.2:
   version "2.6.0"
   resolved "git+ssh://git@github.com/brunobar79/react-native-view-shot.git#17a65dc27222a78ad8942de3d536d7171bb2eb76"
 
-"react-native-webview@git+ssh://git@github.com/brunobar79/react-native-webview.git#e56c638e71958612658ac8931b1d1044fdd358ac":
+"react-native-webview@git+ssh://git@github.com/brunobar79/react-native-webview.git#29368fb2d6d7314fefc0e4b67206b09952706267":
   version "7.0.5"
-  resolved "git+ssh://git@github.com/brunobar79/react-native-webview.git#e56c638e71958612658ac8931b1d1044fdd358ac"
+  resolved "git+ssh://git@github.com/brunobar79/react-native-webview.git#29368fb2d6d7314fefc0e4b67206b09952706267"
   dependencies:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"


### PR DESCRIPTION
iOS 13 dark mode changes the default color of the webview depending on the theme, so when dark mode is enabled the webview default color changes to black and creates a black flash before the content is loaded. This PR fixes that issue