### PR TITLE
Update react native aes crypto forked

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-native": "0.62.2",
     "react-native-actionsheet": "beefe/react-native-actionsheet#107/head",
     "react-native-aes-crypto": "^1.3.9",
-	"react-native-aes-crypto-forked": "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56",
+	"react-native-aes-crypto-forked": "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#397d5db5250e8e7408294807965b5b9fd4ca6a25",
     "react-native-animated-fox": "git+https://github.com/MetaMask/react-native-animated-fox.git#16e38d54d829709e497f196e31fa8ff00cdf2aa9",
     "react-native-background-timer": "2.1.1",
     "react-native-branch": "5.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-native": "0.62.2",
     "react-native-actionsheet": "beefe/react-native-actionsheet#107/head",
     "react-native-aes-crypto": "^1.3.9",
-    "react-native-aes-crypto-forked": "git+https://github.com/andrepimenta/react-native-aes-forked.git#de903003afc81e4ad14ed00e237795a696716e9e",
+	"react-native-aes-crypto-forked": "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56",
     "react-native-animated-fox": "git+https://github.com/MetaMask/react-native-animated-fox.git#16e38d54d829709e497f196e31fa8ff00cdf2aa9",
     "react-native-background-timer": "2.1.1",
     "react-native-branch": "5.0.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,9 +9851,9 @@ react-native-actionsheet@beefe/react-native-actionsheet#107/head:
   version "2.4.2"
   resolved "https://codeload.github.com/beefe/react-native-actionsheet/tar.gz/fb97d7c6a33bc3213b928a36257dd0c23b42fa6f"
 
-"react-native-aes-crypto-forked@git+https://github.com/andrepimenta/react-native-aes-forked.git#de903003afc81e4ad14ed00e237795a696716e9e":
+"react-native-aes-crypto-forked@git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56":
   version "1.2.1"
-  resolved "git+https://github.com/andrepimenta/react-native-aes-forked.git#de903003afc81e4ad14ed00e237795a696716e9e"
+  resolved "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56"
 
 react-native-aes-crypto@^1.3.9:
   version "1.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,9 +9851,9 @@ react-native-actionsheet@beefe/react-native-actionsheet#107/head:
   version "2.4.2"
   resolved "https://codeload.github.com/beefe/react-native-actionsheet/tar.gz/fb97d7c6a33bc3213b928a36257dd0c23b42fa6f"
 
-"react-native-aes-crypto-forked@git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56":
+"react-native-aes-crypto-forked@git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#397d5db5250e8e7408294807965b5b9fd4ca6a25":
   version "1.2.1"
-  resolved "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#807dd4108983ebb3eb62b577c576322b5cceab56"
+  resolved "git+https://github.com/MetaMask/react-native-aes-crypto-forked.git#397d5db5250e8e7408294807965b5b9fd4ca6a25"
 
 react-native-aes-crypto@^1.3.9:
   version "1.3.9"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Update react native aes crypto forked

@ibrahimtaveras00 testing should be more or less the same as what was done for https://github.com/MetaMask/metamask-mobile/pull/1755. So testing updating from an older app version that still uses the old crypto lib, for example, 0.2.19 to this version. Logging with or without password should work and also accounts, either imported or not, should also be there.