### PR TITLE
[1984] Fixing Invalid value for 'projectId': "undefined" error [Android] [iOS]

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -10,5 +10,9 @@
 export MM_PUBNUB_SUB_KEY=""
 export MM_PUBNUB_PUB_KEY=""
 export MM_OPENSEA_KEY=""
-export MM_INFURA_PROJECT_ID=""
 
+# NOTE: Non-Metamask only, will need to create an account and generate
+# API key at https://infura.io in order to connect to main and test nets.
+# More info: https://github.com/MetaMask/metamask-mobile/issues/1984
+
+export MM_INFURA_PROJECT_ID="null"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ yarn install # this will run a lengthy postinstall flow
 cd ios && pod install && cd .. # install pods for iOS
 ```
 
+- _Non-MetaMask Only:_ In the project root folder run
+```
+  cp .ios.env.example .ios.env && \
+  cp .android.env.example .android.env && \
+  cp .js.env.example .js.env
+ ``` 
+- _Non-MetaMask Only:_ Create an account and generate your own API key at [Infura](https://infura.io) in order to connect to main and test nets. Fill `MM_INFURA_PROJECT_ID` in `.js.env`. (App will run without it, but will not be able to connect to actual network.)
+
 - Then, in one terminal, run:
 
 ```bash


### PR DESCRIPTION
**Description**

Since infura 5.x.x empty string is invalid project id. Exception is thrown at launch `[Error: Invalid value for 'projectId': "undefined"] `. This leads to confusion for Non-Metamask users who try to get the project compiled. Changing default value to `MM_INFURA_PROJECT_ID="null"` will stop the exception. Restores behaviour to prior infura update. https://github.com/MetaMask/metamask-mobile/commit/c74ce8902c5e799a87555545949b447a9ab1b950

Non-Metamask users will still not be able to connect to any network. I make a note of this is README.md

**Checklist**

- [x] There is a related GitHub issue
- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/metamask-mobile/issues/1984
