### PR TITLE
Update CircleCI config version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+version: 2.1
 aliases:
   - &restore-node-cache
     keys:
@@ -15,7 +16,6 @@ aliases:
 defaults: &defaults
   working_directory: ~/MetaMask
 
-version: 2
 jobs:
   prep-deps:
     <<: *defaults
@@ -152,7 +152,6 @@ jobs:
           path: sourcemaps/ios
           destination: sourcemaps-ios
 workflows:
-  version: 2
   full_test:
     jobs:
       - prep-deps:


### PR DESCRIPTION
Closes #1446

Short short version: I've enabled Pipelines in CircleCI, this is mostly to test the build still works.

From the docs:<sup>[\[1\]][1]</sup>

> Pipelines are our name for the full set of configurations you run when you trigger work on your projects in CircleCI. Pipelines contain your workflows, which coordinate jobs.

> The pipelines feature enables use of the new API endpoint to trigger builds with workflows and the following use cases:

> - Use pipeline parameters to trigger conditional workflows.
> - Access to version 2.1 config, which provides:
>    - [...]

Upping the version here should both confirm that the build still works and confirm that pipelines have been enabled.

  [1]:https://circleci.com/docs/2.0/build-processing/