### PR TITLE
bugfix: android show hex input instapay send

### DIFF
--- a/app/components/UI/TransactionEdit/index.js
+++ b/app/components/UI/TransactionEdit/index.js
@@ -380,7 +380,7 @@ class TransactionEdit extends PureComponent {
 					onTouchablePress={this.closeDropdowns}
 					keyboardShouldPersistTaps={'handled'}
 				>
-					<View style={[styles.form, Platform.OS === 'android' && !showHexData ? styles.androidForm : {}]}>
+					<View style={[styles.form, Platform.OS === 'android' ? styles.androidForm : {}]}>
 						<View style={[styles.formRow, styles.fromRow]}>
 							<View style={styles.label}>
 								<Text style={styles.labelText}>{strings('transaction.from')}:</Text>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This fixes a bug on instapay send when show hex input is enabled.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
