### PR TITLE
Bugfix/wc connect on app closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Develop Branch
 
 ## v0.2.17 - Jun 12 2020
+- [#1625](https://github.com/MetaMask/metamask-mobile/pull/1625): Bugfix/wc connect on app closed (#1625)
 - [#1624](https://github.com/MetaMask/metamask-mobile/pull/1624): Wallet connect update + Support for simple notifications (#1624)
 - [#1623](https://github.com/MetaMask/metamask-mobile/pull/1623): Fix browser intial load (#1623)
 - [#1621](https://github.com/MetaMask/metamask-mobile/pull/1621): Fix branch (#1621)

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -477,8 +477,8 @@ class Main extends PureComponent {
 			}, AppConstants.TX_CHECK_NORMAL_FREQUENCY);
 		}
 	};
-
 	componentDidMount = async () => {
+		this.initializeWalletConnect();
 		InteractionManager.runAfterInteractions(() => {
 			AppState.addEventListener('change', this.handleAppStateChange);
 			this.lockManager = new LockManager(this.props.navigation, this.props.lockTime);
@@ -552,8 +552,6 @@ class Main extends PureComponent {
 					this.props.showSimpleNotification
 				);
 				this.pollForIncomingTransactions();
-
-				this.initializeWalletConnect();
 
 				// Only if enabled under settings
 				if (this.props.paymentChannelsEnabled) {

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -478,8 +478,8 @@ class Main extends PureComponent {
 		}
 	};
 	componentDidMount = async () => {
-		this.initializeWalletConnect();
 		InteractionManager.runAfterInteractions(() => {
+			this.initializeWalletConnect();
 			AppState.addEventListener('change', this.handleAppStateChange);
 			this.lockManager = new LockManager(this.props.navigation, this.props.lockTime);
 			PushNotification.configure({

--- a/app/components/Views/Entry/index.js
+++ b/app/components/Views/Entry/index.js
@@ -86,9 +86,10 @@ class Entry extends PureComponent {
 	animation = React.createRef();
 	animationName = React.createRef();
 	opacity = new Animated.Value(1);
-	mounted = false;
 
 	async componentDidMount() {
+		DeeplinkManager.init(this.props.navigation);
+		this.unsubscribeFromBranch = Branch.subscribe(this.handleDeeplinks);
 		SplashScreen.hide();
 		const existingUser = await AsyncStorage.getItem('@MetaMask:existingUser');
 		if (existingUser !== null) {
@@ -96,23 +97,9 @@ class Entry extends PureComponent {
 		} else {
 			this.animateAndGoTo('OnboardingRootNav');
 		}
-		DeeplinkManager.init(this.props.navigation);
-		this.unsubscribeFromBranch = Branch.subscribe(this.handleDeeplinks);
-		this.mounted = true;
 	}
 
-	waitUntilMounted = async () => {
-		if (this.mounted) return;
-		await new Promise(resolve => {
-			setTimeout(() => {
-				if (this.mounted) resolve();
-				else this.waitUntilMounted();
-			}, 2000);
-		});
-	};
-
-	handleDeeplinks = async ({ error, params, uri }) => {
-		await this.waitUntilMounted();
+	handleDeeplinks = ({ error, params, uri }) => {
 		if (error) {
 			Logger.error(error, 'Error from Branch');
 			return;

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -71,11 +71,7 @@ class DeeplinkManager {
 
 					switch (action) {
 						case 'wc':
-							params &&
-								params.uri &&
-								setTimeout(() => {
-									WalletConnect.newSession(params.uri, params.redirectUrl, false);
-								}, 1500);
+							params && params.uri && WalletConnect.newSession(params.uri, params.redirectUrl, false);
 							break;
 						case 'dapp':
 							this.handleBrowserUrl(

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -60,7 +60,6 @@ class DeeplinkManager {
 			params = qs.parse(urlObj.query.substring(1));
 		}
 		const { MM_UNIVERSAL_LINK_HOST } = AppConstants;
-
 		switch (urlObj.protocol.replace(':', '')) {
 			case 'http':
 			case 'https':
@@ -71,11 +70,7 @@ class DeeplinkManager {
 
 					switch (action) {
 						case 'wc':
-							params &&
-								params.uri &&
-								setTimeout(() => {
-									WalletConnect.newSession(params.uri, params.redirectUrl, false);
-								}, 1500);
+							params && params.uri && WalletConnect.newSession(params.uri, params.redirectUrl, false);
 							break;
 						case 'dapp':
 							this.handleBrowserUrl(

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -60,6 +60,7 @@ class DeeplinkManager {
 			params = qs.parse(urlObj.query.substring(1));
 		}
 		const { MM_UNIVERSAL_LINK_HOST } = AppConstants;
+
 		switch (urlObj.protocol.replace(':', '')) {
 			case 'http':
 			case 'https':
@@ -70,7 +71,11 @@ class DeeplinkManager {
 
 					switch (action) {
 						case 'wc':
-							params && params.uri && WalletConnect.newSession(params.uri, params.redirectUrl, false);
+							params &&
+								params.uri &&
+								setTimeout(() => {
+									WalletConnect.newSession(params.uri, params.redirectUrl, false);
+								}, 1500);
 							break;
 						case 'dapp':
 							this.handleBrowserUrl(

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -21,10 +21,10 @@ const persistSessions = async () => {
 
 const waitForInitialization = async () => {
 	let i = 0;
-	// eslint-disable-next-line no-unmodified-loop-condition
-	while (!initialized || i > 5) {
+	while (!initialized) {
 		await new Promise(res => setTimeout(() => res(), 1000));
-		i++;
+		console.log('initialized', initialized);
+		if (i++ > 5) initialized = true;
 	}
 };
 

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -23,7 +23,6 @@ const waitForInitialization = async () => {
 	let i = 0;
 	while (!initialized) {
 		await new Promise(res => setTimeout(() => res(), 1000));
-		console.log('initialized', initialized);
 		if (i++ > 5) initialized = true;
 	}
 };

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -9,6 +9,7 @@ import { CLIENT_OPTIONS, WALLET_CONNECT_ORIGIN } from '../util/walletconnect';
 
 const hub = new EventEmitter();
 let connectors = [];
+let initialized = false;
 
 const persistSessions = async () => {
 	const sessions = connectors
@@ -16,6 +17,15 @@ const persistSessions = async () => {
 		.map(connector => connector.walletConnector.session);
 
 	await AsyncStorage.setItem('@MetaMask:walletconnectSessions', JSON.stringify(sessions));
+};
+
+const waitForInitialization = async () => {
+	let i = 0;
+	// eslint-disable-next-line no-unmodified-loop-condition
+	while (!initialized || i > 5) {
+		await new Promise(res => setTimeout(() => res(), 1000));
+		i++;
+	}
 };
 
 class WalletConnect {
@@ -46,7 +56,10 @@ class WalletConnect {
 					...payload.params[0],
 					autosign: this.autosign
 				};
+
 				Logger.log('requesting session with', sessionData);
+
+				await waitForInitialization();
 				await this.sessionRequest(sessionData);
 
 				const { network } = Engine.context.NetworkController.state;
@@ -300,6 +313,7 @@ const instance = {
 				connectors.push(new WalletConnect({ session }));
 			});
 		}
+		initialized = true;
 	},
 	connectors() {
 		return connectors;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes the issue of opening a wallet connect connect request when the app was closed. What was happening was that the wc request was coming first than the app being initialized sometimes, so 

- I moved the initialization (specially the listener of that method) do be the first thing that the app does when is starting.
- Added an `initialized` flag that defines when the `Main` component was mounted to process connect requests from wallet connect.

Because of these reasons I also removed a timeout that we had, we're handling it now.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
