### PR TITLE
Ensure collectibles that use 'transfer' method show a "amount" / fee

### DIFF
--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -185,6 +185,7 @@ function getCollectibleTransfer(args) {
 	} = args;
 	let actionKey;
 	const [, tokenId] = decodeTransferData('transfer', data);
+	const ticker = getTicker(args.ticker);
 	const collectible = collectibleContracts.find(
 		collectible => collectible.address.toLowerCase() === to.toLowerCase()
 	);
@@ -203,6 +204,8 @@ function getCollectibleTransfer(args) {
 	if (primaryCurrency === 'ETH') {
 		transactionDetails = {
 			...transactionDetails,
+			summaryAmount: renderCollectible,
+			summaryFee: `${renderFromWei(totalGas)} ${ticker}`,
 			summaryTotalAmount: `${renderCollectible} ${strings('unit.divisor')} ${renderFromWei(totalGas)} ${strings(
 				'unit.eth'
 			)}`,
@@ -211,6 +214,8 @@ function getCollectibleTransfer(args) {
 	} else {
 		transactionDetails = {
 			...transactionDetails,
+			summaryAmount: renderCollectible,
+			summaryFee: weiToFiat(totalGas, conversionRate, currentCurrency),
 			summaryTotalAmount: weiToFiat(totalGas, conversionRate, currentCurrency),
 			summarySecondaryTotalAmount: `${renderCollectible} ${strings('unit.divisor')} ${renderFromWei(
 				totalGas


### PR DESCRIPTION
This PR addresses the issue described in this comment https://github.com/MetaMask/metamask-mobile/pull/1565#issuecomment-628094784

As explained in a comment in that same PR:

> I figured out why sometimes we are seeing "No fee" and sometimes not. Different collectibles have different transfer methods. We encode some of these specifically in /metamask-mobile/app/util/collectibles-transfer.json. The data we attach to the transaction details is currently a little different depending on whether the collectible contract uses a transfer or transferFrom method.

> The fix is to ensure the fee data is included in both types of transaction data.