### PR TITLE
Add missing brew installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To learn how to develop MetaMask-compatible applications, visit our [Developer D
 ### Building Locally
 
 The code is built using React-Native and running code locally requires a Mac or Linux OS.
+- Install [sentry-cli](https://github.com/getsentry/sentry-cli) tools: `brew install getsentry/tools/sentry-cli`
 
 - Install [Node.js](https://nodejs.org) **version 10 (latest stable) and yarn@1 (latest)**
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Helps to ensure the developer can resolve the following error when building for IOS: 
```
line 7: /usr/local/bin/sentry-cli: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented