### PR TITLE
Use kind-of@6.0.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6596,9 +6596,9 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 klaw-sync@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR updates `kind-of` to address 39922 low-severity security advisories. [More information about the advisory can be found on the advisory page.](https://www.npmjs.com/advisories/1490)

`yarn audit` shows the following:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Validation Bypass                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ kind-of                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=6.0.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-config > jest-jasmine2 > jest-runtime │
│               │ > jest-message-util > micromatch > extglob > define-property │
│               │ > is-descriptor > kind-of                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1490                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
```