### PR TITLE
Android performance improvements: use of asyncstorage on login

### DIFF
--- a/app/actions/user/index.js
+++ b/app/actions/user/index.js
@@ -21,3 +21,17 @@ export function seedphraseNotBackedUp() {
 		type: 'SEEDPHRASE_NOT_BACKED_UP'
 	};
 }
+
+export function onboardingWizardExplored(onboardingWizardExplored) {
+	return {
+		type: 'ONBOARDING_WIZARD_EXPLORED',
+		onboardingWizardExplored
+	};
+}
+
+export function metricsOptIn(metricsOptIn) {
+	return {
+		type: 'METRICS_OPT_IN',
+		metricsOptIn
+	};
+}

--- a/app/actions/user/index.js
+++ b/app/actions/user/index.js
@@ -29,9 +29,9 @@ export function onboardingWizardExplored(onboardingWizardExplored) {
 	};
 }
 
-export function metricsOptIn(metricsOptIn) {
+export function metricsOptIn(metricsOptedIn) {
 	return {
 		type: 'METRICS_OPT_IN',
-		metricsOptIn
+		metricsOptedIn
 	};
 }

--- a/app/components/UI/OnboardingWizard/index.js
+++ b/app/components/UI/OnboardingWizard/index.js
@@ -10,9 +10,9 @@ import Step4 from './Step4';
 import Step5 from './Step5';
 import Step6 from './Step6';
 import setOnboardingWizardStep from '../../../actions/wizard';
+import { onboardingWizardExplored } from '../../../actions/user';
 import { DrawerActions } from 'react-navigation-drawer'; // eslint-disable-line
 import { strings } from '../../../../locales/i18n';
-import AsyncStorage from '@react-native-community/async-storage';
 import ElevatedView from 'react-native-elevated-view';
 import Modal from 'react-native-modal';
 import Device from '../../../util/Device';
@@ -88,7 +88,11 @@ class OnboardingWizard extends PureComponent {
 		/**
 		 * Coachmark ref to get position
 		 */
-		coachmarkRef: PropTypes.object
+		coachmarkRef: PropTypes.object,
+		/**
+		 * Dispatch setting of onboardingWizardExplored
+		 */
+		setOnboardingWizardExplored: PropTypes.func
 	};
 
 	/**
@@ -98,9 +102,10 @@ class OnboardingWizard extends PureComponent {
 		const {
 			setOnboardingWizardStep,
 			navigation,
-			wizard: { step }
+			wizard: { step },
+			setOnboardingWizardExplored
 		} = this.props;
-		await AsyncStorage.setItem('@MetaMask:onboardingWizard', 'explored');
+		setOnboardingWizardExplored();
 		setOnboardingWizardStep && setOnboardingWizardStep(0);
 		navigation && navigation.dispatch(DrawerActions.closeDrawer());
 		closing &&
@@ -188,7 +193,8 @@ class OnboardingWizard extends PureComponent {
 }
 
 const mapDispatchToProps = dispatch => ({
-	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step))
+	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step)),
+	setOnboardingWizardExplored: () => dispatch(onboardingWizardExplored(true))
 });
 
 const mapStateToProps = state => ({

--- a/app/components/UI/OptinMetrics/index.js
+++ b/app/components/UI/OptinMetrics/index.js
@@ -24,6 +24,7 @@ import StyledButton from '../StyledButton';
 import Analytics from '../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
 import { clearOnboardingEvents } from '../../../actions/onboarding';
+import { metricsOptIn } from '../../../actions/user';
 
 const styles = StyleSheet.create({
 	root: {
@@ -117,7 +118,11 @@ class OptinMetrics extends PureComponent {
 		/**
 		 * Action to erase any event stored in onboarding state
 		 */
-		clearOnboardingEvents: PropTypes.func
+		clearOnboardingEvents: PropTypes.func,
+		/**
+		 * Set the state indicating whether a user has opted into metrics
+		 */
+		metricsOptIn: PropTypes.func
 	};
 
 	actionsList = [
@@ -207,7 +212,7 @@ class OptinMetrics extends PureComponent {
 			}
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_METRICS_OPT_OUT);
 			this.props.clearOnboardingEvents();
-			await AsyncStorage.setItem('@MetaMask:metricsOptIn', 'denied');
+			this.props.metricsOptIn('denied');
 			Analytics.disableInstance();
 		});
 		this.continue();
@@ -223,7 +228,7 @@ class OptinMetrics extends PureComponent {
 			}
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_METRICS_OPT_IN);
 			this.props.clearOnboardingEvents();
