### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+*                                    @MetaMask/mobile-devs


### PR DESCRIPTION
Adds `.github/CODEOWNERS` specifying [the MetaMask mobile dev team](https://github.com/orgs/MetaMask/teams/mobile-devs) as the owner for all files in the repo.

This way, we can require codeowner review on branches, and everyone gets a notification when a PR is created and their review is requested.

Just a suggestion, feel free to close!