### PR TITLE
Only enable login button if password meets minimum requirements

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -30,6 +30,7 @@ import {
 	PASSCODE_DISABLED,
 	TRUE
 } from '../../../constants/storage';
+import { getPasswordStrengthWord, passwordRequirementsMet } from '../../../util/password';
 
 import { CHOOSE_PASSWORD_STEPS } from '../../../constants/onboarding';
 
@@ -289,7 +290,7 @@ class ChoosePassword extends PureComponent {
 
 		if (!canSubmit) return;
 		if (loading) return;
-		if (password.length < 8) {
+		if (!passwordRequirementsMet(password)) {
 			Alert.alert('Error', strings('choose_password.password_length_error'));
 			return;
 		} else if (password !== confirmPassword) {
@@ -447,24 +448,6 @@ class ChoosePassword extends PureComponent {
 		current && current.focus();
 	};
 
-	getPasswordStrengthWord() {
-		// this.state.passwordStrength is calculated by zxcvbn
-		// which returns a score based on "entropy to crack time"
-		// 0 is the weakest, 4 the strongest
-		switch (this.state.passwordStrength) {
-			case 0:
-				return 'weak';
-			case 1:
-				return 'weak';
-			case 2:
-				return 'weak';
-			case 3:
-				return 'good';
-			case 4:
-				return 'strong';
-		}
-	}
-
 	renderSwitch = () => {
 		const { biometryType, rememberMe, biometryChoice } = this.state;
 		return (
@@ -518,10 +501,20 @@ class ChoosePassword extends PureComponent {
 	};
 
 	render() {
-		const { isSelected, inputWidth, password, confirmPassword, secureTextEntry, error, loading } = this.state;
+		const {
+			isSelected,
+			inputWidth,
+			password,
+			passwordStrength,
+			confirmPassword,
+			secureTextEntry,
+			error,
+			loading
+		} = this.state;
 		const passwordsMatch = password !== '' && password === confirmPassword;
 		const canSubmit = passwordsMatch && isSelected;
 		const previousScreen = this.props.navigation.getParam(AppConstants.PREVIOUS_SCREEN);
+		const passwordStrengthWord = getPasswordStrengthWord(passwordStrength);
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -582,9 +575,9 @@ class ChoosePassword extends PureComponent {
 									{(password !== '' && (
 										<Text style={styles.hintLabel}>
 											{strings('choose_password.password_strength')}
-											<Text style={styles[`strength_${this.getPasswordStrengthWord()}`]}>
+											<Text style={styles[`strength_${passwordStrengthWord}`]}>
 												{' '}
-												{strings(`choose_password.strength_${this.getPasswordStrengthWord()}`)}
+												{strings(`choose_password.strength_${passwordStrengthWord}`)}
 											</Text>
 										</Text>
 									)) || <Text style={styles.hintLabel} />}

--- a/app/components/Views/ChoosePasswordSimple/index.js
+++ b/app/components/Views/ChoosePasswordSimple/index.js
@@ -22,6 +22,7 @@ import { strings } from '../../../../locales/i18n';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import zxcvbn from 'zxcvbn';
+import { getPasswordStrengthWord, passwordRequirementsMet } from '../../../util/password';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -159,7 +160,7 @@ class ChoosePasswordSimple extends PureComponent {
 	onPressCreate = async () => {
 		if (this.state.loading) return;
 		let error = null;
-		if (this.state.password.length < 8) {
+		if (!passwordRequirementsMet(this.state.password)) {
 			error = strings('choose_password.password_length_error');
 		} else if (this.state.password !== this.state.confirmPassword) {
 			error = strings('choose_password.password_dont_match');
@@ -203,24 +204,6 @@ class ChoosePasswordSimple extends PureComponent {
 		}).start();
 	};
 
-	getPasswordStrengthWord() {
-		// this.state.passwordStrength is calculated by zxcvbn
-		// which returns a score based on "entropy to crack time"
-		// 0 is the weakest, 4 the strongest
-		switch (this.state.passwordStrength) {
-			case 0:
-				return 'weak';
-			case 1:
-				return 'weak';
-			case 2:
-				return 'weak';
-			case 3:
-				return 'good';
-			case 4:
-				return 'strong';
-		}
-	}
-
 	onPasswordChange = val => {
 		const passInfo = zxcvbn(val);
 
@@ -232,7 +215,8 @@ class ChoosePasswordSimple extends PureComponent {
 	};
 
 	render() {
-		const { startX, startY, width, height, initialScale, endX, endY } = this;
+		const { passwordStrength, startX, startY, width, height, initialScale, endX, endY } = this;
+		const passwordStrengthWord = getPasswordStrengthWord(passwordStrength);
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -300,9 +284,9 @@ class ChoosePasswordSimple extends PureComponent {
 								{(this.state.password !== '' && (
 									<Text style={styles.passwordStrengthLabel}>
 										{strings('choose_password.password_strength')}
-										<Text style={styles[`strength_${this.getPasswordStrengthWord()}`]}>
+										<Text style={styles[`strength_${passwordStrengthWord}`]}>
 											{' '}
-											{strings(`choose_password.strength_${this.getPasswordStrengthWord()}`)}
+											{strings(`choose_password.strength_${passwordStrengthWord}`)}
 										</Text>
 									</Text>
 								)) || <Text style={styles.passwordStrengthLabel} />}

--- a/app/components/Views/EnterPasswordSimple/index.js
+++ b/app/components/Views/EnterPasswordSimple/index.js
@@ -7,6 +7,7 @@ import StyledButton from '../../UI/StyledButton';
 import { colors, baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
+import { passwordRequirementsMet } from '../../../util/password';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -60,7 +61,7 @@ export default class EnterPasswordSimple extends PureComponent {
 
 	onPressConfirm = async () => {
 		if (this.state.loading) return;
-		if (this.state.password.length < 8) {
+		if (!passwordRequirementsMet(this.state.password)) {
 			Alert.alert(strings('enter_password.error'), strings('choose_password.password_length_error'));
 		} else {
 			this.props.navigation.state.params.onPasswordSet(this.state.password);
@@ -95,7 +96,9 @@ export default class EnterPasswordSimple extends PureComponent {
 									type={'blue'}
 									onPress={this.onPressConfirm}
 									testID={'submit-button'}
-									disabled={!(this.state.password !== '' || this.state.password.length < 8)}
+									disabled={
+										!(this.state.password !== '' || !passwordRequirementsMet(this.state.password))
+									}
 								>
 									{this.state.loading ? (
 										<ActivityIndicator size="small" color="white" />

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -44,6 +44,7 @@ import {
 } from '../../../constants/storage';
 import { ethers } from 'ethers';
 import Logger from '../../../util/Logger';
+import { getPasswordStrengthWord, passwordRequirementsMet } from '../../../util/password';
 
 const { isValidMnemonic } = ethers.utils;
 
@@ -241,7 +242,7 @@ class ImportFromSeed extends PureComponent {
 
 		if (loading) return;
 		let error = null;
-		if (password.length < 8) {
+		if (!passwordRequirementsMet(this.state.password)) {
 			error = strings('import_from_seed.password_length_error');
 		} else if (password !== confirmPassword) {
 			error = strings('import_from_seed.password_dont_match');
@@ -406,24 +407,6 @@ class ImportFromSeed extends PureComponent {
 		this.setState(({ hideSeedPhraseInput }) => ({ hideSeedPhraseInput: !hideSeedPhraseInput }));
 	};
 
-	getPasswordStrengthWord() {
-		// this.state.passwordStrength is calculated by zxcvbn
-		// which returns a score based on "entropy to crack time"
-		// 0 is the weakest, 4 the strongest
-		switch (this.state.passwordStrength) {
-			case 0:
-				return 'weak';
-			case 1:
-				return 'weak';
-			case 2:
-				return 'weak';
-			case 3:
-				return 'good';
-			case 4:
-				return 'strong';
-		}
-	}
-
 	onQrCodePress = () => {
 		setTimeout(this.toggleHideSeedPhraseInput, 100);
 		this.props.navigation.navigate('QRScanner', {
@@ -449,6 +432,7 @@ class ImportFromSeed extends PureComponent {
 	render() {
 		const {
 			password,
+			passwordStrength,
 			confirmPassword,
 			seed,
 			seedphraseInputFocused,
@@ -458,6 +442,8 @@ class ImportFromSeed extends PureComponent {
 			loading,
 			hideSeedPhraseInput
 		} = this.state;
+
+		const passwordStrengthWord = getPasswordStrengthWord(passwordStrength);
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -548,9 +534,9 @@ class ImportFromSeed extends PureComponent {
 							{(password !== '' && (
 								<Text style={styles.passwordStrengthLabel}>
 									{strings('choose_password.password_strength')}
-									<Text style={styles[`strength_${this.getPasswordStrengthWord()}`]}>
+									<Text style={styles[`strength_${passwordStrengthWord}`]}>
 										{' '}
-										{strings(`choose_password.strength_${this.getPasswordStrengthWord()}`)}
+										{strings(`choose_password.strength_${passwordStrengthWord}`)}
 									</Text>
 								</Text>
 							)) || <Text style={styles.passwordStrengthLabel} />}

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -329,80 +329,85 @@ class Login extends PureComponent {
 		return true;
 	};
 
-	render = () => (
-		<SafeAreaView style={styles.mainWrapper}>
-			<KeyboardAwareScrollView style={styles.wrapper} resetScrollToCoords={{ x: 0, y: 0 }}>
-				<View testID={'login'}>
-					<View style={styles.foxWrapper}>
-						{Device.isAndroid() ? (
-							<Image
-								source={require('../../../images/fox.png')}
-								style={styles.image}
-								resizeMethod={'auto'}
-							/>
-						) : (
-							<AnimatedFox />
-						)}
-					</View>
-					<Text style={styles.title}>{strings('login.title')}</Text>
-					<View style={styles.field}>
-						<Text style={styles.label}>{strings('login.password')}</Text>
-						<OutlinedTextField
-							placeholder={'Password'}
-							testID={'login-password-input'}
-							returnKeyType={'done'}
-							autoCapitalize="none"
-							secureTextEntry
-							ref={this.fieldRef}
-							onChangeText={this.setPassword}
-							value={this.state.password}
-							baseColor={colors.grey500}
-							tintColor={colors.blue}
-							onSubmitEditing={this.onLogin}
-							renderRightAccessory={() => (
-								<BiometryButton
-									onPress={this.tryBiometric}
-									hidden={
-										!(
-											this.state.biometryChoice &&
-											this.state.biometryType &&
-											this.state.hasCredentials
-										)
-									}
-									type={this.state.biometryType}
+	render = () => {
+		const { password } = this.state;
+		const passEmpty = !password.length;
+
+		return (
+			<SafeAreaView style={styles.mainWrapper}>
+				<KeyboardAwareScrollView style={styles.wrapper} resetScrollToCoords={{ x: 0, y: 0 }}>
+					<View testID={'login'}>
+						<View style={styles.foxWrapper}>
+							{Device.isAndroid() ? (
+								<Image
+									source={require('../../../images/fox.png')}
+									style={styles.image}
+									resizeMethod={'auto'}
 								/>
-							)}
-						/>
-					</View>
-
-					{this.renderSwitch()}
-
-					{!!this.state.error && (
-						<Text style={styles.errorMsg} testID={'invalid-password-error'}>
-							{this.state.error}
-						</Text>
-					)}
-
-					<View style={styles.ctaWrapper} testID={'log-in-button'}>
-						<StyledButton type={'confirm'} onPress={this.onLogin}>
-							{this.state.loading ? (
-								<ActivityIndicator size="small" color="white" />
 							) : (
-								strings('login.login_button')
+								<AnimatedFox />
 							)}
-						</StyledButton>
-					</View>
+						</View>
+						<Text style={styles.title}>{strings('login.title')}</Text>
+						<View style={styles.field}>
+							<Text style={styles.label}>{strings('login.password')}</Text>
+							<OutlinedTextField
+								placeholder={'Password'}
+								testID={'login-password-input'}
+								returnKeyType={'done'}
+								autoCapitalize="none"
+								secureTextEntry
+								ref={this.fieldRef}
+								onChangeText={this.setPassword}
+								value={this.state.password}
+								baseColor={colors.grey500}
+								tintColor={colors.blue}
+								onSubmitEditing={this.onLogin}
+								renderRightAccessory={() => (
+									<BiometryButton
+										onPress={this.tryBiometric}
+										hidden={
+											!(
+												this.state.biometryChoice &&
+												this.state.biometryType &&
+												this.state.hasCredentials
+											)
+										}
+										type={this.state.biometryType}
+									/>
+								)}
+							/>
+						</View>
 
-					<View style={styles.footer}>
-						<Button style={styles.goBack} onPress={this.onPressGoBack}>
-							{strings('login.go_back')}
-						</Button>
+						{this.renderSwitch()}
+
+						{!!this.state.error && (
+							<Text style={styles.errorMsg} testID={'invalid-password-error'}>
+								{this.state.error}
+							</Text>
+						)}
+
+						<View style={styles.ctaWrapper} testID={'log-in-button'}>
+							<StyledButton disabled={passEmpty} type={'confirm'} onPress={this.onLogin}>
+								{this.state.loading ? (
+									<ActivityIndicator size="small" color="white" />
+								) : (
+									strings('login.login_button')
+								)}
+							</StyledButton>
+						</View>
+
+						<View style={styles.footer}>
+							<Button style={styles.goBack} onPress={this.onPressGoBack}>
+								{strings('login.go_back')}
+							</Button>
+						</View>
 					</View>
-				</View>
-			</KeyboardAwareScrollView>
-			<FadeOutOverlay />
-		</SafeAreaView>
-	);
+				</KeyboardAwareScrollView>
+				<FadeOutOverlay />
+			</SafeAreaView>
+		);
+	};
 }
 
 const mapStateToProps = state => ({

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -29,6 +29,7 @@ import {
 	TRUE,
 	ORIGINAL
 } from '../../../constants/storage';
+import { passwordRequirementsMet } from '../../../util/password';
 
 const styles = StyleSheet.create({
 	mainWrapper: {
@@ -331,7 +332,7 @@ class Login extends PureComponent {
 
 	render = () => {
 		const { password } = this.state;
-		const passEmpty = !password.length;
+		const disabled = !passwordRequirementsMet(password);
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -388,7 +389,7 @@ class Login extends PureComponent {
 						)}
 
 						<View style={styles.ctaWrapper} testID={'log-in-button'}>
-							<StyledButton disabled={passEmpty} type={'confirm'} onPress={this.onLogin}>
+							<StyledButton disabled={disabled} type={'confirm'} onPress={this.onLogin}>
 								{this.state.loading ? (
 									<ActivityIndicator size="small" color="white" />
 								) : (

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -184,8 +184,8 @@ class Login extends PureComponent {
 		this.mounted = false;
 	}
 
-	onLogin = async () => {
-		if (this.state.loading) return;
+	onLogin = async disabled => {
+		if (this.state.loading || disabled) return;
 		try {
 			this.setState({ loading: true });
 			const { KeyringController } = Engine.context;
@@ -363,7 +363,7 @@ class Login extends PureComponent {
 								value={this.state.password}
 								baseColor={colors.grey500}
 								tintColor={colors.blue}
-								onSubmitEditing={this.onLogin}
+								onSubmitEditing={() => this.onLogin(disabled)}
 								renderRightAccessory={() => (
 									<BiometryButton
 										onPress={this.tryBiometric}

--- a/app/util/password.js
+++ b/app/util/password.js
@@ -1,0 +1,17 @@
+const MIN_PASSWORD_LENGTH = 8;
+export const getPasswordStrengthWord = strength => {
+	switch (strength) {
+		case 0:
+			return 'weak';
+		case 1:
+			return 'weak';
+		case 2:
+			return 'weak';
+		case 3:
+			return 'good';
+		case 4:
+			return 'strong';
+	}
+};
+
+export const passwordRequirementsMet = password => password.length >= MIN_PASSWORD_LENGTH;

--- a/app/util/password.test.js
+++ b/app/util/password.test.js
@@ -1,0 +1,28 @@
+import { getPasswordStrengthWord, passwordRequirementsMet } from './password';
+
+describe('getPasswordStrength', () => {
+	it('should return correct values', () => {
+		for (let i = 0; i < 5; i++) {
+			const password_strength = getPasswordStrengthWord(i);
+			if (i < 3) {
+				expect(password_strength).toEqual('weak');
+			} else if (i === 3) {
+				expect(password_strength).toEqual('good');
+			} else if (i === 4) {
+				expect(password_strength).toEqual('strong');
+			}
+		}
+	});
+});
+
+describe('passwordRequirementsMet', () => {
+	it('should pass when password is 8 in length', () => {
+		expect(passwordRequirementsMet('lolololo')).toEqual(true);
+	});
+	it('should pass when password is gt 8 in length', () => {
+		expect(passwordRequirementsMet('lololololol')).toEqual(true);
+	});
+	it('should fail when password is lt 8 in length', () => {
+		expect(passwordRequirementsMet('lol')).toEqual(false);
+	});
+});


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Previously, we were leaving the login button enabled even if the password was empty:

![image](https://user-images.githubusercontent.com/675259/94390077-9b891b80-011f-11eb-905c-3e336e68dfdb.png)

<strike>I'm actually tempted to leave the login button disabled if the password is also not meeting our password requirements (which is 8 chars in length min)</strike>

Login stays disabled until pw meets our minimum requirements:

![image](https://user-images.githubusercontent.com/675259/94389699-92e41580-011e-11eb-9cd7-704fc5ab4c79.png)
![image](https://user-images.githubusercontent.com/675259/94392446-48669700-0126-11eb-9848-da36f78f1a7d.png)


this should cut down on some of the sentry noise we're seeing for failed login attempts

it's also better UX, the user will not see "Invalid Password" in red if they just slip and try and hit the button

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