-			await AsyncStorage.setItem('@MetaMask:metricsOptIn', 'agreed');
+			this.props.metricsOptIn('agreed');
 		});
 		this.continue();
 	};
@@ -295,7 +300,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
 	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step)),
-	clearOnboardingEvents: () => dispatch(clearOnboardingEvents())
+	clearOnboardingEvents: () => dispatch(clearOnboardingEvents()),
+	metricsOptIn: optInState => dispatch(metricsOptIn(optInState))
 });
 
 export default connect(

--- a/app/components/UI/OptinMetrics/index.js
+++ b/app/components/UI/OptinMetrics/index.js
@@ -12,7 +12,6 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { baseStyles, fontStyles, colors } from '../../../styles/common';
-import AsyncStorage from '@react-native-community/async-storage';
 import Entypo from 'react-native-vector-icons/Entypo';
 import { getOptinMetricsNavbarOptions } from '../Navbar';
 import { strings } from '../../../../locales/i18n';
@@ -122,7 +121,11 @@ class OptinMetrics extends PureComponent {
 		/**
 		 * Set the state indicating whether a user has opted into metrics
 		 */
-		metricsOptIn: PropTypes.func
+		metricsOptIn: PropTypes.func,
+		/**
+		 * Whether the user has completed (including dismissal of) the onboarding wizard
+		 */
+		onboardingWizardExplored: PropTypes.bool
 	};
 
 	actionsList = [
@@ -176,7 +179,7 @@ class OptinMetrics extends PureComponent {
 	 */
 	continue = async () => {
 		// Get onboarding wizard state
-		const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+		const onboardingWizard = this.props.onboardingWizardExplored;
 		if (onboardingWizard) {
 			this.props.navigation.navigate('HomeNav');
 		} else {
@@ -212,7 +215,7 @@ class OptinMetrics extends PureComponent {
 			}
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_METRICS_OPT_OUT);
 			this.props.clearOnboardingEvents();
-			this.props.metricsOptIn('denied');
+			this.props.metricsOptIn(false);
 			Analytics.disableInstance();
 		});
 		this.continue();
@@ -228,7 +231,7 @@ class OptinMetrics extends PureComponent {
 			}
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_METRICS_OPT_IN);
 			this.props.clearOnboardingEvents();
-			this.props.metricsOptIn('agreed');
+			this.props.metricsOptIn(true);
 		});
 		this.continue();
 	};
