### PR TITLE
Add withPreventDoubleClick HoC

### DIFF
--- a/app/components/UI/Button/index.js
+++ b/app/components/UI/Button/index.js
@@ -37,7 +37,7 @@ Button.propTypes = {
 	/**
 	 * Styles to be applied to the Button
 	 */
-	style: ViewPropTypes.style.isRequired,
+	style: ViewPropTypes.style,
 	/**
 	 * Function to be called on press
 	 */

--- a/app/components/UI/Button/index.js
+++ b/app/components/UI/Button/index.js
@@ -41,7 +41,7 @@ Button.propTypes = {
 	/**
 	 * Function to be called on press
 	 */
-	onPress: PropTypes.func.isRequired
+	onPress: PropTypes.func
 };
 
 export default Button;

--- a/app/components/UI/Button/index.js
+++ b/app/components/UI/Button/index.js
@@ -33,15 +33,15 @@ Button.propTypes = {
 	 * it can be a text node, an image, or an icon
 	 * or an Array with a combination of them
 	 */
-	children: PropTypes.any,
+	children: PropTypes.any.isRequired,
 	/**
 	 * Styles to be applied to the Button
 	 */
-	style: ViewPropTypes.style,
+	style: ViewPropTypes.style.isRequired,
 	/**
 	 * Function to be called on press
 	 */
-	onPress: PropTypes.func
+	onPress: PropTypes.func.isRequired
 };
 
 export default Button;

--- a/app/components/UI/SettingsDrawer/index.js
+++ b/app/components/UI/SettingsDrawer/index.js
@@ -5,7 +5,7 @@ import { colors, fontStyles } from '../../../styles/common';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import SettingsNotification from '../SettingsNotification';
 import { strings } from '../../../../locales/i18n';
-import withPreventDoubleClick from '../WithPreventDoubleClick';
+import { withPreventDoubleClick } from '../WithPreventDoubleClick';
 
 const styles = StyleSheet.create({
 	root: {

--- a/app/components/UI/SettingsDrawer/index.js
+++ b/app/components/UI/SettingsDrawer/index.js
@@ -5,6 +5,7 @@ import { colors, fontStyles } from '../../../styles/common';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import SettingsNotification from '../SettingsNotification';
 import { strings } from '../../../../locales/i18n';
+import withPreventDoubleClick from '../WithPreventDoubleClick';
 
 const styles = StyleSheet.create({
 	root: {
@@ -103,4 +104,4 @@ const SettingsDrawer = ({ title, description, noBorder, onPress, warning }) => (
 SettingsDrawer.propTypes = propTypes;
 SettingsDrawer.defaultProps = defaultProps;
 
-export default SettingsDrawer;
+export default withPreventDoubleClick(SettingsDrawer);

--- a/app/components/UI/WithPreventDoubleClick/__snapshots__/index.test.js.snap
+++ b/app/components/UI/WithPreventDoubleClick/__snapshots__/index.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WithPreventDoubleClick should render correctly 1`] = `<Component />`;
+exports[`withPreventDoubleClick should render correctly 1`] = `
+<withPreventDoubleClick(ButtonWithOnPress)
+  onPress={[Function]}
+/>
+`;

--- a/app/components/UI/WithPreventDoubleClick/__snapshots__/index.test.js.snap
+++ b/app/components/UI/WithPreventDoubleClick/__snapshots__/index.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WithPreventDoubleClick should render correctly 1`] = `<Component />`;

--- a/app/components/UI/WithPreventDoubleClick/index.js
+++ b/app/components/UI/WithPreventDoubleClick/index.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export const withPreventDoubleClickErrorMsg = 'Expected Component to wrap';
+export const withPreventDoubleClickName = 'withPreventDoubleClick';
 
 export const withPreventDoubleClick = WrappedComponent => {
 	if (!WrappedComponent) {
@@ -24,6 +25,6 @@ export const withPreventDoubleClick = WrappedComponent => {
 	};
 	const name = WrappedComponent.displayName || WrappedComponent.name;
 	PreventDoubleClick.propTypes = propTypes;
-	PreventDoubleClick.displayName = `withPreventDoubleClick(${name})`;
+	PreventDoubleClick.displayName = `${withPreventDoubleClickName}(${name})`;
 	return PreventDoubleClick;
 };

--- a/app/components/UI/WithPreventDoubleClick/index.js
+++ b/app/components/UI/WithPreventDoubleClick/index.js
@@ -2,11 +2,12 @@ import { debounce } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const propTypes = {
-	onPress: PropTypes.func.isRequired
-};
+export const withPreventDoubleClickErrorMsg = 'Expected Component to wrap';
 
-const withPreventDoubleClick = WrappedComponent => {
+export const withPreventDoubleClick = WrappedComponent => {
+	if (!WrappedComponent) {
+		throw new Error(withPreventDoubleClickErrorMsg);
+	}
 	class PreventDoubleClick extends Component {
 		debouncedOnPress = () => {
 			this.props.onPress && this.props.onPress();
@@ -18,11 +19,11 @@ const withPreventDoubleClick = WrappedComponent => {
 			return <WrappedComponent {...this.props} onPress={this.onPress} />;
 		}
 	}
-
+	const propTypes = {
+		onPress: PropTypes.func.isRequired
+	};
 	const name = WrappedComponent.displayName || WrappedComponent.name;
 	PreventDoubleClick.propTypes = propTypes;
 	PreventDoubleClick.displayName = `withPreventDoubleClick(${name})`;
 	return PreventDoubleClick;
 };
-
-export default withPreventDoubleClick;

--- a/app/components/UI/WithPreventDoubleClick/index.js
+++ b/app/components/UI/WithPreventDoubleClick/index.js
@@ -1,0 +1,28 @@
+import { debounce } from 'lodash';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+	onPress: PropTypes.func.isRequired
+};
+
+const withPreventDoubleClick = WrappedComponent => {
+	class PreventDoubleClick extends Component {
+		debouncedOnPress = () => {
+			this.props.onPress && this.props.onPress();
+		};
+
+		onPress = debounce(this.debouncedOnPress, 300, { leading: true, trailing: false });
+
+		render() {
+			return <WrappedComponent {...this.props} onPress={this.onPress} />;
+		}
+	}
+
+	const name = WrappedComponent.displayName || WrappedComponent.name;
+	PreventDoubleClick.propTypes = propTypes;
+	PreventDoubleClick.displayName = `withPreventDoubleClick(${name})`;
+	return PreventDoubleClick;
+};
+
+export default withPreventDoubleClick;

--- a/app/components/UI/WithPreventDoubleClick/index.js
+++ b/app/components/UI/WithPreventDoubleClick/index.js
@@ -20,11 +20,11 @@ export const withPreventDoubleClick = WrappedComponent => {
 			return <WrappedComponent {...this.props} onPress={this.onPress} />;
 		}
 	}
-	const propTypes = {
+
+	const name = WrappedComponent.displayName || WrappedComponent.name;
+	PreventDoubleClick.propTypes = {
 		onPress: PropTypes.func.isRequired
 	};
-	const name = WrappedComponent.displayName || WrappedComponent.name;
-	PreventDoubleClick.propTypes = propTypes;
 	PreventDoubleClick.displayName = `${withPreventDoubleClickName}(${name})`;
 	return PreventDoubleClick;
 };

--- a/app/components/UI/WithPreventDoubleClick/index.test.js
+++ b/app/components/UI/WithPreventDoubleClick/index.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import WithPreventDoubleClick from './';
+
+describe('WithPreventDoubleClick', () => {
+	it('should render correctly', () => {
+		const wrapper = shallow(<WithPreventDoubleClick onPress={() => ({})} />);
+		expect(wrapper).toMatchSnapshot();
+	});
+});

--- a/app/components/UI/WithPreventDoubleClick/index.test.js
+++ b/app/components/UI/WithPreventDoubleClick/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '../Button';
-import { withPreventDoubleClickErrorMsg, withPreventDoubleClick } from './';
+import { withPreventDoubleClickErrorMsg, withPreventDoubleClick, withPreventDoubleClickName } from './';
 
 const noop = () => ({});
 
@@ -14,7 +14,7 @@ describe('withPreventDoubleClick', () => {
 
 	it('should be wrapped and named correctly', () => {
 		const ButtonWithOnPress = () => <Button onPress={noop} />;
-		const name = `withPreventDoubleClick(${ButtonWithOnPress.name})`;
+		const name = `${withPreventDoubleClickName}(${ButtonWithOnPress.name})`;
 		const WithPreventDoubleClickButton = withPreventDoubleClick(ButtonWithOnPress);
 		const wrapper = <WithPreventDoubleClickButton onPress={noop} />;
 		expect(wrapper.type.displayName).toBe(name);

--- a/app/components/UI/WithPreventDoubleClick/index.test.js
+++ b/app/components/UI/WithPreventDoubleClick/index.test.js
@@ -1,10 +1,30 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import WithPreventDoubleClick from './';
+import Button from '../Button';
+import { withPreventDoubleClickErrorMsg, withPreventDoubleClick } from './';
 
-describe('WithPreventDoubleClick', () => {
+const noop = () => ({});
+
+describe('withPreventDoubleClick', () => {
 	it('should render correctly', () => {
-		const wrapper = shallow(<WithPreventDoubleClick onPress={() => ({})} />);
+		const ButtonWithOnPress = () => <Button onPress={noop} />;
+		const WithPreventDoubleClickButton = withPreventDoubleClick(ButtonWithOnPress);
+		const wrapper = <WithPreventDoubleClickButton onPress={noop} />;
 		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('should be wrapped and named correctly', () => {
+		const ButtonWithOnPress = () => <Button onPress={noop} />;
+		const name = `withPreventDoubleClick(${ButtonWithOnPress.name})`;
+		const WithPreventDoubleClickButton = withPreventDoubleClick(ButtonWithOnPress);
+		const wrapper = <WithPreventDoubleClickButton onPress={noop} />;
+		expect(wrapper.type.displayName).toBe(name);
+	});
+
+	it('should throw an error if Component is not provided', () => {
+		try {
+			withPreventDoubleClick();
+		} catch (e) {
+			expect(e.message).toBe(withPreventDoubleClickErrorMsg);
+		}
 	});
 });

--- a/app/components/Views/Settings/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Settings/__snapshots__/index.test.js.snap
@@ -11,38 +11,38 @@ exports[`Settings should render correctly 1`] = `
     }
   }
 >
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="Currency conversion, primary currency, language and search engine"
     onPress={[Function]}
     title="General"
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="Privacy settings, MetaMetrics, private key and wallet seed phrase"
     onPress={[Function]}
     title="Security & Privacy"
     warning={false}
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="Access developer features, reset account, setup testnets, sync with extension, state logs, IPFS gateway and custom RPC"
     onPress={[Function]}
     title="Advanced"
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="Add, edit, remove, and manage your accounts"
     onPress={[Function]}
     title="Contacts"
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="Add and edit custom RPC networks"
     onPress={[Function]}
     title="Networks"
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     description="WalletConnect & more..."
     onPress={[Function]}
     title="Experimental"
   />
-  <SettingsDrawer
+  <withPreventDoubleClick(SettingsDrawer)
     onPress={[Function]}
     title="About MetaMask"
   />

--- a/app/components/Views/Settings/index.js
+++ b/app/components/Views/Settings/index.js
@@ -39,37 +39,37 @@ class Settings extends PureComponent {
 
 	onPressGeneral = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_GENERAL));
-		this.props.navigation.push('GeneralSettings');
+		this.props.navigation.navigate('GeneralSettings');
 	};
 
 	onPressAdvanced = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_ADVANCED));
-		this.props.navigation.push('AdvancedSettings');
+		this.props.navigation.navigate('AdvancedSettings');
 	};
 
 	onPressSecurity = () => {
 		InteractionManager.runAfterInteractions(() =>
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_SECURITY_AND_PRIVACY)
 		);
-		this.props.navigation.push('SecuritySettings');
+		this.props.navigation.navigate('SecuritySettings');
 	};
 
 	onPressNetworks = () => {
-		this.props.navigation.push('NetworksSettings');
+		this.props.navigation.navigate('NetworksSettings');
 	};
 
 	onPressExperimental = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_EXPERIMENTAL));
-		this.props.navigation.push('ExperimentalSettings');
+		this.props.navigation.navigate('ExperimentalSettings');
 	};
 
 	onPressInfo = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_ABOUT));
-		this.props.navigation.push('CompanySettings');
+		this.props.navigation.navigate('CompanySettings');
 	};
 
 	onPressContacts = () => {
-		this.props.navigation.push('ContactsSettings');
+		this.props.navigation.navigate('ContactsSettings');
 	};
 
 	render = () => {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "is-url": "^1.2.4",
     "json-rpc-engine": "5.1.5",
     "json-rpc-middleware-stream": "2.1.1",
+    "lodash": "^4.17.20",
     "lottie-react-native": "git+https://github.com/MetaMask/lottie-react-native.git#7ce6a78ac4ac7b9891bc513cb3f12f8b9c9d9106",
     "multihashes": "0.4.14",
     "number-to-bn": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8369,6 +8369,11 @@ lodash@4.x.x, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This makes it so you can't double click in Settings (this component might be useful elsewhere?)

**Before:**
(you could double click on a setting and it'll push the same thing to the navigation stack twice)

https://user-images.githubusercontent.com/675259/104971619-4d916f80-59bd-11eb-8cbe-f97a0ab8989a.mp4

**After:**
(accidentally double clicking only pushes one thing to the stack)

https://user-images.githubusercontent.com/675259/104971726-9d703680-59bd-11eb-9cc3-48d939cc1bd0.mp4


**Checklist**

* [x] Tests are included if applicable