### PR TITLE
Use setTimeout hack to get paste context back

### DIFF
--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -189,10 +189,14 @@ class SendFlow extends PureComponent {
 		const { fromAccountName } = this.state;
 		const networkAddressBook = addressBook[network] || {};
 		const ens = await doENSReverseLookup(selectedAddress, network);
+		setTimeout(() => {
+			this.setState({
+				inputWidth: { width: '100%' }
+			});
+		}, 100);
 		this.setState({
 			fromAccountName: ens || fromAccountName,
 			fromAccountBalance: `${renderFromWei(accounts[selectedAddress].balance)} ${getTicker(ticker)}`,
-			inputWidth: { width: '100%' },
 			balanceIsZero: hexToBN(accounts[selectedAddress].balance).isZero()
 		});
 		if (!Object.keys(networkAddressBook).length) {


### PR DESCRIPTION
super weird workaround that I found here: https://github.com/facebook/react-native/issues/23653#issuecomment-498174919. that issue is for `multiline`, but it appears to work none the less.

looking at the existing code a little bit more closely and I see a link to this: https://github.com/facebook/react-native/issues/9958. (@estebanmino it appears we ran into the same problem before?) if you look at the hack outlined, they actually used a setTimeout... It doesn't seem to work unless the width is reset a little later.

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable (not applicable)
* [x] Any added code is fully documented

**Issue**

Resolves #1442 
