### PR TITLE
Set navigation param silent to false when switching to a tab

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -146,7 +146,7 @@ class Browser extends PureComponent {
 			...this.props.navigation.state.params,
 			showTabs: false,
 			url,
-			silent: true
+			silent: false
 		});
 	};
 


### PR DESCRIPTION
**Description**

Fixes #1319 

In particular, this fixes a bug that can be reproduced with the following steps:
- open three different web pages in three different tabs
- close the MetaMask app (maybe also turn off the device)
- open the metamask app
- view all tabs
- click a tab other than the present one
- the screen is blank

This was caused because we were setting the `silent` navigation prop to true when switching to a new tab. That prop is used as a check in the `BrowserTab` component when deciding whether to load the url. It needs to be false in cases where we do not want another url load, but this isn't one.

Setting that prop to false fixes the problem and does not, as far as I can tell, change any other behaviour.


