### PR TITLE
Add option to use Blockies Identicon and use Jazz Icons as default

### DIFF
--- a/app/actions/settings/index.js
+++ b/app/actions/settings/index.js
@@ -32,3 +32,10 @@ export function setEnablePaymentChannels(paymentChannelsEnabled) {
 		paymentChannelsEnabled
 	};
 }
+
+export function setUseBlockieIcon(useBlockieIcon) {
+	return {
+		type: 'SET_USE_BLOCKIE_ICON',
+		useBlockieIcon
+	};
+}

--- a/app/components/UI/AccountInfoCard/__snapshots__/index.test.js.snap
+++ b/app/components/UI/AccountInfoCard/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`AccountInfoCard should render correctly 1`] = `
     }
   }
 >
-  <Component
+  <Connect(Component)
     address="0x0"
     customStyle={
       Object {

--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -228,7 +228,7 @@ class AccountOverview extends PureComponent {
 							onPress={this.toggleAccountsModal}
 							testID={'wallet-account-identicon'}
 						>
-							<Identicon address={address} size="38" noFadeIn={onboardingWizard} />
+							<Identicon address={address} diameter={38} noFadeIn={onboardingWizard} />
 						</TouchableOpacity>
 						<View ref={this.editableLabelRef} style={styles.data} collapsable={false}>
 							{accountLabelEditable ? (

--- a/app/components/UI/Identicon/__snapshots__/index.test.js.snap
+++ b/app/components/UI/Identicon/__snapshots__/index.test.js.snap
@@ -1,3 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Identicon should render correctly 1`] = `""`;
+exports[`Identicon should render correctly when useBlockieIcon is false 1`] = `
+<Component
+  diameter={46}
+  dispatch={[Function]}
+  useBlockieIcon={false}
+/>
+`;
+
+exports[`Identicon should render correctly when useBlockieIcon is true 1`] = `
+<Component
+  diameter={46}
+  dispatch={[Function]}
+  useBlockieIcon={true}
+/>
+`;

--- a/app/components/UI/Identicon/index.js
+++ b/app/components/UI/Identicon/index.js
@@ -4,31 +4,40 @@ import { Image } from 'react-native';
 import { toDataUrl } from '../../../util/blockies.js';
 import FadeIn from 'react-native-fade-in-image';
 import { colors } from '../../../styles/common.js';
+import Jazzicon from 'react-native-jazzicon';
+import { connect } from 'react-redux';
 
 /**
  * UI component that renders an Identicon
  * for now it's just a blockie
  * but we could add more types in the future
  */
