### PR TITLE
Feature/hide seedphrase on import

### DIFF
--- a/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -54,15 +54,16 @@ exports[`ImportFromSeed should render correctly 1`] = `
         autoCorrect={false}
         blurOnSubmit={true}
         keyboardType="default"
-        multiline={true}
+        multiline={false}
         numberOfLines={3}
-        onBlur={[Function]}
+        onBlur={null}
         onChangeText={[Function]}
-        onFocus={[Function]}
+        onFocus={null}
         onSubmitEditing={[Function]}
         placeholder="Enter your seed phrase here"
         placeholderTextColor="#bbc0c5"
         returnKeyType="next"
+        secureTextEntry={true}
         style={
           Array [
             Object {
@@ -89,29 +90,56 @@ exports[`ImportFromSeed should render correctly 1`] = `
         testID="input-seed-phrase"
         value=""
       />
-      <TouchableOpacity
-        onPress={[Function]}
+      <View
         style={
           Object {
-            "alignSelf": "flex-end",
-            "borderColor": "#d6d9dc",
-            "borderRadius": 6,
-            "borderWidth": 1,
+            "flexDirection": "row-reverse",
             "marginBottom": 30,
-            "marginRight": 10,
             "marginTop": -50,
-            "paddingHorizontal": 6,
-            "paddingVertical": 4,
           }
         }
       >
