### PR TITLE
Fix seedphrase handling in QRScanner

### DIFF
--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -30,7 +30,7 @@ import TermsAndConditions from '../TermsAndConditions';
 import zxcvbn from 'zxcvbn';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import Device from '../../../util/Device';
-import { failedSeedPhraseRequirements } from '../../../util/validators';
+import { failedSeedPhraseRequirements, isValidMnemonic } from '../../../util/validators';
 import { OutlinedTextField } from 'react-native-material-textfield';
 import {
 	SEED_PHRASE_HINTS,
@@ -41,12 +41,9 @@ import {
 	METRICS_OPT_IN,
 	TRUE
 } from '../../../constants/storage';
-import { ethers } from 'ethers';
 import Logger from '../../../util/Logger';
 import { getPasswordStrengthWord, passwordRequirementsMet } from '../../../util/password';
 import importAdditionalAccounts from '../../../util/importAdditionalAccounts';
-
-const { isValidMnemonic } = ethers.utils;
 
 const styles = StyleSheet.create({
 	mainWrapper: {

--- a/app/util/validators.js
+++ b/app/util/validators.js
@@ -1,5 +1,8 @@
-// eslint-disable-next-line import/prefer-default-export
+import { ethers } from 'ethers';
+
 export const failedSeedPhraseRequirements = seed => {
 	const wordCount = seed.split(/\s/u).length;
 	return wordCount % 3 !== 0 || wordCount > 24 || wordCount < 12;
 };
+
+export const { isValidMnemonic } = ethers.utils;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

As it stands importing from seed phrase when using a QR code that holds a 24 character mnemonic fails spectacularly:

<img src=https://user-images.githubusercontent.com/675259/98896140-4c503d80-2476-11eb-8308-0760b9356ed1.png width=320 />

(it would appear it's trying to handle it as a deeplink.)

this PR utilizes validators that were recently added to handle this properly.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