+
 // eslint-disable-next-line react/display-name
 const Identicon = React.memo(props => {
-	const { diameter, address, customStyle, noFadeIn } = props;
+	const { diameter, address, customStyle, noFadeIn, useBlockieIcon } = props;
 	if (!address) return null;
-	const uri = toDataUrl(address);
 
-	const image = (
-		<Image
-			source={{ uri }}
-			style={[
-				{
-					height: diameter,
-					width: diameter,
-					borderRadius: diameter / 2
-				},
-				customStyle
-			]}
-		/>
-	);
+	let image;
+	if (useBlockieIcon) {
+		const uri = toDataUrl(address);
+
+		image = (
+			<Image
+				source={{ uri }}
+				style={[
+					{
+						height: diameter,
+						width: diameter,
+						borderRadius: diameter / 2
+					},
+					customStyle
+				]}
+			/>
+		);
+	} else {
+		image = <Jazzicon size={diameter} address={address} />;
+	}
 
 	if (noFadeIn) {
 		return image;
@@ -52,11 +61,19 @@ Identicon.propTypes = {
 	/**
 	 * True if render is happening without fade in
 	 */
-	noFadeIn: PropTypes.bool
+	noFadeIn: PropTypes.bool,
+	/**
+	 * Show a BlockieIcon instead of JazzIcon
+	 */
+	useBlockieIcon: PropTypes.bool
 };
 
 Identicon.defaultProps = {
 	diameter: 46
 };
 
-export default Identicon;
+const mapStateToProps = state => ({
+	useBlockieIcon: state.settings.useBlockieIcon
+});
+
+export default connect(mapStateToProps)(Identicon);

--- a/app/components/UI/Identicon/index.js
+++ b/app/components/UI/Identicon/index.js
@@ -18,26 +18,21 @@ const Identicon = React.memo(props => {
 	const { diameter, address, customStyle, noFadeIn, useBlockieIcon } = props;
 	if (!address) return null;
 
-	let image;
-	if (useBlockieIcon) {
-		const uri = toDataUrl(address);
-
-		image = (
-			<Image
-				source={{ uri }}
-				style={[
-					{
-						height: diameter,
-						width: diameter,
-						borderRadius: diameter / 2
-					},
-					customStyle
-				]}
-			/>
-		);
-	} else {
-		image = <Jazzicon size={diameter} address={address} />;
-	}
+	const image = useBlockieIcon ? (
+		<Image
+			source={toDataUrl(address)}
+			style={[
+				{
+					height: diameter,
+					width: diameter,
+					borderRadius: diameter / 2
+				},
+				customStyle
+			]}
+		/>
+	) : (
+		<Jazzicon size={diameter} address={address} />
+	);
 
 	if (noFadeIn) {
 		return image;

--- a/app/components/UI/Identicon/index.js
+++ b/app/components/UI/Identicon/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Image } from 'react-native';
+import { Image, View } from 'react-native';
 import { toDataUrl } from '../../../util/blockies.js';
 import FadeIn from 'react-native-fade-in-image';
 import { colors } from '../../../styles/common.js';
@@ -32,7 +32,9 @@ const Identicon = React.memo(props => {
 			]}
 		/>
 	) : (
-		<Jazzicon size={diameter} address={address} />
+		<View style={customStyle}>
+			<Jazzicon size={diameter} address={address} />
+		</View>
 	);
 
 	if (noFadeIn) {

--- a/app/components/UI/Identicon/index.js
+++ b/app/components/UI/Identicon/index.js
@@ -69,7 +69,8 @@ Identicon.propTypes = {
 };
 
 Identicon.defaultProps = {
-	diameter: 46
+	diameter: 46,
+	useBlockieIcon: false
 };
 
 const mapStateToProps = state => ({

--- a/app/components/UI/Identicon/index.js
+++ b/app/components/UI/Identicon/index.js
@@ -17,10 +17,11 @@ import { connect } from 'react-redux';
 const Identicon = React.memo(props => {
 	const { diameter, address, customStyle, noFadeIn, useBlockieIcon } = props;
 	if (!address) return null;
+	const uri = useBlockieIcon && toDataUrl(address);
 
 	const image = useBlockieIcon ? (
 		<Image
-			source={toDataUrl(address)}
+			source={{ uri }}
 			style={[
 				{
 					height: diameter,

--- a/app/components/UI/Identicon/index.test.js
+++ b/app/components/UI/Identicon/index.test.js
@@ -1,10 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Identicon from './';
+import configureMockStore from 'redux-mock-store';
+
+const mockStore = configureMockStore();
 
 describe('Identicon', () => {
 	it('should render correctly', () => {
-		const wrapper = shallow(<Identicon />);
-		expect(wrapper).toMatchSnapshot();
+		const initialState = {
+			settings: { useBlockieIcon: false }
+		};
+
+		const wrapper = shallow(<Identicon />, {
+			context: { store: mockStore(initialState) }
+		});
+		expect(wrapper.dive()).toMatchSnapshot();
 	});
 });

--- a/app/components/UI/Identicon/index.test.js
+++ b/app/components/UI/Identicon/index.test.js
@@ -3,10 +3,19 @@ import { shallow } from 'enzyme';
 import Identicon from './';
 import configureMockStore from 'redux-mock-store';
 
-const mockStore = configureMockStore();
-
 describe('Identicon', () => {
-	it('should render correctly', () => {
+	const mockStore = configureMockStore();
+	it('should render correctly when useBlockieIcon is true', () => {
+		const initialState = {
+			settings: { useBlockieIcon: true }
+		};
+
+		const wrapper = shallow(<Identicon />, {
+			context: { store: mockStore(initialState) }
+		});
+		expect(wrapper).toMatchSnapshot();
+	});
+	it('should render correctly when useBlockieIcon is false', () => {
 		const initialState = {
 			settings: { useBlockieIcon: false }
 		};
@@ -14,6 +23,6 @@ describe('Identicon', () => {
 		const wrapper = shallow(<Identicon />, {
 			context: { store: mockStore(initialState) }
 		});
-		expect(wrapper.dive()).toMatchSnapshot();
+		expect(wrapper).toMatchSnapshot();
 	});
 });

--- a/app/components/UI/PaymentChannelApproval/__snapshots__/index.test.js.snap
+++ b/app/components/UI/PaymentChannelApproval/__snapshots__/index.test.js.snap
@@ -66,7 +66,7 @@ exports[`PaymentChannelApproval should render correctly 1`] = `
             }
           }
         >
-          <Component
+          <Connect(Component)
             address="0xe7E125654064EEa56229f273dA586F10DF96B0a1"
             diameter={54}
           />

--- a/app/components/UI/TokenImage/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TokenImage/__snapshots__/index.test.js.snap
@@ -16,9 +16,8 @@ exports[`TokenImage should render correctly 1`] = `
     ]
   }
 >
-  <Component
+  <Connect(Component)
     address="0x123"
-    diameter={46}
   />
 </View>
 `;

--- a/app/components/Views/SendFlow/AddressElement/__snapshots__/index.test.js.snap
+++ b/app/components/Views/SendFlow/AddressElement/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`AddressElement should render correctly 1`] = `
       }
     }
   >
-    <Component
+    <Connect(Component)
       diameter={28}
     />
   </View>

--- a/app/components/Views/Settings/AdvancedSettings/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Settings/AdvancedSettings/__snapshots__/index.test.js.snap
@@ -346,6 +346,45 @@ exports[`AdvancedSettings should render correctly 1`] = `
             }
           }
         >
+          Use Blockies Identicon
+        </Text>
+        <View
+          style={
+            Object {
+              "marginTop": 18,
+            }
+          }
+        >
+          <Switch
+            ios_backgroundColor="#f2f3f4"
+            onValueChange={[Function]}
+            trackColor={
+              Object {
+                "false": "#f2f3f4",
+                "true": "#037dd6",
+              }
+            }
+          />
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 50,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#000000",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+            }
+          }
+        >
           State Logs
         </Text>
         <Text

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -125,7 +125,13 @@ class AdvancedSettings extends PureComponent {
 		 * Entire redux state used to generate state logs
 		 */
 		fullState: PropTypes.object,
+		/**
+		 * Show a BlockieIcon instead of JazzIcon
+		 */
 		useBlockieIcon: PropTypes.bool,
+		/**
+		 * called to toggle BlockieIcon
+		 */
 		setUseBlockieIcon: PropTypes.func
 	};
 
@@ -349,7 +355,6 @@ class AdvancedSettings extends PureComponent {
 						</View>
 						<View style={styles.setting}>
 							<Text style={styles.title}>{strings('app_settings.show_blockies_identicon')}</Text>
-							{/*<Text style={styles.desc}>{strings('app_settings.hex_desc')}</Text>*/}
 							<View style={styles.switchElement}>
 								<Switch
 									value={useBlockieIcon}

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -192,8 +192,8 @@ class AdvancedSettings extends PureComponent {
 		this.props.setShowHexData(showHexData);
 	};
 
-	toggleUseBlockieIcon = useuseBlockieIcon => {
-		this.props.setUseBlockieIcon(useuseBlockieIcon);
+	toggleUseBlockieIcon = useBlockieIcon => {
+		this.props.setUseBlockieIcon(useBlockieIcon);
 	};
 
 	goToSyncWithExtension = () => {
@@ -342,7 +342,7 @@ class AdvancedSettings extends PureComponent {
 								<Switch
 									value={showHexData}
 									onValueChange={this.toggleShowHexData}
-									trackColor={Device.isIos() ? { true: colors.blue, false: colors.grey000 } : null}
+									trackColor={Device.isIos() && { true: colors.blue, false: colors.grey000 }}
 									ios_backgroundColor={colors.grey000}
 								/>
 							</View>
@@ -354,7 +354,7 @@ class AdvancedSettings extends PureComponent {
 								<Switch
 									value={useBlockieIcon}
 									onValueChange={this.toggleUseBlockieIcon}
-									trackColor={Device.isIos() ? { true: colors.blue, false: colors.grey000 } : null}
+									trackColor={Device.isIos() && { true: colors.blue, false: colors.grey000 }}
 									ios_backgroundColor={colors.grey000}
 								/>
 							</View>

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -9,7 +9,7 @@ import Engine from '../../../../core/Engine';
 import StyledButton from '../../../UI/StyledButton';
 import { colors, fontStyles, baseStyles } from '../../../../styles/common';
 import { getNavigationOptionsTitle } from '../../../UI/Navbar';
-import { setShowHexData } from '../../../../actions/settings';
+import { setShowHexData, setUseBlockieIcon } from '../../../../actions/settings';
 import { strings } from '../../../../../locales/i18n';
 import { getApplicationName, getVersion, getBuildNumber } from 'react-native-device-info';
 import Share from 'react-native-share'; // eslint-disable-line  import/default
@@ -124,7 +124,9 @@ class AdvancedSettings extends PureComponent {
 		/**
 		 * Entire redux state used to generate state logs
 		 */
-		fullState: PropTypes.object
+		fullState: PropTypes.object,
+		useBlockieIcon: PropTypes.bool,
+		setUseBlockieIcon: PropTypes.func
 	};
 
 	static navigationOptions = ({ navigation }) =>
@@ -188,6 +190,10 @@ class AdvancedSettings extends PureComponent {
 
 	toggleShowHexData = showHexData => {
 		this.props.setShowHexData(showHexData);
+	};
+
+	toggleUseBlockieIcon = useuseBlockieIcon => {
+		this.props.setUseBlockieIcon(useuseBlockieIcon);
 	};
 
 	goToSyncWithExtension = () => {
@@ -265,7 +271,7 @@ class AdvancedSettings extends PureComponent {
 	};
 
 	render = () => {
-		const { showHexData, ipfsGateway, paymentChannelsEnabled } = this.props;
+		const { showHexData, useBlockieIcon, ipfsGateway, paymentChannelsEnabled } = this.props;
 		const { resetModalVisible, onlineIpfsGateways } = this.state;
 		return (
 			<SafeAreaView style={baseStyles.flexGrow}>
@@ -342,6 +348,18 @@ class AdvancedSettings extends PureComponent {
 							</View>
 						</View>
 						<View style={styles.setting}>
+							<Text style={styles.title}>{strings('app_settings.show_blockies_identicon')}</Text>
+							{/*<Text style={styles.desc}>{strings('app_settings.hex_desc')}</Text>*/}
+							<View style={styles.switchElement}>
+								<Switch
+									value={useBlockieIcon}
+									onValueChange={this.toggleUseBlockieIcon}
+									trackColor={Device.isIos() ? { true: colors.blue, false: colors.grey000 } : null}
+									ios_backgroundColor={colors.grey000}
+								/>
+							</View>
+						</View>
+						<View style={styles.setting}>
 							<Text style={styles.title}>{strings('app_settings.state_logs')}</Text>
 							<Text style={styles.desc}>{strings('app_settings.state_logs_desc')}</Text>
 							<StyledButton
@@ -375,12 +393,14 @@ class AdvancedSettings extends PureComponent {
 const mapStateToProps = state => ({
 	ipfsGateway: state.engine.backgroundState.PreferencesController.ipfsGateway,
 	showHexData: state.settings.showHexData,
+	useBlockieIcon: state.settings.useBlockieIcon,
 	paymentChannelsEnabled: state.settings.paymentChannelsEnabled,
 	fullState: state
 });
 
 const mapDispatchToProps = dispatch => ({
-	setShowHexData: showHexData => dispatch(setShowHexData(showHexData))
+	setShowHexData: showHexData => dispatch(setShowHexData(showHexData)),
+	setUseBlockieIcon: useBlockieIcon => dispatch(setUseBlockieIcon(useBlockieIcon))
 });
 
 export default connect(

--- a/app/reducers/settings/index.js
+++ b/app/reducers/settings/index.js
@@ -5,7 +5,8 @@ const initialState = {
 	searchEngine: AppConstants.DEFAULT_SEARCH_ENGINE,
 	primaryCurrency: 'ETH',
 	lockTime: -1, // Disabled by default
-	paymentChannelsEnabled: false
+	paymentChannelsEnabled: false,
+	useBlockieIcon: false
 };
 
 const settingsReducer = (state = initialState, action) => {
@@ -29,6 +30,11 @@ const settingsReducer = (state = initialState, action) => {
 			return {
 				...state,
 				showHexData: action.showHexData
+			};
+		case 'SET_USE_BLOCKIE_ICON':
+			return {
+				...state,
+				useBlockieIcon: action.useBlockieIcon
 			};
 		case 'SET_PRIMARY_CURRENCY':
 			return {

--- a/locales/en.json
+++ b/locales/en.json
@@ -376,6 +376,7 @@
 		"privacy_mode": "Privacy mode",
 		"privacy_mode_desc": "Websites must request access to view your account information.",
 		"show_hex_data": "Show Hex Data",
+		"show_blockies_identicon": "Use Blockies Identicon",
 		"show_hex_data_desc": "Select this to show the hex data field on the send screen.",
 		"general_title": "General",
 		"general_desc": "Currency conversion, primary currency, language and search engine",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-i18n": "2.0.15",
+    "react-native-jazzicon": "^0.1.2",
     "react-native-keyboard-aware-scroll-view": "0.8.0",
     "react-native-keychain": "git+https://github.com/MetaMask/react-native-keychain.git#80e497ed3c167e1b122231c29d951d2c06efe58f",
     "react-native-level-fs": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,7 +2963,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -2982,15 +2982,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
+  integrity sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
 
 colorette@^1.0.7:
   version "1.2.0"
@@ -6318,6 +6334,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-bigint@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.0.tgz#73da8c33208d00f130e9b5e15d23eac9215601c4"
@@ -7980,6 +8001,16 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     readable-stream "^2.0.0"
     rlp "^2.0.0"
     semaphore ">=1.0.1"
+
+mersenne-twister@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
+  integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
+
+metamask-mobile-provider@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/metamask-mobile-provider/-/metamask-mobile-provider-1.1.0.tgz#477aa8ee55d91bd79a0f4c00a5083be159a5a678"
+  integrity sha512-GZLiq2sCPvYlHT4xYVklrAg6hWA/RZyFoekCtQz+842LbFtajHYmSb0DW5GDgEdQ/unaABU9A6BfKpfUurOe2A==
 
 methods@^1.1.1:
   version "1.1.2"
@@ -10000,6 +10031,14 @@ react-native-iphone-x-helper@^1.0.3, react-native-iphone-x-helper@^1.2.0:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
 
+react-native-jazzicon@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-jazzicon/-/react-native-jazzicon-0.1.2.tgz#af0bd041685644ce283c0a330e3cf639d470720a"
+  integrity sha512-kncAj+5LizALDJisDqj2DjkGUvChsrXNhzUnFof9TWRXfBHEhvUbp7DN++SkSgcNYATY02G6Yd5Cre9O6fTNsA==
+  dependencies:
+    color "^3.0.0"
+    mersenne-twister "^1.1.0"
+
 react-native-keyboard-aware-scroll-view@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.8.0.tgz#00bcaa38c91323913bb7a733059ad2bc4875f88c"
@@ -11188,6 +11227,13 @@ simple-plist@^1.0.0:
     bplist-creator "0.0.8"
     bplist-parser "0.2.0"
     plist "^3.0.1"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 single-call-balance-checker-abi@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This gives us a new option to enable blockies Identicons instead of the now default jazzicons thus matching what exists in the extension today:

![image](https://user-images.githubusercontent.com/675259/89700844-b8635880-d8ff-11ea-847a-e1c01399f72d.png)

Which of course changes the avatar style that's used to Blockies (what we use currenctly) from the new detault:

![image](https://user-images.githubusercontent.com/675259/89698935-e8a3fa80-d8f1-11ea-931b-327a1814d23f.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #232
