### PR TITLE
Feature/show previously created accounts on seed phrase import

### DIFF
--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -45,6 +45,7 @@ import {
 import { ethers } from 'ethers';
 import Logger from '../../../util/Logger';
 import { getPasswordStrengthWord, passwordRequirementsMet } from '../../../util/password';
+import importAdditionalAccounts from '../../../util/importAdditionalAccounts';
 
 const { isValidMnemonic } = ethers.utils;
 
@@ -264,6 +265,7 @@ class ImportFromSeed extends PureComponent {
 				await Engine.resetState();
 				await AsyncStorage.removeItem(NEXT_MAKER_REMINDER);
 				await KeyringController.createNewVaultAndRestore(this.state.password, this.state.seed);
+				await importAdditionalAccounts();
 
 				if (this.state.biometryType && this.state.biometryChoice) {
 					const authOptions = {

--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -265,7 +265,6 @@ class ImportFromSeed extends PureComponent {
 				await Engine.resetState();
 				await AsyncStorage.removeItem(NEXT_MAKER_REMINDER);
 				await KeyringController.createNewVaultAndRestore(this.state.password, this.state.seed);
-				await importAdditionalAccounts();
 
 				if (this.state.biometryType && this.state.biometryChoice) {
 					const authOptions = {
@@ -316,6 +315,7 @@ class ImportFromSeed extends PureComponent {
 						NavigationActions.navigate({ routeName: 'WalletView' })
 					);
 				}
+				await importAdditionalAccounts();
 			} catch (error) {
 				// Should we force people to enable passcode / biometrics?
 				if (error.toString() === PASSCODE_NOT_SET_ERROR) {

--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -26,8 +26,22 @@ const getBalance = async (address, ethQuery) =>
 		});
 	});
 
+const updateIdentities = async accounts => {
+	const { KeyringController, PreferencesController } = Engine.context;
+	const newAccounts = await KeyringController.getAccounts();
+	PreferencesController.updateIdentities(newAccounts);
+	newAccounts.forEach(selectedAddress => {
+		if (!accounts.includes(selectedAddress)) {
+			PreferencesController.update({ selectedAddress });
+		}
+	});
+
+	// setSelectedAddress to the initial account
+	PreferencesController.setSelectedAddress(accounts[0]);
+};
+
 export default async () => {
-	const { KeyringController, NetworkController, PreferencesController } = Engine.context;
+	const { KeyringController, NetworkController } = Engine.context;
 	const { provider } = NetworkController;
 
 	const ethQuery = new EthQuery(provider);
@@ -49,14 +63,5 @@ export default async () => {
 		i++;
 	}
 
-	const newAccounts = await KeyringController.getAccounts();
-	PreferencesController.updateIdentities(newAccounts);
-	newAccounts.forEach(selectedAddress => {
-		if (!accounts.includes(selectedAddress)) {
-			PreferencesController.update({ selectedAddress });
-		}
-	});
-
-	// setSelectedAddress to the initial account
-	PreferencesController.setSelectedAddress(accounts[0]);
+	updateIdentities(accounts);
 };

--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -43,11 +43,19 @@ export default async () => {
 	// seek out the first zero balance
 	while (lastBalance !== ZERO_BALANCE) {
 		if (i === MAX) break;
-		await KeyringController.addNewAccount(primaryKeyring);
+		await KeyringController.addNewAccountWithoutUpdate(primaryKeyring);
 		accounts = await KeyringController.getAccounts();
 		lastBalance = await getBalance(accounts[accounts.length - 1], ethQuery);
 		i++;
 	}
+
+	const newAccounts = await KeyringController.getAccounts();
+	PreferencesController.updateIdentities(newAccounts);
+	newAccounts.forEach(selectedAddress => {
+		if (!accounts.includes(selectedAddress)) {
+			PreferencesController.update({ selectedAddress });
+		}
+	});
 
 	// setSelectedAddress to the initial account
 	PreferencesController.setSelectedAddress(accounts[0]);

--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -1,0 +1,54 @@
+import Engine from '../core/Engine';
+import { BNToHex } from '../util/number';
+import EthQuery from 'ethjs-query';
+import Logger from '../util/Logger';
+
+const HD_KEY_TREE = 'HD Key Tree';
+const HD_KEY_TREE_ERROR = 'MetamaskController - No HD Key Tree found';
+const ZERO_BALANCE = '0x0';
+const MAX = 20;
+
+/**
+ * Get an account balance from the network.
+ * @param {string} address - The account address
+ * @param {EthQuery} ethQuery - The EthQuery instance to use when asking the network
+ */
+const getBalance = async (address, ethQuery) =>
+	new Promise((resolve, reject) => {
+		ethQuery.getBalance(address, (error, balance) => {
+			if (error) {
+				reject(error);
+				Logger.error(error);
+			} else {
+				const balanceHex = BNToHex(balance);
+				resolve(balanceHex || ZERO_BALANCE);
+			}
+		});
+	});
+
+export default async () => {
+	const { KeyringController, NetworkController, PreferencesController } = Engine.context;
+	const { provider } = NetworkController;
+
+	const ethQuery = new EthQuery(provider);
+	let accounts = await KeyringController.getAccounts();
+	let lastBalance = await getBalance(accounts[accounts.length - 1], ethQuery);
+
+	const { keyrings } = KeyringController.state;
+	const filteredKeyrings = keyrings.filter(keyring => keyring.type === HD_KEY_TREE);
+	const primaryKeyring = filteredKeyrings[0];
+	if (!primaryKeyring) throw new Error(HD_KEY_TREE_ERROR);
+
+	let i = 0;
+	// seek out the first zero balance
+	while (lastBalance !== ZERO_BALANCE) {
+		if (i === MAX) break;
+		await KeyringController.addNewAccount(primaryKeyring);
+		accounts = await KeyringController.getAccounts();
+		lastBalance = await getBalance(accounts[accounts.length - 1], ethQuery);
+		i++;
+	}
+
+	// setSelectedAddress to the initial account
+	PreferencesController.setSelectedAddress(accounts[0]);
+};

--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -26,6 +26,10 @@ const getBalance = async (address, ethQuery) =>
 		});
 	});
 
