### PR TITLE
Fix isBookmark functionality

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -768,7 +768,8 @@ export const BrowserTab = props => {
 
 	const isBookmark = () => {
 		const { bookmarks } = props;
-		return bookmarks.some(({ url: bookmark }) => bookmark === url.current);
+		const maskedUrl = getMaskedUrl(url.current);
+		return bookmarks.some(({ url: bookmark }) => bookmark === maskedUrl);
 	};
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I noticed a small regression that now allows users to bookmark ENS domains over and over again:

![image](https://user-images.githubusercontent.com/675259/101829411-f916ec80-3b00-11eb-80b8-c29c918179e6.png)

This PR fixes that.