### PR TITLE
Coerce non error objects into errors before sending to sentry

### DIFF
--- a/app/util/Logger.js
+++ b/app/util/Logger.js
@@ -40,6 +40,11 @@ export default class Logger {
 	static async error(error, extra) {
 		// Check if user passed accepted opt-in to metrics
 		const metricsOptIn = await AsyncStorage.getItem(METRICS_OPT_IN);
+		let exception = error.error || error.message || error.originalError || error;
+		if (!(error instanceof Error)) {
+			exception = new Error('error to capture is not an error instance');
+			exception.originalError = error;
+		}
 		if (__DEV__) {
 			console.warn(DEBUG, error); // eslint-disable-line no-console
 		} else if (metricsOptIn === AGREED) {
@@ -49,10 +54,10 @@ export default class Logger {
 				}
 				withScope(scope => {
 					scope.setExtras(extra);
-					captureException(error);
+					captureException(exception);
 				});
 			} else {
-				captureException(error);
+				captureException(exception);
 			}
 		}
 	}

--- a/app/util/Logger.js
+++ b/app/util/Logger.js
@@ -42,7 +42,17 @@ export default class Logger {
 		const metricsOptIn = await AsyncStorage.getItem(METRICS_OPT_IN);
 		let exception = error.error || error.message || error.originalError || error;
 		if (!(error instanceof Error)) {
-			exception = new Error('error to capture is not an error instance');
+			const type = typeof error;
+			switch (type) {
+				case 'string':
+					exception = new Error(error);
+					break;
+				case 'object':
+					exception = new Error(JSON.stringify(error));
+					break;
+				default:
+					exception = new Error('error to capture is not an error instance');
+			}
 			exception.originalError = error;
 		}
 		if (__DEV__) {

--- a/app/util/Logger.js
+++ b/app/util/Logger.js
@@ -40,24 +40,24 @@ export default class Logger {
 	static async error(error, extra) {
 		// Check if user passed accepted opt-in to metrics
 		const metricsOptIn = await AsyncStorage.getItem(METRICS_OPT_IN);
-		let exception = error.error || error.message || error.originalError || error;
-		if (!(error instanceof Error)) {
-			const type = typeof error;
-			switch (type) {
-				case 'string':
-					exception = new Error(error);
-					break;
-				case 'object':
-					exception = new Error(JSON.stringify(error));
-					break;
-				default:
-					exception = new Error('error to capture is not an error instance');
-			}
-			exception.originalError = error;
-		}
 		if (__DEV__) {
 			console.warn(DEBUG, error); // eslint-disable-line no-console
 		} else if (metricsOptIn === AGREED) {
+			let exception = error.error || error.message || error.originalError || error;
+			if (!(error instanceof Error)) {
+				const type = typeof error;
+				switch (type) {
+					case 'string':
+						exception = new Error(error);
+						break;
+					case 'object':
+						exception = new Error(JSON.stringify(error));
+						break;
+					default:
+						exception = new Error('error to capture is not an error instance');
+				}
+				exception.originalError = error;
+			}
 			if (extra) {
 				if (typeof extra === 'string') {
 					extra = { message: extra };


### PR DESCRIPTION
It seems like we're passing non errors to sentry

re: https://sentry.io/organizations/metamask/issues/1641747298/?project=2299799&query=is%3Aunresolved&statsPeriod=14d

I realise we should fix this underlying issue, but adding this will allow us to make mistakes without upsetting the Sentry gods
At least, that's my hope :pray:

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
