### PR TITLE
Change source commit for react-native-webview in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "react-native-v8": "0.59.10-patch.4",
     "react-native-vector-icons": "6.4.2",
     "react-native-view-shot": "git+ssh://git@github.com/MetaMask/react-native-view-shot.git#androidx",
-    "react-native-webview": "git+ssh://git@github.com/MetaMask/react-native-webview.git#c756513b1f5a635cb49d0cfd01e25ca5c0887678",
+    "react-native-webview": "git+ssh://git@github.com/MetaMask/react-native-webview.git#aeaf987f07dbce99c5b56aaba9bdf0d8c98772df",
     "react-navigation": "4.0.10",
     "react-navigation-drawer": "1.4.0",
     "react-navigation-stack": "1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,9 +9673,9 @@ react-native-vector-icons@6.4.2:
   version "2.6.0"
   resolved "git+ssh://git@github.com/MetaMask/react-native-view-shot.git#17a65dc27222a78ad8942de3d536d7171bb2eb76"
 
-"react-native-webview@git+ssh://git@github.com/MetaMask/react-native-webview.git#c756513b1f5a635cb49d0cfd01e25ca5c0887678":
+"react-native-webview@git+ssh://git@github.com/MetaMask/react-native-webview.git#aeaf987f07dbce99c5b56aaba9bdf0d8c98772df":
   version "7.0.5"
-  resolved "git+ssh://git@github.com/MetaMask/react-native-webview.git#c756513b1f5a635cb49d0cfd01e25ca5c0887678"
+  resolved "git+ssh://git@github.com/MetaMask/react-native-webview.git#aeaf987f07dbce99c5b56aaba9bdf0d8c98772df"
   dependencies:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"


### PR DESCRIPTION
Updates package.json to point to the latest commit on our react-native-webview fork.

This will include the changes added with https://github.com/MetaMask/react-native-webview/pull/2

fixes https://github.com/MetaMask/metamask-mobile/issues/1242

