### PR TITLE
Use @metamask/controllers@2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@exodus/react-native-payments": "https://github.com/wachunei/react-native-payments.git#package-json-hack",
-    "@metamask/controllers": "2.0.3",
+    "@metamask/controllers": "^2.0.5",
     "@react-native-community/async-storage": "1.9.0",
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/checkbox": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,10 +1004,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@metamask/controllers@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-2.0.3.tgz#3a63ae133f4fd468e88c6729f4145838e99a1d80"
-  integrity sha512-Tpcyi0YSyEDIjJxL7qYfD8ECLtb80LPqkyGkqpQ8rqX2X1zWgClZ5aSVf878Qkg9Wn67m4fHnCgI1cDdGotUsA==
+"@metamask/controllers@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-2.0.5.tgz#302dbae0595b269f2660253ee40c4c7f9bce069e"
+  integrity sha512-i+BjTEMy0XQFdcyXeEHmQ7xzktdNPBuw/R9QNBIllOvV4atR0JkZ9of6hi4tDFyjV40CBudqnIgS0iUVLWNGbA==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.11.0"


### PR DESCRIPTION
This PR updates the `@metamask/controllers` dependency to the latest published version.

Most notably changed here:

- Use jsDelivr instead of the GitHub API for content (MetaMask/controllers#256)
- Lower phishing config poll rate to 1 req/hr (MetaMask/controllers#257)