@@ -295,7 +298,8 @@ class OptinMetrics extends PureComponent {
 }
 
 const mapStateToProps = state => ({
-	events: state.onboarding.events
+	events: state.onboarding.events,
+	onboardingWizardExplored: state.user.onboardingWizardExplored
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/components/Views/CreateWallet/index.js
+++ b/app/components/Views/CreateWallet/index.js
@@ -98,7 +98,15 @@ class CreateWallet extends PureComponent {
 		/**
 		 * React navigation prop to know if this view is focused
 		 */
-		isFocused: PropTypes.bool
+		isFocused: PropTypes.bool,
+		/**
+		 * Whether the user has completed (including dismissal of) the onboarding wizard
+		 */
+		onboardingWizardExplored: PropTypes.bool,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	// Temporary disabling the back button so users can't go back
@@ -121,9 +129,9 @@ class CreateWallet extends PureComponent {
 			await AsyncStorage.removeItem('@MetaMask:nextMakerReminder');
 			await AsyncStorage.setItem('@MetaMask:existingUser', 'true');
 			// Get onboarding wizard state
-			const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+			const onboardingWizard = this.props.onboardingWizardExplored;
 			// Check if user passed through metrics opt-in screen
-			const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+			const metricsOptIn = this.props.metricsOptedIn;
 			// Making sure we reset the flag while going to
 			// the first time flow
 			this.props.passwordUnset();
@@ -178,6 +186,11 @@ class CreateWallet extends PureComponent {
 	}
 }
 
+const mapStateToProps = state => ({
+	metricsOptedIn: state.user.metricsOptedIn,
+	onboardingWizardExplored: state.user.onboardingWizardExplored
+});
+
 const mapDispatchToProps = dispatch => ({
 	setLockTime: time => dispatch(setLockTime(time)),
 	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step)),
@@ -186,6 +199,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(
-	null,
+	mapStateToProps,
 	mapDispatchToProps
 )(withNavigationFocus(CreateWallet));

--- a/app/components/Views/Entry/index.js
+++ b/app/components/Views/Entry/index.js
@@ -76,7 +76,15 @@ class Entry extends PureComponent {
 		/**
 		 * Action to set onboarding wizard step
 		 */
-		setOnboardingWizardStep: PropTypes.func
+		setOnboardingWizardStep: PropTypes.func,
+		/**
+		 * Whether the user has completed (including dismissal of) the onboarding wizard
+		 */
+		onboardingWizardExplored: PropTypes.bool,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	state = {
@@ -161,9 +169,9 @@ class Entry extends PureComponent {
 				const { KeyringController } = Engine.context;
 				await KeyringController.submitPassword(credentials.password);
 				// Get onboarding wizard state
-				const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+				const onboardingWizard = this.props.onboardingWizardExplored;
 				// Check if user passed through metrics opt-in screen
-				const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+				const metricsOptIn = this.props.metricsOptedIn;
 				if (!metricsOptIn) {
 					this.animateAndGoTo('OptinMetrics');
 				} else if (onboardingWizard) {
@@ -229,7 +237,9 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-	passwordSet: state.user.passwordSet
+	passwordSet: state.user.passwordSet,
+	metricsOptedIn: state.user.metricsOptedIn,
+	onboardingWizardExplored: state.user.onboardingWizardExplored
 });
 
 export default connect(

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -190,7 +190,15 @@ class ImportFromSeed extends PureComponent {
 		/**
 		 * Action to set onboarding wizard step
 		 */
-		setOnboardingWizardStep: PropTypes.func
+		setOnboardingWizardStep: PropTypes.func,
+		/**
+		 * Whether the user has completed (including dismissal of) the onboarding wizard
+		 */
+		onboardingWizardExplored: PropTypes.bool,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	state = {
@@ -285,9 +293,9 @@ class ImportFromSeed extends PureComponent {
 					await AsyncStorage.setItem('@MetaMask:passcodeDisabled', 'true');
 				}
 				// Get onboarding wizard state
-				const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+				const onboardingWizard = this.props.onboardingWizardExplored;
 				// Check if user passed through metrics opt-in screen
-				const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+				const metricsOptIn = this.props.metricsOptedIn;
 				// mark the user as existing so it doesn't see the create password screen again
 				await AsyncStorage.setItem('@MetaMask:existingUser', 'true');
 				this.setState({ loading: false });
@@ -629,6 +637,11 @@ class ImportFromSeed extends PureComponent {
 	}
 }
 
+const mapStateToProps = state => ({
+	events: state.onboarding.events,
+	onboardingWizardExplored: state.user.onboardingWizardExplored
+});
+
 const mapDispatchToProps = dispatch => ({
 	setLockTime: time => dispatch(setLockTime(time)),
 	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step)),
@@ -637,6 +650,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(
-	null,
+	mapStateToProps,
 	mapDispatchToProps
 )(ImportFromSeed);

--- a/app/components/Views/ImportWallet/index.js
+++ b/app/components/Views/ImportWallet/index.js
@@ -134,7 +134,11 @@ class ImportWallet extends PureComponent {
 		/**
 		 * Save onboarding event to state
 		 */
-		saveOnboardingEvent: PropTypes.func
+		saveOnboardingEvent: PropTypes.func,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	seedwords = null;
@@ -378,7 +382,7 @@ class ImportWallet extends PureComponent {
 					Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_IMPORT_WITH_SEEDPHRASE);
 					return;
 				}
-				const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+				const metricsOptIn = this.props.metricsOptedIn;
 				if (!metricsOptIn) {
 					this.props.saveOnboardingEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_IMPORT_WITH_SEEDPHRASE);
 				}
@@ -415,7 +419,7 @@ class ImportWallet extends PureComponent {
 				Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_SYNC_WITH_EXTENSION);
 				return;
 			}
-			const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+			const metricsOptIn = this.props.metricsOptedIn;
 			if (!metricsOptIn) {
 				this.props.saveOnboardingEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_SYNC_WITH_EXTENSION);
 			}
@@ -509,7 +513,8 @@ class ImportWallet extends PureComponent {
 const mapStateToProps = state => ({
 	selectedAddress: state.engine.backgroundState.PreferencesController.selectedAddress,
 	accounts: state.engine.backgroundState.AccountTrackerController.accounts,
-	passwordSet: state.user.passwordSet
+	passwordSet: state.user.passwordSet,
+	metricsOptedIn: state.user.metricsOptedIn
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/components/Views/Login/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Login should render correctly 1`] = `
 <Login
   accountsLength={1}
+  metricsOptIn={false}
   networkType="ropsten"
   setOnboardingWizardStep={[Function]}
   tokensLength={0}

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -353,7 +353,7 @@ const mapStateToProps = state => ({
 	tokensLength: state.engine.backgroundState.AssetsController.tokens.length,
 	networkType: state.engine.backgroundState.NetworkController.provider.type,
 	metricsOptIn: Boolean(state.user.metricsOptIn),
-	onboardingWizardExplored: state.user.onboardingWizardExplored
+	onboardingWizardExplored: Boolean(state.user.onboardingWizardExplored)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/components/Views/Login/index.test.js
+++ b/app/components/Views/Login/index.test.js
@@ -22,7 +22,8 @@ describe('Login', () => {
 						tokens: []
 					}
 				}
-			}
+			},
+			user: {}
 		};
 
 		const wrapper = shallow(<Login />, {

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -85,7 +85,11 @@ class Onboarding extends PureComponent {
 		/**
 		 * Save onboarding event to state
 		 */
-		saveOnboardingEvent: PropTypes.func
+		saveOnboardingEvent: PropTypes.func,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	state = {
@@ -125,7 +129,7 @@ class Onboarding extends PureComponent {
 					Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_CREATE_NEW_WALLET);
 					return;
 				}
-				const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+				const metricsOptIn = this.props.metricsOptedIn;
 				if (!metricsOptIn) {
 					this.props.saveOnboardingEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_CREATE_NEW_WALLET);
 				}
@@ -145,7 +149,7 @@ class Onboarding extends PureComponent {
 				Analytics.trackEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_IMPORT_WALLET);
 				return;
 			}
-			const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+			const metricsOptIn = this.props.metricsOptedIn;
 			if (!metricsOptIn) {
 				this.props.saveOnboardingEvent(ANALYTICS_EVENT_OPTS.ONBOARDING_SELECTED_IMPORT_WALLET);
 			}
@@ -220,6 +224,7 @@ class Onboarding extends PureComponent {
 }
 
 const mapStateToProps = state => ({
+	metricsOptedIn: state.user.metricsOptedIn,
 	passwordSet: state.user.passwordSet
 });
 

--- a/app/components/Views/SyncWithExtensionSuccess/index.js
+++ b/app/components/Views/SyncWithExtensionSuccess/index.js
@@ -6,7 +6,6 @@ import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import StyledButton from '../../UI/StyledButton';
 import { getOnboardingNavbarOptions } from '../../UI/Navbar';
-import AsyncStorage from '@react-native-community/async-storage';
 import setOnboardingWizardStep from '../../../actions/wizard';
 // eslint-disable-next-line import/named
 import { NavigationActions } from 'react-navigation';
@@ -64,7 +63,15 @@ class SyncWithExtensionSuccess extends PureComponent {
 		/**
 		 * Action to set onboarding wizard step
 		 */
-		setOnboardingWizardStep: PropTypes.func
+		setOnboardingWizardStep: PropTypes.func,
+		/**
+		 * Whether the user has completed (including dismissal of) the onboarding wizard
+		 */
+		onboardingWizardExplored: PropTypes.bool,
+		/**
+		 * Whether the user has opted into metrics
+		 */
+		metricsOptedIn: PropTypes.bool
 	};
 
 	static navigationOptions = ({ navigation }) => ({
@@ -89,9 +96,9 @@ class SyncWithExtensionSuccess extends PureComponent {
 
 	continue = async () => {
 		// Get onboarding wizard state
-		const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+		const onboardingWizard = this.props.onboardingWizardExplored;
 		// Check if user passed through metrics opt-in screen
-		const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+		const metricsOptIn = this.props.metricsOptedIn;
 		if (!metricsOptIn) {
 			this.props.navigation.navigate('OptinMetrics');
 		} else if (onboardingWizard) {
@@ -133,11 +140,15 @@ class SyncWithExtensionSuccess extends PureComponent {
 	);
 }
 
+const mapStateToProps = state => ({
+	metricsOptedIn: state.user.metricsOptedIn
+});
+
 const mapDispatchToProps = dispatch => ({
 	setOnboardingWizardStep: step => dispatch(setOnboardingWizardStep(step))
 });
 
 export default connect(
-	null,
+	mapStateToProps,
 	mapDispatchToProps
 )(SyncWithExtensionSuccess);

--- a/app/reducers/user/index.js
+++ b/app/reducers/user/index.js
@@ -42,7 +42,7 @@ const userReducer = (state = initialState, action) => {
 		case 'METRICS_OPT_IN':
 			return {
 				...state,
-				metricsOptIn: action.metricsOptIn
+				metricsOptedIn: action.metricsOptedIn
 			};
 		default:
 			return state;

--- a/app/reducers/user/index.js
+++ b/app/reducers/user/index.js
@@ -2,7 +2,9 @@ import { REHYDRATE } from 'redux-persist';
 
 const initialState = {
 	passwordSet: false,
-	seedphraseBackedUp: false
+	seedphraseBackedUp: false,
+	onboardingWizardExplored: false,
+	metricsOptIn: null
 };
 
 const userReducer = (state = initialState, action) => {
@@ -31,6 +33,16 @@ const userReducer = (state = initialState, action) => {
 			return {
 				...state,
 				seedphraseBackedUp: true
+			};
+		case 'ONBOARDING_WIZARD_EXPLORED':
+			return {
+				...state,
+				onboardingWizardExplored: action.onboardingWizardExplored
+			};
+		case 'METRICS_OPT_IN':
+			return {
+				...state,
+				metricsOptIn: action.metricsOptIn
 			};
 		default:
 			return state;

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -47,8 +47,8 @@ const migrations = {
 		const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
 
 		const newState = { ...state };
-		newState.user.metricsOptIn = metricsOptIn;
-		newState.user.onboardingWizardExplored = onboardingWizard;
+		newState.user.metricsOptedIn = metricsOptIn === 'agreed';
+		newState.user.onboardingWizardExplored = onboardingWizard === 'explored';
 
 		return newState;
 	}

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -38,15 +38,28 @@ const migrations = {
 		const newState = { ...state };
 		delete newState.newTransaction;
 		return newState;
+	},
+	// Move onboardingWizard and metricsOptIn to redux persistance
+	3: async state => {
+		// Get onboarding wizard state
+		const onboardingWizard = await AsyncStorage.getItem('@MetaMask:onboardingWizard');
+		// Check if user passed through metrics opt-in screen
+		const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+
+		const newState = { ...state };
+		newState.user.metricsOptIn = metricsOptIn;
+		newState.user.onboardingWizardExplored = onboardingWizard;
+
+		return newState;
 	}
 };
 
 const persistConfig = {
 	key: 'root',
-	version: 1,
+	version: 3,
 	storage: AsyncStorage,
 	stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
-	migrate: createMigrate(migrations, { debug: false })
+	migrate: createMigrate(migrations, { debug: true })
 };
 
 const pReducer = persistReducer(persistConfig, rootReducer);

--- a/app/util/Logger.js
+++ b/app/util/Logger.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { addBreadcrumb, captureException, withScope } from '@sentry/react-native';
-import AsyncStorage from '@react-native-community/async-storage';
+import { store } from '../store';
 
 /**
  * Wrapper class that allows us to override
@@ -18,11 +18,11 @@ export default class Logger {
 	 */
 	static async log(...args) {
 		// Check if user passed accepted opt-in to metrics
-		const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+		const metricsOptIn = store.getState().user.metricsOptedIn;
 		if (__DEV__) {
 			args.unshift('[MetaMask DEBUG]:');
 			console.log.apply(null, args); // eslint-disable-line no-console
-		} else if (metricsOptIn === 'agreed') {
+		} else if (metricsOptIn) {
 			addBreadcrumb({
 				message: JSON.stringify(args)
 			});
@@ -38,10 +38,10 @@ export default class Logger {
 	 */
 	static async error(error, extra) {
 		// Check if user passed accepted opt-in to metrics
-		const metricsOptIn = await AsyncStorage.getItem('@MetaMask:metricsOptIn');
+		const metricsOptIn = store.getState().user.metricsOptedIn;
 		if (__DEV__) {
 			console.warn('[MetaMask DEBUG]:', error); // eslint-disable-line no-console
-		} else if (metricsOptIn === 'agreed') {
+		} else if (metricsOptIn) {
 			if (extra) {
 				if (typeof extra === 'string') {
 					extra = { message: extra };


### PR DESCRIPTION
This PR explicitly aims at improve the time it takes to go from submission of password on the login page to rendering content to the user.

The focus is on removing the `AsyncStorage` calls to get `onboardingWizard` and `metricsOptIn ` variables in the `onLogin` method of the Login view.

When testing under conditions of system resource constraint, I found that these calls could take more than 1 second each. This is consistent with performance measurement of `AsyncStorage` (https://medium.com/@Sendbird/extreme-optimization-of-asyncstorage-in-react-native-b2a1e0107b34)

My moving the data under redux and redux-persist, it is retrieved as part of the batch of all data, and we avoid the performance cost on these individual calls. Can save close to 2 seconds on slow systems.