### PR TITLE
Add overlayColor

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -103,7 +103,8 @@ const HomeNav = createDrawerNavigator(
 	},
 	{
 		contentComponent: DrawerView,
-		drawerWidth: 315
+		drawerWidth: 315,
+		overlayColor: 'rgba(0, 0, 0, 0.7)'
 	}
 );
 

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -104,7 +104,7 @@ const HomeNav = createDrawerNavigator(
 	{
 		contentComponent: DrawerView,
 		drawerWidth: 315,
-		overlayColor: 'rgba(0, 0, 0, 0.7)'
+		overlayColor: 'rgba(0, 0, 0, 0.5)'
 	}
 );
 


### PR DESCRIPTION
this needs to be set in order for the opacity to work correctly after the RN upgrade

this api is entirely different now, but doing this makes it work in the old one

~we can further discuss what the opacity should be~ (I updated to match what's in the prototype)

https://github.com/react-navigation/react-navigation/issues/6208#issuecomment-524091241
