### PR TITLE
Change warning type so it displays, closes #1610

### DIFF
--- a/app/components/UI/StyledButton/styledButtonStyles.js
+++ b/app/components/UI/StyledButton/styledButtonStyles.js
@@ -84,6 +84,9 @@ const styles = StyleSheet.create({
 	warningText: {
 		color: colors.white
 	},
+	warningTextEmpty: {
+		color: colors.red
+	},
 	neutral: {
 		backgroundColor: colors.white,
 		borderWidth: 1,
@@ -155,7 +158,7 @@ function getStyles(type) {
 			containerStyle = styles.warning;
 			break;
 		case 'warning-empty':
-			fontStyle = styles.warningText;
+			fontStyle = styles.warningTextEmpty;
 			containerStyle = styles.transparent;
 			break;
 		case 'info':


### PR DESCRIPTION
**Description**

Update `warning-empty` styles so the button shows up:

![image](https://user-images.githubusercontent.com/675259/83582007-5147b300-a50e-11ea-94f7-7f53d33394b4.png)


<strike>If this makes sense we should also remove the case here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/UI/StyledButton/styledButtonStyles.js#L157-L160 since this was the only one that was using this.</strike>

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #1610 
