### PR TITLE
Skip Sentry upload during iOS Debug build

### DIFF
--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -2429,7 +2429,7 @@
 			outputPaths = (
 			);
 			shellPath = /bin/sh;
-			shellScript = "if [ ! -e \"${SENTRY_PROPERTIES}\" ]; then\n    export SENTRY_PROPERTIES=../sentry.properties\nfi\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+			shellScript = "if [ ! -e \"${SENTRY_PROPERTIES}\" ]; then\n    export SENTRY_PROPERTIES=../sentry.properties\nfi\nif [ \"${CONFIGURATION}\" != \"Debug\" ]; then\n    ../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This step is already skipped during the Android debug build.

This ensures a local develop build will work correctly without a Sentry auth token. This was implemented incorrectly in #1376
