### PR TITLE
Display correct balance from state when creating an account that already holds funds

### DIFF
--- a/app/components/UI/AccountList/AccountElement/index.js
+++ b/app/components/UI/AccountList/AccountElement/index.js
@@ -100,17 +100,9 @@ class AccountElement extends PureComponent {
 		disabled: PropTypes.bool,
 		item: PropTypes.object,
 		/**
-		 * Selected address as string
+		 * Updated balance using stored in state
 		 */
-		selectedAddress: PropTypes.string,
-		/**
-		 * The currently selected account
-		 */
-		selectedAccount: PropTypes.object,
-		/**
-		 * Does the currently selected account have a balance?
-		 */
-		selectedAccountHasBalance: PropTypes.bool
+		updatedBalanceFromStore: PropTypes.string
 	};
 
 	onPress = () => {
@@ -126,8 +118,8 @@ class AccountElement extends PureComponent {
 	};
 
 	render() {
-		const { disabled, selectedAddress, selectedAccount, selectedAccountHasBalance } = this.props;
-		const { address, balance, ticker, name, isSelected, isImported, balanceError } = this.props.item;
+		const { disabled, updatedBalanceFromStore } = this.props;
+		const { address, ticker, name, isSelected, isImported, balanceError } = this.props.item;
 		const selected = isSelected ? <Icon name="check-circle" size={30} color={colors.blue} /> : null;
 		const imported = isImported ? (
 			<View style={styles.importedWrapper}>
@@ -136,11 +128,6 @@ class AccountElement extends PureComponent {
 				</Text>
 			</View>
 		) : null;
-
-		const updatedBalanceFromState =
-			balance === EMPTY && selectedAddress === address && selectedAccount && selectedAccountHasBalance
-				? selectedAccount[BALANCE_KEY]
-				: balance;
 
 		return (
 			<TouchableOpacity
@@ -158,7 +145,7 @@ class AccountElement extends PureComponent {
 						</Text>
 						<View style={styles.accountBalanceWrapper}>
 							<Text style={styles.accountBalance}>
-								{renderFromWei(updatedBalanceFromState)} {getTicker(ticker)}
+								{renderFromWei(updatedBalanceFromStore)} {getTicker(ticker)}
 							</Text>
 							{!!balanceError && (
 								<Text style={[styles.accountBalance, styles.accountBalanceError]}>{balanceError}</Text>
@@ -173,20 +160,25 @@ class AccountElement extends PureComponent {
 	}
 }
 
-const mapStateToProps = ({
-	engine: {
-		backgroundState: { PreferencesController, AccountTrackerController }
-	}
-}) => {
+const mapStateToProps = (
+	{
+		engine: {
+			backgroundState: { PreferencesController, AccountTrackerController }
+		}
+	},
+	{ item: { balance, address } }
+) => {
 	const { selectedAddress } = PreferencesController;
 	const { accounts } = AccountTrackerController;
 	const selectedAccount = accounts[selectedAddress];
 	const selectedAccountHasBalance =
 		selectedAccount && Object.prototype.hasOwnProperty.call(selectedAccount, BALANCE_KEY);
+	const updatedBalanceFromStore =
+		balance === EMPTY && selectedAddress === address && selectedAccount && selectedAccountHasBalance
+			? selectedAccount[BALANCE_KEY]
+			: balance;
 	return {
-		selectedAddress,
-		selectedAccount,
-		selectedAccountHasBalance
+		updatedBalanceFromStore
 	};
 };
 

--- a/app/components/UI/AccountList/AccountElement/index.js
+++ b/app/components/UI/AccountList/AccountElement/index.js
@@ -104,10 +104,6 @@ class AccountElement extends PureComponent {
 		 */
 		selectedAddress: PropTypes.string,
 		/**
-		 * List of accounts from the AccountTrackerController
-		 */
-		accounts: PropTypes.object,
-		/**
 		 * The currently selected account
 		 */
 		selectedAccount: PropTypes.object,
@@ -130,7 +126,7 @@ class AccountElement extends PureComponent {
 	};
 
 	render() {
-		const { disabled, selectedAddress, accounts, selectedAccount, selectedAccountHasBalance } = this.props;
+		const { disabled, selectedAddress, selectedAccount, selectedAccountHasBalance } = this.props;
 		const { address, balance, ticker, name, isSelected, isImported, balanceError } = this.props.item;
 		const selected = isSelected ? <Icon name="check-circle" size={30} color={colors.blue} /> : null;
 		const imported = isImported ? (
@@ -143,7 +139,7 @@ class AccountElement extends PureComponent {
 
 		const updatedBalanceFromState =
 			balance === EMPTY && selectedAddress === address && selectedAccount && selectedAccountHasBalance
-				? accounts[selectedAddress][BALANCE_KEY]
+				? selectedAccount[BALANCE_KEY]
 				: balance;
 
 		return (
@@ -188,7 +184,6 @@ const mapStateToProps = ({
 	const selectedAccountHasBalance =
 		selectedAccount && Object.prototype.hasOwnProperty.call(selectedAccount, BALANCE_KEY);
 	return {
-		accounts,
 		selectedAddress,
 		selectedAccount,
 		selectedAccountHasBalance

--- a/app/components/UI/AccountList/AccountElement/index.js
+++ b/app/components/UI/AccountList/AccountElement/index.js
@@ -107,7 +107,13 @@ class AccountElement extends PureComponent {
 		 * List of accounts from the AccountTrackerController
 		 */
 		accounts: PropTypes.object,
+		/**
+		 * The currently selected account
+		 */
 		selectedAccount: PropTypes.object,
+		/**
+		 * Does the currently selected account have a balance?
+		 */
 		selectedAccountHasBalance: PropTypes.bool
 	};
 


### PR DESCRIPTION
**Description**

re: https://trello.com/c/NytEfYLU/191-after-importing-a-wallet-with-seedphrase-new-account-shows-0-balance-until-another-account-is-created

Previously when adding a new account that already has funds we'd see it displayed with zero in the drawer:

![image](https://user-images.githubusercontent.com/675259/89753073-e0d88780-daa4-11ea-86ea-c1cbce2fa882.png)

(you can see the fiat balance is correct in the background)

Now we check state to see if we have the amount and display it if there's a balance for the matching account:

![image](https://user-images.githubusercontent.com/675259/89753280-9d324d80-daa5-11ea-912d-ffe932b20535.png)

**Checklist**

* [x] There is a related Trello card
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #???
