### PR TITLE
bugfix: inpage bridge chainid

### DIFF
--- a/app/core/InpageBridge.js
+++ b/app/core/InpageBridge.js
@@ -44,7 +44,7 @@ class InpageBridge {
 		this.selectedAddress = this._selectedAddress;
 		this.networkVersion = this._network;
 		if (!isNaN(this._network)) {
-			this.chainId = 'Ox' + parseInt(this._network, 10).toString(16);
+			this.chainId = '0x' + parseInt(this._network, 10).toString(16);
 		}
 
 		oldAddress !== undefined &&


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Inpage was returning `Ox` instead of `0x`
fixes #1274

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
