### PR TITLE
Add parseSeedPhrase behavior from extension

### DIFF
--- a/app/components/Views/ImportFromSeed/index.js
+++ b/app/components/Views/ImportFromSeed/index.js
@@ -318,8 +318,8 @@ class ImportFromSeed extends PureComponent {
 		this.setState({ biometryChoice: value });
 	};
 
-	onSeedWordsChange = value => {
-		this.setState({ seed: value });
+	onSeedWordsChange = seed => {
+		this.setState({ seed });
 	};
 
 	onPasswordChange = val => {

--- a/app/util/validators.js
+++ b/app/util/validators.js
@@ -5,4 +5,11 @@ export const failedSeedPhraseRequirements = seed => {
 	return wordCount % 3 !== 0 || wordCount > 24 || wordCount < 12;
 };
 
+export const parseSeedPhrase = seedPhrase =>
+	(seedPhrase || '')
+		.trim()
+		.toLowerCase()
+		.match(/\w+/gu)
+		?.join(' ') || '';
+
 export const { isValidMnemonic } = ethers.utils;

--- a/app/util/validators.test.js
+++ b/app/util/validators.test.js
@@ -1,4 +1,4 @@
-import { failedSeedPhraseRequirements } from './validators';
+import { failedSeedPhraseRequirements, parseSeedPhrase } from './validators';
 
 const VALID_24 =
 	'verb middle giant soon wage common wide tool gentle garlic issue nut retreat until album recall expire bronze bundle live accident expect dry cook';
@@ -20,5 +20,20 @@ describe('failedSeedPhraseRequirements', () => {
 	it('Should fail for 24 + 1 word mnemonic', () => {
 		const plus_one = VALID_24 + ' lol';
 		expect(failedSeedPhraseRequirements(plus_one)).toEqual(true);
+	});
+});
+
+describe('parseSeedPhrase', () => {
+	it('Should handle leading spaces', () => {
+		expect(parseSeedPhrase(`   ${VALID_12}`)).toEqual(VALID_12);
+	});
+	it('Should handle trailing spaces', () => {
+		expect(parseSeedPhrase(`${VALID_12}   `)).toEqual(VALID_12);
+	});
+	it('Should handle additional spaces', () => {
+		expect(parseSeedPhrase(`${VALID_12.split(' ').join('   ')}   `)).toEqual(VALID_12);
+	});
+	it('Should handle uppercase', () => {
+		expect(parseSeedPhrase(`   ${String(VALID_12).toUpperCase()}`)).toEqual(VALID_12);
 	});
 });


### PR DESCRIPTION
**Description**

Before this change we required the seed phrase to be structurally correct _before_ the abilty to import was granted (the button stayed disabled). This change instead incorporates behavior that exists in the extention where the seed phrase can contain extra leading/trailing spaces as well as extra spaces in between the seed phrase words. The method is `parseSeedPhrase` from [here](https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js#L38)

**Checklist**

* [x] This came up in a support call
* [x] Tests are included if applicable
* [x] Any added code is fully documented
