### PR TITLE
Fix network color indicator on transactionHeader for connect screens

### DIFF
--- a/app/components/UI/NavbarBrowserTitle/index.js
+++ b/app/components/UI/NavbarBrowserTitle/index.js
@@ -119,12 +119,7 @@ class NavbarBrowserTitle extends PureComponent {
 					</Text>
 				</View>
 				<View style={styles.network}>
-					<View
-						style={[
-							styles.networkIcon,
-							color ? { backgroundColor: color } : { backgroundColor: colors.red }
-						]}
-					/>
+					<View style={[styles.networkIcon, { backgroundColor: color || colors.red }]} />
 					<Text style={styles.networkName} testID={'navbar-title-network'}>
 						{name}
 					</Text>

--- a/app/components/UI/NavbarBrowserTitle/index.js
+++ b/app/components/UI/NavbarBrowserTitle/index.js
@@ -119,7 +119,12 @@ class NavbarBrowserTitle extends PureComponent {
 					</Text>
 				</View>
 				<View style={styles.network}>
-					<View style={[styles.networkIcon, color ? { backgroundColor: color } : styles.otherNetworkIcon]} />
+					<View
+						style={[
+							styles.networkIcon,
+							color ? { backgroundColor: color } : { backgroundColor: colors.red }
+						]}
+					/>
 					<Text style={styles.networkName} testID={'navbar-title-network'}>
 						{name}
 					</Text>

--- a/app/components/UI/TransactionHeader/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionHeader/__snapshots__/index.test.js.snap
@@ -79,7 +79,7 @@ exports[`TransactionHeader should render correctly 1`] = `
             "width": 5,
           },
           Object {
-            "backgroundColor": "green",
+            "backgroundColor": "#ff4a8d",
           },
         ]
       }

--- a/app/components/UI/TransactionHeader/index.js
+++ b/app/components/UI/TransactionHeader/index.js
@@ -80,7 +80,7 @@ class TransactionHeader extends PureComponent {
 	 */
 	renderNetworkStatusIndicator = () => {
 		const { networkType } = this.props;
-		const networkStatusIndicatorColor = (networkList[networkType] && networkList[networkType].color) || null;
+		const networkStatusIndicatorColor = (networkList[networkType] && networkList[networkType].color) || colors.red;
 		const networkStatusIndicator = (
 			<View style={[styles.networkStatusIndicator, { backgroundColor: networkStatusIndicatorColor }]} />
 		);

--- a/app/components/UI/TransactionHeader/index.js
+++ b/app/components/UI/TransactionHeader/index.js
@@ -70,11 +70,7 @@ class TransactionHeader extends PureComponent {
 		/**
 		 * String representing the selected network
 		 */
-		networkType: PropTypes.string,
-		/**
-		 * Object representing the status of infura networks
-		 */
-		networkStatus: PropTypes.object
+		networkType: PropTypes.string
 	};
 
 	/**
@@ -83,8 +79,8 @@ class TransactionHeader extends PureComponent {
 	 * @return {element} - JSX view element
 	 */
 	renderNetworkStatusIndicator = () => {
-		const { networkType, networkStatus } = this.props;
-		const networkStatusIndicatorColor = networkStatus[networkType] === 'ok' ? 'green' : 'red';
+		const { networkType } = this.props;
+		const networkStatusIndicatorColor = (networkList[networkType] && networkList[networkType].color) || null;
 		const networkStatusIndicator = (
 			<View style={[styles.networkStatusIndicator, { backgroundColor: networkStatusIndicatorColor }]} />
 		);


### PR DESCRIPTION
the colour indicator on the connect screen seems to be green (online) or red (offline).

this change makes it so we use the appropriate colour mapping for each network.

we may want to revisit this to incorporate `networkStatus` elsewhere

Before:

![image](https://user-images.githubusercontent.com/675259/84527514-13842080-acac-11ea-9688-9394cdda7888.png)

After:

![image](https://user-images.githubusercontent.com/675259/84527581-27c81d80-acac-11ea-80e6-39f469513ad8.png)

