### PR TITLE
Make 'Use Max' flow consistent with browser extension

### DIFF
--- a/app/actions/transaction/index.js
+++ b/app/actions/transaction/index.js
@@ -126,6 +126,18 @@ export function setTransactionObject(transaction) {
 }
 
 /**
+ * Toggles Max Mode
+ *
+ * @param {boolean} maxMode - maxMode initial state
+ */
+export function toggleMaxMode(maxMode) {
+	return {
+		type: 'TOGGLE_MAX_MODE',
+		maxMode
+	};
+}
+
+/**
  * Enable selectable tokens (ERC20 and Ether) to send in a transaction
  *
  * @param {object} asset - Asset to start the transaction with

--- a/app/components/Views/SendFlow/Amount/__snapshots__/index.test.js.snap
+++ b/app/components/Views/SendFlow/Amount/__snapshots__/index.test.js.snap
@@ -99,18 +99,35 @@ exports[`Amount should render correctly 1`] = `
         <TouchableOpacity
           disabled={true}
           onPress={[Function]}
-          style={Object {}}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "borderColor": "#037dd6",
+                "borderRadius": 100,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "paddingHorizontal": 16,
+                "paddingVertical": 2,
+              },
+              undefined,
+            ]
+          }
         >
           <Text
             style={
-              Object {
-                "alignSelf": "flex-end",
-                "color": "#037dd6",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 12,
-                "fontWeight": "400",
-                "textTransform": "uppercase",
-              }
+              Array [
+                Object {
+                  "alignSelf": "flex-end",
+                  "color": "#037dd6",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 12,
+                  "fontWeight": "400",
+                  "paddingVertical": 2,
+                  "textTransform": "uppercase",
+                },
+                undefined,
+              ]
             }
           >
             Use max
@@ -135,16 +152,20 @@ exports[`Amount should render correctly 1`] = `
           }
         >
           <TextInput
+            editable={true}
             keyboardType="numeric"
             onChangeText={[Function]}
             placeholder="0"
             style={
-              Object {
-                "fontFamily": "Roboto-Light",
-                "fontSize": 44,
-                "fontWeight": "300",
-                "textAlign": "center",
-              }
+              Array [
+                Object {
+                  "fontFamily": "Roboto-Light",
+                  "fontSize": 44,
+                  "fontWeight": "300",
+                  "textAlign": "center",
+                },
+                undefined,
+              ]
             }
             testID="txn-amount-input"
           />

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -13,7 +13,12 @@ import {
 	InteractionManager
 } from 'react-native';
 import { connect } from 'react-redux';
-import { setSelectedAsset, prepareTransaction, setTransactionObject } from '../../../../actions/transaction';
+import {
+	setSelectedAsset,
+	prepareTransaction,
+	setTransactionObject,
+	toggleMaxMode
+} from '../../../../actions/transaction';
 import { getSendFlowTitle } from '../../../UI/Navbar';
 import StyledButton from '../../../UI/StyledButton';
 import PropTypes from 'prop-types';
@@ -384,7 +389,15 @@ class Amount extends PureComponent {
 		/**
 		 * function to call when the 'Next' button is clicked
 		 */
