### PR TITLE
Fix collectible image icon & send flow styles

### DIFF
--- a/app/components/UI/CollectibleImage/__snapshots__/index.test.js.snap
+++ b/app/components/UI/CollectibleImage/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`CollectibleImage should render correctly 1`] = `
   style={
     Array [
       Object {
-        "borderRadius": 25,
+        "borderRadius": 10,
         "height": 50,
         "overflow": "hidden",
         "width": 50,

--- a/app/components/UI/CollectibleImage/index.js
+++ b/app/components/UI/CollectibleImage/index.js
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
 	listWrapper: {
 		width: 50,
 		height: 50,
-		borderRadius: 25,
+		borderRadius: 10,
 		overflow: 'hidden'
 	},
 	fullWrapper: {

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -674,7 +674,7 @@ class Amount extends PureComponent {
 				onPress={() => this.pickSelectedAsset(collectible)}
 			>
 				<View style={styles.assetElement}>
-					<CollectibleImage collectible={collectible} />
+					<CollectibleImage collectible={collectible} iconStyle={styles.tokenImage} containerStyle={styles.tokenImage} />
 					<View style={styles.assetInformationWrapper}>
 						<Text style={styles.textAssetTitle}>{name}</Text>
 					</View>


### PR DESCRIPTION
**Description**

For NFT tokens, when the image was a square like [this icon](https://opensea.io/assets/0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85/33852247701911005913959546112520393578660484597778186078514455088147154761227) the image appeared to be cropped. 
With a red background it's easy to see the problem, the image does not fully cover the circle:
<img width="92" alt="Screenshot 2020-04-02 at 22 41 38" src="https://user-images.githubusercontent.com/4960833/78360528-d7975580-75ae-11ea-9d6f-fee835bc9d50.png">

Also, you can see that the NFT image is bigger than the other tokens, making it not aligned.

Fixes:
- Modify the circle to be a square with rounded circles, accommodating all NFT images including squares.
- Pass the same styles of the tokens to the NFT `CollectibleImage` component to make it aligned.

Final result:
<img width="103" alt="Screenshot 2020-04-03 at 12 18 01" src="https://user-images.githubusercontent.com/4960833/78361965-2a720c80-75b1-11ea-9716-032be48f13e5.png">

**Issue**

Resolves #1407 
