### PR TITLE
Add ScrollView so we can scroll to errorMessage

### DIFF
--- a/app/components/Views/SendFlow/Amount/__snapshots__/index.test.js.snap
+++ b/app/components/Views/SendFlow/Amount/__snapshots__/index.test.js.snap
@@ -10,169 +10,177 @@ exports[`Amount should render correctly 1`] = `
   }
   testID="amount-screen"
 >
-  <View
+  <ScrollViewMock
     style={
       Object {
-        "flex": 1,
-        "marginHorizontal": 24,
-        "marginTop": 30,
+        "marginBottom": 60,
       }
     }
   >
     <View
       style={
         Object {
-          "flexDirection": "row",
+          "flex": 1,
+          "marginHorizontal": 24,
+          "marginTop": 30,
         }
       }
     >
       <View
         style={
           Object {
-            "flex": 0.8,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-          }
-        }
-      >
-        <TouchableOpacity
-          onPress={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#037dd6",
-              "borderRadius": 100,
-              "flexDirection": "row",
-              "paddingHorizontal": 16,
-              "paddingVertical": 2,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#FFFFFF",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "paddingVertical": 2,
-              }
-            }
-          >
-            Collectible
-          </Text>
-          <View>
-            <Icon
-              allowFontScaling={false}
-              color="#FFFFFF"
-              name="ios-arrow-down"
-              size={16}
-              style={
-                Object {
-                  "paddingLeft": 10,
-                }
-              }
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "flex": 0.8,
-            },
-            Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-            },
-          ]
-        }
-      >
-        <TouchableOpacity
-          disabled={true}
-          onPress={[Function]}
-          style={Object {}}
-        >
-          <Text
-            style={
-              Object {
-                "alignSelf": "flex-end",
-                "color": "#037dd6",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 12,
-                "fontWeight": "400",
-                "textTransform": "uppercase",
-              }
-            }
-          >
-            Use max
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "marginVertical": 16,
+            "flexDirection": "row",
           }
         }
       >
         <View
           style={
             Object {
-              "flexDirection": "row",
+              "flex": 0.8,
             }
           }
-        >
-          <TextInput
-            keyboardType="numeric"
-            onChangeText={[Function]}
-            placeholder="0"
-            style={
-              Object {
-                "fontFamily": "Roboto-Light",
-                "fontSize": 44,
-                "fontWeight": "300",
-                "textAlign": "center",
-              }
-            }
-            testID="txn-amount-input"
-          />
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "marginVertical": 16,
-          }
-        }
-      >
-        <Text
+        />
+        <View
           style={
             Object {
-              "alignSelf": "center",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 12,
-              "fontWeight": "400",
-              "lineHeight": 16,
+              "alignItems": "center",
+              "flex": 1,
             }
           }
         >
-          Balance: undefined
-        </Text>
+          <TouchableOpacity
+            onPress={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#037dd6",
+                "borderRadius": 100,
+                "flexDirection": "row",
+                "paddingHorizontal": 16,
+                "paddingVertical": 2,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "paddingVertical": 2,
+                }
+              }
+            >
+              Collectible
+            </Text>
+            <View>
+              <Icon
+                allowFontScaling={false}
+                color="#FFFFFF"
+                name="ios-arrow-down"
+                size={16}
+                style={
+                  Object {
+                    "paddingLeft": 10,
+                  }
+                }
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flex": 0.8,
+              },
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "flex-end",
+              },
+            ]
+          }
+        >
+          <TouchableOpacity
+            disabled={true}
+            onPress={[Function]}
+            style={Object {}}
+          >
+            <Text
+              style={
+                Object {
+                  "alignSelf": "flex-end",
+                  "color": "#037dd6",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 12,
+                  "fontWeight": "400",
+                  "textTransform": "uppercase",
+                }
+              }
+            >
+              Use max
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "marginVertical": 16,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+              }
+            }
+          >
+            <TextInput
+              keyboardType="numeric"
+              onChangeText={[Function]}
+              placeholder="0"
+              style={
+                Object {
+                  "fontFamily": "Roboto-Light",
+                  "fontSize": 44,
+                  "fontWeight": "300",
+                  "textAlign": "center",
+                }
+              }
+              testID="txn-amount-input"
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginVertical": 16,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "alignSelf": "center",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 12,
+                "fontWeight": "400",
+                "lineHeight": 16,
+              }
+            }
+          >
+            Balance: undefined
+          </Text>
+        </View>
       </View>
     </View>
-  </View>
+  </ScrollViewMock>
   <KeyboardAvoidingView
     behavior="padding"
     enabled={true}

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -53,6 +53,7 @@ import Device from '../../../../util/Device';
 import { BN } from 'ethereumjs-util';
 import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
+import dismissKeyboard from 'react-native/Libraries/Utilities/dismissKeyboard';
 
 const { hexToBN, BNToHex } = util;
 
@@ -479,6 +480,7 @@ class Amount extends PureComponent {
 			const invalidCollectibleOwnership = await this.validateCollectibleOwnership();
 			if (invalidCollectibleOwnership) {
 				this.setState({ amountError: invalidCollectibleOwnership });
+				dismissKeyboard();
 			}
 		}
 
@@ -634,7 +636,10 @@ class Amount extends PureComponent {
 		} else {
 			amountError = strings('transaction.invalid_amount');
 		}
-		this.setState({ amountError });
+		if (amountError) {
+			this.setState({ amountError });
+			dismissKeyboard();
+		}
 		return !!amountError;
 	};
 

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -10,7 +10,8 @@ import {
 	KeyboardAvoidingView,
 	FlatList,
 	Image,
-	InteractionManager
+	InteractionManager,
+	ScrollView
 } from 'react-native';
 import { connect } from 'react-redux';
 import { setSelectedAsset, prepareTransaction, setTransactionObject } from '../../../../actions/transaction';
@@ -63,6 +64,9 @@ const styles = StyleSheet.create({
 	wrapper: {
 		flex: 1,
 		backgroundColor: colors.white
+	},
+	scrollWrapper: {
+		marginBottom: 60
 	},
 	buttonNextWrapper: {
 		flex: 1,
@@ -1019,44 +1023,46 @@ class Amount extends PureComponent {
 
 		return (
 			<SafeAreaView style={styles.wrapper} testID={'amount-screen'}>
-				<View style={styles.inputWrapper}>
-					<View style={styles.actionsWrapper}>
-						<View style={styles.actionBorder} />
-						<View style={styles.action}>
-							<TouchableOpacity
-								style={styles.actionDropdown}
-								disabled={paymentChannelTransaction || isPaymentRequest}
-								onPress={this.toggleAssetsModal}
-							>
-								<Text style={styles.textDropdown}>
-									{selectedAsset.symbol || strings('wallet.collectible')}
-								</Text>
-								{!paymentChannelTransaction && (
-									<View styles={styles.arrow}>
-										<Ionicons
-											name="ios-arrow-down"
-											size={16}
-											color={colors.white}
-											style={styles.iconDropdown}
-										/>
-									</View>
-								)}
-							</TouchableOpacity>
-						</View>
-						<View style={[styles.actionBorder, styles.actionMax]}>
-							{!selectedAsset.tokenId && (
+				<ScrollView style={styles.scrollWrapper}>
+					<View style={styles.inputWrapper}>
+						<View style={styles.actionsWrapper}>
+							<View style={styles.actionBorder} />
+							<View style={styles.action}>
 								<TouchableOpacity
-									style={styles.actionMaxTouchable}
-									disabled={!paymentChannelTransaction && !estimatedTotalGas}
-									onPress={this.useMax}
+									style={styles.actionDropdown}
+									disabled={paymentChannelTransaction || isPaymentRequest}
+									onPress={this.toggleAssetsModal}
 								>
-									<Text style={styles.maxText}>{strings('transaction.use_max')}</Text>
+									<Text style={styles.textDropdown}>
+										{selectedAsset.symbol || strings('wallet.collectible')}
+									</Text>
+									{!paymentChannelTransaction && (
+										<View styles={styles.arrow}>
+											<Ionicons
+												name="ios-arrow-down"
+												size={16}
+												color={colors.white}
+												style={styles.iconDropdown}
+											/>
+										</View>
+									)}
 								</TouchableOpacity>
-							)}
+							</View>
+							<View style={[styles.actionBorder, styles.actionMax]}>
+								{!selectedAsset.tokenId && (
+									<TouchableOpacity
+										style={styles.actionMaxTouchable}
+										disabled={!paymentChannelTransaction && !estimatedTotalGas}
+										onPress={this.useMax}
+									>
+										<Text style={styles.maxText}>{strings('transaction.use_max')}</Text>
+									</TouchableOpacity>
+								)}
+							</View>
 						</View>
+						{selectedAsset.tokenId ? this.renderCollectibleInput() : this.renderTokenInput()}
 					</View>
-					{selectedAsset.tokenId ? this.renderCollectibleInput() : this.renderTokenInput()}
-				</View>
+				</ScrollView>
 
 				<KeyboardAvoidingView
 					style={styles.nextActionWrapper}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Previously the insufficient funds `errorMessage` was hidden behind the next button when the keyboard was open:

![image](https://user-images.githubusercontent.com/675259/92141475-7c2cf600-ede0-11ea-9e69-ba6c0d090b08.png)

Now on smaller devices you can scroll to see the insufficient funds `errorMessage`

![image](https://user-images.githubusercontent.com/675259/92141590-a383c300-ede0-11ea-8f07-68d0aebed510.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
