### PR TITLE
Ensure seedphrase hint is not the actual seedphrase

### DIFF
--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -243,7 +243,8 @@ class ManualBackupStep2 extends PureComponent {
 		if (this.validateWords()) {
 			seedphraseBackedUp();
 			InteractionManager.runAfterInteractions(() => {
-				navigation.navigate('ManualBackupStep3', { steps: this.steps });
+				const words = navigation.getParam('words');
+				navigation.navigate('ManualBackupStep3', { steps: this.steps, words });
 			});
 		} else {
 			Alert.alert(strings('account_backup_step_5.error_title'), strings('account_backup_step_5.error_message'));

--- a/app/components/Views/ManualBackupStep3/index.js
+++ b/app/components/Views/ManualBackupStep3/index.js
@@ -7,7 +7,8 @@ import {
 	Keyboard,
 	TouchableOpacity,
 	TouchableWithoutFeedback,
-	TextInput
+	TextInput,
+	Alert
 } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -144,15 +145,23 @@ class ManualBackupStep3 extends PureComponent {
 			title: strings('drawer.metamask_support')
 		});
 
+	isHintSeedPhrase = hintText => {
+		const words = this.props.navigation.getParam('words');
+		const lower = string => String(string).toLowerCase();
+		return lower(hintText) === lower(words.join(' '));
+	};
+
 	saveSeedphrase = async () => {
-		if (!this.state.hintText) return;
-		this.toggleHint();
+		const { hintText } = this.state;
+		if (!hintText) return;
 		const currentSeedphraseHints = await AsyncStorage.getItem('seedphraseHints');
 		const parsedHints = JSON.parse(currentSeedphraseHints);
-		await AsyncStorage.setItem(
-			'seedphraseHints',
-			JSON.stringify({ ...parsedHints, manualBackup: this.state.hintText })
-		);
+		if (this.isHintSeedPhrase(hintText)) {
+			Alert.alert('Error!', strings('manual_backup_step_3.no_seedphrase'));
+			return;
+		}
+		this.toggleHint();
+		await AsyncStorage.setItem('seedphraseHints', JSON.stringify({ ...parsedHints, manualBackup: hintText }));
 	};
 
 	done = async () => {

--- a/app/components/Views/ManualBackupStep3/index.js
+++ b/app/components/Views/ManualBackupStep3/index.js
@@ -147,8 +147,11 @@ class ManualBackupStep3 extends PureComponent {
 
 	isHintSeedPhrase = hintText => {
 		const words = this.props.navigation.getParam('words');
-		const lower = string => String(string).toLowerCase();
-		return lower(hintText) === lower(words.join(' '));
+		if (words) {
+			const lower = string => String(string).toLowerCase();
+			return lower(hintText) === lower(words.join(' '));
+		}
+		return false;
 	};
 
 	saveSeedphrase = async () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This is based on what I brought up on the team call earlier today. we ask the user not to save their seed phrase as their hint... this ensures that's actually the case:

![image](https://user-images.githubusercontent.com/675259/96809462-e75e7600-13e8-11eb-9838-7bf3761a93b2.png)

whenever we say "don't do x" we should _always_ assume that's the first thing an user will do (and then, when possible, try and prevent them from doing it).

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