-		onConfirm: PropTypes.func
+		onConfirm: PropTypes.func,
+		/**
+		 * function to toggle Max Mode
+		 */
+		toggleMaxMode: PropTypes.func,
+		/**
+		 * Max Mode is on or off
+		 */
+		maxMode: PropTypes.bool
 	};
 
 	state = {
@@ -395,8 +408,7 @@ class Amount extends PureComponent {
 		assetsModalVisible: false,
 		internalPrimaryCurrencyIsCrypto: this.props.primaryCurrency === 'ETH',
 		estimatedTotalGas: undefined,
-		hasExchangeRate: false,
-		maxMode: false
+		hasExchangeRate: false
 	};
 
 	amountInput = React.createRef();
@@ -687,9 +699,11 @@ class Amount extends PureComponent {
 			selectedAsset,
 			conversionRate,
 			contractExchangeRates,
-			transactionState: { paymentChannelTransaction }
+			transactionState: { paymentChannelTransaction },
+			toggleMaxMode,
+			maxMode
 		} = this.props;
-		const { internalPrimaryCurrencyIsCrypto, estimatedTotalGas, maxMode } = this.state;
+		const { internalPrimaryCurrencyIsCrypto, estimatedTotalGas } = this.state;
 		if (maxMode) {
 			this.onInputChange('0');
 			setTimeout(() => this.amountInput && this.amountInput.current && this.amountInput.current.focus(), 100);
@@ -721,7 +735,7 @@ class Amount extends PureComponent {
 			}
 			this.onInputChange(input, undefined, true);
 		}
-		this.setState({ maxMode: !maxMode });
+		toggleMaxMode(maxMode);
 	};
 
 	onInputChange = (inputValue, selectedAsset, useMax) => {
@@ -963,10 +977,9 @@ class Amount extends PureComponent {
 			amountError,
 			hasExchangeRate,
 			internalPrimaryCurrencyIsCrypto,
-			currentBalance,
-			maxMode
+			currentBalance
 		} = this.state;
-		const { currentCurrency } = this.props;
+		const { currentCurrency, maxMode } = this.props;
 		return (
 			<View>
 				<View style={styles.inputContainerWrapper}>
@@ -1037,10 +1050,11 @@ class Amount extends PureComponent {
 	};
 
 	render = () => {
-		const { estimatedTotalGas, maxMode } = this.state;
+		const { estimatedTotalGas } = this.state;
 		const {
 			selectedAsset,
-			transactionState: { paymentChannelTransaction, isPaymentRequest }
+			transactionState: { paymentChannelTransaction, isPaymentRequest },
+			maxMode
 		} = this.props;
 
 		return (
@@ -1124,13 +1138,15 @@ const mapStateToProps = (state, ownProps) => ({
 	ticker: state.engine.backgroundState.NetworkController.provider.ticker,
 	tokens: state.engine.backgroundState.AssetsController.tokens,
 	transactionState: ownProps.transaction || state.transaction,
-	selectedAsset: state.transaction.selectedAsset
+	selectedAsset: state.transaction.selectedAsset,
+	maxMode: state.transaction.maxMode
 });
 
 const mapDispatchToProps = dispatch => ({
 	setTransactionObject: transaction => dispatch(setTransactionObject(transaction)),
 	prepareTransaction: transaction => dispatch(prepareTransaction(transaction)),
-	setSelectedAsset: selectedAsset => dispatch(setSelectedAsset(selectedAsset))
+	setSelectedAsset: selectedAsset => dispatch(setSelectedAsset(selectedAsset)),
+	toggleMaxMode: maxMode => dispatch(toggleMaxMode(maxMode))
 });
 
 export default connect(

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -157,6 +157,9 @@ const styles = StyleSheet.create({
 		fontSize: 44,
 		textAlign: 'center'
 	},
+	textInputMaxOn: {
+		color: colors.grey500
+	},
 	switch: {
 		flex: 1,
 		marginTop: Device.isIos() ? 0 : 2
@@ -689,6 +692,7 @@ class Amount extends PureComponent {
 		const { internalPrimaryCurrencyIsCrypto, estimatedTotalGas, maxMode } = this.state;
 		if (maxMode) {
 			this.onInputChange('0');
+			setTimeout(() => this.amountInput && this.amountInput.current && this.amountInput.current.focus(), 100);
 		} else {
 			let input;
 			if (paymentChannelTransaction) {
@@ -959,7 +963,8 @@ class Amount extends PureComponent {
 			amountError,
 			hasExchangeRate,
 			internalPrimaryCurrencyIsCrypto,
-			currentBalance
+			currentBalance,
+			maxMode
 		} = this.state;
 		const { currentCurrency } = this.props;
 		return (
@@ -971,12 +976,13 @@ class Amount extends PureComponent {
 						)}
 						<TextInput
 							ref={this.amountInput}
-							style={styles.textInput}
+							style={[styles.textInput, maxMode && styles.textInputMaxOn]}
 							value={inputValue}
 							onChangeText={this.onInputChange}
 							keyboardType={'numeric'}
 							placeholder={'0'}
 							testID={'txn-amount-input'}
+							editable={!maxMode}
 						/>
 					</View>
 				</View>

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -448,6 +448,11 @@ class Amount extends PureComponent {
 		}
 	};
 
+	componentWillUnmount = () => {
+		const { maxMode, toggleMaxMode } = this.props;
+		maxMode && toggleMaxMode(maxMode);
+	};
+
 	validateCollectibleOwnership = async () => {
 		const { AssetsContractController } = Engine.context;
 		const {
@@ -709,6 +714,7 @@ class Amount extends PureComponent {
 			setTimeout(() => this.amountInput && this.amountInput.current && this.amountInput.current.focus(), 100);
 		} else {
 			let input;
+			let maxFiatInput;
 			if (paymentChannelTransaction) {
 				input = selectedAsset.assetBalance;
 			} else if (selectedAsset.isETH) {
@@ -719,7 +725,7 @@ class Amount extends PureComponent {
 					input = fromWei(maxValue);
 				} else {
 					input = `${weiToFiatNumber(maxValue, conversionRate)}`;
-					this.setState({ maxFiatInput: `${weiToFiatNumber(maxValue, conversionRate, 12)}` });
+					maxFiatInput = `${weiToFiatNumber(maxValue, conversionRate, 12)}`;
 				}
 			} else {
 				const exchangeRate = contractExchangeRates[selectedAsset.address];
@@ -733,12 +739,12 @@ class Amount extends PureComponent {
 					)}`;
 				}
 			}
-			this.onInputChange(input, undefined, true);
+			this.onInputChange(input, undefined, { maxFiatInput });
 		}
 		toggleMaxMode(maxMode);
 	};
 
-	onInputChange = (inputValue, selectedAsset, useMax) => {
+	onInputChange = (inputValue, selectedAsset, max) => {
 		const { contractExchangeRates, conversionRate, currentCurrency, ticker } = this.props;
 		const { internalPrimaryCurrencyIsCrypto } = this.state;
 		let inputValueConversion, renderableInputValueConversion, hasExchangeRate, comma;
@@ -798,7 +804,7 @@ class Amount extends PureComponent {
 			renderableInputValueConversion,
 			amountError: undefined,
 			hasExchangeRate,
-			maxFiatInput: !useMax && undefined
+			maxFiatInput: (max && max.maxFiatInput) || undefined
 		});
 	};
 

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -108,6 +108,7 @@ const styles = StyleSheet.create({
 	maxText: {
 		...fontStyles.normal,
 		fontSize: 12,
+		paddingVertical: 2,
 		color: colors.blue,
 		alignSelf: 'flex-end',
 		textTransform: 'uppercase'
@@ -117,7 +118,15 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'flex-end'
 	},
-	actionMaxTouchable: {},
+	actionMaxTouchable: {
+		borderWidth: 1,
+		borderColor: colors.blue,
+		paddingHorizontal: 16,
+		paddingVertical: 2,
+		borderRadius: 100,
+		flexDirection: 'row',
+		alignItems: 'center'
+	},
 	inputContainerWrapper: {
 		marginVertical: 16,
 		alignItems: 'center'

--- a/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.js.snap
+++ b/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.js.snap
@@ -266,7 +266,6 @@ exports[`Confirm should render correctly 1`] = `
   >
     <Connect(CustomGas)
       handleGasFeeSelection={[Function]}
-      handleSetGasFee={[Function]}
       parentStateReady={[Function]}
       selected="average"
       toggleCustomGasModal={[Function]}

--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -22,7 +22,8 @@ const initialState = {
 	paymentRequest: undefined,
 	readableValue: undefined,
 	id: undefined,
-	type: undefined
+	type: undefined,
+	maxMode: undefined
 };
 
 const getAssetType = selectedAsset => {
@@ -95,6 +96,12 @@ const transactionReducer = (state = initialState, action) => {
 					...getTxData(action.transaction)
 				},
 				...txMeta
+			};
+		}
+		case 'TOGGLE_MAX_MODE': {
+			return {
+				...state,
+				maxMode: !action.maxMode
 			};
 		}
 		case 'SET_TOKENS_TRANSACTION': {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

In the extension, max is a 'mode' that toggles on and off. When on, the input field becomes disabled and when the gas price changes the amount updates accordingly. On mobile the input remains enabled- and when the gas price changes it shows insufficient funds, which isn't an ideal user flow.

**Checklist**

**Issue**
https://trello.com/c/MI0kqA1l/186-make-use-max-send-flow-consistent-with-the-browser-extension