-        <Icon
-          allowFontScaling={false}
-          color="#777777"
-          name="qrcode"
-          size={20}
-        />
-      </TouchableOpacity>
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            Object {
+              "borderColor": "#d6d9dc",
+              "borderRadius": 6,
+              "borderWidth": 1,
+              "marginRight": 10,
+              "paddingHorizontal": 6,
+              "paddingVertical": 4,
+            }
+          }
+        >
+          <Icon
+            allowFontScaling={false}
+            color="#777777"
+            name="qrcode"
+            size={20}
+          />
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={[Function]}
+          style={
+            Object {
+              "borderColor": "#d6d9dc",
+              "borderRadius": 6,
+              "borderWidth": 1,
+              "marginRight": 10,
+              "paddingHorizontal": 6,
+              "paddingVertical": 4,
+            }
+          }
+        >
+          <Icon
+            allowFontScaling={false}
+            color="#777777"
+            name="eye-slash"
+            size={20}
+          />
+        </TouchableOpacity>
+      </View>
       <View
         style={
           Object {

--- a/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -114,12 +114,9 @@ exports[`ImportFromSeed should render correctly 1`] = `
           autoCapitalize="none"
           baseColor="#6a737d"
           containerStyle={
-            Array [
-              Object {
-                "width": "99%",
-              },
-              undefined,
-            ]
+            Object {
+              "width": "99%",
+            }
           }
           disableFullscreenUI={true}
           disabled={false}

--- a/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -107,74 +107,65 @@ exports[`ImportFromSeed should render correctly 1`] = `
           </TouchableOpacity>
         </View>
       </View>
-      <View>
-        <OutlinedTextField
-          activeLineWidth={2}
-          animationDuration={225}
-          autoCapitalize="none"
-          baseColor="#6a737d"
-          containerStyle={
-            Object {
-              "width": "99%",
-            }
+      <OutlinedTextField
+        activeLineWidth={2}
+        animationDuration={225}
+        autoCapitalize="none"
+        baseColor="#6a737d"
+        containerStyle={
+          Object {
+            "width": "99%",
           }
-          disableFullscreenUI={true}
-          disabled={false}
-          disabledLineType="dotted"
-          disabledLineWidth={0.5}
-          editable={true}
-          errorColor="rgb(213, 0, 0)"
-          fontSize={16}
-          inputContainerStyle={
-            Object {
-              "paddingRight": 46,
-            }
+        }
+        disableFullscreenUI={true}
+        disabled={false}
+        disabledLineType="dotted"
+        disabledLineWidth={0.5}
+        editable={true}
+        errorColor="rgb(213, 0, 0)"
+        fontSize={16}
+        inputContainerStyle={
+          Object {
+            "paddingRight": 46,
           }
-          labelFontSize={12}
-          lineType="solid"
-          lineWidth={1}
-          onChangeText={[Function]}
-          onSubmitEditing={[Function]}
-          placeholder="Enter your seed phrase here"
-          returnKeyType="next"
-          secureTextEntry={true}
-          testID="input-seed-phrase"
-          textColor="rgba(0, 0, 0, .87)"
-          tintColor="#037dd6"
-          underlineColorAndroid="transparent"
-          value=""
+        }
+        labelFontSize={12}
+        lineType="solid"
+        lineWidth={1}
+        onChangeText={[Function]}
+        onSubmitEditing={[Function]}
+        placeholder="Enter your seed phrase here"
+        returnKeyType="next"
+        secureTextEntry={true}
+        testID="input-seed-phrase"
+        textColor="rgba(0, 0, 0, .87)"
+        tintColor="#037dd6"
+        underlineColorAndroid="transparent"
+        value=""
+      />
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          Object {
+            "alignSelf": "flex-end",
+            "borderColor": "#d6d9dc",
+            "borderRadius": 6,
+            "borderWidth": 1,
+            "marginBottom": 30,
+            "marginRight": 10,
+            "marginTop": -50,
+            "paddingHorizontal": 6,
+            "paddingVertical": 4,
+          }
+        }
+      >
+        <Icon
+          allowFontScaling={false}
+          color="#777777"
+          name="qrcode"
+          size={20}
         />
-        <View
-          style={
-            Object {
-              "flexDirection": "row-reverse",
-              "marginBottom": 30,
-              "marginTop": -50,
-            }
-          }
-        >
-          <TouchableOpacity
-            onPress={[Function]}
-            style={
-              Object {
-                "borderColor": "#d6d9dc",
-                "borderRadius": 6,
-                "borderWidth": 1,
-                "marginRight": 10,
-                "paddingHorizontal": 6,
-                "paddingVertical": 4,
-              }
-            }
-          >
-            <Icon
-              allowFontScaling={false}
-              color="#777777"
-              name="qrcode"
-              size={20}
-            />
-          </TouchableOpacity>
-        </View>
-      </View>
+      </TouchableOpacity>
       <View
         style={
           Object {

--- a/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -49,6 +49,51 @@ exports[`ImportFromSeed should render correctly 1`] = `
       >
         Import from seed
       </Text>
+      <View
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "width": "50%",
+            }
+          }
+        />
+        <View
+          style={
+            Array [
+              Object {
+                "width": "50%",
+              },
+              Object {
+                "flexDirection": "row-reverse",
+              },
+            ]
+          }
+        >
+          <TouchableOpacity
+            onPress={[Function]}
+          >
+            <Text
+              style={
+                Object {
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "marginBottom": 12,
+                }
+              }
+            >
+              Show
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
       <TextInput
         autoCapitalize="none"
         autoCorrect={false}
@@ -75,7 +120,7 @@ exports[`ImportFromSeed should render correctly 1`] = `
               "fontSize": 20,
               "fontWeight": "400",
               "height": "auto",
-              "marginVertical": 10,
+              "marginBottom": 10,
               "minHeight": 110,
               "paddingBottom": 20,
               "paddingHorizontal": 20,
@@ -119,26 +164,6 @@ exports[`ImportFromSeed should render correctly 1`] = `
             size={20}
           />
         </TouchableOpacity>
-        <TouchableOpacity
-          onPress={[Function]}
-          style={
-            Object {
-              "borderColor": "#d6d9dc",
-              "borderRadius": 6,
-              "borderWidth": 1,
-              "marginRight": 10,
-              "paddingHorizontal": 6,
-              "paddingVertical": 4,
-            }
-          }
-        >
-          <Icon
-            allowFontScaling={false}
-            color="#777777"
-            name="eye-slash"
-            size={20}
-          />
-        </TouchableOpacity>
       </View>
       <View
         style={
@@ -147,18 +172,64 @@ exports[`ImportFromSeed should render correctly 1`] = `
           }
         }
       >
-        <Text
+        <View
           style={
             Object {
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "marginBottom": 12,
+              "alignItems": "flex-end",
+              "flexDirection": "row",
             }
           }
         >
-          New Password
-        </Text>
+          <View
+            style={
+              Object {
+                "width": "50%",
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "marginBottom": 12,
+                }
+              }
+            >
+              New Password
+            </Text>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "width": "50%",
+                },
+                Object {
+                  "flexDirection": "row-reverse",
+                },
+              ]
+            }
+          >
+            <TouchableOpacity
+              onPress={[Function]}
+            >
+              <Text
+                style={
+                  Object {
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "marginBottom": 12,
+                  }
+                }
+              >
+                Show
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
         <OutlinedTextField
           activeLineWidth={2}
           animationDuration={225}
