### PR TITLE
Trim white space from gas wait estimation

### DIFF
--- a/app/util/custom-gas.js
+++ b/app/util/custom-gas.js
@@ -92,7 +92,7 @@ export function parseWaitTime(min) {
 			parsed += ` ${Math.ceil(val)}${strings('unit.second')}`;
 		}
 	}
-	return parsed;
+	return parsed.trim();
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Noticed this one while going through design QA. In some cases `wait` has a leading white space.

**before:**

![image](https://user-images.githubusercontent.com/675259/77387444-d3c03380-6d63-11ea-8b8d-2b0498deb13e.png)

**after:**

![image](https://user-images.githubusercontent.com/675259/77387466-e175b900-6d63-11ea-9ec4-fb2c93c73b7d.png)
