### PR TITLE
Handle icon parsing without faviconkit

### DIFF
--- a/app/components/UI/WebsiteIcon/__snapshots__/index.test.js.snap
+++ b/app/components/UI/WebsiteIcon/__snapshots__/index.test.js.snap
@@ -12,11 +12,7 @@ exports[`WebsiteIcon should render correctly 1`] = `
   >
     <Image
       onError={[Function]}
-      source={
-        Object {
-          "uri": "https://api.faviconkit.com/url.com/64",
-        }
-      }
+      source={null}
     />
   </FadeIn>
 </View>

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -61,26 +61,39 @@ export default class WebsiteIcon extends PureComponent {
 		apiLogoUrl: null
 	};
 
-	componentDidMount = async () => {
+	/**
+	 * Get and parse HTML
+	 */
+	getDocument = async () => {
 		const { url } = this.props;
-		const protocol = url.split('://')[0];
 
 		const response = await fetch(url);
 		const html = await response.text();
 
-		const doc = new DOMParser({
+		return new DOMParser({
 			locator: {},
 			errorHandler: (level, msg) => {
 				console.log(level, msg);
 			}
 		}).parseFromString(html, 'text/html');
+	};
+
+	componentDidMount = async () => {
+		const { url } = this.props;
+		const protocol = url.split('://')[0];
+
+		const doc = await this.getDocument();
+
+		// get all <link> tags
 		const nodeList = doc.getElementsByTagName('link');
 
+		// collect all <link>'s into an array for filtering
 		const links = [];
 		for (let i = 0; i < nodeList.length; i++) {
 			links.push(nodeList[i]);
 		}
 
+		// filter out non icons (like stylesheets)
 		const icons = links.filter(el => {
 			const sizes = el.getAttribute('sizes');
 			return sizes && el;
@@ -91,6 +104,9 @@ export default class WebsiteIcon extends PureComponent {
 		});
 	};
 
+	/**
+	 * Get the best favicon available based on size
+	 */
 	getBestIcon = (icons, siteUrl) => {
 		let size = 0;
 		let icon;

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -106,10 +106,8 @@ export default class WebsiteIcon extends PureComponent {
 	 * Find the best icon based on sizes attribute
 	 */
 	findBestIcon = (acc, curr) => {
-		const curr_sizes = curr.getAttribute('sizes');
-		const acc_sizes = acc.getAttribute('sizes');
-		const curr_size = this.parseSize(curr_sizes);
-		const acc_size = this.parseSize(acc_sizes);
+		const [acc_sizes, curr_sizes] = [acc, curr].map(el => el.getAttribute('sizes'));
+		const [acc_size, curr_size] = [acc_sizes, curr_sizes].map(this.parseSize);
 		return acc_size > curr_size ? acc : curr;
 	};
 

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -87,10 +87,7 @@ export default class WebsiteIcon extends PureComponent {
 		const nodeList = doc.getElementsByTagName('link');
 
 		// collect all <link>'s into an array for filtering
-		const links = [];
-		for (let i = 0; i < nodeList.length; i++) {
-			links.push(nodeList[i]);
-		}
+		const links = Array.from(nodeList);
 
 		// filter out non icons (like stylesheets)
 		const icons = links.filter(el => {

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -90,7 +90,7 @@ export default class WebsiteIcon extends PureComponent {
 	 */
 	formatHref = bestIcon => {
 		const { url } = this.props;
-		const href = bestIcon.getAttribute('href') || false;
+		const href = bestIcon.getAttribute('href') || '';
 
 		const PROTOCOL = '://';
 
@@ -124,7 +124,7 @@ export default class WebsiteIcon extends PureComponent {
 		const nodeList = doc.getElementsByTagName('link');
 
 		// collect all <link>'s into an array for filtering
-		const links = Array.from(nodeList);
+		const links = nodeList ? Array.from(nodeList) : [];
 
 		// icons based on size attribute
 		const sizedIcons = links.filter(el => el.hasAttribute('sizes'));

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -143,7 +143,7 @@ export default class WebsiteIcon extends PureComponent {
 		// fall back to faviconkit if we absolutely have to (meaning there's only a .ico resource)
 		const fallback = `https://api.faviconkit.com/${getHost(url)}/64`;
 		const uri = bestIcon ? this.formatHref(bestIcon) : fallback;
