### PR TITLE
Add safety to toLowerCase calls

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -930,8 +930,10 @@ class DrawerView extends PureComponent {
 								{section
 									.filter(item => {
 										if (!item) return undefined;
-										if (item.name.toLowerCase().indexOf('etherscan') !== -1) {
-											return this.hasBlockExplorer(network.provider.type);
+										const { name = undefined } = item;
+										if (name && name.toLowerCase().indexOf('etherscan') !== -1) {
+											const type = network.provider?.type;
+											return (type && this.hasBlockExplorer(type)) || undefined;
 										}
 										return true;
 									})

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -245,7 +245,10 @@ class ChoosePassword extends PureComponent {
 	async componentDidMount() {
 		const biometryType = await SecureKeychain.getSupportedBiometryType();
 		if (biometryType) {
-			this.setState({ biometryType, biometryChoice: true });
+			this.setState({
+				biometryType: (biometryType && biometryType.toLowerCase()) || null,
+				biometryChoice: true
+			});
 		}
 		setTimeout(() => {
 			this.setState({
@@ -471,9 +474,7 @@ class ChoosePassword extends PureComponent {
 			<View style={styles.biometrics}>
 				{biometryType ? (
 					<>
-						<Text style={styles.biometryLabel}>
-							{strings(`biometrics.enable_${biometryType.toLowerCase()}`)}
-						</Text>
+						<Text style={styles.biometryLabel}>{strings(`biometrics.enable_${biometryType}`)}</Text>
 						<View>
 							<Switch
 								onValueChange={biometryChoice => this.setState({ biometryChoice })} // eslint-disable-line react/jsx-no-bind

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -223,7 +223,10 @@ class ImportFromSeed extends PureComponent {
 			if (previouslyDisabled && previouslyDisabled === TRUE) {
 				enabled = false;
 			}
-			this.setState({ biometryType, biometryChoice: enabled });
+			this.setState({
+				biometryType: (biometryType && biometryType.toLowerCase()) || null,
+				biometryChoice: enabled
+			});
 		}
 		// Workaround https://github.com/facebook/react-native/issues/9958
 		setTimeout(() => {
@@ -360,9 +363,7 @@ class ImportFromSeed extends PureComponent {
 		if (this.state.biometryType) {
 			return (
 				<View style={styles.biometrics}>
-					<Text style={styles.biometryLabel}>
-						{strings(`biometrics.enable_${this.state.biometryType.toLowerCase()}`)}
-					</Text>
+					<Text style={styles.biometryLabel}>{strings(`biometrics.enable_${this.state.biometryType}`)}</Text>
 					<Switch
 						onValueChange={biometryChoice => this.setState({ biometryChoice })} // eslint-disable-line react/jsx-no-bind
 						value={this.state.biometryChoice}

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -162,7 +162,7 @@ class Login extends PureComponent {
 				}
 
 				this.setState({
-					biometryType,
+					biometryType: (biometryType && biometryType.toLowerCase()) || null,
 					biometryChoice: enabled,
 					biometryPreviouslyDisabled: !!previouslyDisabled
 				});
@@ -277,15 +277,14 @@ class Login extends PureComponent {
 	};
 
 	renderSwitch = () => {
-		if (this.state.biometryType && !this.state.biometryPreviouslyDisabled) {
+		const { biometryType, biometryPreviouslyDisabled, biometryChoice } = this.state;
+		if (biometryType && !biometryPreviouslyDisabled) {
 			return (
 				<View style={styles.biometrics}>
-					<Text style={styles.biometryLabel}>
-						{strings(`biometrics.enable_${this.state.biometryType.toLowerCase()}`)}
-					</Text>
+					<Text style={styles.biometryLabel}>{strings(`biometrics.enable_${biometryType}`)}</Text>
 					<Switch
 						onValueChange={biometryChoice => this.updateBiometryChoice(biometryChoice)} // eslint-disable-line react/jsx-no-bind
-						value={this.state.biometryChoice}
+						value={biometryChoice}
 						style={styles.biometrySwitch}
 						trackColor={Device.isIos() ? { true: colors.green300, false: colors.grey300 } : null}
 						ios_backgroundColor={colors.grey300}

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -241,7 +241,12 @@ class Settings extends PureComponent {
 			}
 		}
 		const metricsOptIn = Analytics.getEnabled();
-		this.setState({ biometryType, biometryChoice: bioEnabled, metricsOptIn, passcodeChoice: passcodeEnabled });
+		this.setState({
+			biometryType: (biometryType && biometryType.toLowerCase()) || null,
+			biometryChoice: bioEnabled,
+			metricsOptIn,
+			passcodeChoice: passcodeEnabled
+		});
 	};
 
 	onSecuritySettingChange = async (enabled, type) => {
@@ -538,9 +543,7 @@ class Settings extends PureComponent {
 					</View>
 					{biometryType && (
 						<View style={styles.setting} testID={'biometrics-option'}>
-							<Text style={styles.title}>
-								{strings(`biometrics.enable_${this.state.biometryType.toLowerCase()}`)}
-							</Text>
+							<Text style={styles.title}>{strings(`biometrics.enable_${this.state.biometryType}`)}</Text>
 							<View style={styles.switchElement}>
 								<Switch
 									// eslint-disable-next-line react/jsx-no-bind


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We're using `toLowerCase()` in quite a few places in the codebase without actually checking what the value of the item is.

eg:
```
> undefined.toLowerCase()
Thrown:
TypeError: Cannot read property 'toLowerCase' of undefined
```

While we should ensure that things are indeed being set in predictable ways, we can add some guardrails by verifying the value is set before calling `toLowerCase()`

we should also avoid calls to `toLowerCase()` in `render()` methods and instead call it when we're setting the value in state

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???

This resolves at least two problems that I am seeing on Sentry
