### PR TITLE
Add settings to nav bar

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -765,6 +765,10 @@ class DrawerView extends PureComponent {
 			],
 			[
 				{
+					name: strings('drawer.settings'),
+					action: this.showSettings
+				},
+				{
 					name: strings('drawer.help'),
 					action: this.showHelp
 				},

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -756,18 +756,22 @@ class DrawerView extends PureComponent {
 			[
 				{
 					name: strings('drawer.settings'),
+					icon: this.getFeatherIcon('settings'),
 					action: this.showSettings
 				},
 				{
 					name: strings('drawer.help'),
+					icon: this.getFeatherIcon('help-circle'),
 					action: this.showHelp
 				},
 				{
 					name: strings('drawer.submit_feedback'),
+					icon: this.getFeatherIcon('message-square'),
 					action: this.submitFeedback
 				},
 				{
 					name: strings('drawer.logout'),
+					icon: this.getFeatherIcon('log-out'),
 					action: this.logout
 				}
 			]

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -64,16 +64,6 @@ const styles = StyleSheet.create({
 		flexDirection: 'column',
 		paddingBottom: 0
 	},
-	settings: {
-		paddingHorizontal: 12,
-		alignSelf: 'flex-end',
-		alignItems: 'center',
-		marginRight: 3,
-		marginTop: Device.isAndroid() ? -3 : -10
-	},
-	settingsIcon: {
-		marginBottom: 12
-	},
 	metamaskLogo: {
 		flexDirection: 'row',
 		flex: 1,
@@ -852,13 +842,6 @@ class DrawerView extends PureComponent {
 							<Image source={metamask_fox} style={styles.metamaskFox} resizeMethod={'auto'} />
 							<Image source={metamask_name} style={styles.metamaskName} resizeMethod={'auto'} />
 						</View>
-						<TouchableOpacity
-							style={styles.settings}
-							testID={`settings-button`}
-							onPress={this.showSettings}
-						>
-							<FeatherIcon name="settings" size={22} style={styles.settingsIcon} />
-						</TouchableOpacity>
 					</View>
 					<View style={styles.account}>
 						<View style={styles.accountBgOverlay}>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

re: #1537 this adds a "Settings" link above "Get help" on the sidebar:

![image](https://user-images.githubusercontent.com/675259/80996340-a60fe500-8e0d-11ea-9ad0-7dba1e04eae7.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #1537
