### PR TITLE
Make hintText display regardless of biometryType

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -309,7 +309,10 @@ class Settings extends PureComponent {
 				hintText: manualBackup
 			});
 		} else {
-			this.setState({ metricsOptIn });
+			this.setState({
+				metricsOptIn,
+				hintText: manualBackup
+			});
 		}
 	};
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

@ibrahimtaveras00 discovered a bug,

tuns out the `hintText` was only being set in state if the `biometryType` was set

whoops.

this fixes that.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
