### PR TITLE
use optional chaining and default values so we're not calling toLowerCase where name is undefined

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -930,8 +930,10 @@ class DrawerView extends PureComponent {
 								{section
 									.filter(item => {
 										if (!item) return undefined;
-										if (item.name.toLowerCase().indexOf('etherscan') !== -1) {
-											return this.hasBlockExplorer(network.provider.type);
+										const { name = undefined } = item;
+										if (name && name.toLowerCase().indexOf('etherscan') !== -1) {
+											const type = network.provider?.type;
+											return (type && this.hasBlockExplorer(type)) || undefined;
 										}
 										return true;
 									})


### PR DESCRIPTION
there's a bug here from the item.name.toLowerCase() where name is undefined on sentry: https://sentry.io/organizations/metamask/issues/1903751096/?project=2299799&query=is%3Aunresolved+toLowerCase&statsPeriod=14d

<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

_Write a short description of the changes included in this pull request._

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
