### PR TITLE
Support provider.once

### DIFF
--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -290,6 +290,18 @@ class InpageBridge {
 	}
 
 	/**
+	 * Simulate the once event to keep parity with the EventEmitter interface
+	 * because there are some apps that use it
+	 *
+	 * @param {string} event - Event name
+	 * @param {Function} listener - Callback invoked when event triggered
+	 * @returns {InpageBridge}
+	 */
+	once(event, listener) {
+		this.on(event, listener);
+	}
+
+	/**
 	 * Remove a listener for a specific event
 	 *
 	 * @param {string} event - Event name

--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -291,7 +291,7 @@ class InpageBridge {
 
 	/**
 	 * Simulate the once event to keep parity with the EventEmitter interface
-	 * because there are some apps that use it
+	 * because there are some dapps that use it
 	 *
 	 * @param {string} event - Event name
 	 * @param {Function} listener - Callback invoked when event triggered


### PR DESCRIPTION
Some dapps are using provider.once to listen to the accountChanged and networkChanged events.
Because our provider is not a real EventEmitter it was throwing an error.

This PR mocks the behavior of it by calling provider.on internally.