### PR TITLE
Add transaction_error_msg and send error to sentry

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -777,6 +777,7 @@ class Main extends PureComponent {
 			Alert.alert(strings('transactions.transaction_error'), error && error.message, [
 				{ text: strings('navigation.ok') }
 			]);
+			Logger.error(error, 'error while trying to send transaction (Main)');
 			this.setState({ transactionHandled: false });
 		}
 	};

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -15,6 +15,7 @@ import { getTransactionReviewActionKey, getNormalizedTxState } from '../../../ut
 import { strings } from '../../../../locales/i18n';
 import { safeToChecksumAddress } from '../../../util/address';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
+import Logger from '../../../util/Logger';
 
 const REVIEW = 'review';
 const EDIT = 'edit';
@@ -220,6 +221,7 @@ class Approval extends PureComponent {
 			Alert.alert(strings('transactions.transaction_error'), error && error.message, [
 				{ text: strings('navigation.ok') }
 			]);
+			Logger.error(error, 'error while trying to send transaction (Approval)');
 			this.setState({ transactionHandled: false });
 		}
 		this.trackOnConfirm();

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -37,6 +37,7 @@ import IonicIcon from 'react-native-vector-icons/Ionicons';
 import TransactionReviewDetailsCard from '../../../UI/TransactionReview/TransactionReivewDetailsCard';
 import StyledButton from '../../../UI/StyledButton';
 import currencySymbols from '../../../../util/currency-symbols.json';
+import Logger from '../../../../util/Logger';
 
 const { BNToHex, hexToBN } = util;
 const styles = StyleSheet.create({
@@ -664,6 +665,7 @@ class Approve extends PureComponent {
 			this.trackApproveEvent(ANALYTICS_EVENT_OPTS.DAPP_APPROVE_SCREEN_APPROVE);
 		} catch (error) {
 			Alert.alert(strings('transactions.transaction_error'), error && error.message, [{ text: 'OK' }]);
+			Logger.error(error, 'error while trying to send transaction (Approve)');
 			this.setState({ transactionHandled: false });
 		}
 	};

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -534,6 +534,7 @@ class Send extends PureComponent {
 			Alert.alert(strings('transactions.transaction_error'), error && error.message, [
 				{ text: strings('navigation.ok') }
 			]);
+			Logger.error(error, 'error while trying to send transaction (Send)');
 			this.setState({ transactionConfirmed: false });
 			await this.reset();
 		}

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -801,6 +801,7 @@ class Confirm extends PureComponent {
 			Alert.alert(strings('transactions.transaction_error'), error && error.message, [
 				{ text: strings('navigation.ok') }
 			]);
+			Logger.error(error, 'error while trying to send transaction (Confirm)');
 		}
 		this.setState({ transactionConfirmed: false });
 	};


### PR DESCRIPTION
previously we were showing the error to the end user for send/confirm transactions:

![image](https://user-images.githubusercontent.com/675259/89546954-29f1b880-d7d3-11ea-8137-944b4e1c4604.png)

instead we now display a more generic error message and send the error to sentry.

there's a few other spots where we likely want to do the same thing:

here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Nav/Main/index.js#L764
here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Views/Approval/index.js#L209
here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Views/ApproveView/Approve/index.js#L666
<strike>and here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Views/SendFlow/Confirm/index.js#L801</strike>

we should probably update those as well.