### PR TITLE
Fix amount validation for large token payment requests

### DIFF
--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -640,7 +640,7 @@ class Confirm extends PureComponent {
 			} else {
 				const [, , amount] = decodeTransferData('transfer', transaction.data);
 				weiBalance = contractBalances[selectedAsset.address];
-				weiInput = toBN(amount);
+				weiInput = hexToBN(amount);
 				errorMessage =
 					weiBalance && weiBalance.gte(weiInput)
 						? undefined


### PR DESCRIPTION
Fixes #1571

Demo of working balance check: https://streamable.com/vuvgj2

The `validateAmount` method in the confirm view component was using the wrong method to convert from hex to BNs, causing conversion errors for large token amounts. The sort of error can be seen here:

![Screenshot from 2020-05-13 16-31-37](https://user-images.githubusercontent.com/7499938/81854207-29c98000-9538-11ea-89cf-ba228410a5a1.png)
