### PR TITLE
Add location permission to AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-sdk tools:overrideLibrary="com.tectiv3.aes" />
 
     <application


### PR DESCRIPTION
**Description**

I am developing a DApp that requires users to provide their location for certain actions. However, if app-wide location permission is not included in the `AndroidManifest.xml` it seems there is now way to ask for it later on in Android, see [here](https://developer.android.com/training/permissions/requesting.html#perm-add). Unlike on iOS - there permissions can be granted later on at runtime apparently without having been "announced" app-wide first.

Since you are providing a browser and probably (?) want to support all kind of web-based DApps, asking users for their location (and potentially other permissions?) should be possible📍

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #1180 
