### PR TITLE
Temporarily disabling e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,15 +173,15 @@ workflows:
       - test-unit:
           requires:
             - prep-node-deps
-      - test-e2e-ios:
-          requires:
-            - prep-node-deps
-            - test-unit
+    #   - test-e2e-ios:
+    #       requires:
+    #         - prep-node-deps
+    #         - test-unit
       - all-tests-pass:
           requires:
             - lint
             - test-unit
-            - test-e2e-ios
+    #       - test-e2e-ios
     #   - upload-coverage:
     #       requires:
     #         - test-unit


### PR DESCRIPTION
Discussed with @ibrahimtaveras00 
For now he will run e2e locally for every PR we submit  until we deal with #1160 
Once we are back at reasonable build times we can re-enable