+/**
+ * Updates identities in the preferences controllers
+ * @param {array} accounts - an array of addresses
+ */
 const updateIdentities = async accounts => {
 	const { KeyringController, PreferencesController } = Engine.context;
 	const newAccounts = await KeyringController.getAccounts();
@@ -40,6 +44,9 @@ const updateIdentities = async accounts => {
 	PreferencesController.setSelectedAddress(accounts[0]);
 };
 
+/**
+ * Add additional accounts in the wallet based on balance
+ */
 export default async () => {
 	const { KeyringController, NetworkController } = Engine.context;
 	const { provider } = NetworkController;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@exodus/react-native-payments": "https://github.com/wachunei/react-native-payments.git#package-json-hack",
-    "@metamask/controllers": "3.0.0",
+    "@metamask/controllers": "3.2.0",
     "@react-native-community/async-storage": "1.9.0",
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/checkbox": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,33 +1337,33 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@metamask/controllers@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-3.0.0.tgz#e189c3f002da1037e7afadd91d0c7cc816bda305"
-  integrity sha512-zlaI4ZoJgS8/2uM2HxfzyG+i6SUtP2H73JrqJGdqXbQvdFXaCB6bWsr2H6zUgfpm9rS7V0dErlq7/4C2mjyp+g==
+"@metamask/controllers@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-3.2.0.tgz#8ad2e63f7953d294712d9b5bacaea1c5261ce588"
+  integrity sha512-Nysutcny5ddsr4eP4XvYuNMAwMqvCO/krughnNUzT69LljslutJyxS2MnT0MnWyKYNa6+CBaV9gxdV+Mm6fAFA==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.11.0"
     eth-ens-namehash "^2.0.8"
-    eth-json-rpc-infura "^5.0.0"
+    eth-json-rpc-infura "^5.1.0"
     eth-keyring-controller "^5.6.1"
     eth-method-registry "1.1.0"
     eth-phishing-detect "^1.1.13"
     eth-query "^2.1.2"
-    eth-rpc-errors "^2.1.1"
+    eth-rpc-errors "^3.0.0"
     eth-sig-util "^2.3.0"
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "0.6.0"
     ethjs-query "^0.3.8"
     human-standard-collectible-abi "^1.0.2"
     human-standard-token-abi "^2.0.0"
-    isomorphic-fetch "^2.2.1"
+    isomorphic-fetch "^3.0.0"
     jsonschema "^1.2.4"
     percentile "^1.2.1"
     single-call-balance-checker-abi "^1.0.0"
     uuid "^3.3.2"
     web3 "^0.20.7"
-    web3-provider-engine "^15.0.4"
+    web3-provider-engine "^16.0.1"
 
 "@metamask/mobile-provider@1.3.0":
   version "1.3.0"
@@ -3580,7 +3580,7 @@ create-react-class@^15.6.2, create-react-class@^15.6.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-fetch@^2.1.0, cross-fetch@^2.1.1:
+cross-fetch@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
   integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
@@ -4820,7 +4820,7 @@ eth-json-rpc-errors@^2.0.0, eth-json-rpc-errors@^2.0.1, eth-json-rpc-errors@^2.0
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-filters@4.1.1, eth-json-rpc-filters@^4.1.1:
+eth-json-rpc-filters@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz#15277c66790236d85f798f4d7dc6bab99a798cd2"
   integrity sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==
@@ -4854,26 +4854,6 @@ eth-json-rpc-infura@5.1.0, eth-json-rpc-infura@^5.1.0:
     json-rpc-engine "^5.3.0"
     node-fetch "^2.6.0"
 
-eth-json-rpc-infura@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.2.tgz#8af1a1a2e9a0a82aaa302bbc96fb1a4c15d69b83"
-  integrity sha512-dvgOrci9lZqpjpp0hoC3Zfedhg3aIpLFVDH0TdlKxRlkhR75hTrKTwxghDrQwE0bn3eKrC8RsN1m/JdnIWltpw==
-  dependencies:
-    cross-fetch "^2.1.1"
-    eth-json-rpc-errors "^1.0.1"
-    eth-json-rpc-middleware "^4.1.4"
-    json-rpc-engine "^5.1.3"
-
-eth-json-rpc-infura@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-5.0.0.tgz#a666efe860659ffa09e918abdf9aab9f2434e508"
-  integrity sha512-TvRgnDHsxNblUpFo1KTqsgfeZ0rMEg6Ga+v+Zbqjb467txODg6oPamKJKh/odOs+MXtYpt9e7d4yJCy+5azq5w==
-  dependencies:
-    eth-json-rpc-middleware "^4.4.0"
-    eth-rpc-errors "^3.0.0"
-    json-rpc-engine "^5.1.3"
-    node-fetch "^2.6.0"
-
 eth-json-rpc-middleware@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.3.0.tgz#d3e72efb60b6f601f022ce01384481eaed552b6b"
@@ -4894,7 +4874,7 @@ eth-json-rpc-middleware@4.3.0:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-middleware@^4.4.0:
+eth-json-rpc-middleware@^4.1.4:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz#07d3dd0724c24a8d31e4a172ee96271da71b4228"
   integrity sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==
@@ -4967,13 +4947,6 @@ eth-query@^2.1.0, eth-query@^2.1.2:
   dependencies:
     json-rpc-random-id "^1.0.0"
     xtend "^4.0.1"
-
-eth-rpc-errors@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
-  integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
-  dependencies:
-    fast-safe-stringify "^2.0.6"
 
 eth-rpc-errors@^3.0.0:
   version "3.0.0"
@@ -7058,13 +7031,21 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
+isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"
@@ -12771,34 +12752,6 @@ weak@^1.0.0:
     bindings "^1.2.1"
     nan "^2.0.5"
 
-web3-provider-engine@^15.0.4:
-  version "15.0.12"
-  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-15.0.12.tgz#24d7f2f6fb6de856824c7306291018c4fc543ac3"
-  integrity sha512-/OfhQalKPND1iB5ggvGuYF0+SIb2Qj5OFTrT2VrZWP79UhMTdP7T+L2FtblmRdCeOetoAzZHdBaIwLOZsmIX+w==
-  dependencies:
-    async "^2.5.0"
-    backoff "^2.5.0"
-    clone "^2.0.0"
-    cross-fetch "^2.1.0"
-    eth-block-tracker "^4.4.2"
-    eth-json-rpc-errors "^2.0.2"
-    eth-json-rpc-filters "^4.1.1"
-    eth-json-rpc-infura "^4.0.1"
-    eth-json-rpc-middleware "^4.1.5"
-    eth-sig-util "^1.4.2"
-    ethereumjs-block "^1.2.2"
-    ethereumjs-tx "^1.2.0"
-    ethereumjs-util "^5.1.5"
-    ethereumjs-vm "^2.3.4"
-    json-stable-stringify "^1.0.1"
-    promise-to-callback "^1.0.0"
-    readable-stream "^2.2.9"
-    request "^2.85.0"
-    semaphore "^1.0.3"
-    ws "^5.1.1"
-    xhr "^2.2.0"
-    xtend "^4.0.1"
-
 web3-provider-engine@^16.0.1:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-16.0.1.tgz#2600a39ede364cdc0a1fc773bf40a94f2177e605"
@@ -12859,6 +12812,11 @@ whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
+whatwg-fetch@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Previously when importing from seed phrase we only imported the initial account:

![image](https://user-images.githubusercontent.com/675259/95374514-6cf00b00-08ac-11eb-9888-ab69b7b98c52.png)

Now we match extension functionality and import until we hit an account with a zero balance, which for me looks like this:

![image](https://user-images.githubusercontent.com/675259/95374720-b0e31000-08ac-11eb-92fb-1e404028fa77.png)


**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #1824
