### PR TITLE
fixed typo on country name

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1284,7 +1284,7 @@
 		"wyre_max": "Max $450 weekly",
 		"wyre_requires_debit_card": "Requires debit card",
 		"wyre_us_only": "🇺🇸 U.S. only",
-		"wyre_modal_text": "Paying with Apple Pay, powered by Wyre is supported in the United Sates 🇺🇸 except for CT, HI, NC, NH, NY, VA and VT.",
+		"wyre_modal_text": "Paying with Apple Pay, powered by Wyre is supported in the United States 🇺🇸 except for CT, HI, NC, NH, NY, VA and VT.",
 		"wyre_modal_terms_of_service_apply": "Wyre terms of service apply.",
 		"wyre_minimum_deposit": "Minimum deposit is {{amount}}",
 		"wyre_maximum_deposit": "Maximum deposit is {{amount}}",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Fixes typo on country name in the Wyre country support modal. (United Sates => United States)

**Checklist**

* [ ] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented

**Issue**

Resolves #???
