### PR TITLE
Add padding to CustomGas back button

### DIFF
--- a/app/components/Views/SendFlow/CustomGas/index.js
+++ b/app/components/Views/SendFlow/CustomGas/index.js
@@ -18,6 +18,9 @@ import Radio from '../../../UI/Radio';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const styles = StyleSheet.create({
+	back: {
+		padding: 10
+	},
 	root: {
 		backgroundColor: colors.white,
 		minHeight: 200,
@@ -544,7 +547,7 @@ class CustomGas extends PureComponent {
 				<View style={styles.root}>
 					<KeyboardAwareScrollView resetScrollToCoords={{ x: 0, y: 0 }}>
 						<View style={styles.customGasHeader}>
-							<TouchableOpacity onPress={toggleCustomGasModal}>
+							<TouchableOpacity style={styles.back} onPress={toggleCustomGasModal}>
 								<IonicIcon name={'ios-arrow-back'} size={24} color={colors.black} />
 							</TouchableOpacity>
 							<Text style={styles.customGasModalTitleText}>


### PR DESCRIPTION
This is a tiny one I noticed on Friday, but it's really hard to hit the back chevron in the `CustomGas` component (especially on device).

This PR adds some `padding` so it's a bit easier.

I've attached screenshots that contain an added red border to illustrate:

**BEFORE:**

![Screenshot from 2020-06-15 16 05 56](https://user-images.githubusercontent.com/675259/84701388-dffefb80-af22-11ea-9088-ad105faddab4.png)

**AFTER:**

![Screenshot from 2020-06-15 16 06 16](https://user-images.githubusercontent.com/675259/84701354-ceb5ef00-af22-11ea-8628-7d742e241413.png)
