### PR TITLE
Add gms:play-services-wallet dependency 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -151,7 +151,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
  * and the benefits of using Hermes will therefore be sharply reduced.
  */
-def enableHermes = project.ext.react.get("enableHermes", false);
+def enableHermes = project.ext.react.get("enableHermes", false)
 
 android {
 
@@ -250,16 +250,18 @@ android {
 	}
 }
 
-dependencies {	
+dependencies {
 	implementation project(':lottie-react-native')
 
 	implementation project(':react-native-gesture-handler')
-	
-	implementation 'androidx.multidex:multidex:2.0.0'
+
+	implementation 'androidx.multidex:multidex:2.0.1'
 	implementation 'androidx.annotation:annotation:1.1.0'
-	implementation 'androidx.appcompat:appcompat:1.0.0'
+	implementation 'androidx.appcompat:appcompat:1.2.0'
 	implementation "com.facebook.react:react-native:+"  // From node_modules
 	implementation 'org.chromium:v8-android:+'
+
+	implementation 'com.google.android.gms:play-services-wallet:18.0.0'
 
 	implementation "io.branch.sdk.android:library:5.+"
 


### PR DESCRIPTION
After we landed payments it broke the debugger on android:

![image](https://user-images.githubusercontent.com/675259/93545224-e8a20c00-f92d-11ea-84af-77af8c8f5923.png)

Adding `android.gms:play-services-wallet` as a dep fixes the failed resolution.

I also took the liberty of updating a couple of other deps and cleaning the gradle file up a bit

(these were auto suggestions from Android studio).

