### PR TITLE
Direct to proper screen on address QR code scan

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -689,7 +689,11 @@ export function getOfflineModalNavbar(navigation) {
 export function getWalletNavbarOptions(title, navigation) {
 	const onScanSuccess = data => {
 		if (data.target_address) {
-			navigation.navigate('SendFlowView', { txMeta: data });
+			if (data?.parameters?.value) {
+				navigation.navigate('SendView', { txMeta: data });
+			} else {
+				navigation.navigate('SendFlowView', { txMeta: data });
+			}
 		} else if (data.private_key) {
 			Alert.alert(
 				strings('wallet.private_key_detected'),

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -687,7 +687,7 @@ export function getOfflineModalNavbar(navigation) {
  * @returns {Object} - Corresponding navbar options containing headerTitle, headerTitle and headerTitle
  */
 export function getWalletNavbarOptions(title, navigation) {
-	const onScanSuccess = data => {
+	const onScanSuccess = (data, content) => {
 		if (data.target_address) {
 			if (data?.parameters?.value || data?.function_name === 'transfer') {
 				navigation.navigate('SendView', { txMeta: data });

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -689,7 +689,7 @@ export function getOfflineModalNavbar(navigation) {
 export function getWalletNavbarOptions(title, navigation) {
 	const onScanSuccess = data => {
 		if (data.target_address) {
-			if (data?.parameters?.value) {
+			if (data?.parameters?.value || data?.function_name === 'transfer') {
 				navigation.navigate('SendView', { txMeta: data });
 			} else {
 				navigation.navigate('SendFlowView', { txMeta: data });

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -687,8 +687,10 @@ export function getOfflineModalNavbar(navigation) {
  * @returns {Object} - Corresponding navbar options containing headerTitle, headerTitle and headerTitle
  */
 export function getWalletNavbarOptions(title, navigation) {
-	const onScanSuccess = (data, content) => {
-		if (data.private_key) {
+	const onScanSuccess = data => {
+		if (data.target_address) {
+			navigation.navigate('SendFlowView', { txMeta: data });
+		} else if (data.private_key) {
 			Alert.alert(
 				strings('wallet.private_key_detected'),
 				strings('wallet.do_you_want_to_import_this_account'),

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -235,6 +235,8 @@ class SendFlow extends PureComponent {
 		if (!Object.keys(networkAddressBook).length) {
 			this.addressToInputRef && this.addressToInputRef.current && this.addressToInputRef.current.focus();
 		}
+		//Fills in to address if coming from QR code scan
+		this.onToSelectedAddressChange(navigation.getParam('txMeta', null)?.target_address);
 	};
 
 	toggleFromAccountModal = () => {
@@ -491,7 +493,6 @@ class SendFlow extends PureComponent {
 			toInputHighlighted,
 			inputWidth
 		} = this.state;
-
 		return (
 			<SafeAreaView style={styles.wrapper} testID={'send-screen'}>
 				<View style={styles.imputWrapper}>

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -147,6 +147,10 @@ class SendFlow extends PureComponent {
 		 */
 		navigation: PropTypes.object,
 		/**
+		 * Start transaction with asset
+		 */
+		newAssetTransaction: PropTypes.func.isRequired,
+		/**
 		 * Selected address as string
 		 */
 		selectedAddress: PropTypes.string,
@@ -235,8 +239,12 @@ class SendFlow extends PureComponent {
 		if (!Object.keys(networkAddressBook).length) {
 			this.addressToInputRef && this.addressToInputRef.current && this.addressToInputRef.current.focus();
 		}
-		//Fills in to address if coming from QR code scan
-		this.onToSelectedAddressChange(navigation.getParam('txMeta', null)?.target_address);
+		//Fills in to address and sets the transaction if coming from QR code scan
+		const targetAddress = navigation.getParam('txMeta', null)?.target_address;
+		if (targetAddress) {
+			this.props.newAssetTransaction(getEther());
+			this.onToSelectedAddressChange(targetAddress);
+		}
 	};
 
 	toggleFromAccountModal = () => {


### PR DESCRIPTION
https://trello.com/c/V51d5FO6/204-public-address-qr-code-scanning-opens-confirm-screen-should-be-just-the-prefilled-recipient-address-screen