### PR TITLE
Bugfix: go back to homepage and refresh favorites

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -852,10 +852,11 @@ export class BrowserTab extends PureComponent {
 		const homepageScripts = `
 			window.__mmFavorites = ${JSON.stringify(this.props.bookmarks)};
 			window.__mmSearchEngine="${this.props.searchEngine}";
+			window.postMessage('updateFavorites', '*');
 		`;
 		this.setState({ homepageScripts }, () => {
 			const { current } = this.webview;
-			if (this.isHomepage() && current) {
+			if (current) {
 				current.injectJavaScript(homepageScripts);
 			}
 		});
@@ -1072,8 +1073,6 @@ export class BrowserTab extends PureComponent {
 		Analytics.trackEvent(ANALYTICS_EVENT_OPTS.DAPP_HOME);
 		setTimeout(() => {
 			this.lastUrlBeforeHome = lastUrlBeforeHome;
-			// update bookmarks on homepage
-			this.refreshHomeScripts();
 		}, 1000);
 	};
 
@@ -1271,6 +1270,9 @@ export class BrowserTab extends PureComponent {
 	};
 
 	onPageChange = ({ url }) => {
+		if (this.isHomepage(url)) {
+			this.refreshHomeScripts();
+		}
 		if (url === this.state.url) return;
 		const { ipfsGateway } = this.props;
 		const data = {};


### PR DESCRIPTION
This is the the second part of the fix for #1057.
Favorites not refreshing when using the back button in the browser.

Fixes #1057 