### PR TITLE
Add padding to top and bottom of hamburgerButton

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -56,6 +56,12 @@ const styles = StyleSheet.create({
 	shareIconIOS: {
 		marginHorizontal: -5
 	},
+	hamburgerButton: {
+		paddingLeft: Device.isAndroid() ? 22 : 18,
+		paddingRight: Device.isAndroid() ? 22 : 18,
+		paddingTop: 14,
+		paddingBottom: 14
+	},
 	backButton: {
 		paddingLeft: Device.isAndroid() ? 22 : 18,
 		paddingRight: Device.isAndroid() ? 22 : 18,
@@ -71,9 +77,6 @@ const styles = StyleSheet.create({
 	},
 	infoIcon: {
 		color: colors.blue
-	},
-	moreIcon: {
-		marginTop: 5
 	},
 	flex: {
 		flex: 1
@@ -210,11 +213,7 @@ export function getPaymentRequestOptionsTitle(title, navigation) {
 		headerTintColor: colors.blue,
 		headerLeft: goBack ? (
 			// eslint-disable-next-line react/jsx-no-bind
-			<TouchableOpacity
-				onPress={() => goBack()}
-				style={styles.backButton}
-				testID={'request-search-asset-back-button'}
-			>
+			<TouchableOpacity onPress={goBack} style={styles.backButton} testID={'request-search-asset-back-button'}>
 				<IonicIcon
 					name={Device.isAndroid() ? 'md-arrow-back' : 'ios-arrow-back'}
 					size={Device.isAndroid() ? 24 : 28}
@@ -385,7 +384,7 @@ export function getBrowserViewNavbarOptions(navigation) {
 
 	return {
 		headerLeft: (
-			<TouchableOpacity onPress={onPress} style={styles.backButton} testID={'hamburger-menu-button-browser'}>
+			<TouchableOpacity onPress={onPress} style={styles.hamburgerButton} testID={'hamburger-menu-button-browser'}>
 				<IonicIcon
 					name={Device.isAndroid() ? 'md-menu' : 'ios-menu'}
 					size={Device.isAndroid() ? 24 : 28}

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -59,8 +59,8 @@ const styles = StyleSheet.create({
 	hamburgerButton: {
 		paddingLeft: Device.isAndroid() ? 22 : 18,
 		paddingRight: Device.isAndroid() ? 22 : 18,
-		paddingTop: 14,
-		paddingBottom: 14
+		paddingTop: Device.isAndroid() ? 14 : 10,
+		paddingBottom: Device.isAndroid() ? 14 : 10
 	},
 	backButton: {
 		paddingLeft: Device.isAndroid() ? 22 : 18,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Similar to #1333 this increases top and bottom padding for the hamburger menu icon so there's less chance of missing it. I also removed the `moreIcon` which is unused and opted to create a new `hamburgerButton` style key since `backButton` is being used for other items.

this will need to be tested.

**Before**

![image](https://user-images.githubusercontent.com/675259/74862086-7d517680-5319-11ea-9519-2a19a67163a9.png)

**After**

![image](https://user-images.githubusercontent.com/675259/74862445-27c99980-531a-11ea-888b-46edc7f2dca2.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