-
+		console.log(uri);
 		return uri;
 	};
 

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -4,7 +4,7 @@ import { StyleSheet, View, Text, Image } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 import { colors, fontStyles } from '../../../styles/common';
 import { getHost } from '../../../util/browser';
-import { DOMParser } from 'react-native-html-parser';
+import fetchIcon from '../../../util/icon';
 
 const styles = StyleSheet.create({
 	fallback: {
@@ -61,92 +61,9 @@ export default class WebsiteIcon extends PureComponent {
 		apiLogoUrl: null
 	};
 
-	/**
-	 * Get and parse HTML
-	 */
-	getDocument = async () => {
-		const { url } = this.props;
-
-		const response = await fetch(url);
-		const html = await response.text();
-
-		return new DOMParser({
-			// eslint-disable-next-line no-empty-function
-			errorHandler: (level, msg) => {},
-			locator: {}
-		}).parseFromString(html, 'text/html');
-	};
-
-	/**
-	 * parse a size int from string eg: "192x192" -> 192
-	 */
-	parseSize = sizes => {
-		const length = sizes.indexOf('x');
-		return parseInt(sizes.substr(0, length)) || null;
-	};
-
-	/**
-	 * Format href (needed because assets can be relative or absolute)
-	 */
-	formatHref = bestIcon => {
-		const { url } = this.props;
-		const href = bestIcon.getAttribute('href') || '';
-
-		const PROTOCOL = '://';
-
-		const hrefLength = href.indexOf(PROTOCOL);
-		const protocolLength = url.indexOf(PROTOCOL);
-		const protocol = url.substr(0, protocolLength);
-		const host = getHost(url);
-
-		return hrefLength === -1 ? `${protocol}${PROTOCOL}${host}${href}` : href;
-	};
-
-	/**
-	 * Find the best icon based on sizes attribute
-	 */
-	findBestIcon = (acc, curr) => {
-		const [acc_sizes, curr_sizes] = [acc, curr].map(el => el.getAttribute('sizes'));
-		const [acc_size, curr_size] = [acc_sizes, curr_sizes].map(this.parseSize);
-		return acc_size > curr_size ? acc : curr;
-	};
-
-	/**
-	 * Attempt to fetch icon from document and fall back to faviconkit if we have to
-	 */
-	fetchIcon = async () => {
-		const { url } = this.props;
-		const doc = await this.getDocument();
-
-		// get all <link> tags
-		const nodeList = doc.getElementsByTagName('link');
-
-		// collect all <link>'s into an array for filtering
-		const links = nodeList ? Array.from(nodeList) : [];
-
-		// icons based on size attribute
-		const sizedIcons = links.filter(el => el.hasAttribute('sizes'));
-
-		// all icons (based on rel key containing "icon")
-		const allIcons = links.filter(el => el.hasAttribute('rel') && /icon/.test(el.getAttribute('rel')));
-
-		// since we can't determine what's best, just pick one
-		const anyIcon = allIcons.pop();
-
-		// bestIcon from above based on if there are sizedIcons or not
-		const bestIcon = (sizedIcons.length ? sizedIcons.reduce(this.findBestIcon) : anyIcon) || null;
-
-		// !bestIcon && console.log('no best icon ;(');
-
-		// fall back to faviconkit if we absolutely have to (meaning there's only a .ico resource)
-		const fallback = `https://api.faviconkit.com/${getHost(url)}/64`;
-		const uri = bestIcon ? this.formatHref(bestIcon) : fallback;
-
-		return uri;
-	};
-
 	componentDidMount = async () => {
-		const uri = await this.fetchIcon();
+		const { url } = this.props;
+		const uri = await fetchIcon(url);
 		this.setState(() => ({ apiLogoUrl: { uri } }));
 	};
 

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -148,9 +148,8 @@ export default class WebsiteIcon extends PureComponent {
 	};
 
 	componentDidMount = async () => {
-		const { renderIconUrlError } = this.state;
 		const uri = await this.fetchIcon();
-		this.setState(() => (renderIconUrlError ? { renderIconUrlError: true } : { apiLogoUrl: { uri } }));
+		this.setState(() => ({ apiLogoUrl: { uri } }));
 	};
 
 	/**

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -143,7 +143,7 @@ export default class WebsiteIcon extends PureComponent {
 		// fall back to faviconkit if we absolutely have to (meaning there's only a .ico resource)
 		const fallback = `https://api.faviconkit.com/${getHost(url)}/64`;
 		const uri = bestIcon ? this.formatHref(bestIcon) : fallback;
-		console.log(uri);
+
 		return uri;
 	};
 

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -81,8 +81,8 @@ export default class WebsiteIcon extends PureComponent {
 	 * parse a size int from string eg: "192x192" -> 192
 	 */
 	parseSize = sizes => {
-		const from = sizes.indexOf('x');
-		return parseInt(sizes.substr(0, from)) || null;
+		const length = sizes.indexOf('x');
+		return parseInt(sizes.substr(0, length)) || null;
 	};
 
 	/**
@@ -94,12 +94,12 @@ export default class WebsiteIcon extends PureComponent {
 
 		const PROTOCOL = '://';
 
-		const hrefFrom = href.indexOf(PROTOCOL);
-		const protocolFrom = url.indexOf(PROTOCOL);
-		const protocol = url.substr(0, protocolFrom);
+		const hrefLength = href.indexOf(PROTOCOL);
+		const protocolLength = url.indexOf(PROTOCOL);
+		const protocol = url.substr(0, protocolLength);
 		const host = getHost(url);
 
-		return hrefFrom === -1 ? `${protocol}${PROTOCOL}${host}${href}` : href;
+		return hrefLength === -1 ? `${protocol}${PROTOCOL}${host}${href}` : href;
 	};
 
 	/**

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -30,7 +30,8 @@ import WebviewProgressBar from '../../UI/WebviewProgressBar';
 import { colors, baseStyles, fontStyles } from '../../../styles/common';
 import Networks from '../../../util/networks';
 import Logger from '../../../util/Logger';
-import onUrlSubmit, { getHost, getUrlObj } from '../../../util/browser';
+import fetchIcon from '../../../util/icon';
+import onUrlSubmit, { getUrlObj } from '../../../util/browser';
 import { SPA_urlChangeListener, JS_WINDOW_INFORMATION, JS_DESELECT_TEXT } from '../../../util/browserScripts';
 import resolveEnsToIpfsContentId from '../../../lib/ens-ipfs/resolver';
 import Button from '../../UI/Button';
@@ -1168,12 +1169,13 @@ export class BrowserTab extends PureComponent {
 				onAddBookmark: async ({ name, url }) => {
 					this.props.addBookmark({ name, url });
 					if (Device.isIos()) {
+						const uri = await fetchIcon(url);
 						const item = {
 							uniqueIdentifier: url,
 							title: name || url,
 							contentDescription: `Launch ${name || url} on MetaMask`,
 							keywords: [name.split(' '), url, 'dapp'],
-							thumbnail: { uri: `https://api.faviconkit.com/${getHost(url)}/256` }
+							thumbnail: { uri }
 						};
 						try {
 							SearchApi.indexSpotlightItem(item);

--- a/app/util/icon.js
+++ b/app/util/icon.js
@@ -1,0 +1,86 @@
+import { getHost } from './browser';
+import { DOMParser } from 'react-native-html-parser';
+
+/**
+ * Get and parse HTML
+ */
+const getDocument = async url => {
+	// const { url } = this.props;
+
+	const response = await fetch(url);
+	const html = await response.text();
+
+	return new DOMParser({
+		// eslint-disable-next-line no-empty-function
+		errorHandler: (level, msg) => {},
+		locator: {}
+	}).parseFromString(html, 'text/html');
+};
+
+/**
+ * parse a size int from string eg: "192x192" -> 192
+ */
+const parseSize = sizes => {
+	const length = sizes.indexOf('x');
+	return parseInt(sizes.substr(0, length)) || null;
+};
+
+/**
+ * Format href (needed because assets can be relative or absolute)
+ */
+const formatHref = (bestIcon, url) => {
+	// const { url } = this.props;
+	const href = bestIcon.getAttribute('href') || '';
+
+	const PROTOCOL = '://';
+
+	const hrefLength = href.indexOf(PROTOCOL);
+	const protocolLength = url.indexOf(PROTOCOL);
+	const protocol = url.substr(0, protocolLength);
+	const host = getHost(url);
+
+	return hrefLength === -1 ? `${protocol}${PROTOCOL}${host}${href}` : href;
+};
+
+/**
+ * Find the best icon based on sizes attribute
+ */
+const findBestIcon = (acc, curr) => {
+	const [acc_sizes, curr_sizes] = [acc, curr].map(el => el.getAttribute('sizes'));
+	const [acc_size, curr_size] = [acc_sizes, curr_sizes].map(parseSize);
+	return acc_size > curr_size ? acc : curr;
+};
+
+/**
+ * Attempt to fetch icon from document and fall back to faviconkit if we have to
+ */
+export default async url => {
+	// const { url } = this.props;
+	const doc = await getDocument(url);
+
+	// get all <link> tags
+	const nodeList = doc.getElementsByTagName('link');
+
+	// collect all <link>'s into an array for filtering
+	const links = nodeList ? Array.from(nodeList) : [];
+
+	// icons based on size attribute
+	const sizedIcons = links.filter(el => el.hasAttribute('sizes'));
+
+	// all icons (based on rel key containing "icon")
+	const allIcons = links.filter(el => el.hasAttribute('rel') && /icon/.test(el.getAttribute('rel')));
+
+	// since we can't determine what's best, just pick one
+	const anyIcon = allIcons.pop();
+
+	// bestIcon from above based on if there are sizedIcons or not
+	const bestIcon = (sizedIcons.length ? sizedIcons.reduce(findBestIcon) : anyIcon) || null;
+
+	// !bestIcon && console.log('no best icon ;(');
+
+	// fall back to faviconkit if we absolutely have to (meaning there's only a .ico resource)
+	const fallback = `https://api.faviconkit.com/${getHost(url)}/64`;
+	const uri = bestIcon ? formatHref(bestIcon, url) : fallback;
+
+	return uri;
+};

--- a/app/util/icon.js
+++ b/app/util/icon.js
@@ -5,8 +5,6 @@ import { DOMParser } from 'react-native-html-parser';
  * Get and parse HTML
  */
 const getDocument = async url => {
-	// const { url } = this.props;
-
 	const response = await fetch(url);
 	const html = await response.text();
 
@@ -29,7 +27,6 @@ const parseSize = sizes => {
  * Format href (needed because assets can be relative or absolute)
  */
 const formatHref = (bestIcon, url) => {
-	// const { url } = this.props;
 	const href = bestIcon.getAttribute('href') || '';
 
 	const PROTOCOL = '://';
@@ -55,7 +52,6 @@ const findBestIcon = (acc, curr) => {
  * Attempt to fetch icon from document and fall back to faviconkit if we have to
  */
 export default async url => {
-	// const { url } = this.props;
 	const doc = await getDocument(url);
 
 	// get all <link> tags

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-native-flash-message": "0.1.11",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",
+    "react-native-html-parser": "^0.1.0",
     "react-native-i18n": "2.0.15",
     "react-native-keyboard-aware-scroll-view": "0.8.0",
     "react-native-keychain": "git+ssh://git@github.com/MetaMask/react-native-keychain.git#80e497ed3c167e1b122231c29d951d2c06efe58f",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10112,6 +10112,11 @@ react-native-gesture-handler@^1.6.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-html-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-html-parser/-/react-native-html-parser-0.1.0.tgz#c35de1dc325562da26e68befa423bac34505ba48"
+  integrity sha512-G5d0pk7TA9YgjVJhLRf2zMOOf1HXd8ItM9JYsTS2pXoEfSRfMfRU5iTj03LGwvHU2NT9kc18NDJeLgZY6+Bbvg==
+
 react-native-i18n@2.0.15:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/react-native-i18n/-/react-native-i18n-2.0.15.tgz#09b5a9836116fa7dbd0054c46e2d1014c1ef3c65"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Relying on a 3rd party to handle our icons has proven unreliable; this can be seen in #1261 and #1335. There's also some additional details here: https://github.com/MetaMask/metamask-mobile/issues/1261#issuecomment-575782124. This adds a single dep and parses favicons directly in the client rather than relying on faviconkit (when possible).