@@ -177,7 +248,6 @@ exports[`ImportFromSeed should render correctly 1`] = `
           onChangeText={[Function]}
           onSubmitEditing={[Function]}
           placeholder="New Password"
-          renderRightAccessory={[Function]}
           returnKeyType="next"
           secureTextEntry={true}
           style={

--- a/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ImportFromSeed/__snapshots__/index.test.js.snap
@@ -63,7 +63,20 @@ exports[`ImportFromSeed should render correctly 1`] = `
               "width": "50%",
             }
           }
-        />
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "marginBottom": 12,
+              }
+            }
+          >
+            Seed phrase
+          </Text>
+        </View>
         <View
           style={
             Array [
@@ -94,76 +107,76 @@ exports[`ImportFromSeed should render correctly 1`] = `
           </TouchableOpacity>
         </View>
       </View>
-      <TextInput
-        autoCapitalize="none"
-        autoCorrect={false}
-        blurOnSubmit={true}
-        keyboardType="default"
-        multiline={false}
-        numberOfLines={3}
-        onBlur={null}
-        onChangeText={[Function]}
-        onFocus={null}
-        onSubmitEditing={[Function]}
-        placeholder="Enter your seed phrase here"
-        placeholderTextColor="#bbc0c5"
-        returnKeyType="next"
-        secureTextEntry={true}
-        style={
-          Array [
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#6a737d",
-              "borderRadius": 10,
-              "borderWidth": 1,
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 20,
-              "fontWeight": "400",
-              "height": "auto",
-              "marginBottom": 10,
-              "minHeight": 110,
-              "paddingBottom": 20,
-              "paddingHorizontal": 20,
-              "paddingTop": 20,
-            },
-            Object {
-              "width": "99%",
-            },
-            false,
-          ]
-        }
-        testID="input-seed-phrase"
-        value=""
-      />
-      <View
-        style={
-          Object {
-            "flexDirection": "row-reverse",
-            "marginBottom": 30,
-            "marginTop": -50,
+      <View>
+        <OutlinedTextField
+          activeLineWidth={2}
+          animationDuration={225}
+          autoCapitalize="none"
+          baseColor="#6a737d"
+          containerStyle={
+            Array [
+              Object {
+                "width": "99%",
+              },
+              undefined,
+            ]
           }
-        }
-      >
-        <TouchableOpacity
-          onPress={[Function]}
+          disableFullscreenUI={true}
+          disabled={false}
+          disabledLineType="dotted"
+          disabledLineWidth={0.5}
+          editable={true}
+          errorColor="rgb(213, 0, 0)"
+          fontSize={16}
+          inputContainerStyle={
+            Object {
+              "paddingRight": 46,
+            }
+          }
+          labelFontSize={12}
+          lineType="solid"
+          lineWidth={1}
+          onChangeText={[Function]}
+          onSubmitEditing={[Function]}
+          placeholder="Enter your seed phrase here"
+          returnKeyType="next"
+          secureTextEntry={true}
+          testID="input-seed-phrase"
+          textColor="rgba(0, 0, 0, .87)"
+          tintColor="#037dd6"
+          underlineColorAndroid="transparent"
+          value=""
+        />
+        <View
           style={
             Object {
-              "borderColor": "#d6d9dc",
-              "borderRadius": 6,
-              "borderWidth": 1,
-              "marginRight": 10,
-              "paddingHorizontal": 6,
-              "paddingVertical": 4,
+              "flexDirection": "row-reverse",
+              "marginBottom": 30,
+              "marginTop": -50,
             }
           }
         >
-          <Icon
-            allowFontScaling={false}
-            color="#777777"
-            name="qrcode"
-            size={20}
-          />
-        </TouchableOpacity>
+          <TouchableOpacity
+            onPress={[Function]}
+            style={
+              Object {
+                "borderColor": "#d6d9dc",
+                "borderRadius": 6,
+                "borderWidth": 1,
+                "marginRight": 10,
+                "paddingHorizontal": 6,
+                "paddingVertical": 4,
+              }
+            }
+          >
+            <Icon
+              allowFontScaling={false}
+              color="#777777"
+              name="qrcode"
+              size={20}
+            />
+          </TouchableOpacity>
+        </View>
       </View>
       <View
         style={
@@ -235,6 +248,11 @@ exports[`ImportFromSeed should render correctly 1`] = `
           animationDuration={225}
           autoCapitalize="none"
           baseColor="#6a737d"
+          containerStyle={
+            Object {
+              "width": "99%",
+            }
+          }
           disableFullscreenUI={true}
           disabled={false}
           disabledLineType="dotted"
@@ -250,11 +268,6 @@ exports[`ImportFromSeed should render correctly 1`] = `
           placeholder="New Password"
           returnKeyType="next"
           secureTextEntry={true}
-          style={
-            Object {
-              "width": "99%",
-            }
-          }
           testID="input-password-field"
           textColor="rgba(0, 0, 0, .87)"
           tintColor="#037dd6"
@@ -300,6 +313,11 @@ exports[`ImportFromSeed should render correctly 1`] = `
           animationDuration={225}
           autoCapitalize="none"
           baseColor="#6a737d"
+          containerStyle={
+            Object {
+              "width": "99%",
+            }
+          }
           disableFullscreenUI={true}
           disabled={false}
           disabledLineType="dotted"
@@ -315,11 +333,6 @@ exports[`ImportFromSeed should render correctly 1`] = `
           placeholder="Confirm password"
           returnKeyType="next"
           secureTextEntry={true}
-          style={
-            Object {
-              "width": "99%",
-            }
-          }
           testID="input-password-field-confirm"
           textColor="rgba(0, 0, 0, .87)"
           tintColor="#037dd6"

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -47,11 +47,6 @@ const styles = StyleSheet.create({
 		backgroundColor: colors.white,
 		flex: 1
 	},
-	seedPhraseControls: {
-		flexDirection: 'row-reverse',
-		marginTop: -50,
-		marginBottom: 30
-	},
 	wrapper: {
 		flex: 1,
 		paddingHorizontal: 32
@@ -156,7 +151,10 @@ const styles = StyleSheet.create({
 		borderRadius: 6,
 		borderColor: colors.grey100,
 		paddingVertical: 4,
-		paddingHorizontal: 6
+		paddingHorizontal: 6,
+		marginTop: -50,
+		marginBottom: 30,
+		alignSelf: 'flex-end'
 	},
 	inputFocused: {
 		borderColor: colors.blue,
@@ -463,55 +461,47 @@ class ImportFromSeed extends PureComponent {
 								</TouchableOpacity>
 							</View>
 						</View>
-						<View styles={styles.position}>
-							{hideSeedPhraseInput ? (
-								<OutlinedTextField
-									containerStyle={inputWidth}
-									inputContainerStyle={styles.padding}
-									placeholder={strings('import_from_seed.seed_phrase_placeholder')}
-									testID="input-seed-phrase"
-									returnKeyType="next"
-									autoCapitalize="none"
-									secureTextEntry={hideSeedPhraseInput}
-									onChangeText={this.onSeedWordsChange}
-									value={seed}
-									baseColor={colors.grey500}
-									tintColor={colors.blue}
-									onSubmitEditing={this.jumpToPassword}
-								/>
-							) : (
-								<TextInput
-									value={seed}
-									numberOfLines={3}
-									style={[
-										styles.seedPhrase,
-										inputWidth,
-										seedphraseInputFocused && styles.inputFocused
-									]}
-									secureTextEntry
-									multiline={!hideSeedPhraseInput}
-									placeholder={strings('import_from_seed.seed_phrase_placeholder')}
-									placeholderTextColor={colors.grey200}
-									onChangeText={this.onSeedWordsChange}
-									testID="input-seed-phrase"
-									blurOnSubmit
-									onSubmitEditing={this.jumpToPassword}
-									returnKeyType="next"
-									keyboardType={
-										(!hideSeedPhraseInput && Device.isAndroid() && 'visible-password') || 'default'
-									}
-									autoCapitalize="none"
-									autoCorrect={false}
-									onFocus={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
-									onBlur={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
-								/>
-							)}
-							<View style={styles.seedPhraseControls}>
-								<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
-									<Icon name="qrcode" size={20} color={colors.fontSecondary} />
-								</TouchableOpacity>
-							</View>
-						</View>
+						{hideSeedPhraseInput ? (
+							<OutlinedTextField
+								containerStyle={inputWidth}
+								inputContainerStyle={styles.padding}
+								placeholder={strings('import_from_seed.seed_phrase_placeholder')}
+								testID="input-seed-phrase"
+								returnKeyType="next"
+								autoCapitalize="none"
+								secureTextEntry={hideSeedPhraseInput}
+								onChangeText={this.onSeedWordsChange}
+								value={seed}
+								baseColor={colors.grey500}
+								tintColor={colors.blue}
+								onSubmitEditing={this.jumpToPassword}
+							/>
+						) : (
+							<TextInput
+								value={seed}
+								numberOfLines={3}
+								style={[styles.seedPhrase, inputWidth, seedphraseInputFocused && styles.inputFocused]}
+								secureTextEntry
+								multiline={!hideSeedPhraseInput}
+								placeholder={strings('import_from_seed.seed_phrase_placeholder')}
+								placeholderTextColor={colors.grey200}
+								onChangeText={this.onSeedWordsChange}
+								testID="input-seed-phrase"
+								blurOnSubmit
+								onSubmitEditing={this.jumpToPassword}
+								returnKeyType="next"
+								keyboardType={
+									(!hideSeedPhraseInput && Device.isAndroid() && 'visible-password') || 'default'
+								}
+								autoCapitalize="none"
+								autoCorrect={false}
+								onFocus={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
+								onBlur={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
+							/>
+						)}
+						<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
+							<Icon name="qrcode" size={20} color={colors.fontSecondary} />
+						</TouchableOpacity>
 						<View style={styles.field}>
 							<View style={styles.fieldRow}>
 								<View style={styles.fieldCol}>

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -420,13 +420,13 @@ class ImportFromSeed extends PureComponent {
 			onScanSuccess: ({ seed = undefined }) => {
 				if (seed) {
 					this.setState({ seed });
-					this.toggleHideSeedPhraseInput();
 				} else {
 					Alert.alert(
 						strings('import_from_seed.invalid_qr_code_title'),
 						strings('import_from_seed.invalid_qr_code_message')
 					);
 				}
+				this.toggleHideSeedPhraseInput();
 			}
 		});
 	};

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -471,8 +471,8 @@ class ImportFromSeed extends PureComponent {
 							}
 							autoCapitalize="none"
 							autoCorrect={false}
-							onFocus={!hideSeedPhraseInput && this.seedphraseInputFocused}
-							onBlur={!hideSeedPhraseInput && this.seedphraseInputFocused}
+							onFocus={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
+							onBlur={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
 						/>
 						<View style={styles.seedPhraseControls}>
 							<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -68,6 +68,16 @@ const styles = StyleSheet.create({
 	field: {
 		marginVertical: 5
 	},
+	fieldRow: {
+		flexDirection: 'row',
+		alignItems: 'flex-end'
+	},
+	fieldCol: {
+		width: '50%'
+	},
+	fieldColRight: {
+		flexDirection: 'row-reverse'
+	},
 	label: {
 		fontSize: 14,
 		marginBottom: 12,
@@ -82,7 +92,7 @@ const styles = StyleSheet.create({
 		...fontStyles.normal
 	},
 	seedPhrase: {
-		marginVertical: 10,
+		marginBottom: 10,
 		paddingTop: 20,
 		paddingBottom: 20,
 		paddingHorizontal: 20,
@@ -132,25 +142,12 @@ const styles = StyleSheet.create({
 	strength_strong: {
 		color: colors.green300
 	},
-	showHideToggle: {
-		backgroundColor: colors.white,
-		marginTop: 8,
-		alignSelf: 'flex-end'
-	},
 	showMatchingPasswords: {
 		position: 'absolute',
 		marginTop: 8,
 		alignSelf: 'flex-end'
 	},
 	qrCode: {
-		marginRight: 10,
-		borderWidth: 1,
-		borderRadius: 6,
-		borderColor: colors.grey100,
-		paddingVertical: 4,
-		paddingHorizontal: 6
-	},
-	seedPhraseVisibility: {
 		marginRight: 10,
 		borderWidth: 1,
 		borderRadius: 6,
@@ -446,13 +443,21 @@ class ImportFromSeed extends PureComponent {
 			hideSeedPhraseInput
 		} = this.state;
 
-		const iconName = hideSeedPhraseInput ? 'eye-slash' : 'eye';
-
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
 				<KeyboardAwareScrollView style={styles.wrapper} resetScrollToCoords={{ x: 0, y: 0 }}>
 					<View testID={'import-from-seed-screen'}>
 						<Text style={styles.title}>{strings('import_from_seed.title')}</Text>
+						<View style={styles.fieldRow}>
+							<View style={styles.fieldCol} />
+							<View style={[styles.fieldCol, styles.fieldColRight]}>
+								<TouchableOpacity onPress={this.toggleHideSeedPhraseInput}>
+									<Text style={styles.label}>
+										{strings(`choose_password.${hideSeedPhraseInput ? 'show' : 'hide'}`)}
+									</Text>
+								</TouchableOpacity>
+							</View>
+						</View>
 						<TextInput
 							value={seed}
 							numberOfLines={3}
@@ -478,15 +483,20 @@ class ImportFromSeed extends PureComponent {
 							<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
 								<Icon name="qrcode" size={20} color={colors.fontSecondary} />
 							</TouchableOpacity>
-							<TouchableOpacity
-								style={styles.seedPhraseVisibility}
-								onPress={this.toggleHideSeedPhraseInput}
-							>
-								<Icon name={iconName} size={20} color={colors.fontSecondary} />
-							</TouchableOpacity>
 						</View>
 						<View style={styles.field}>
-							<Text style={styles.label}>{strings('import_from_seed.new_password')}</Text>
+							<View style={styles.fieldRow}>
+								<View style={styles.fieldCol}>
+									<Text style={styles.label}>{strings('import_from_seed.new_password')}</Text>
+								</View>
+								<View style={[styles.fieldCol, styles.fieldColRight]}>
+									<TouchableOpacity onPress={this.toggleShowHide}>
+										<Text style={styles.label}>
+											{strings(`choose_password.${secureTextEntry ? 'show' : 'hide'}`)}
+										</Text>
+									</TouchableOpacity>
+								</View>
+							</View>
 							<OutlinedTextField
 								style={inputWidth}
 								ref={this.passwordInput}
@@ -500,13 +510,6 @@ class ImportFromSeed extends PureComponent {
 								baseColor={colors.grey500}
 								tintColor={colors.blue}
 								onSubmitEditing={this.jumpToConfirmPassword}
-								renderRightAccessory={() => (
-									<TouchableOpacity onPress={this.toggleShowHide} style={styles.showHideToggle}>
-										<Text style={styles.passwordStrengthLabel}>
-											{strings(`choose_password.${secureTextEntry ? 'show' : 'hide'}`)}
-										</Text>
-									</TouchableOpacity>
-								)}
 							/>
 
 							{(password !== '' && (

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -105,6 +105,9 @@ const styles = StyleSheet.create({
 		backgroundColor: colors.white,
 		...fontStyles.normal
 	},
+	padding: {
+		paddingRight: 46
+	},
 	biometrics: {
 		alignItems: 'flex-start',
 		marginTop: 10
@@ -449,7 +452,9 @@ class ImportFromSeed extends PureComponent {
 					<View testID={'import-from-seed-screen'}>
 						<Text style={styles.title}>{strings('import_from_seed.title')}</Text>
 						<View style={styles.fieldRow}>
-							<View style={styles.fieldCol} />
+							<View style={styles.fieldCol}>
+								<Text style={styles.label}>{strings('choose_password.seed_phrase')}</Text>
+							</View>
 							<View style={[styles.fieldCol, styles.fieldColRight]}>
 								<TouchableOpacity onPress={this.toggleHideSeedPhraseInput}>
 									<Text style={styles.label}>
@@ -458,31 +463,54 @@ class ImportFromSeed extends PureComponent {
 								</TouchableOpacity>
 							</View>
 						</View>
-						<TextInput
-							value={seed}
-							numberOfLines={3}
-							style={[styles.seedPhrase, inputWidth, seedphraseInputFocused && styles.inputFocused]}
-							secureTextEntry
-							multiline={!hideSeedPhraseInput}
-							placeholder={strings('import_from_seed.seed_phrase_placeholder')}
-							placeholderTextColor={colors.grey200}
-							onChangeText={this.onSeedWordsChange}
-							testID={'input-seed-phrase'}
-							blurOnSubmit
-							onSubmitEditing={this.jumpToPassword}
-							returnKeyType={'next'}
-							keyboardType={
-								(!hideSeedPhraseInput && Device.isAndroid() && 'visible-password') || 'default'
-							}
-							autoCapitalize="none"
-							autoCorrect={false}
-							onFocus={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
-							onBlur={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
-						/>
-						<View style={styles.seedPhraseControls}>
-							<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
-								<Icon name="qrcode" size={20} color={colors.fontSecondary} />
-							</TouchableOpacity>
+						<View styles={styles.position}>
+							{hideSeedPhraseInput ? (
+								<OutlinedTextField
+									containerStyle={[inputWidth, styles.zIndex]}
+									inputContainerStyle={styles.padding}
+									placeholder={strings('import_from_seed.seed_phrase_placeholder')}
+									testID="input-seed-phrase"
+									returnKeyType="next"
+									autoCapitalize="none"
+									secureTextEntry={hideSeedPhraseInput}
+									onChangeText={this.onSeedWordsChange}
+									value={seed}
+									baseColor={colors.grey500}
+									tintColor={colors.blue}
+									onSubmitEditing={this.jumpToPassword}
+								/>
+							) : (
+								<TextInput
+									value={seed}
+									numberOfLines={3}
+									style={[
+										styles.seedPhrase,
+										inputWidth,
+										seedphraseInputFocused && styles.inputFocused
+									]}
+									secureTextEntry
+									multiline={!hideSeedPhraseInput}
+									placeholder={strings('import_from_seed.seed_phrase_placeholder')}
+									placeholderTextColor={colors.grey200}
+									onChangeText={this.onSeedWordsChange}
+									testID="input-seed-phrase"
+									blurOnSubmit
+									onSubmitEditing={this.jumpToPassword}
+									returnKeyType="next"
+									keyboardType={
+										(!hideSeedPhraseInput && Device.isAndroid() && 'visible-password') || 'default'
+									}
+									autoCapitalize="none"
+									autoCorrect={false}
+									onFocus={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
+									onBlur={(!hideSeedPhraseInput && this.seedphraseInputFocused) || null}
+								/>
+							)}
+							<View style={styles.seedPhraseControls}>
+								<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
+									<Icon name="qrcode" size={20} color={colors.fontSecondary} />
+								</TouchableOpacity>
+							</View>
 						</View>
 						<View style={styles.field}>
 							<View style={styles.fieldRow}>
@@ -498,7 +526,7 @@ class ImportFromSeed extends PureComponent {
 								</View>
 							</View>
 							<OutlinedTextField
-								style={inputWidth}
+								containerStyle={inputWidth}
 								ref={this.passwordInput}
 								placeholder={strings('import_from_seed.new_password')}
 								testID={'input-password-field'}
@@ -526,7 +554,7 @@ class ImportFromSeed extends PureComponent {
 						<View style={styles.field}>
 							<Text style={styles.label}>{strings('import_from_seed.confirm_password')}</Text>
 							<OutlinedTextField
-								style={inputWidth}
+								containerStyle={inputWidth}
 								ref={this.confirmPasswordInput}
 								testID={'input-password-field-confirm'}
 								onChangeText={this.onPasswordConfirmChange}

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -393,7 +393,7 @@ class ImportFromSeed extends PureComponent {
 	};
 
 	toggleHideSeedPhraseInput = () => {
-		this.setState({ hideSeedPhraseInput: !this.state.hideSeedPhraseInput });
+		this.setState(({ hideSeedPhraseInput }) => ({ hideSeedPhraseInput: !hideSeedPhraseInput }));
 	};
 
 	getPasswordStrengthWord() {
@@ -415,10 +415,12 @@ class ImportFromSeed extends PureComponent {
 	}
 
 	onQrCodePress = () => {
+		setTimeout(this.toggleHideSeedPhraseInput, 100);
 		this.props.navigation.navigate('QRScanner', {
-			onScanSuccess: meta => {
-				if (meta && meta.seed) {
-					this.setState({ seed: meta.seed });
+			onScanSuccess: ({ seed = undefined }) => {
+				if (seed) {
+					this.setState({ seed });
+					this.toggleHideSeedPhraseInput();
 				} else {
 					Alert.alert(
 						strings('import_from_seed.invalid_qr_code_title'),

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -47,6 +47,11 @@ const styles = StyleSheet.create({
 		backgroundColor: colors.white,
 		flex: 1
 	},
+	seedPhraseControls: {
+		flexDirection: 'row-reverse',
+		marginTop: -50,
+		marginBottom: 30
+	},
 	wrapper: {
 		flex: 1,
 		paddingHorizontal: 32
@@ -138,9 +143,14 @@ const styles = StyleSheet.create({
 		alignSelf: 'flex-end'
 	},
 	qrCode: {
-		marginTop: -50,
-		marginBottom: 30,
-		alignSelf: 'flex-end',
+		marginRight: 10,
+		borderWidth: 1,
+		borderRadius: 6,
+		borderColor: colors.grey100,
+		paddingVertical: 4,
+		paddingHorizontal: 6
+	},
+	seedPhraseVisibility: {
 		marginRight: 10,
 		borderWidth: 1,
 		borderRadius: 6,
@@ -200,7 +210,8 @@ class ImportFromSeed extends PureComponent {
 		loading: false,
 		error: null,
 		seedphraseInputFocused: false,
-		inputWidth: { width: '99%' }
+		inputWidth: { width: '99%' },
+		hideSeedPhraseInput: true
 	};
 
 	passwordInput = React.createRef();
@@ -383,6 +394,10 @@ class ImportFromSeed extends PureComponent {
 		this.setState({ secureTextEntry: !this.state.secureTextEntry });
 	};
 
+	toggleHideSeedPhraseInput = () => {
+		this.setState({ hideSeedPhraseInput: !this.state.hideSeedPhraseInput });
+	};
+
 	getPasswordStrengthWord() {
 		// this.state.passwordStrength is calculated by zxcvbn
 		// which returns a score based on "entropy to crack time"
@@ -427,8 +442,11 @@ class ImportFromSeed extends PureComponent {
 			inputWidth,
 			secureTextEntry,
 			error,
-			loading
+			loading,
+			hideSeedPhraseInput
 		} = this.state;
+
+		const iconName = hideSeedPhraseInput ? 'eye-slash' : 'eye';
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -438,8 +456,9 @@ class ImportFromSeed extends PureComponent {
 						<TextInput
 							value={seed}
 							numberOfLines={3}
-							multiline
 							style={[styles.seedPhrase, inputWidth, seedphraseInputFocused && styles.inputFocused]}
+							secureTextEntry
+							multiline={!hideSeedPhraseInput}
 							placeholder={strings('import_from_seed.seed_phrase_placeholder')}
 							placeholderTextColor={colors.grey200}
 							onChangeText={this.onSeedWordsChange}
@@ -447,15 +466,25 @@ class ImportFromSeed extends PureComponent {
 							blurOnSubmit
 							onSubmitEditing={this.jumpToPassword}
 							returnKeyType={'next'}
-							keyboardType={Device.isAndroid() ? 'visible-password' : 'default'}
+							keyboardType={
+								(!hideSeedPhraseInput && Device.isAndroid() && 'visible-password') || 'default'
+							}
 							autoCapitalize="none"
 							autoCorrect={false}
-							onFocus={this.seedphraseInputFocused}
-							onBlur={this.seedphraseInputFocused}
+							onFocus={!hideSeedPhraseInput && this.seedphraseInputFocused}
+							onBlur={!hideSeedPhraseInput && this.seedphraseInputFocused}
 						/>
-						<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
-							<Icon name="qrcode" size={20} color={colors.fontSecondary} />
-						</TouchableOpacity>
+						<View style={styles.seedPhraseControls}>
+							<TouchableOpacity style={styles.qrCode} onPress={this.onQrCodePress}>
+								<Icon name="qrcode" size={20} color={colors.fontSecondary} />
+							</TouchableOpacity>
+							<TouchableOpacity
+								style={styles.seedPhraseVisibility}
+								onPress={this.toggleHideSeedPhraseInput}
+							>
+								<Icon name={iconName} size={20} color={colors.fontSecondary} />
+							</TouchableOpacity>
+						</View>
 						<View style={styles.field}>
 							<Text style={styles.label}>{strings('import_from_seed.new_password')}</Text>
 							<OutlinedTextField

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -466,7 +466,7 @@ class ImportFromSeed extends PureComponent {
 						<View styles={styles.position}>
 							{hideSeedPhraseInput ? (
 								<OutlinedTextField
-									containerStyle={[inputWidth, styles.zIndex]}
+									containerStyle={inputWidth}
 									inputContainerStyle={styles.padding}
 									placeholder={strings('import_from_seed.seed_phrase_placeholder')}
 									testID="input-seed-phrase"

--- a/locales/en.json
+++ b/locales/en.json
@@ -151,6 +151,7 @@
 		"strength_strong": "Strong",
 		"show": "Show",
 		"hide": "Hide",
+		"seed_phrase": "Seed phrase",
 		"must_be_at_least": "Must be at least {{number}} characters",
 		"remember_me": "Remember me",
 		"security_alert_title": "Security Alert",

--- a/locales/es.json
+++ b/locales/es.json
@@ -131,6 +131,7 @@
 		"strength_strong": "Segura",
 		"show": "Mostrar",
 		"hide": "Ocultar",
+		"seed_phrase": "Frase semilla",
 		"must_be_at_least": "Debe contener al menos {{number}} caracteres",
 		"remember_me": "Recordarme",
 		"security_alert_title": "Alerta de seguridad",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Similar to https://github.com/MetaMask/metamask-extension/pull/8730 this makes it so the seedphrase is hidden by default on import so the user can paste it without ever showing it on screen:

![image](https://user-images.githubusercontent.com/675259/91202988-92e09800-e6d0-11ea-8236-b670c3163130.png)

If the user absolutely _needs_ to see their seedphrase on screen they can show it by toggling the visibility:

![image](https://user-images.githubusercontent.com/675259/91203085-b3a8ed80-e6d0-11ea-9c9b-403fd151bc7b.png)

We may want to change the placeholder text (similar to what we did on the extension) as well.




**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
