### PR TITLE
Disable confirm screen edit button when no tokens of a payment request

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -326,6 +326,7 @@ export function getTransactionOptionsTitle(_title, navigation) {
 	const transactionMode = navigation.getParam('mode', '');
 	const { routeName } = navigation.state;
 	const leftText = transactionMode === 'edit' ? strings('transaction.cancel') : strings('transaction.edit');
+	const disableModeChange = navigation.getParam('disableModeChange');
 	const modeChange = navigation.getParam('dispatch', () => {
 		'';
 	});
@@ -338,8 +339,17 @@ export function getTransactionOptionsTitle(_title, navigation) {
 		headerLeft:
 			transactionMode !== 'edit' ? (
 				// eslint-disable-next-line react/jsx-no-bind
-				<TouchableOpacity onPress={leftAction} style={styles.closeButton} testID={'confirm-txn-edit-button'}>
-					<Text style={styles.closeButtonText}>{leftText}</Text>
+				<TouchableOpacity
+					disabled={disableModeChange}
+					onPress={leftAction}
+					style={styles.closeButton}
+					testID={'confirm-txn-edit-button'}
+				>
+					<Text
+						style={disableModeChange ? [styles.closeButtonText, styles.disabled] : [styles.closeButtonText]}
+					>
+						{leftText}
+					</Text>
 				</TouchableOpacity>
 			) : (
 				<View />

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -180,7 +180,11 @@ class Send extends PureComponent {
 
 	componentDidUpdate(prevProps) {
 		const prevNavigation = prevProps.navigation;
-		const { navigation, transaction, contractBalances } = this.props;
+		const {
+			navigation,
+			transaction: { assetType, selectedAsset },
+			contractBalances
+		} = this.props;
 		if (prevNavigation && navigation) {
 			const prevTxMeta = prevNavigation.getParam('txMeta', null);
 			const currentTxMeta = navigation.getParam('txMeta', null);
@@ -192,10 +196,14 @@ class Send extends PureComponent {
 				this.handleNewTxMeta(currentTxMeta);
 			}
 		}
-		if (prevProps.transaction.assetType === undefined && transaction.assetType === 'ERC20') {
+
+		const contractBalance = contractBalances[selectedAsset.address];
+		const contractBalanceChanged = prevProps.contractBalances[selectedAsset.address] !== contractBalance;
+		const assetTypeDefined = prevProps.transaction.assetType === undefined && assetType === 'ERC20';
+		if (assetType === 'ERC20' && (assetTypeDefined || contractBalanceChanged)) {
 			navigation &&
 				navigation.setParams({
-					disableModeChange: contractBalances[transaction.selectedAsset.address] === undefined
+					disableModeChange: contractBalance === undefined
 				});
 		}
 	}

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -198,9 +198,10 @@ class Send extends PureComponent {
 		}
 
 		const contractBalance = contractBalances[selectedAsset.address];
-		const contractBalanceChanged = prevProps.contractBalances[selectedAsset.address] !== contractBalance;
+		const erc20ContractBalanceChanged =
+			assetType === 'ERC20' && prevProps.contractBalances[selectedAsset.address] !== contractBalance;
 		const assetTypeDefined = prevProps.transaction.assetType === undefined && assetType === 'ERC20';
-		if (assetType === 'ERC20' && (assetTypeDefined || contractBalanceChanged)) {
+		if (assetTypeDefined || erc20ContractBalanceChanged) {
 			navigation &&
 				navigation.setParams({
 					disableModeChange: contractBalance === undefined

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -94,7 +94,11 @@ class Send extends PureComponent {
 		/**
 		 * Selected address as string
 		 */
-		selectedAddress: PropTypes.string
+		selectedAddress: PropTypes.string,
+		/**
+		 * Object containing token balances in the format address => balance
+		 */
+		contractBalances: PropTypes.object
 	};
 
 	state = {
@@ -145,8 +149,17 @@ class Send extends PureComponent {
 	 * Sets state mounted to true, resets transaction and check for deeplinks
 	 */
 	async componentDidMount() {
-		const { navigation } = this.props;
-		navigation && navigation.setParams({ mode: REVIEW, dispatch: this.onModeChange });
+		const {
+			navigation,
+			transaction: { assetType, selectedAsset },
+			contractBalances
+		} = this.props;
+		navigation &&
+			navigation.setParams({
+				mode: REVIEW,
+				dispatch: this.onModeChange,
+				disableModeChange: assetType === 'ERC20' && contractBalances[selectedAsset.address] === undefined
+			});
 		this.mounted = true;
 		await this.reset();
 		this.checkForDeeplinks();
@@ -167,7 +180,7 @@ class Send extends PureComponent {
 
 	componentDidUpdate(prevProps) {
 		const prevNavigation = prevProps.navigation;
-		const { navigation } = this.props;
+		const { navigation, transaction, contractBalances } = this.props;
 		if (prevNavigation && navigation) {
 			const prevTxMeta = prevNavigation.getParam('txMeta', null);
 			const currentTxMeta = navigation.getParam('txMeta', null);
@@ -178,6 +191,12 @@ class Send extends PureComponent {
 			) {
 				this.handleNewTxMeta(currentTxMeta);
 			}
+		}
+		if (prevProps.transaction.assetType === undefined && transaction.assetType === 'ERC20') {
+			navigation &&
+				navigation.setParams({
+					disableModeChange: contractBalances[transaction.selectedAsset.address] === undefined
+				});
 		}
 	}
 


### PR DESCRIPTION
Addresses issue 1 of #1566 by disabling the edit button when the token has no defined balance.

https://streamable.com/9z30zu