### PR TITLE
Provide error feedback without actually submitting

### DIFF
--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -79,7 +79,8 @@ const styles = StyleSheet.create({
 	},
 	errorMsg: {
 		color: colors.red,
-		...fontStyles.normal
+		...fontStyles.normal,
+		lineHeight: 20
 	},
 	goBack: {
 		color: colors.fontSecondary,
@@ -184,10 +185,11 @@ class Login extends PureComponent {
 		this.mounted = false;
 	}
 
-	onLogin = async disabled => {
-		if (this.state.loading || disabled) return;
+	onLogin = async locked => {
+		if (locked) this.setState({ error: strings('login.invalid_password') });
+		if (this.state.loading || locked) return;
 		try {
-			this.setState({ loading: true });
+			this.setState({ loading: true, error: null });
 			const { KeyringController } = Engine.context;
 
 			// Restore vault with user entered password
@@ -332,7 +334,7 @@ class Login extends PureComponent {
 
 	render = () => {
 		const { password } = this.state;
-		const disabled = !passwordRequirementsMet(password);
+		const locked = !passwordRequirementsMet(password);
 
 		return (
 			<SafeAreaView style={styles.mainWrapper}>
@@ -363,7 +365,7 @@ class Login extends PureComponent {
 								value={this.state.password}
 								baseColor={colors.grey500}
 								tintColor={colors.blue}
-								onSubmitEditing={() => this.onLogin(disabled)}
+								onSubmitEditing={() => this.onLogin(locked)}
 								renderRightAccessory={() => (
 									<BiometryButton
 										onPress={this.tryBiometric}
@@ -389,7 +391,7 @@ class Login extends PureComponent {
 						)}
 
 						<View style={styles.ctaWrapper} testID={'log-in-button'}>
-							<StyledButton disabled={disabled} type={'confirm'} onPress={() => this.onLogin(disabled)}>
+							<StyledButton type={'confirm'} onPress={() => this.onLogin(locked)}>
 								{this.state.loading ? (
 									<ActivityIndicator size="small" color="white" />
 								) : (

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -185,7 +185,9 @@ class Login extends PureComponent {
 		this.mounted = false;
 	}
 
-	onLogin = async locked => {
+	onLogin = async () => {
+		const { password } = this.state;
+		const locked = !passwordRequirementsMet(password);
 		if (locked) this.setState({ error: strings('login.invalid_password') });
 		if (this.state.loading || locked) return;
 		try {
@@ -332,85 +334,80 @@ class Login extends PureComponent {
 		return true;
 	};
 
-	render = () => {
-		const { password } = this.state;
-		const locked = !passwordRequirementsMet(password);
-
-		return (
-			<SafeAreaView style={styles.mainWrapper}>
-				<KeyboardAwareScrollView style={styles.wrapper} resetScrollToCoords={{ x: 0, y: 0 }}>
-					<View testID={'login'}>
-						<View style={styles.foxWrapper}>
-							{Device.isAndroid() ? (
-								<Image
-									source={require('../../../images/fox.png')}
-									style={styles.image}
-									resizeMethod={'auto'}
-								/>
-							) : (
-								<AnimatedFox />
-							)}
-						</View>
-						<Text style={styles.title}>{strings('login.title')}</Text>
-						<View style={styles.field}>
-							<Text style={styles.label}>{strings('login.password')}</Text>
-							<OutlinedTextField
-								placeholder={'Password'}
-								testID={'login-password-input'}
-								returnKeyType={'done'}
-								autoCapitalize="none"
-								secureTextEntry
-								ref={this.fieldRef}
-								onChangeText={this.setPassword}
-								value={this.state.password}
-								baseColor={colors.grey500}
-								tintColor={colors.blue}
-								onSubmitEditing={() => this.onLogin(locked)}
-								renderRightAccessory={() => (
-									<BiometryButton
-										onPress={this.tryBiometric}
-										hidden={
-											!(
-												this.state.biometryChoice &&
-												this.state.biometryType &&
-												this.state.hasCredentials
-											)
-										}
-										type={this.state.biometryType}
-									/>
-								)}
+	render = () => (
+		<SafeAreaView style={styles.mainWrapper}>
+			<KeyboardAwareScrollView style={styles.wrapper} resetScrollToCoords={{ x: 0, y: 0 }}>
+				<View testID={'login'}>
+					<View style={styles.foxWrapper}>
+						{Device.isAndroid() ? (
+							<Image
+								source={require('../../../images/fox.png')}
+								style={styles.image}
+								resizeMethod={'auto'}
 							/>
-						</View>
-
-						{this.renderSwitch()}
-
-						{!!this.state.error && (
-							<Text style={styles.errorMsg} testID={'invalid-password-error'}>
-								{this.state.error}
-							</Text>
+						) : (
+							<AnimatedFox />
 						)}
-
-						<View style={styles.ctaWrapper} testID={'log-in-button'}>
-							<StyledButton type={'confirm'} onPress={() => this.onLogin(locked)}>
-								{this.state.loading ? (
-									<ActivityIndicator size="small" color="white" />
-								) : (
-									strings('login.login_button')
-								)}
-							</StyledButton>
-						</View>
-
-						<View style={styles.footer}>
-							<Button style={styles.goBack} onPress={this.onPressGoBack}>
-								{strings('login.go_back')}
-							</Button>
-						</View>
 					</View>
-				</KeyboardAwareScrollView>
-				<FadeOutOverlay />
-			</SafeAreaView>
-		);
-	};
+					<Text style={styles.title}>{strings('login.title')}</Text>
+					<View style={styles.field}>
+						<Text style={styles.label}>{strings('login.password')}</Text>
+						<OutlinedTextField
+							placeholder={'Password'}
+							testID={'login-password-input'}
+							returnKeyType={'done'}
+							autoCapitalize="none"
+							secureTextEntry
+							ref={this.fieldRef}
+							onChangeText={this.setPassword}
+							value={this.state.password}
+							baseColor={colors.grey500}
+							tintColor={colors.blue}
+							onSubmitEditing={this.onLogin}
+							renderRightAccessory={() => (
+								<BiometryButton
+									onPress={this.tryBiometric}
+									hidden={
+										!(
+											this.state.biometryChoice &&
+											this.state.biometryType &&
+											this.state.hasCredentials
+										)
+									}
+									type={this.state.biometryType}
+								/>
+							)}
+						/>
+					</View>
+
+					{this.renderSwitch()}
+
+					{!!this.state.error && (
+						<Text style={styles.errorMsg} testID={'invalid-password-error'}>
+							{this.state.error}
+						</Text>
+					)}
+
+					<View style={styles.ctaWrapper} testID={'log-in-button'}>
+						<StyledButton type={'confirm'} onPress={this.onLogin}>
+							{this.state.loading ? (
+								<ActivityIndicator size="small" color="white" />
+							) : (
+								strings('login.login_button')
+							)}
+						</StyledButton>
+					</View>
+
+					<View style={styles.footer}>
+						<Button style={styles.goBack} onPress={this.onPressGoBack}>
+							{strings('login.go_back')}
+						</Button>
+					</View>
+				</View>
+			</KeyboardAwareScrollView>
+			<FadeOutOverlay />
+		</SafeAreaView>
+	);
 }
 
 const mapStateToProps = state => ({

--- a/app/components/Views/Root/index.js
+++ b/app/components/Views/Root/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import propTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/lib/integration/react';
 
@@ -14,9 +15,17 @@ import EntryScriptWeb3 from '../../../core/EntryScriptWeb3';
  * App component is wrapped by the provider from react-redux
  */
 export default class Root extends PureComponent {
+	static propTypes = {
+		foxCode: propTypes.string
+	};
+
+	static defaultProps = {
+		foxCode: 'null'
+	};
+
 	constructor(props) {
 		super(props);
-		SecureKeychain.init(props.foxCode); // eslint-disable-line
+		SecureKeychain.init(props.foxCode);
 		// Init EntryScriptWeb3 asynchronously on the background
 		EntryScriptWeb3.init();
 		SplashScreen.hide();


### PR DESCRIPTION
My earlier idea of keeping the login button disabled is just going to be confusing to users (I find it confusing myself now that I've been using it). We should provide feedback and keep the button enabled. But! We're still not attempting to Unlock for real (until requirements are met), which I think is ultimately what we want here.

![image](https://user-images.githubusercontent.com/675259/94984011-b5f33880-0515-11eb-8bd7-ede9e649bc12.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
