### PR TITLE
Fix blank browser tab

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -369,7 +369,7 @@ export class BrowserTab extends PureComponent {
 			showApprovalDialog: false,
 			showPhishingModal: false,
 			timeout: false,
-			url: null,
+			url: props.initialUrl || HOMEPAGE_URL,
 			contentHeight: 0,
 			forwardEnabled: false,
 			forceReload: false,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This fixes homepage not loading on a previously opened tab after a user completely closes a opens the app.

**Issue**

Resolves #1635
