### PR TITLE
Remove unused metamask-mobile-provider dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "jest": "^25.2.7",
     "jest-serializer": "24.4.0",
     "lint-staged": "8.1.5",
-    "metamask-mobile-provider": "^1.0.2",
     "metro": "^0.59.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "octonode": "0.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8115,11 +8115,6 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     rlp "^2.0.0"
     semaphore ">=1.0.1"
 
-metamask-mobile-provider@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/metamask-mobile-provider/-/metamask-mobile-provider-1.1.0.tgz#477aa8ee55d91bd79a0f4c00a5083be159a5a678"
-  integrity sha512-GZLiq2sCPvYlHT4xYVklrAg6hWA/RZyFoekCtQz+842LbFtajHYmSb0DW5GDgEdQ/unaABU9A6BfKpfUurOe2A==
-
 methods@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"


### PR DESCRIPTION
This PR removes the unused `metamask-mobile-provider` package.

The package was removed in #1517 and inadvertently re-added in #1586.