### PR TITLE
Feature/make insufficient fee descriptive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ local.properties
 android/.project
 android/app/.project
 android/app/bin/
+android/app/gradle*
+android/app/_build*
+
+# if we ever want to add google services
+android/app/google-services.json
 
 # node.js
 node_modules/

--- a/app/components/Base/Summary.js
+++ b/app/components/Base/Summary.js
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
 	row: {
 		flexDirection: 'row',
 		justifyContent: 'space-between',
-		marginVertical: 6
+		marginVertical: 2
 	},
 	rowEnd: {
 		justifyContent: 'flex-end'

--- a/app/components/Base/Summary.js
+++ b/app/components/Base/Summary.js
@@ -13,14 +13,14 @@ const styles = StyleSheet.create({
 	row: {
 		flexDirection: 'row',
 		justifyContent: 'space-between',
-		marginVertical: 2
+		marginVertical: 3
 	},
 	rowEnd: {
 		justifyContent: 'flex-end'
 	},
 	rowLast: {
 		marginBottom: 0,
-		marginTop: 6
+		marginTop: 3
 	},
 	col: {
 		flexDirection: 'row',

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -417,7 +417,11 @@ const Main = props => {
 
 	const renderDappTransactionModal = () =>
 		props.dappTransactionModalVisible && (
-			<Approval dappTransactionModalVisible toggleDappTransactionModal={props.toggleDappTransactionModal} />
+			<Approval
+				navigation={props.navigation}
+				dappTransactionModalVisible
+				toggleDappTransactionModal={props.toggleDappTransactionModal}
+			/>
 		);
 
 	const renderApproveModal = () =>

--- a/app/components/UI/AccountApproval/index.test.js
+++ b/app/components/UI/AccountApproval/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import AccountApproval from './';
 import { shallow } from 'enzyme';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -15,7 +16,7 @@ describe('AccountApproval', () => {
 					},
 					NetworkController: {
 						provider: {
-							type: 'ropsten'
+							type: ROPSTEN
 						}
 					},
 					AssetsController: {

--- a/app/components/UI/ApproveTransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/UI/ApproveTransactionReview/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApproveTransactionModal should render correctly 1`] = `
-<ApproveTransactionReview
+<withNavigation(ApproveTransactionReview)
   accounts={
     Object {
       "0x2": Object {

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -37,7 +37,7 @@ import Device from '../../../util/Device';
 import AppConstants from '../../../core/AppConstants';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
 import { withNavigation } from 'react-navigation';
-import { getNetworkName } from '../../../util/networks';
+import { getNetworkName, isMainNet } from '../../../util/networks';
 import { capitalize } from '../../../util/format';
 
 const { hexToBN } = util;
@@ -598,11 +598,6 @@ class ApproveTransactionReview extends PureComponent {
 		});
 	};
 
-	isMainNet = () => {
-		const { network } = this.props;
-		return network === String(1);
-	};
-
 	render = () => {
 		const {
 			host,
@@ -624,14 +619,14 @@ class ApproveTransactionReview extends PureComponent {
 			network,
 			over
 		} = this.props;
-
+		const is_main_net = isMainNet(network);
 		const isFiat = primaryCurrency.toLowerCase() === 'fiat';
 		const currencySymbol = currencySymbols[currentCurrency];
 		const totalGasFiatRounded = Math.round(totalGasFiat * 100) / 100;
 		const originIsDeeplink = origin === ORIGIN_DEEPLINK || origin === ORIGIN_QR_CODE;
-		const errorPress = this.isMainNet() ? this.buyEth : this.gotoFaucet;
+		const errorPress = is_main_net ? this.buyEth : this.gotoFaucet;
 		const networkName = capitalize(getNetworkName(network));
-		const errorLinkText = this.isMainNet()
+		const errorLinkText = is_main_net
 			? strings('transaction.buy_more_eth')
 			: strings('transaction.get_ether', { networkName });
 
@@ -718,7 +713,7 @@ class ApproveTransactionReview extends PureComponent {
 														<TouchableOpacity onPress={errorPress}>
 															<Text style={styles.error}>{gasError}</Text>
 															{/* only show buy more on mainnet */}
-															{over && this.isMainNet() && (
+															{over && is_main_net && (
 																<Text style={[styles.error, styles.underline]}>
 																	{errorLinkText}
 																</Text>

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -23,7 +23,6 @@ import {
 	getMethodData
 } from '../../../util/transactions';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-// import ErrorMessage from '../../Views/SendFlow/ErrorMessage';
 import { showAlert } from '../../../actions/alert';
 import Analytics from '../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -717,7 +717,8 @@ class ApproveTransactionReview extends PureComponent {
 													<View style={styles.errorWrapper}>
 														<TouchableOpacity onPress={errorPress}>
 															<Text style={styles.error}>{gasError}</Text>
-															{over && (
+															{/* only show buy more on mainnet */}
+															{over && this.isMainNet() && (
 																<Text style={[styles.error, styles.underline]}>
 																	{errorLinkText}
 																</Text>

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -631,8 +631,6 @@ class ApproveTransactionReview extends PureComponent {
 		const originIsDeeplink = origin === ORIGIN_DEEPLINK || origin === ORIGIN_QR_CODE;
 		const errorPress = this.isMainNet() ? this.buyEth : this.gotoFaucet;
 		const networkName = capitalize(getNetworkName(network));
-		console.log(this.isMainNet());
-		console.log({ over2: over });
 		const errorLinkText = this.isMainNet()
 			? strings('transaction.buy_more_eth')
 			: strings('transaction.get_ether', { networkName });

--- a/app/components/UI/CollectibleContractInformation/index.js
+++ b/app/components/UI/CollectibleContractInformation/index.js
@@ -14,6 +14,7 @@ import { colors, fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import Device from '../../../util/Device';
 import { connect } from 'react-redux';
+import { isMainNet } from '../../../util/networks';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -148,7 +149,7 @@ class CollectibleContractInformation extends PureComponent {
 			collectibleContract: { name, description, totalSupply, address },
 			network
 		} = this.props;
-		const isMainnet = network?.provider?.type === 'mainnet';
+		const is_main_net = isMainNet(network);
 
 		return (
 			<SafeAreaView style={styles.wrapper}>
@@ -174,7 +175,7 @@ class CollectibleContractInformation extends PureComponent {
 						<Text style={styles.label}>{strings('asset_overview.address')}</Text>
 						<Text style={[styles.content, styles.address]}>{address}</Text>
 					</View>
-					{isMainnet && (
+					{is_main_net && (
 						<View style={styles.creditsView}>
 							<TouchableOpacity style={styles.credits} onPress={this.goToOpenSea}>
 								<View style={styles.creditsElements}>

--- a/app/components/UI/CollectibleContractInformation/index.js
+++ b/app/components/UI/CollectibleContractInformation/index.js
@@ -148,7 +148,7 @@ class CollectibleContractInformation extends PureComponent {
 			collectibleContract: { name, description, totalSupply, address },
 			network
 		} = this.props;
-		const isMainnet = network.provider.type === 'mainnet';
+		const isMainnet = network?.provider?.type === 'mainnet';
 
 		return (
 			<SafeAreaView style={styles.wrapper}>

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -38,6 +38,7 @@ import { protectWalletModalVisible } from '../../../actions/user';
 import DeeplinkManager from '../../../core/DeeplinkManager';
 import SettingsNotification from '../SettingsNotification';
 import WhatsNewModal from '../WhatsNewModal';
+import { RPC } from '../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -582,7 +583,7 @@ class DrawerView extends PureComponent {
 			},
 			frequentRpcList
 		} = this.props;
-		if (network.provider.type === 'rpc') {
+		if (network.provider.type === RPC) {
 			const blockExplorer = findBlockExplorerForRpc(rpcTarget, frequentRpcList);
 			const url = `${blockExplorer}/address/${selectedAddress}`;
 			const title = new URL(blockExplorer).hostname;
@@ -642,7 +643,7 @@ class DrawerView extends PureComponent {
 
 	hasBlockExplorer = providerType => {
 		const { frequentRpcList } = this.props;
-		if (providerType === 'rpc') {
+		if (providerType === RPC) {
 			const {
 				network: {
 					provider: { rpcTarget }
@@ -697,7 +698,7 @@ class DrawerView extends PureComponent {
 			paymentChannelsEnabled
 		} = this.props;
 		let blockExplorer, blockExplorerName;
-		if (type === 'rpc') {
+		if (type === RPC) {
 			blockExplorer = findBlockExplorerForRpc(rpcTarget, frequentRpcList);
 			blockExplorerName = getBlockExplorerName(blockExplorer);
 		}

--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -9,6 +9,7 @@ import Networks, { getAllNetworks } from '../../../util/networks';
 import { connect } from 'react-redux';
 import Analytics from '../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
+import { MAINNET } from '../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -209,7 +210,7 @@ export class NetworkList extends PureComponent {
 	renderMainnet() {
 		const { provider } = this.props;
 		const isMainnet =
-			provider.type === 'mainnet' ? <Icon name="check" size={15} color={colors.fontSecondary} /> : null;
+			provider.type === MAINNET ? <Icon name="check" size={15} color={colors.fontSecondary} /> : null;
 		const { color: mainnetColor, name: mainnetName } = Networks.mainnet;
 
 		return (
@@ -217,7 +218,7 @@ export class NetworkList extends PureComponent {
 				<TouchableOpacity
 					style={[styles.network, styles.mainnet]}
 					key={`network-mainnet`}
-					onPress={() => this.onNetworkChange('mainnet')} // eslint-disable-line
+					onPress={() => this.onNetworkChange(MAINNET)} // eslint-disable-line
 					testID={'network-name'}
 				>
 					<View style={styles.networkWrapper}>

--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -9,7 +9,7 @@ import Networks, { getAllNetworks } from '../../../util/networks';
 import { connect } from 'react-redux';
 import Analytics from '../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
-import { MAINNET } from '../../../constants/network';
+import { MAINNET, RPC } from '../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -200,7 +200,7 @@ export class NetworkList extends PureComponent {
 		return frequentRpcList.map(({ nickname, rpcUrl }, i) => {
 			const { color, name } = { name: nickname || rpcUrl, color: null };
 			const selected =
-				provider.rpcTarget === rpcUrl && provider.type === 'rpc' ? (
+				provider.rpcTarget === rpcUrl && provider.type === RPC ? (
 					<Icon name="check" size={20} color={colors.fontSecondary} />
 				) : null;
 			return this.networkElement(selected, this.onSetRpcTarget, name, color, i, rpcUrl);

--- a/app/components/UI/SignatureRequest/index.test.js
+++ b/app/components/UI/SignatureRequest/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import SignatureRequest from './';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -19,7 +20,7 @@ describe('SignatureRequest', () => {
 					},
 					NetworkController: {
 						provider: {
-							type: 'ropsten'
+							type: ROPSTEN
 						}
 					}
 				}

--- a/app/components/UI/TransactionEditor/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionEditor/__snapshots__/index.test.js.snap
@@ -22,8 +22,16 @@ exports[`TransactionEditor should render correctly 1`] = `
       review={[Function]}
     >
       <Connect(TransactionReview)
+        navigation={
+          Object {
+            "state": Object {
+              "params": Object {},
+            },
+          }
+        }
         onCancel={[Function]}
         onConfirm={[Function]}
+        over={false}
         ready={false}
         validate={[Function]}
       />

--- a/app/components/UI/TransactionEditor/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionEditor/__snapshots__/index.test.js.snap
@@ -22,13 +22,6 @@ exports[`TransactionEditor should render correctly 1`] = `
       review={[Function]}
     >
       <Connect(TransactionReview)
-        navigation={
-          Object {
-            "state": Object {
-              "params": Object {},
-            },
-          }
-        }
         onCancel={[Function]}
         onConfirm={[Function]}
         over={false}

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -91,6 +91,9 @@ class TransactionEditor extends PureComponent {
 		 * Whether was prompted from approval
 		 */
 		promptedFromApproval: PropTypes.bool,
+		/**
+		 * A number that specifies the ETH/USD conversion rate
+		 */
 		conversionRate: PropTypes.number,
 		/**
 		 * Object that represents the navigator

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -90,11 +90,7 @@ class TransactionEditor extends PureComponent {
 		/**
 		 * Whether was prompted from approval
 		 */
-		promptedFromApproval: PropTypes.bool,
-		/**
-		 * Object that represents the navigator
-		 */
-		navigation: PropTypes.object
+		promptedFromApproval: PropTypes.bool
 	};
 
 	state = {
@@ -619,7 +615,7 @@ class TransactionEditor extends PureComponent {
 	};
 
 	render = () => {
-		const { mode, transactionConfirmed, transaction, onModeChange, navigation } = this.props;
+		const { mode, transactionConfirmed, transaction, onModeChange } = this.props;
 		const { basicGasEstimates, ready, gasError, over } = this.state;
 		const paymentChannelTransaction = transaction ? transaction.paymentChannelTransaction : false;
 		return (
@@ -635,7 +631,6 @@ class TransactionEditor extends PureComponent {
 								ready={ready}
 								transactionConfirmed={transactionConfirmed}
 								over={over}
-								navigation={navigation}
 							/>
 							<CustomGas
 								handleGasFeeSelection={this.updateGas}

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -19,6 +19,7 @@ import contractMap from '@metamask/contract-metadata';
 import PaymentChannelsClient from '../../../core/PaymentChannelsClient';
 import { safeToChecksumAddress } from '../../../util/address';
 import TransactionTypes from '../../../core/TransactionTypes';
+import { MAINNET } from '../../../constants/network';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -553,7 +554,7 @@ class TransactionEditor extends PureComponent {
 			return undefined;
 		}
 		const address = toChecksumAddress(to);
-		if (networkType === 'mainnet') {
+		if (networkType === MAINNET) {
 			const contractMapToken = contractMap[address];
 			if (contractMapToken) return strings('transaction.known_asset_contract');
 		}

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -415,6 +415,7 @@ class TransactionEditor extends PureComponent {
 				const tokenSymbol = getTicker(ticker);
 				return strings('transaction.insufficient_amount', { amount, tokenSymbol });
 			}
+			this.setState({ over: false });
 		}
 		return error;
 	};

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -401,8 +401,13 @@ class TransactionEditor extends PureComponent {
 			const fromAccount = this.props.accounts[checksummedFrom];
 			const total = value.add(gas.mul(gasPrice));
 			const { balance } = fromAccount;
-			if (!value || !gas || !gasPrice || !from) return strings('transaction.invalid_amount');
-			if (value && !isBN(value)) return strings('transaction.invalid_amount');
+
+			if (!value || !gas || !gasPrice || !from) {
+				return strings('transaction.invalid_amount');
+			}
+			if (value && !isBN(value)) {
+				return strings('transaction.invalid_amount');
+			}
 			if (value && fromAccount && isBN(gas) && isBN(gasPrice) && isBN(value) && hexToBN(balance).lt(total)) {
 				this.setState({ over: true });
 				const amount = renderFromWei(total.sub(value));

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -415,7 +415,6 @@ class TransactionEditor extends PureComponent {
 				const tokenSymbol = getTicker(ticker);
 				return strings('transaction.insufficient_amount', { amount, tokenSymbol });
 			}
-			this.setState({ over: false });
 		}
 		return error;
 	};

--- a/app/components/UI/TransactionEditor/index.test.js
+++ b/app/components/UI/TransactionEditor/index.test.js
@@ -14,6 +14,9 @@ describe('TransactionEditor', () => {
 					AccountTrackerController: {
 						accounts: { '0x2': { balance: '0' } }
 					},
+					CurrencyRateController: {
+						conversionRate: 621.92
+					},
 					TokenBalancesController: {
 						contractBalances: { '0x2': new BN(0) }
 					},

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -21,6 +21,7 @@ import AppConstants from '../../../../core/AppConstants';
 import StatusText from '../../../Base/StatusText';
 import Text from '../../../Base/Text';
 import DetailsModal from '../../../Base/DetailsModal';
+import { RPC } from '../../../../constants/network';
 
 const styles = StyleSheet.create({
 	viewOnEtherscan: {
@@ -107,7 +108,7 @@ class TransactionDetails extends PureComponent {
 			frequentRpcList
 		} = this.props;
 		let blockExplorer;
-		if (type === 'rpc') {
+		if (type === RPC) {
 			blockExplorer = findBlockExplorerForRpc(rpcTarget, frequentRpcList) || NO_RPC_BLOCK_EXPLORER;
 		}
 		this.setState({ rpcBlockExplorer: blockExplorer });
@@ -125,7 +126,7 @@ class TransactionDetails extends PureComponent {
 		} = this.props;
 		const { rpcBlockExplorer } = this.state;
 		try {
-			if (type === 'rpc') {
+			if (type === RPC) {
 				const url = `${rpcBlockExplorer}/tx/${transactionHash}`;
 				const title = new URL(rpcBlockExplorer).hostname;
 				navigation.push('Webview', {

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import TransactionDetails from './';
 import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
+import { RPC } from '../../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -20,7 +21,7 @@ describe('TransactionDetails', () => {
 					NetworkController: {
 						provider: {
 							rpcTarget: '',
-							type: 'rpc'
+							type: RPC
 						}
 					}
 				}

--- a/app/components/UI/TransactionHeader/index.test.js
+++ b/app/components/UI/TransactionHeader/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import TransactionHeader from './';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -12,7 +13,7 @@ describe('TransactionHeader', () => {
 				backgroundState: {
 					NetworkController: {
 						provider: {
-							type: 'ropsten'
+							type: ROPSTEN
 						}
 					}
 				}

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/__snapshots__/index.test.js.snap
@@ -118,11 +118,7 @@ exports[`TransactionReviewFeeCard should render correctly 1`] = `
       right={false}
       small={false}
       strikethrough={false}
-      style={
-        Array [
-          undefined,
-        ]
-      }
+      style={null}
       upper={false}
     >
       Total

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/__snapshots__/index.test.js.snap
@@ -118,6 +118,11 @@ exports[`TransactionReviewFeeCard should render correctly 1`] = `
       right={false}
       small={false}
       strikethrough={false}
+      style={
+        Array [
+          undefined,
+        ]
+      }
       upper={false}
     >
       Total

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -13,6 +13,9 @@ const styles = StyleSheet.create({
 	loader: {
 		backgroundColor: colors.white,
 		height: 10
+	},
+	over: {
+		color: colors.red
 	}
 });
 
@@ -56,7 +59,8 @@ class TransactionReviewFeeCard extends PureComponent {
 		/**
 		 * Changes mode to edit
 		 */
-		edit: PropTypes.func
+		edit: PropTypes.func,
+		over: PropTypes.bool
 	};
 
 	renderIfGasEstimationReady = children => {
@@ -80,7 +84,8 @@ class TransactionReviewFeeCard extends PureComponent {
 			transactionValue,
 			primaryCurrency,
 			gasEstimationReady,
-			edit
+			edit,
+			over
 		} = this.props;
 		let amount;
 		let networkFee;
@@ -128,13 +133,13 @@ class TransactionReviewFeeCard extends PureComponent {
 				</Summary.Row>
 				<Summary.Separator />
 				<Summary.Row>
-					<Text primary bold>
+					<Text primary bold style={over && styles.over}>
 						{strings('transaction.total')} {strings('transaction.amount')}
 					</Text>
 					{!!totalFiat && this.renderIfGasEstimationReady(totalAmount)}
 				</Summary.Row>
 				<Summary.Row end last>
-					{this.renderIfGasEstimationReady(<Text bold>{equivalentTotalAmount}</Text>)}
+					{this.renderIfGasEstimationReady(equivalentTotalAmount)}
 				</Summary.Row>
 			</Summary>
 		);

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -60,6 +60,9 @@ class TransactionReviewFeeCard extends PureComponent {
 		 * Changes mode to edit
 		 */
 		edit: PropTypes.func,
+		/**
+		 * True if transaction is over the available funds
+		 */
 		over: PropTypes.bool
 	};
 

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -133,7 +133,7 @@ class TransactionReviewFeeCard extends PureComponent {
 				</Summary.Row>
 				<Summary.Separator />
 				<Summary.Row>
-					<Text primary bold style={over && styles.over}>
+					<Text primary bold style={[over && styles.over]}>
 						{strings('transaction.total')} {strings('transaction.amount')}
 					</Text>
 					{!!totalFiat && this.renderIfGasEstimationReady(totalAmount)}

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -136,7 +136,7 @@ class TransactionReviewFeeCard extends PureComponent {
 				</Summary.Row>
 				<Summary.Separator />
 				<Summary.Row>
-					<Text primary bold style={[over && styles.over]}>
+					<Text primary bold style={(over && styles.over) || null}>
 						{strings('transaction.total')} {strings('transaction.amount')}
 					</Text>
 					{!!totalFiat && this.renderIfGasEstimationReady(totalAmount)}

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/__snapshots__/index.test.js.snap
@@ -1,43 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionReviewInformation should render correctly 1`] = `
-<Fragment>
-  <TransactionReviewFeeCard
-    edit={[Function]}
-    primaryCurrency="ETH"
-    totalGasEth="< 0.00001 ETH"
-    totalGasFiat="$0"
-  />
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "marginTop": 16,
-      }
-    }
-  >
-    <TouchableOpacity
-      style={
-        Object {
-          "alignSelf": "center",
-        }
-      }
-    >
-      <Text
-        style={
-          Object {
-            "alignSelf": "center",
-            "color": "#037dd6",
-            "fontFamily": "EuclidCircularB-Bold",
-            "fontSize": 12,
-            "fontWeight": "600",
-            "textAlign": "center",
-          }
-        }
-      >
-        View Data
-      </Text>
-    </TouchableOpacity>
-  </View>
-</Fragment>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -319,7 +319,11 @@ class TransactionReviewInformation extends PureComponent {
 					<View style={styles.errorWrapper}>
 						<TouchableOpacity onPress={this.buyEth}>
 							<Text style={styles.error}>{error}</Text>
-							<Text style={[styles.error, styles.underline]}>Buy more ETH</Text>
+							{over && (
+								<Text style={[styles.error, styles.underline]}>
+									{strings('transaction.buy_more_eth')}
+								</Text>
+							)}
 						</TouchableOpacity>
 					</View>
 				)}

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -192,7 +192,7 @@ class TransactionReviewInformation extends PureComponent {
 				const totalValue = (
 					<Text
 						style={totalFiat ? styles.overviewEth : [styles.overviewPrimary, styles.overviewAccent]}
-					>{`${renderFromWei(totalEth)} ${getTicker(ticker)} `}</Text>
+					>{`${renderFromWei(totalEth)} ${getTicker(ticker)}`}</Text>
 				);
 				return [totalFiat, totalValue];
 			},

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -18,6 +18,7 @@ import { getTicker, getNormalizedTxState } from '../../../../util/transactions';
 import TransactionReviewFeeCard from '../TransactionReviewFeeCard';
 import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
+import { withNavigation } from 'react-navigation';
 
 const styles = StyleSheet.create({
 	overviewAlert: {
@@ -354,4 +355,4 @@ const mapStateToProps = state => ({
 	primaryCurrency: state.settings.primaryCurrency
 });
 
-export default connect(mapStateToProps)(TransactionReviewInformation);
+export default connect(mapStateToProps)(withNavigation(TransactionReviewInformation));

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -52,11 +52,14 @@ const styles = StyleSheet.create({
 		color: colors.blue
 	},
 	overviewEth: {
-		...fontStyles.normal,
+		...fontStyles.bold,
 		color: colors.fontPrimary,
 		fontSize: 14,
 		textAlign: 'right',
 		textTransform: 'uppercase'
+	},
+	over: {
+		color: colors.red
 	},
 	assetName: {
 		maxWidth: 200
@@ -151,7 +154,8 @@ class TransactionReviewInformation extends PureComponent {
 		 * Whether or not basic gas estimates have been fetched
 		 */
 		ready: PropTypes.bool,
-		error: PropTypes.string
+		error: PropTypes.string,
+		over: PropTypes.bool
 	};
 
 	state = {
@@ -180,18 +184,25 @@ class TransactionReviewInformation extends PureComponent {
 			currentCurrency,
 			conversionRate,
 			contractExchangeRates,
-			ticker
+			ticker,
+			over
 		} = this.props;
 
 		const totals = {
 			ETH: () => {
 				const totalEth = isBN(value) ? value.add(totalGas) : totalGas;
 				const totalFiat = (
-					<Text style={styles.overviewEth}>{weiToFiat(totalEth, conversionRate, currentCurrency)}</Text>
+					<Text style={[styles.overviewEth, over && styles.over]}>
+						{weiToFiat(totalEth, conversionRate, currentCurrency)}
+					</Text>
 				);
 				const totalValue = (
 					<Text
-						style={totalFiat ? styles.overviewEth : [styles.overviewPrimary, styles.overviewAccent]}
+						style={
+							totalFiat
+								? [styles.overviewEth, over && styles.over]
+								: [styles.overviewPrimary, styles.overviewAccent]
+						}
 					>{`${renderFromWei(totalEth)} ${getTicker(ticker)}`}</Text>
 				);
 				return [totalFiat, totalValue];
@@ -251,7 +262,8 @@ class TransactionReviewInformation extends PureComponent {
 			currentCurrency,
 			conversionRate,
 			ticker,
-			error
+			error,
+			over
 		} = this.props;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const totalGasFiat = weiToFiat(totalGas, conversionRate, currentCurrency);
@@ -269,6 +281,7 @@ class TransactionReviewInformation extends PureComponent {
 					primaryCurrency={primaryCurrency}
 					gasEstimationReady={ready}
 					edit={this.edit}
+					over={over}
 				/>
 				{!!amountError && (
 					<View style={styles.overviewAlert}>

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -327,11 +327,13 @@ class TransactionReviewInformation extends PureComponent {
 						</TouchableOpacity>
 					</View>
 				)}
-				<View style={styles.viewDataWrapper}>
-					<TouchableOpacity style={styles.viewDataButton} onPress={toggleDataView}>
-						<Text style={styles.viewDataText}>{strings('transaction.view_data')}</Text>
-					</TouchableOpacity>
-				</View>
+				{!over && (
+					<View style={styles.viewDataWrapper}>
+						<TouchableOpacity style={styles.viewDataButton} onPress={toggleDataView}>
+							<Text style={styles.viewDataText}>{strings('transaction.view_data')}</Text>
+						</TouchableOpacity>
+					</View>
+				)}
 			</React.Fragment>
 		);
 	}

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -82,6 +82,23 @@ const styles = StyleSheet.create({
 		fontSize: 12,
 		...fontStyles.bold,
 		alignSelf: 'center'
+	},
+	errorWrapper: {
+		marginHorizontal: 24,
+		marginTop: 12,
+		paddingHorizontal: 10,
+		paddingVertical: 8,
+		backgroundColor: colors.red000,
+		borderColor: colors.red,
+		borderRadius: 8,
+		borderWidth: 1,
+		justifyContent: 'center',
+		alignItems: 'center'
+	},
+	error: {
+		color: colors.red,
+		fontSize: 12,
+		...fontStyles.normal
 	}
 });
 
@@ -133,7 +150,8 @@ class TransactionReviewInformation extends PureComponent {
 		/**
 		 * Whether or not basic gas estimates have been fetched
 		 */
-		ready: PropTypes.bool
+		ready: PropTypes.bool,
+		error: PropTypes.string
 	};
 
 	state = {
@@ -232,7 +250,8 @@ class TransactionReviewInformation extends PureComponent {
 			transaction: { gas, gasPrice },
 			currentCurrency,
 			conversionRate,
-			ticker
+			ticker,
+			error
 		} = this.props;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const totalGasFiat = weiToFiat(totalGas, conversionRate, currentCurrency);
@@ -257,6 +276,11 @@ class TransactionReviewInformation extends PureComponent {
 						<Text style={styles.overviewAlertText}>
 							{strings('transaction.alert')}: {amountError}.
 						</Text>
+					</View>
+				)}
+				{!!error && (
+					<View style={styles.errorWrapper}>
+						<Text style={styles.error}>{error}</Text>
 					</View>
 				)}
 				<View style={styles.viewDataWrapper}>

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -160,7 +160,13 @@ class TransactionReviewInformation extends PureComponent {
 		 * Whether or not basic gas estimates have been fetched
 		 */
 		ready: PropTypes.bool,
+		/**
+		 * Transaction error
+		 */
 		error: PropTypes.string,
+		/**
+		 * True if transaction is over the available funds
+		 */
 		over: PropTypes.bool,
 		/**
 		 * Object that represents the navigator

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -304,7 +304,7 @@ class TransactionReviewInformation extends PureComponent {
 
 	isMainNet = () => {
 		const { network } = this.props;
-		return network === 0;
+		return network === String(1);
 	};
 
 	capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
@@ -333,7 +333,7 @@ class TransactionReviewInformation extends PureComponent {
 		const networkName = this.capitalize(getNetworkName(network));
 		const errorLinkText = this.isMainNet()
 			? strings('transaction.buy_more_eth')
-			: strings('transaction.get_ether', { network: networkName });
+			: strings('transaction.get_ether', { networkName });
 
 		return (
 			<React.Fragment>

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -20,6 +20,7 @@ import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
 import { withNavigation } from 'react-navigation';
 import { getNetworkName } from '../../../../util/networks';
+import { capitalize } from '../../../../util/format';
 
 const styles = StyleSheet.create({
 	overviewAlert: {
@@ -307,8 +308,6 @@ class TransactionReviewInformation extends PureComponent {
 		return network === String(1);
 	};
 
-	capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
-
 	render() {
 		const { amountError } = this.state;
 		const {
@@ -330,7 +329,7 @@ class TransactionReviewInformation extends PureComponent {
 		const totalGasEth = `${renderFromWei(totalGas)} ${getTicker(ticker)}`;
 		const [totalFiat, totalValue] = this.getRenderTotals(totalGas, totalGasFiat)();
 		const errorPress = this.isMainNet() ? this.buyEth : this.gotoFaucet;
-		const networkName = this.capitalize(getNetworkName(network));
+		const networkName = capitalize(getNetworkName(network));
 		const errorLinkText = this.isMainNet()
 			? strings('transaction.buy_more_eth')
 			: strings('transaction.get_ether', { networkName });

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -19,6 +19,7 @@ import TransactionReviewFeeCard from '../TransactionReviewFeeCard';
 import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
 import { withNavigation } from 'react-navigation';
+import { getNetworkName } from '../../../../util/networks';
 
 const styles = StyleSheet.create({
 	overviewAlert: {
@@ -108,7 +109,8 @@ const styles = StyleSheet.create({
 		textAlign: 'center'
 	},
 	underline: {
-		textDecorationLine: 'underline'
+		textDecorationLine: 'underline',
+		...fontStyles.bold
 	}
 });
 
@@ -294,9 +296,8 @@ class TransactionReviewInformation extends PureComponent {
 		const mmFaucetUrl = 'https://faucet.metamask.io/';
 		InteractionManager.runAfterInteractions(() => {
 			this.onCancelPress();
-			this.props.navigation.navigate('Webview', {
-				url: mmFaucetUrl,
-				title: 'MetaMask Faucet'
+			this.props.navigation.navigate('BrowserView', {
+				newTabUrl: mmFaucetUrl
 			});
 		});
 	};
@@ -305,6 +306,8 @@ class TransactionReviewInformation extends PureComponent {
 		const { network } = this.props;
 		return network === 0;
 	};
+
+	capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
 
 	render() {
 		const { amountError } = this.state;
@@ -319,13 +322,18 @@ class TransactionReviewInformation extends PureComponent {
 			conversionRate,
 			ticker,
 			error,
-			over
+			over,
+			network
 		} = this.props;
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const totalGasFiat = weiToFiat(totalGas, conversionRate, currentCurrency);
 		const totalGasEth = `${renderFromWei(totalGas)} ${getTicker(ticker)}`;
 		const [totalFiat, totalValue] = this.getRenderTotals(totalGas, totalGasFiat)();
 		const errorPress = this.isMainNet() ? this.buyEth : this.gotoFaucet;
+		const networkName = this.capitalize(getNetworkName(network));
+		const errorLinkText = this.isMainNet()
+			? strings('transaction.buy_more_eth')
+			: strings('transaction.get_ether', { network: networkName });
 
 		return (
 			<React.Fragment>
@@ -353,11 +361,7 @@ class TransactionReviewInformation extends PureComponent {
 					<View style={styles.errorWrapper}>
 						<TouchableOpacity onPress={errorPress}>
 							<Text style={styles.error}>{error}</Text>
-							{over && (
-								<Text style={[styles.error, styles.underline]}>
-									{strings('transaction.buy_more_eth')}
-								</Text>
-							)}
+							{over && <Text style={[styles.error, styles.underline]}>{errorLinkText}</Text>}
 						</TouchableOpacity>
 					</View>
 				)}

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -19,7 +19,7 @@ import TransactionReviewFeeCard from '../TransactionReviewFeeCard';
 import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
 import { withNavigation } from 'react-navigation';
-import { getNetworkName } from '../../../../util/networks';
+import { getNetworkName, isMainNet } from '../../../../util/networks';
 import { capitalize } from '../../../../util/format';
 
 const styles = StyleSheet.create({
@@ -303,11 +303,6 @@ class TransactionReviewInformation extends PureComponent {
 		});
 	};
 
-	isMainNet = () => {
-		const { network } = this.props;
-		return network === String(1);
-	};
-
 	render() {
 		const { amountError } = this.state;
 		const {
@@ -324,13 +319,14 @@ class TransactionReviewInformation extends PureComponent {
 			over,
 			network
 		} = this.props;
+		const is_main_net = isMainNet(network);
 		const totalGas = isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : toBN('0x0');
 		const totalGasFiat = weiToFiat(totalGas, conversionRate, currentCurrency);
 		const totalGasEth = `${renderFromWei(totalGas)} ${getTicker(ticker)}`;
 		const [totalFiat, totalValue] = this.getRenderTotals(totalGas, totalGasFiat)();
-		const errorPress = this.isMainNet() ? this.buyEth : this.gotoFaucet;
+		const errorPress = is_main_net ? this.buyEth : this.gotoFaucet;
 		const networkName = capitalize(getNetworkName(network));
-		const errorLinkText = this.isMainNet()
+		const errorLinkText = is_main_net
 			? strings('transaction.buy_more_eth')
 			: strings('transaction.get_ether', { networkName });
 
@@ -361,7 +357,7 @@ class TransactionReviewInformation extends PureComponent {
 						<TouchableOpacity onPress={errorPress}>
 							<Text style={styles.error}>{error}</Text>
 							{/* only show buy more on mainnet */}
-							{over && this.isMainNet() && (
+							{over && is_main_net && (
 								<Text style={[styles.error, styles.underline]}>{errorLinkText}</Text>
 							)}
 						</TouchableOpacity>

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -360,7 +360,10 @@ class TransactionReviewInformation extends PureComponent {
 					<View style={styles.errorWrapper}>
 						<TouchableOpacity onPress={errorPress}>
 							<Text style={styles.error}>{error}</Text>
-							{over && <Text style={[styles.error, styles.underline]}>{errorLinkText}</Text>}
+							{/* only show buy more on mainnet */}
+							{over && this.isMainNet() && (
+								<Text style={[styles.error, styles.underline]}>{errorLinkText}</Text>
+							)}
 						</TouchableOpacity>
 					</View>
 				)}

--- a/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
@@ -17,7 +17,7 @@ exports[`TransactionReview should render correctly 1`] = `
     <View
       style={
         Object {
-          "height": 385,
+          "height": 415,
         }
       }
     >
@@ -35,7 +35,7 @@ exports[`TransactionReview should render correctly 1`] = `
         <View
           style={
             Object {
-              "height": 300,
+              "height": 340,
             }
           }
         >
@@ -51,6 +51,13 @@ exports[`TransactionReview should render correctly 1`] = `
           </View>
           <Connect(TransactionReviewInformation)
             edit={[Function]}
+            navigation={
+              Object {
+                "state": Object {
+                  "params": Object {},
+                },
+              }
+            }
             toggleDataView={[Function]}
           />
         </View>

--- a/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
@@ -35,7 +35,7 @@ exports[`TransactionReview should render correctly 1`] = `
         <View
           style={
             Object {
-              "height": 340,
+              "height": 330,
             }
           }
         >

--- a/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
+++ b/app/components/UI/TransactionReview/__snapshots__/index.test.js.snap
@@ -49,15 +49,8 @@ exports[`TransactionReview should render correctly 1`] = `
           >
             <Connect(AccountInfoCard) />
           </View>
-          <Connect(TransactionReviewInformation)
+          <Connect(withNavigation(TransactionReviewInformation))
             edit={[Function]}
-            navigation={
-              Object {
-                "state": Object {
-                  "params": Object {},
-                },
-              }
-            }
             toggleDataView={[Function]}
           />
         </View>

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
 		height: Device.isMediumDevice() ? 230 : 415
 	},
 	actionViewChildren: {
-		height: 340
+		height: 330
 	},
 	accountInfoCardWrapper: {
 		paddingHorizontal: 24,

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -320,6 +320,7 @@ class TransactionReview extends PureComponent {
 									assetAmount={assetAmount}
 									fiatValue={fiatValue}
 									toggleDataView={this.toggleDataView}
+									// over
 								/>
 							</View>
 						</ActionView>

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -152,6 +152,9 @@ class TransactionReview extends PureComponent {
 		 * Hides or shows TransactionReviewData
 		 */
 		hideData: PropTypes.bool,
+		/**
+		 * True if transaction is over the available funds
+		 */
 		over: PropTypes.bool,
 		/**
 		 * Object that represents the navigator

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -155,11 +155,7 @@ class TransactionReview extends PureComponent {
 		/**
 		 * True if transaction is over the available funds
 		 */
-		over: PropTypes.bool,
-		/**
-		 * Object that represents the navigator
-		 */
-		navigation: PropTypes.object
+		over: PropTypes.bool
 	};
 
 	state = {
@@ -330,7 +326,6 @@ class TransactionReview extends PureComponent {
 									fiatValue={fiatValue}
 									toggleDataView={this.toggleDataView}
 									over={over}
-									navigation={this.props.navigation}
 									onCancelPress={this.props.onCancel}
 								/>
 							</View>

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -151,7 +151,12 @@ class TransactionReview extends PureComponent {
 		/**
 		 * Hides or shows TransactionReviewData
 		 */
-		hideData: PropTypes.bool
+		hideData: PropTypes.bool,
+		over: PropTypes.bool,
+		/**
+		 * Object that represents the navigator
+		 */
+		navigation: PropTypes.object
 	};
 
 	state = {
@@ -284,7 +289,8 @@ class TransactionReview extends PureComponent {
 			generateTransform,
 			hideData,
 			saveTransactionReviewDataHeight,
-			customGasHeight
+			customGasHeight,
+			over
 		} = this.props;
 		const { actionKey, error, assetAmount, conversionRate, fiatValue, approveTransaction } = this.state;
 		const currentPageInformation = { url: this.getUrlFromBrowser() };
@@ -320,7 +326,9 @@ class TransactionReview extends PureComponent {
 									assetAmount={assetAmount}
 									fiatValue={fiatValue}
 									toggleDataView={this.toggleDataView}
-									// over
+									over={over}
+									navigation={this.props.navigation}
+									onCancelPress={this.props.onCancel}
 								/>
 							</View>
 						</ActionView>

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, View, InteractionManager, Animated } from 'react-native';
+import { StyleSheet, View, InteractionManager, Animated } from 'react-native';
 import { colors, fontStyles } from '../../../styles/common';
 import { connect } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
@@ -47,31 +47,14 @@ const styles = StyleSheet.create({
 		...fontStyles.bold
 	},
 	actionViewWrapper: {
-		height: Device.isMediumDevice() ? 200 : 385
+		height: Device.isMediumDevice() ? 230 : 415
 	},
 	actionViewChildren: {
-		height: 300
+		height: 340
 	},
 	accountInfoCardWrapper: {
 		paddingHorizontal: 24,
 		paddingBottom: 12
-	},
-	errorWrapper: {
-		marginHorizontal: 24,
-		marginBottom: 12,
-		paddingHorizontal: 10,
-		paddingVertical: 8,
-		backgroundColor: colors.red000,
-		borderColor: colors.red,
-		borderRadius: 8,
-		borderWidth: 1,
-		justifyContent: 'center',
-		alignItems: 'center'
-	},
-	error: {
-		color: colors.red,
-		fontSize: 12,
-		...fontStyles.normal
 	},
 	transactionData: {
 		position: 'absolute',
@@ -317,11 +300,6 @@ class TransactionReview extends PureComponent {
 						approveTransaction={approveTransaction}
 						primaryCurrency={primaryCurrency}
 					/>
-					{!!error && (
-						<View style={styles.errorWrapper}>
-							<Text style={styles.error}>{error}</Text>
-						</View>
-					)}
 					<View style={styles.actionViewWrapper}>
 						<ActionView
 							confirmButtonMode="confirm"
@@ -336,6 +314,7 @@ class TransactionReview extends PureComponent {
 									<AccountInfoCard />
 								</View>
 								<TransactionReviewInformation
+									error={error}
 									edit={this.edit}
 									ready={ready}
 									assetAmount={assetAmount}

--- a/app/components/UI/UrlAutocomplete/index.test.js
+++ b/app/components/UI/UrlAutocomplete/index.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import UrlAutocomplete from './';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 const store = mockStore({});
@@ -11,7 +12,7 @@ describe('UrlAutocomplete', () => {
 	it('should render correctly', () => {
 		const wrapper = shallow(
 			<Provider store={store}>
-				<UrlAutocomplete network={'ropsten'} />
+				<UrlAutocomplete network={ROPSTEN} />
 			</Provider>
 		);
 		expect(wrapper).toMatchSnapshot();

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -38,7 +38,7 @@ class Approval extends PureComponent {
 		/**
 		 * react-navigation object used for switching between screens
 		 */
-		navigation: PropTypes.object,
+		navigation: PropTypes.object.isRequired,
 		/**
 		 * Action that cleans transaction state
 		 */

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -279,7 +279,7 @@ class Approval extends PureComponent {
 	}
 
 	render = () => {
-		const { transaction, dappTransactionModalVisible } = this.props;
+		const { transaction, dappTransactionModalVisible, navigation } = this.props;
 		const { mode } = this.state;
 		return (
 			<Modal
@@ -303,7 +303,7 @@ class Approval extends PureComponent {
 					onConfirm={this.onConfirm}
 					onModeChange={this.onModeChange}
 					transaction={transaction}
-					navigation={this.props.navigation}
+					navigation={navigation}
 					dappTransactionModalVisible={dappTransactionModalVisible}
 				/>
 			</Modal>

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -279,7 +279,7 @@ class Approval extends PureComponent {
 	}
 
 	render = () => {
-		const { transaction, dappTransactionModalVisible, navigation } = this.props;
+		const { transaction, dappTransactionModalVisible } = this.props;
 		const { mode } = this.state;
 		return (
 			<Modal
@@ -303,7 +303,6 @@ class Approval extends PureComponent {
 					onConfirm={this.onConfirm}
 					onModeChange={this.onModeChange}
 					transaction={transaction}
-					navigation={navigation}
 					dappTransactionModalVisible={dappTransactionModalVisible}
 				/>
 			</Modal>

--- a/app/components/Views/Approval/index.test.js
+++ b/app/components/Views/Approval/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Approval from './';
 import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -28,7 +29,7 @@ describe('Approval', () => {
 					},
 					NetworkController: {
 						provider: {
-							type: 'ropsten'
+							type: ROPSTEN
 						}
 					}
 				}

--- a/app/components/Views/ApproveView/Approve/__snapshots__/index.test.js.snap
+++ b/app/components/Views/ApproveView/Approve/__snapshots__/index.test.js.snap
@@ -11,6 +11,7 @@ exports[`Approve should render correctly 1`] = `
   }
   accountsLength={1}
   setTransactionObject={[Function]}
+  ticker="ETH"
   tokensLength={0}
   transaction={Object {}}
   transactions={Array []}

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -169,10 +169,7 @@ class Approve extends PureComponent {
 			const tokenSymbol = getTicker(ticker);
 			error = strings('transaction.insufficient_amount', { amount, tokenSymbol });
 		}
-		this.setState({
-			gasError: error,
-			over: false
-		});
+		this.setState({ gasError: error });
 		return error;
 	};
 

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -234,7 +234,6 @@ class Approve extends PureComponent {
 
 	render = () => {
 		const { gasError, basicGasEstimates, mode, ready, over } = this.state;
-		console.log({ over1: over });
 		const { transaction } = this.props;
 		if (!transaction.id) return null;
 		return (

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -169,7 +169,10 @@ class Approve extends PureComponent {
 			const tokenSymbol = getTicker(ticker);
 			error = strings('transaction.insufficient_amount', { amount, tokenSymbol });
 		}
-		this.setState({ gasError: error });
+		this.setState({
+			gasError: error,
+			over: false
+		});
 		return error;
 	};
 

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -9,6 +9,7 @@ import Transactions from '../../UI/Transactions';
 import { getNetworkNavbarOptions } from '../../UI/Navbar';
 import Engine from '../../../core/Engine';
 import { safeToChecksumAddress } from '../../../util/address';
+import { RPC } from '../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -140,7 +141,7 @@ class Asset extends PureComponent {
 		return (
 			(safeToChecksumAddress(from) === selectedAddress || safeToChecksumAddress(to) === selectedAddress) &&
 			((networkId && networkId.toString() === tx.networkID) ||
-				(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
+				(networkType === RPC && !isKnownNetwork(tx.networkID))) &&
 			tx.status !== 'unapproved'
 		);
 	};
@@ -157,7 +158,7 @@ class Asset extends PureComponent {
 		return (
 			(from & (from.toLowerCase() === this.navAddress) || (to && to.toLowerCase() === this.navAddress)) &&
 			((networkId && networkId.toString() === tx.networkID) ||
-				(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
+				(networkType === RPC && !isKnownNetwork(tx.networkID))) &&
 			tx.status !== 'unapproved'
 		);
 	};

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -59,6 +59,7 @@ import { ethErrors } from 'eth-json-rpc-errors';
 import EntryScriptWeb3 from '../../../core/EntryScriptWeb3';
 import { getVersion } from 'react-native-device-info';
 import ErrorBoundary from '../ErrorBoundary';
+import { RPC } from '../../../constants/network';
 
 const { HOMEPAGE_URL, USER_AGENT, NOTIFICATION_NAMES } = AppConstants;
 const HOMEPAGE_HOST = 'home.metamask.io';
@@ -511,7 +512,7 @@ export const BrowserTab = props => {
 					const data = JSON.parse(req.params[1]);
 					const chainId = data.domain.chainId;
 					const activeChainId =
-						props.networkType === 'rpc' ? props.network : Networks[props.networkType].networkId;
+						props.networkType === RPC ? props.network : Networks[props.networkType].networkId;
 
 					// eslint-disable-next-line
 					if (chainId && chainId != activeChainId) {
@@ -545,7 +546,7 @@ export const BrowserTab = props => {
 					const data = JSON.parse(req.params[1]);
 					const chainId = data.domain.chainId;
 					const activeChainId =
-						props.networkType === 'rpc' ? props.network : Networks[props.networkType].networkId;
+						props.networkType === RPC ? props.network : Networks[props.networkType].networkId;
 
 					// eslint-disable-next-line eqeqeq
 					if (chainId && chainId != activeChainId) {

--- a/app/components/Views/Login/index.test.js
+++ b/app/components/Views/Login/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Login from './';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -15,7 +16,7 @@ describe('Login', () => {
 					},
 					NetworkController: {
 						provider: {
-							type: 'ropsten'
+							type: ROPSTEN
 						}
 					},
 					AssetsController: {

--- a/app/components/Views/PaymentChannel/PaymentChannelDeposit/index.test.js
+++ b/app/components/Views/PaymentChannel/PaymentChannelDeposit/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import PaymentChannelDeposit from './';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -24,7 +25,7 @@ describe('PaymentChannelDeposit', () => {
 					},
 					NetworkController: {
 						provider: {
-							type: 'ropsten',
+							type: ROPSTEN,
 							ticker: 'ETH'
 						}
 					}

--- a/app/components/Views/PaymentChannel/PaymentChannelSend/index.js
+++ b/app/components/Views/PaymentChannel/PaymentChannelSend/index.js
@@ -136,7 +136,6 @@ class PaymentChannelSend extends PureComponent {
 		<SafeAreaView style={styles.wrapper}>
 			{this.state.ready ? (
 				<TransactionEditor
-					navigation={this.props.navigation}
 					mode={this.state.mode}
 					onCancel={this.onCancel}
 					onModeChange={this.onModeChange}

--- a/app/components/Views/PaymentChannel/index.test.js
+++ b/app/components/Views/PaymentChannel/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import PaymentChannel from './';
 import configureMockStore from 'redux-mock-store';
+import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
 
@@ -15,7 +16,7 @@ describe('PaymentChannel', () => {
 				backgroundState: {
 					NetworkController: {
 						provider: {
-							type: 'ropsten',
+							type: ROPSTEN,
 							ticker: 'ETH'
 						}
 					},

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -27,6 +27,7 @@ import {
 import Logger from '../../../util/Logger';
 import { isENS } from '../../../util/address';
 import TransactionTypes from '../../../core/TransactionTypes';
+import { MAINNET } from '../../../constants/network';
 
 const REVIEW = 'review';
 const EDIT = 'edit';
@@ -440,7 +441,7 @@ class Send extends PureComponent {
 	 */
 	removeCollectible = () => {
 		const { selectedAsset, assetType, providerType } = this.props.transaction;
-		if (assetType === 'ERC721' && providerType !== 'mainnet') {
+		if (assetType === 'ERC721' && providerType !== MAINNET) {
 			const { AssetsController } = Engine.context;
 			AssetsController.removeCollectible(selectedAsset.address, selectedAsset.tokenId);
 		}

--- a/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.js.snap
+++ b/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.js.snap
@@ -89,6 +89,7 @@ exports[`Confirm should render correctly 1`] = `
       edit={[Function]}
       fiat=""
       gasEstimationReady={false}
+      over={false}
       totalFiat={<Text />}
       totalGasFiat=""
       totalValue={<Text />}

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -209,6 +209,10 @@ const styles = StyleSheet.create({
 	underline: {
 		textDecorationLine: 'underline',
 		...fontStyles.bold
+	},
+	over: {
+		color: colors.red,
+		...fontStyles.bold
 	}
 });
 
@@ -446,7 +450,7 @@ class Confirm extends PureComponent {
 			ticker,
 			isPaymentChannelTransaction
 		} = this.props;
-		const { fromSelectedAddress } = this.state;
+		const { fromSelectedAddress, over } = this.state;
 		let fromAccountBalance,
 			transactionValue,
 			transactionValueFiat,
@@ -469,12 +473,12 @@ class Confirm extends PureComponent {
 			transactionValueFiat = weiToFiat(valueBN, conversionRate, currentCurrency);
 			const transactionTotalAmountBN = weiTransactionFee && weiTransactionFee.add(valueBN);
 			transactionTotalAmount = (
-				<Text style={styles.totalAmount}>
+				<Text style={[styles.totalAmount, over && styles.over]}>
 					{renderFromWei(transactionTotalAmountBN)} {parsedTicker}
 				</Text>
 			);
 			transactionTotalAmountFiat = (
-				<Text style={styles.totalAmount}>
+				<Text style={[styles.totalAmount, over && styles.over]}>
 					{weiToFiat(transactionTotalAmountBN, conversionRate, currentCurrency)}
 				</Text>
 			);
@@ -909,8 +913,6 @@ class Confirm extends PureComponent {
 
 	buyEth = () => {
 		const { navigation } = this.props;
-		/* this is kinda weird, we have to reject the transaction to collapse the modal */
-		this.onCancelPress();
 		navigation.navigate('PaymentMethodSelector');
 		InteractionManager.runAfterInteractions(() => {
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.RECEIVE_OPTIONS_PAYMENT_REQUEST);
@@ -920,7 +922,6 @@ class Confirm extends PureComponent {
 	gotoFaucet = () => {
 		const mmFaucetUrl = 'https://faucet.metamask.io/';
 		InteractionManager.runAfterInteractions(() => {
-			this.onCancelPress();
 			this.props.navigation.navigate('BrowserView', {
 				newTabUrl: mmFaucetUrl
 			});

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -647,6 +647,8 @@ class Confirm extends PureComponent {
 					const amount = renderFromWei(weiInput.sub(weiBalance));
 					const tokenSymbol = getTicker(ticker);
 					errorMessage = strings('transaction.insufficient_amount', { amount, tokenSymbol });
+				} else {
+					this.setState({ over: false });
 				}
 			} else if (selectedAsset.isETH || selectedAsset.tokenId) {
 				const totalGas = gas ? gas.mul(gasPrice) : toBN('0x0');
@@ -657,6 +659,8 @@ class Confirm extends PureComponent {
 					const amount = renderFromWei(weiInput.sub(weiBalance));
 					const tokenSymbol = getTicker(ticker);
 					errorMessage = strings('transaction.insufficient_amount', { amount, tokenSymbol });
+				} else {
+					this.setState({ over: false });
 				}
 			} else {
 				const [, , amount] = decodeTransferData('transfer', transaction.data);

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -45,7 +45,6 @@ import AccountList from '../../../UI/AccountList';
 import AnimatedTransactionModal from '../../../UI/AnimatedTransactionModal';
 import TransactionReviewFeeCard from '../../../UI/TransactionReview/TransactionReviewFeeCard';
 import CustomGas from '../../../UI/CustomGas';
-import ErrorMessage from '../ErrorMessage';
 import { doENSReverseLookup } from '../../../../util/ENSUtils';
 import NotificationManager from '../../../../core/NotificationManager';
 import { strings } from '../../../../../locales/i18n';
@@ -56,6 +55,8 @@ import IonicIcon from 'react-native-vector-icons/Ionicons';
 import TransactionTypes from '../../../../core/TransactionTypes';
 import Analytics from '../../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
+import { capitalize } from '../../../../util/format';
+import { isMainNet, getNetworkName } from '../../../../util/networks';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -116,10 +117,6 @@ const styles = StyleSheet.create({
 	},
 	actionsWrapper: {
 		margin: 24
-	},
-	errorMessageWrapper: {
-		marginTop: 16,
-		marginHorizontal: 24
 	},
 	collectibleImageWrapper: {
 		flexDirection: 'column',
@@ -190,6 +187,28 @@ const styles = StyleSheet.create({
 	keyboardAwareWrapper: {
 		flex: 1,
 		justifyContent: 'flex-end'
+	},
+	errorWrapper: {
+		marginHorizontal: 24,
+		marginTop: 12,
+		paddingHorizontal: 10,
+		paddingVertical: 8,
+		backgroundColor: colors.red000,
+		borderColor: colors.red,
+		borderRadius: 8,
+		borderWidth: 1,
+		justifyContent: 'center',
+		alignItems: 'center'
+	},
+	error: {
+		color: colors.red,
+		fontSize: 12,
+		...fontStyles.normal,
+		textAlign: 'center'
+	},
+	underline: {
+		textDecorationLine: 'underline',
+		...fontStyles.bold
 	}
 });
 
@@ -299,7 +318,8 @@ class Confirm extends PureComponent {
 		fromAccountModalVisible: false,
 		paymentChannelBalance: this.props.selectedAsset.assetBalance,
 		paymentChannelReady: false,
-		mode: REVIEW
+		mode: REVIEW,
+		over: false
 	};
 
 	componentDidMount = async () => {
@@ -607,22 +627,33 @@ class Confirm extends PureComponent {
 			contractBalances,
 			selectedAsset,
 			transactionState: {
+				ticker,
 				paymentChannelTransaction,
-				transaction: { gas, gasPrice }
+				transaction: { value, gas, gasPrice }
 			}
 		} = this.props;
 		const selectedAddress = transaction.from;
 		let weiBalance, weiInput, errorMessage;
-		if (isDecimal(transaction.value)) {
+		if (isDecimal(value)) {
 			if (paymentChannelTransaction) {
 				weiBalance = toWei(Number(selectedAsset.assetBalance));
-				weiInput = toWei(transaction.value);
-				errorMessage = weiBalance.gte(weiInput) ? undefined : strings('transaction.insufficient');
+				weiInput = toWei(value);
+				if (!weiBalance.gte(weiInput)) {
+					this.setState({ over: true });
+					const amount = renderFromWei(weiInput.sub(weiBalance));
+					const tokenSymbol = getTicker(ticker);
+					errorMessage = strings('transaction.insufficient_amount', { amount, tokenSymbol });
+				}
 			} else if (selectedAsset.isETH || selectedAsset.tokenId) {
 				const totalGas = gas ? gas.mul(gasPrice) : toBN('0x0');
 				weiBalance = hexToBN(accounts[selectedAddress].balance);
-				weiInput = hexToBN(transaction.value).add(totalGas);
-				errorMessage = weiBalance.gte(weiInput) ? undefined : strings('transaction.insufficient');
+				weiInput = hexToBN(value).add(totalGas);
+				if (!weiBalance.gte(weiInput)) {
+					this.setState({ over: true });
+					const amount = renderFromWei(weiInput.sub(weiBalance));
+					const tokenSymbol = getTicker(ticker);
+					errorMessage = strings('transaction.insufficient_amount', { amount, tokenSymbol });
+				}
 			} else {
 				const [, , amount] = decodeTransferData('transfer', transaction.data);
 				weiBalance = contractBalances[selectedAsset.address];
@@ -876,9 +907,29 @@ class Confirm extends PureComponent {
 		);
 	};
 
+	buyEth = () => {
+		const { navigation } = this.props;
+		/* this is kinda weird, we have to reject the transaction to collapse the modal */
+		this.onCancelPress();
+		navigation.navigate('PaymentMethodSelector');
+		InteractionManager.runAfterInteractions(() => {
+			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.RECEIVE_OPTIONS_PAYMENT_REQUEST);
+		});
+	};
+
+	gotoFaucet = () => {
+		const mmFaucetUrl = 'https://faucet.metamask.io/';
+		InteractionManager.runAfterInteractions(() => {
+			this.onCancelPress();
+			this.props.navigation.navigate('BrowserView', {
+				newTabUrl: mmFaucetUrl
+			});
+		});
+	};
+
 	render = () => {
 		const { transactionToName, selectedAsset, paymentRequest } = this.props.transactionState;
-		const { showHexData, isPaymentChannelTransaction, primaryCurrency } = this.props;
+		const { showHexData, isPaymentChannelTransaction, primaryCurrency, network } = this.props;
 		const {
 			gasEstimationReady,
 			fromAccountBalance,
@@ -894,8 +945,16 @@ class Confirm extends PureComponent {
 			errorMessage,
 			transactionConfirmed,
 			paymentChannelBalance,
-			mode
+			mode,
+			over
 		} = this.state;
+
+		const is_main_net = isMainNet(network);
+		const errorPress = is_main_net ? this.buyEth : this.gotoFaucet;
+		const networkName = capitalize(getNetworkName(network));
+		const errorLinkText = is_main_net
+			? strings('transaction.buy_more_eth')
+			: strings('transaction.get_ether', { networkName });
 		return (
 			<SafeAreaView style={styles.wrapper} testID={'txn-confirm-screen'}>
 				<View style={styles.inputWrapper}>
@@ -949,11 +1008,18 @@ class Confirm extends PureComponent {
 							primaryCurrency={primaryCurrency}
 							gasEstimationReady={gasEstimationReady}
 							edit={this.edit}
+							over={over}
 						/>
 					)}
 					{errorMessage && (
-						<View style={styles.errorMessageWrapper}>
-							<ErrorMessage errorMessage={errorMessage} />
+						<View style={styles.errorWrapper}>
+							<TouchableOpacity onPress={errorPress}>
+								<Text style={styles.error}>{errorMessage}</Text>
+								{/* only show buy more on mainnet */}
+								{over && is_main_net && (
+									<Text style={[styles.error, styles.underline]}>{errorLinkText}</Text>
+								)}
+							</TouchableOpacity>
 						</View>
 					)}
 					<View style={styles.actionsWrapper}>

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { colors, fontStyles } from '../../../../../styles/common';
 import { getNavigationOptionsTitle } from '../../../../UI/Navbar';
 import { strings } from '../../../../../../locales/i18n';
-import Networks, { isprivateConnection } from '../../../../../util/networks';
+import Networks, { isprivateConnection, getAllNetworks } from '../../../../../util/networks';
 import { getEtherscanBaseUrl } from '../../../../../util/etherscan';
 import StyledButton from '../../../../UI/StyledButton';
 import Engine from '../../../../../core/Engine';
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
 	}
 });
 
-const allNetworks = ['mainnet', 'ropsten', 'kovan', 'rinkeby', 'goerli'];
+const allNetworks = getAllNetworks();
 const allNetworksblockExplorerUrl = `https://api.infura.io/v1/jsonrpc/`;
 /**
  * Main view for app configurations

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -9,6 +9,7 @@ import { strings } from '../../../../../locales/i18n';
 import Networks, { getAllNetworks } from '../../../../util/networks';
 import StyledButton from '../../../UI/StyledButton';
 import Engine from '../../../../core/Engine';
+import { MAINNET, RPC } from '../../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -105,7 +106,7 @@ class NetworksSettings extends PureComponent {
 	switchToMainnet = () => {
 		const { NetworkController, CurrencyRateController } = Engine.context;
 		CurrencyRateController.configure({ nativeCurrency: 'ETH' });
-		NetworkController.setProviderType('mainnet');
+		NetworkController.setProviderType(MAINNET);
 		this.props.thirdPartyApiMode &&
 			setTimeout(() => {
 				Engine.refreshTransactionHistory();
@@ -115,7 +116,7 @@ class NetworksSettings extends PureComponent {
 	removeNetwork = () => {
 		// Check if it's the selected network and then switch to mainnet first
 		const { provider } = this.props;
-		if (provider.rpcTarget === this.networkToRemove && provider.type === 'rpc') {
+		if (provider.rpcTarget === this.networkToRemove && provider.type === RPC) {
 			this.switchToMainnet();
 		}
 		const { PreferencesController } = Engine.context;
@@ -180,8 +181,8 @@ class NetworksSettings extends PureComponent {
 			<View style={styles.mainnetHeader}>
 				<TouchableOpacity
 					style={styles.network}
-					key={`network-mainnet`}
-					onPress={() => this.onPress('mainnet')} // eslint-disable-line
+					key={`network-${MAINNET}`}
+					onPress={() => this.onPress(MAINNET)} // eslint-disable-line
 				>
 					<View style={styles.networkWrapper}>
 						<View style={[styles.networkIcon, { backgroundColor: mainnetColor }]} />

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -9,6 +9,7 @@ import { colors } from '../../../styles/common';
 import Transactions from '../../UI/Transactions';
 import Networks, { isKnownNetwork } from '../../../util/networks';
 import { safeToChecksumAddress } from '../../../util/address';
+import { RPC } from '../../../constants/network';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -120,7 +121,7 @@ class TransactionsView extends PureComponent {
 		return (
 			(safeToChecksumAddress(from) === selectedAddress || safeToChecksumAddress(to) === selectedAddress) &&
 			((networkId && networkId.toString() === tx.networkID) ||
-				(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
+				(networkType === RPC && !isKnownNetwork(tx.networkID))) &&
 			tx.status !== 'unapproved'
 		);
 	};

--- a/app/constants/network.js
+++ b/app/constants/network.js
@@ -1,0 +1,6 @@
+export const MAINNET = 'mainnet';
+export const ROPSTEN = 'ropsten';
+export const KOVAN = 'kovan';
+export const RINKEBY = 'rinkeby';
+export const GOERLI = 'goerli';
+export const RPC = 'rpc';

--- a/app/core/AppConstants.js
+++ b/app/core/AppConstants.js
@@ -1,4 +1,5 @@
 import Device from '../util/Device';
+import { MAINNET, RINKEBY } from '../constants/network';
 
 export default {
 	DEFAULT_LOCK_TIMEOUT: 30000,
@@ -21,7 +22,7 @@ export default {
 			4: '0x0Fa90eC3AC3245112c6955d8F9DD74Ec9D599996',
 			1: '0xdfa6edAe2EC0cF1d4A60542422724A48195A5071'
 		},
-		SUPPORTED_NETWORKS: ['mainnet', 'rinkeby']
+		SUPPORTED_NETWORKS: [MAINNET, RINKEBY]
 	},
 	MM_UNIVERSAL_LINK_HOST: 'metamask.app.link',
 	SAI_ADDRESS: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359',

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -32,6 +32,7 @@ import NotificationManager from './NotificationManager';
 import contractMap from '@metamask/contract-metadata';
 import Logger from '../util/Logger';
 import { LAST_INCOMING_TX_BLOCK_INFO } from '../constants/storage';
+import { MAINNET } from '../constants/network';
 
 const encryptor = new Encryptor();
 let refreshing = false;
@@ -103,7 +104,7 @@ class Engine {
 								}
 							}
 						},
-						{ network: '1', provider: { type: 'mainnet' } }
+						{ network: '1', provider: { type: MAINNET } }
 					),
 					new PhishingController(),
 					new PreferencesController(
@@ -353,7 +354,7 @@ class Engine {
 			Object.keys(preferences.accountTokens[address]).forEach(
 				networkType =>
 					(allTokens[checksummedAddress][networkType] =
-						networkType !== 'mainnet'
+						networkType !== MAINNET
 							? preferences.accountTokens[address][networkType]
 							: preferences.accountTokens[address][networkType]
 									.filter(({ address }) =>

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -11,6 +11,7 @@ import { Alert, AppState } from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import AppConstants from './AppConstants';
 import { PUSH_NOTIFICATIONS_PROMPT_COUNT, PUSH_NOTIFICATIONS_PROMPT_TIME } from '../constants/storage';
+import { RPC } from '../constants/network';
 
 /**
  * Singleton class responsible for managing all the
@@ -382,7 +383,7 @@ class NotificationManager {
 						toChecksumAddress(tx.transaction.to) === selectedAddress &&
 						toChecksumAddress(tx.transaction.from) !== selectedAddress &&
 						((networkId && networkId.toString() === tx.networkID) ||
-							(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
+							(networkType === RPC && !isKnownNetwork(tx.networkID))) &&
 						tx.status === 'confirmed' &&
 						lastBlock <= parseInt(tx.blockNumber, 10) &&
 						tx.time > oldestTimeAllowed

--- a/app/core/PaymentChannelsClient.js
+++ b/app/core/PaymentChannelsClient.js
@@ -14,6 +14,7 @@ import AppConstants from './AppConstants';
 import byteArrayToHex from '../util/bytes';
 import Networks from '../util/networks';
 import { LAST_KNOWN_INSTANT_PAYMENT_ID } from '../constants/storage';
+import { MAINNET, RINKEBY } from '../constants/network';
 
 const {
 	CONNEXT: { CONTRACTS }
@@ -94,10 +95,10 @@ class PaymentChannelsClient {
 		let hubUrl;
 		const ethprovider = new EthQuery(infuraProvider);
 		switch (type) {
-			case 'rinkeby':
+			case RINKEBY:
 				hubUrl = `https://rinkeby.${PUBLIC_URL}/api/hub`;
 				break;
-			case 'mainnet':
+			case MAINNET:
 				hubUrl = `https://${PUBLIC_URL}/api/hub`;
 				break;
 			default:

--- a/app/util/accountSecurity.js
+++ b/app/util/accountSecurity.js
@@ -3,6 +3,7 @@ import Networks, { isKnownNetwork } from './networks';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { toBN, hexToBN, renderFromWei, renderFromTokenMinimalUnit } from './number';
 import { strings } from '../../locales/i18n';
+import { RPC } from '../constants/network';
 
 export default async function findFirstIncomingTransaction(networkType, selectedAddress, thirPartyApiMode) {
 	// Pull txs if allowed
@@ -17,7 +18,7 @@ export default async function findFirstIncomingTransaction(networkType, selected
 				tx.transaction.to &&
 				toChecksumAddress(tx.transaction.to) === selectedAddress &&
 				((networkId && networkId.toString() === tx.networkID) ||
-					(networkType === 'rpc' && !isKnownNetwork(tx.networkID))) &&
+					(networkType === RPC && !isKnownNetwork(tx.networkID))) &&
 				tx.status === 'confirmed'
 		);
 		if (txs.length > 0) {

--- a/app/util/etherscan.js
+++ b/app/util/etherscan.js
@@ -1,3 +1,5 @@
+import { MAINNET } from '../constants/network';
+
 /**
  * Gets the etherscan link for an address in a specific network
  *
@@ -27,6 +29,6 @@ export function getEtherscanTransactionUrl(network, tx_hash) {
  * @returns - string
  */
 export function getEtherscanBaseUrl(network) {
-	const subdomain = network.toLowerCase() === 'mainnet' ? '' : `${network.toLowerCase()}.`;
+	const subdomain = network.toLowerCase() === MAINNET ? '' : `${network.toLowerCase()}.`;
 	return `https://${subdomain}etherscan.io`;
 }

--- a/app/util/format.js
+++ b/app/util/format.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
+export const capitalize = str => (str && str.charAt(0).toUpperCase() + str.slice(1)) || false;

--- a/app/util/format.js
+++ b/app/util/format.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -53,9 +53,7 @@ const NetworkList = {
 
 export default NetworkList;
 
-export function getAllNetworks() {
-	return ['mainnet', 'ropsten', 'kovan', 'rinkeby', 'goerli'];
-}
+export const getAllNetworks = () => Object.keys(NetworkList).filter(name => name !== 'rpc');
 
 export function getNetworkTypeById(id) {
 	const network = Object.keys(NetworkList).filter(key => NetworkList[key].networkId === parseInt(id, 10));

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -57,10 +57,7 @@ export default NetworkList;
 
 export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc');
 
-export const getNetworkName = id => {
-	const name = NetworkListKeys.find(key => NetworkList[key].networkId === Number(id));
-	return name;
-};
+export const getNetworkName = id => NetworkListKeys.find(key => NetworkList[key].networkId === Number(id));
 
 export function getNetworkTypeById(id) {
 	const network = NetworkListKeys.filter(key => NetworkList[key].networkId === parseInt(id, 10));

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -60,6 +60,9 @@ export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc
 export const getNetworkName = id => NetworkListKeys.find(key => NetworkList[key].networkId === Number(id));
 
 export function getNetworkTypeById(id) {
+	if (!id) {
+		throw new Error('Missing network Id');
+	}
 	const network = NetworkListKeys.filter(key => NetworkList[key].networkId === parseInt(id, 10));
 	if (network.length > 0) {
 		return network[0];

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -58,7 +58,7 @@ export default NetworkList;
 export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc');
 
 export const getNetworkName = id => {
-	const name = NetworkListKeys.find(key => NetworkList[key].networkId === parseInt(id, 10));
+	const name = NetworkListKeys.find(key => NetworkList[key].networkId === Number(id));
 	return name;
 };
 

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -51,12 +51,19 @@ const NetworkList = {
 	}
 };
 
+const NetworkListKeys = Object.keys(NetworkList);
+
 export default NetworkList;
 
-export const getAllNetworks = () => Object.keys(NetworkList).filter(name => name !== 'rpc');
+export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc');
+
+export const getNetworkName = id => {
+	const name = NetworkListKeys.find(key => NetworkList[key].networkId === parseInt(id, 10));
+	return name;
+};
 
 export function getNetworkTypeById(id) {
-	const network = Object.keys(NetworkList).filter(key => NetworkList[key].networkId === parseInt(id, 10));
+	const network = NetworkListKeys.filter(key => NetworkList[key].networkId === parseInt(id, 10));
 	if (network.length > 0) {
 		return network[0];
 	}
@@ -69,9 +76,7 @@ export function hasBlockExplorer(key) {
 }
 
 export function isKnownNetwork(id) {
-	const knownNetworks = Object.keys(NetworkList)
-		.map(key => NetworkList[key].networkId)
-		.filter(id => id !== undefined);
+	const knownNetworks = NetworkListKeys.map(key => NetworkList[key].networkId).filter(id => id !== undefined);
 	return knownNetworks.includes(parseInt(id, 10));
 }
 

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -57,6 +57,11 @@ export default NetworkList;
 
 export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc');
 
+export const isMainNet = network => {
+	const is_main = network?.provider?.type === 'mainnet' || network === String(1);
+	return is_main;
+};
+
 export const getNetworkName = id => NetworkListKeys.find(key => NetworkList[key].networkId === Number(id));
 
 export function getNetworkTypeById(id) {

--- a/app/util/networks.js
+++ b/app/util/networks.js
@@ -1,5 +1,6 @@
 import { colors } from '../styles/common';
 import URL from 'url-parse';
+import { MAINNET, ROPSTEN, KOVAN, RINKEBY, GOERLI, RPC } from '../../app/constants/network';
 
 /**
  * List of the supported networks
@@ -9,42 +10,42 @@ import URL from 'url-parse';
  * navbar and the network switcher.
  */
 const NetworkList = {
-	mainnet: {
+	[MAINNET]: {
 		name: 'Ethereum Main Network',
 		shortName: 'Ethereum',
 		networkId: 1,
 		chainId: 1,
 		color: '#3cc29e'
 	},
-	ropsten: {
+	[ROPSTEN]: {
 		name: 'Ropsten Test Network',
 		shortName: 'Ropsten',
 		networkId: 3,
 		chainId: 3,
 		color: '#ff4a8d'
 	},
-	kovan: {
+	[KOVAN]: {
 		name: 'Kovan Test Network',
 		shortName: 'Kovan',
 		networkId: 42,
 		chainId: 42,
 		color: '#7057ff'
 	},
-	rinkeby: {
+	[RINKEBY]: {
 		name: 'Rinkeby Test Network',
 		shortName: 'Rinkeby',
 		networkId: 4,
 		chainId: 4,
 		color: '#f6c343'
 	},
-	goerli: {
+	[GOERLI]: {
 		name: 'Goerli Test Network',
 		shortName: 'Goerli',
 		networkId: 5,
 		chainId: 5,
 		color: '#3099f2'
 	},
-	rpc: {
+	[RPC]: {
 		name: 'Private Network',
 		shortName: 'Private',
 		color: colors.grey000
@@ -55,10 +56,10 @@ const NetworkListKeys = Object.keys(NetworkList);
 
 export default NetworkList;
 
-export const getAllNetworks = () => NetworkListKeys.filter(name => name !== 'rpc');
+export const getAllNetworks = () => NetworkListKeys.filter(name => name !== RPC);
 
-export const isMainNet = network => {
-	const is_main = network?.provider?.type === 'mainnet' || network === String(1);
+export const isMainNet = (network, provider) => {
+	const is_main = network?.provider?.type === MAINNET || network === String(1);
 	return is_main;
 };
 
@@ -77,7 +78,7 @@ export function getNetworkTypeById(id) {
 }
 
 export function hasBlockExplorer(key) {
-	return key.toLowerCase() !== 'rpc';
+	return key.toLowerCase() !== RPC;
 }
 
 export function isKnownNetwork(id) {

--- a/app/util/networks.test.js
+++ b/app/util/networks.test.js
@@ -1,0 +1,42 @@
+import { getNetworkName, getAllNetworks, getNetworkTypeById } from './networks';
+
+describe('getAllNetworks', () => {
+	const allNetworks = getAllNetworks();
+	it('should get all networks', () => {
+		expect(allNetworks.includes('mainnet')).toEqual(true);
+		expect(allNetworks.includes('ropsten')).toEqual(true);
+		expect(allNetworks.includes('goerli')).toEqual(true);
+	});
+	it('should exclude rpc', () => {
+		expect(allNetworks.includes('rpc')).toEqual(false);
+	});
+});
+
+describe('getNetworkName', () => {
+	it('should get network name', () => {
+		const main = getNetworkName(String(1));
+		expect(main).toEqual('mainnet');
+	});
+});
+
+describe('getNetworkTypeById', () => {
+	it('should get network type by Id', () => {
+		const type = getNetworkTypeById(42);
+		expect(type).toEqual('kovan');
+	});
+	it('should fail if network Id is missing', () => {
+		try {
+			getNetworkTypeById();
+		} catch (error) {
+			expect(error.message).toEqual('Missing network Id');
+		}
+	});
+	it('should fail if network Id is unknown', () => {
+		const id = 9999;
+		try {
+			getNetworkTypeById(id);
+		} catch (error) {
+			expect(error.message).toEqual(`Unknown network with id ${id}`);
+		}
+	});
+});

--- a/app/util/networks.test.js
+++ b/app/util/networks.test.js
@@ -1,5 +1,5 @@
 import { isMainNet, getNetworkName, getAllNetworks, getNetworkTypeById } from './networks';
-import { MAINNET, ROPSTEN, GOERLI, RPC } from '../../app/constants/network';
+import { MAINNET, ROPSTEN, GOERLI, RPC, KOVAN } from '../../app/constants/network';
 
 describe('getAllNetworks', () => {
 	const allNetworks = getAllNetworks();
@@ -48,7 +48,7 @@ describe('getNetworkName', () => {
 describe('getNetworkTypeById', () => {
 	it('should get network type by Id', () => {
 		const type = getNetworkTypeById(42);
-		expect(type).toEqual('kovan');
+		expect(type).toEqual(KOVAN);
 	});
 	it('should fail if network Id is missing', () => {
 		try {

--- a/app/util/networks.test.js
+++ b/app/util/networks.test.js
@@ -1,21 +1,47 @@
-import { getNetworkName, getAllNetworks, getNetworkTypeById } from './networks';
+import { isMainNet, getNetworkName, getAllNetworks, getNetworkTypeById } from './networks';
+import { MAINNET, ROPSTEN, GOERLI, RPC } from '../../app/constants/network';
 
 describe('getAllNetworks', () => {
 	const allNetworks = getAllNetworks();
 	it('should get all networks', () => {
-		expect(allNetworks.includes('mainnet')).toEqual(true);
-		expect(allNetworks.includes('ropsten')).toEqual(true);
-		expect(allNetworks.includes('goerli')).toEqual(true);
+		expect(allNetworks.includes(MAINNET)).toEqual(true);
+		expect(allNetworks.includes(ROPSTEN)).toEqual(true);
+		expect(allNetworks.includes(GOERLI)).toEqual(true);
 	});
 	it('should exclude rpc', () => {
-		expect(allNetworks.includes('rpc')).toEqual(false);
+		expect(allNetworks.includes(RPC)).toEqual(false);
+	});
+});
+
+describe('isMainNet', () => {
+	it(`should return true if the selected network is ${MAINNET}`, () => {
+		expect(isMainNet('1')).toEqual(true);
+		expect(
+			isMainNet({
+				provider: {
+					type: MAINNET
+				}
+			})
+		).toEqual(true);
+	});
+	it(`should return false if the selected network is not ${MAINNET}`, () => {
+		expect(isMainNet('42')).toEqual(false);
+		expect(
+			isMainNet({
+				network: {
+					provider: {
+						type: ROPSTEN
+					}
+				}
+			})
+		).toEqual(false);
 	});
 });
 
 describe('getNetworkName', () => {
 	it('should get network name', () => {
 		const main = getNetworkName(String(1));
-		expect(main).toEqual('mainnet');
+		expect(main).toEqual(MAINNET);
 	});
 });
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -579,6 +579,7 @@
 		"review_function": "Function",
 		"review_hex_data": "Hex data",
 		"insufficient": "Insufficient funds",
+		"insufficient_amount": "You need {{amount}} more ETH to complete this transaction.",
 		"insufficient_tokens": "Insufficient {{token}}",
 		"invalid_address": "Invalid address",
 		"invalid_amount": "Invalid amount",

--- a/locales/en.json
+++ b/locales/en.json
@@ -580,6 +580,7 @@
 		"review_hex_data": "Hex data",
 		"insufficient": "Insufficient funds",
 		"insufficient_amount": "You need {{amount}} more ETH to complete this transaction.",
+		"buy_more_eth": "Buy more ETH",
 		"insufficient_tokens": "Insufficient {{token}}",
 		"invalid_address": "Invalid address",
 		"invalid_amount": "Invalid amount",

--- a/locales/en.json
+++ b/locales/en.json
@@ -579,7 +579,7 @@
 		"review_function": "Function",
 		"review_hex_data": "Hex data",
 		"insufficient": "Insufficient funds",
-		"insufficient_amount": "You need {{amount}} more ETH to complete this transaction.",
+		"insufficient_amount": "You need {{amount}} more {{tokenSymbol}} to complete this transaction.",
 		"buy_more_eth": "Buy more ETH",
 		"insufficient_tokens": "Insufficient {{token}}",
 		"invalid_address": "Invalid address",

--- a/locales/en.json
+++ b/locales/en.json
@@ -581,6 +581,7 @@
 		"insufficient": "Insufficient funds",
 		"insufficient_amount": "You need {{amount}} more {{tokenSymbol}} to complete this transaction.",
 		"buy_more_eth": "Buy more ETH",
+		"get_ether": "Get Ether for the {{network}} network.",
 		"insufficient_tokens": "Insufficient {{token}}",
 		"invalid_address": "Invalid address",
 		"invalid_amount": "Invalid amount",

--- a/locales/en.json
+++ b/locales/en.json
@@ -581,7 +581,7 @@
 		"insufficient": "Insufficient funds",
 		"insufficient_amount": "You need {{amount}} more {{tokenSymbol}} to complete this transaction.",
 		"buy_more_eth": "Buy more ETH",
-		"get_ether": "Get Ether for the {{network}} network.",
+		"get_ether": "Get Ether for the {{networkName}} network.",
 		"insufficient_tokens": "Insufficient {{token}}",
 		"invalid_address": "Invalid address",
 		"invalid_amount": "Invalid amount",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Make 'Insufficient fee' error descriptive & add link to Buy ETH

Previously we were only displaying "Insufficient funds":

![image](https://user-images.githubusercontent.com/675259/102513912-d2edd100-4059-11eb-9396-ba026d477c87.png)

Now we display a more detailed error with the amount of ETH required along with a link to buy more ETH:

![image](https://user-images.githubusercontent.com/675259/102653276-c55d4780-413c-11eb-8e51-b7e95087160d.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/mobile-planning/issues/7
