### PR TITLE
Feature/improve nav browser title

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1427,7 +1427,7 @@ export class BrowserTab extends PureComponent {
 			this.setState({
 				url,
 				inputValue: url,
-				autocompletInputValue: url,
+				autocompleteInputValue: url,
 				currentPageTitle: title,
 				forwardEnabled: false
 			});

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1608,7 +1608,6 @@ export class BrowserTab extends PureComponent {
 	 * reset autocompleteInputValue to be the url if the input has been left empty
 	 */
 	resetAutocompleteInputValue = urlParam => {
-		console.log(urlParam);
 		const { autocompleteInputValue } = this.state;
 		if (autocompleteInputValue === '') {
 			this.setState({

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1604,6 +1604,19 @@ export class BrowserTab extends PureComponent {
 		this.props.navigation.setParams(params);
 	};
 
+	/**
+	 * reset autocompleteInputValue to be the url if the input has been left empty
+	 */
+	resetAutocompleteInputValue = urlParam => {
+		console.log(urlParam);
+		const { autocompleteInputValue } = this.state;
+		if (autocompleteInputValue === '') {
+			this.setState({
+				autocompleteInputValue: urlParam
+			});
+		}
+	};
+
 	hideUrlModal = url => {
 		const urlParam = typeof url === 'string' && url ? url : this.props.navigation.state.params.url;
 		this.props.navigation.setParams({
@@ -1611,6 +1624,8 @@ export class BrowserTab extends PureComponent {
 			url: urlParam,
 			showUrlModal: false
 		});
+
+		this.resetAutocompleteInputValue(urlParam);
 
 		if (this.isHomepage()) {
 			const { current } = this.webview;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

So previously if a user cleared the url input the domain would go away when re-opening it... steps to reproduce:

1. visit a url, say `google.ca` for example:

![image](https://user-images.githubusercontent.com/675259/91477172-ffdc6500-e86b-11ea-9b73-9552509df9ac.png)

2. click the title bar to edit the input value:

![image](https://user-images.githubusercontent.com/675259/91477268-213d5100-e86c-11ea-8d92-738aa7cbd969.png)

3. clear the input value:

![image](https://user-images.githubusercontent.com/675259/91477332-3619e480-e86c-11ea-9a15-08440c644c0d.png)

4. close the modal:

![image](https://user-images.githubusercontent.com/675259/91477384-47fb8780-e86c-11ea-9ad1-dd917cb195fd.png)

5. open the modal again to see the search input remains empty:

![image](https://user-images.githubusercontent.com/675259/91477489-69f50a00-e86c-11ea-9c7f-f25e4b8e8560.png)

This PR makes it so that if the user clears the search input and leaves the url will return when they reopen the modal:

![image](https://user-images.githubusercontent.com/675259/91477696-bb9d9480-e86c-11ea-9acb-d67c0b215466.png)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
