### PR TITLE
Use setTimeout hack to get paste context back

### DIFF
--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -189,10 +189,14 @@ class SendFlow extends PureComponent {
 		const { fromAccountName } = this.state;
 		const networkAddressBook = addressBook[network] || {};
 		const ens = await doENSReverseLookup(selectedAddress, network);
+		setTimeout(() => {
+			this.setState({
+				inputWidth: { width: '100%' }
+			});
+		}, 100);
 		this.setState({
 			fromAccountName: ens || fromAccountName,
 			fromAccountBalance: `${renderFromWei(accounts[selectedAddress].balance)} ${getTicker(ticker)}`,
-			inputWidth: { width: '100%' },
 			balanceIsZero: hexToBN(accounts[selectedAddress].balance).isZero()
 		});
 		if (!Object.keys(networkAddressBook).length) {

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -191,14 +191,12 @@ class SendFlow extends PureComponent {
 		const ens = await doENSReverseLookup(selectedAddress, network);
 		setTimeout(() => {
 			this.setState({
+				fromAccountName: ens || fromAccountName,
+				fromAccountBalance: `${renderFromWei(accounts[selectedAddress].balance)} ${getTicker(ticker)}`,
+				balanceIsZero: hexToBN(accounts[selectedAddress].balance).isZero(),
 				inputWidth: { width: '100%' }
 			});
 		}, 100);
-		this.setState({
-			fromAccountName: ens || fromAccountName,
-			fromAccountBalance: `${renderFromWei(accounts[selectedAddress].balance)} ${getTicker(ticker)}`,
-			balanceIsZero: hexToBN(accounts[selectedAddress].balance).isZero()
-		});
 		if (!Object.keys(networkAddressBook).length) {
 			this.addressToInputRef && this.addressToInputRef.current && this.addressToInputRef.current.focus();
 		}


### PR DESCRIPTION
super weird workaround that I found here: https://github.com/facebook/react-native/issues/23653#issuecomment-498174919. that issue is for `multiline`, but it appears to work here none the less.

looking at the existing code a little bit more closely and I see a link to this: https://github.com/facebook/react-native/issues/9958. (@estebanmino it appears we ran into the same problem before?) if you look at the hack outlined, they actually used a `setTimeout`... It doesn't seem to work unless the width is reset a little later.

**Before (paste context does not appear on Rinkeby):**

![Screenshot_20200322-120323](https://user-images.githubusercontent.com/675259/77254164-cc027100-6c35-11ea-8225-641645f30e3e.png)

**After:**

![Screenshot_20200322-120406](https://user-images.githubusercontent.com/675259/77254172-d7559c80-6c35-11ea-9557-f5f0852fba90.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable (not applicable)
* [x] Any added code is fully documented

**Issue**

Resolves #1442 
