### PR TITLE
Don't allow for zero in custom gas price

### DIFF
--- a/app/components/Views/SendFlow/CustomGas/index.js
+++ b/app/components/Views/SendFlow/CustomGas/index.js
@@ -392,7 +392,7 @@ class CustomGas extends PureComponent {
 	onGasPriceChange = value => {
 		let warningGasPrice;
 		const { customGasLimit, warningGasLimit } = this.state;
-		if (!value || value === '' || !isDecimal(value)) {
+		if (value === '0' || !value || value === '' || !isDecimal(value)) {
 			warningGasPrice = strings('transaction.invalid_gas_price');
 			this.setState({ customGasPrice: value, warningGasPrice });
 			this.props.handleGasFeeSelection({ error: warningGasPrice });


### PR DESCRIPTION
this fixes the issue for when a user inputs `0` for custom gas price. however I don't know if this is how we should be patching this? seems odd that we're not treating the input value as a int here?