### PR TITLE
Detox: Fix Browser Tests

### DIFF
--- a/e2e/browser-tests.spec.js
+++ b/e2e/browser-tests.spec.js
@@ -308,6 +308,11 @@ describe('Browser Tests', () => {
 		await TestHelpers.delay(1000);
 		// Check that account approval is displayed with correct dapp name
 		await TestHelpers.checkIfHasText('dapp-name-title', 'Uniswap Exchange');
+
+		// There is a yellow warning that pops up in dev mode, when canceling the connection request
+		// go to index.js and add this to the list of warnings
+		// to block in order to get it to work = "Error in RPC response",
+
 		// Tap on CANCEL button
 		await TestHelpers.tapByText('CANCEL');
 
@@ -326,10 +331,12 @@ describe('Browser Tests', () => {
 		await TestHelpers.checkIfVisible('browser-screen');
 		// Tap on options
 		await TestHelpers.waitAndTap('options-button');
-		// Tap on New tab
+		// Tap on Add to Favorites
 		await TestHelpers.tapByText('Add to Favorites');
+		// Check that we are on the correct screen
+		await TestHelpers.checkIfVisible('add-bookmark-screen');
 		// Tap on ADD button
-		await TestHelpers.tapByText('ADD');
+		await TestHelpers.tap('add-bookmark-confirm-button');
 	});
 
 	it('should go back home and navigate to favorites', async () => {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ useScreens();
 // List of warnings that we're ignoring
 YellowBox.ignoreWarnings([
 	'{}',
+	// Uncomment the below line to run browser-tests.spec.js in debug mode
+	// in e2e tests until issue https://github.com/MetaMask/metamask-mobile/issues/1395 is resolved
+	//"Error in RPC response",
 	"Can't perform a React state update",
 	'Error evaluating injectedJavaScript',
 	'createErrorFromErrorData',


### PR DESCRIPTION
This PR fixes the failed browser-tests.spec.js file in e2e tests

![Screen Shot 2020-03-02 at 7 24 57 PM](https://user-images.githubusercontent.com/41752922/75738245-c917fe80-5ccf-11ea-9280-49a2acc2ed62.png)

This will work fine in release mode, however, fails in debug mode because of https://github.com/MetaMask/metamask-mobile/issues/1395

If you add that warning to index.js then it works, however, this is not ideal as we would want to see that warning.