### PR TITLE
Fix proptype warning for WebviewError

### DIFF
--- a/app/components/UI/WebviewError/index.js
+++ b/app/components/UI/WebviewError/index.js
@@ -64,11 +64,15 @@ export default class WebviewError extends PureComponent {
 		/**
 		 * error info
 		 */
-		error: PropTypes.object,
+		error: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
 		/**
 		 * Function that reloads the page
 		 */
 		onReload: PropTypes.func
+	};
+
+	static defaultProps = {
+		error: false
 	};
 
 	onReload = () => {
@@ -77,10 +81,7 @@ export default class WebviewError extends PureComponent {
 
 	render() {
 		const { error } = this.props;
-		if (!error) {
-			return null;
-		}
-		return (
+		return error ? (
 			<View style={styles.wrapper}>
 				<View style={styles.foxWrapper}>
 					{Device.isAndroid() ? (
@@ -104,6 +105,6 @@ export default class WebviewError extends PureComponent {
 					</StyledButton>
 				</View>
 			</View>
-		);
+		) : null;
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I see a proptype failure on the WebViewError:

![image](https://user-images.githubusercontent.com/675259/94768558-c4a6e780-037d-11eb-97c3-7d4fd8f0e85c.png)

this fixes that

this is happening because in the `BrowserTab/index.js` we're setting the error as a bool here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Views/BrowserTab/index.js#L1229

and then as `errorInfo` obj here: https://github.com/MetaMask/metamask-mobile/blob/develop/app/components/Views/BrowserTab/index.js#L1418

but in props validation it can only be `object`

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
