### PR TITLE
Patch bip39 to use native crypto lib pbkdf2

### DIFF
--- a/patches/bip39+2.6.0.patch
+++ b/patches/bip39+2.6.0.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/bip39/index.js b/node_modules/bip39/index.js
+index efed68c..1725549 100644
+--- a/node_modules/bip39/index.js
++++ b/node_modules/bip39/index.js
+@@ -4,6 +4,8 @@ var _pbkdf2 = require('pbkdf2')
+ var pbkdf2 = _pbkdf2.pbkdf2Sync
+ var pbkdf2Async = _pbkdf2.pbkdf2
+ var randomBytes = require('randombytes')
++import { NativeModules } from 'react-native';
++const Aes = NativeModules.Aes;
+ 
+ // use unorm until String.prototype.normalize gets better browser support
+ var unorm = require('unorm')
+@@ -53,7 +55,12 @@ function mnemonicToSeed (mnemonic, password) {
+   var mnemonicBuffer = Buffer.from(unorm.nfkd(mnemonic), 'utf8')
+   var saltBuffer = Buffer.from(salt(unorm.nfkd(password)), 'utf8')
+ 
+-  return pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
++  // Bellow is the native equivalent to pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
++
++  const seed = Aes.pbkdf2Sync(mnemonicBuffer.toString('utf8'), saltBuffer.toString('utf8'), 2048, 512);
++  const seedBuffer = global.Buffer.from(seed, "hex")
++
++  return seedBuffer
+ }
+ 
+ function mnemonicToSeedHex (mnemonic, password) {

--- a/patches/bip39+2.6.0.patch
+++ b/patches/bip39+2.6.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/bip39/index.js b/node_modules/bip39/index.js
-index efed68c..1725549 100644
+index efed68c..e978df8 100644
 --- a/node_modules/bip39/index.js
 +++ b/node_modules/bip39/index.js
 @@ -4,6 +4,8 @@ var _pbkdf2 = require('pbkdf2')
@@ -16,7 +16,7 @@ index efed68c..1725549 100644
    var saltBuffer = Buffer.from(salt(unorm.nfkd(password)), 'utf8')
  
 -  return pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
-+  // Bellow is the native equivalent to pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
++  // Bellow is the native equivalent of pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')
 +
 +  const seed = Aes.pbkdf2Sync(mnemonicBuffer.toString('utf8'), saltBuffer.toString('utf8'), 2048, 512);
 +  const seedBuffer = global.Buffer.from(seed, "hex")

--- a/patches/bip39+2.6.0.patch
+++ b/patches/bip39+2.6.0.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/bip39/index.js b/node_modules/bip39/index.js
-index efed68c..e978df8 100644
+index efed68c..8461160 100644
 --- a/node_modules/bip39/index.js
 +++ b/node_modules/bip39/index.js
 @@ -4,6 +4,8 @@ var _pbkdf2 = require('pbkdf2')
  var pbkdf2 = _pbkdf2.pbkdf2Sync
  var pbkdf2Async = _pbkdf2.pbkdf2
  var randomBytes = require('randombytes')
-+import { NativeModules } from 'react-native';
++const { NativeModules } = require('react-native');
 +const Aes = NativeModules.Aes;
  
  // use unorm until String.prototype.normalize gets better browser support

--- a/patches/react-native-aes-crypto+1.3.9.patch
+++ b/patches/react-native-aes-crypto+1.3.9.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/react-native-aes-crypto/android/src/main/java/com/tectiv3/aes/RCTAes.java b/node_modules/react-native-aes-crypto/android/src/main/java/com/tectiv3/aes/RCTAes.java
+index 6843507..86ae4c6 100755
+--- a/node_modules/react-native-aes-crypto/android/src/main/java/com/tectiv3/aes/RCTAes.java
++++ b/node_modules/react-native-aes-crypto/android/src/main/java/com/tectiv3/aes/RCTAes.java
+@@ -81,6 +81,14 @@ public class RCTAes extends ReactContextBaseJavaModule {
+         } catch (Exception e) {
+             promise.reject("-1", e.getMessage());
+         }
++	}
++	
++	@ReactMethod(isBlockingSynchronousMethod = true)
++	public String pbkdf2Sync(String pwd, String salt, Integer cost, Integer length)
++	throws NoSuchAlgorithmException, InvalidKeySpecException, UnsupportedEncodingException
++	{
++        	String strs = pbkdf2(pwd, salt, cost, length);
++			return strs;
+     }
+ 
+     @ReactMethod
+diff --git a/node_modules/react-native-aes-crypto/ios/RCTAes/RCTAes.m b/node_modules/react-native-aes-crypto/ios/RCTAes/RCTAes.m
+index ded93b6..6bc1b0b 100755
+--- a/node_modules/react-native-aes-crypto/ios/RCTAes/RCTAes.m
++++ b/node_modules/react-native-aes-crypto/ios/RCTAes/RCTAes.m
+@@ -51,6 +51,13 @@ @implementation RCTAes
+     }
+ }
+ 
++RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(pbkdf2Sync:(NSString *)password salt:(NSString *)salt
++                  cost:(NSInteger)cost length:(NSInteger)length){
++	
++	return [AesCrypt pbkdf2:password salt:salt cost:cost length:length];
++}
++
++
+ RCT_EXPORT_METHOD(hmac256:(NSString *)base64 key:(NSString *)key
+                   resolver:(RCTPromiseResolveBlock)resolve
+                   rejecter:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR improves/fixes the android startup time by making bip39 use a native version of pbkdf2.

First it was needed to add a synchronous pbkdf2 function on the library react native aes crypto. Not doing so would make us have to change a lot of logic that uses bip39. So this was introduced on react-native-aes-crypto-lib:
Android side:
```	
@ReactMethod(isBlockingSynchronousMethod = true)
	public String pbkdf2Sync(String pwd, String salt, Integer cost, Integer length)
	throws NoSuchAlgorithmException, InvalidKeySpecException, UnsupportedEncodingException
	{
        	String strs = pbkdf2(pwd, salt, cost, length);
			return strs;
    }
```

iOS side:
```
RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(pbkdf2Sync:(NSString *)password salt:(NSString *)salt
                  cost:(NSInteger)cost length:(NSInteger)length){
	
	return [AesCrypt pbkdf2:password salt:salt cost:cost length:length];
}
```

And then on bip39:
```
  // Bellow is the native equivalent of pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512')

  const seed = Aes.pbkdf2Sync(mnemonicBuffer.toString('utf8'), saltBuffer.toString('utf8'), 2048, 512);
  const seedBuffer = global.Buffer.from(seed, "hex")
```
