### PR TITLE
Initialize NetworkController.provider with chainId

### DIFF
--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -78,37 +78,34 @@ class Engine {
 					}),
 					new PersonalMessageManager(),
 					new MessageManager(),
-					new NetworkController(
-						{
-							infuraProjectId: process.env.MM_INFURA_PROJECT_ID || EMPTY,
-							providerConfig: {
-								static: {
-									eth_sendTransaction: async (payload, next, end) => {
-										const { TransactionController } = this.datamodel.context;
-										try {
-											const hash = await (await TransactionController.addTransaction(
-												payload.params[0],
-												payload.origin
-											)).result;
-											end(undefined, hash);
-										} catch (error) {
-											end(error);
-										}
+					new NetworkController({
+						infuraProjectId: process.env.MM_INFURA_PROJECT_ID || EMPTY,
+						providerConfig: {
+							static: {
+								eth_sendTransaction: async (payload, next, end) => {
+									const { TransactionController } = this.datamodel.context;
+									try {
+										const hash = await (await TransactionController.addTransaction(
+											payload.params[0],
+											payload.origin
+										)).result;
+										end(undefined, hash);
+									} catch (error) {
+										end(error);
 									}
-								},
-								getAccounts: (end, payload) => {
-									const { approvedHosts, privacyMode } = store.getState();
-									const isEnabled = !privacyMode || approvedHosts[payload.hostname];
-									const { KeyringController } = this.datamodel.context;
-									const isUnlocked = KeyringController.isUnlocked();
-									const selectedAddress = this.datamodel.context.PreferencesController.state
-										.selectedAddress;
-									end(null, isUnlocked && isEnabled && selectedAddress ? [selectedAddress] : []);
 								}
+							},
+							getAccounts: (end, payload) => {
+								const { approvedHosts, privacyMode } = store.getState();
+								const isEnabled = !privacyMode || approvedHosts[payload.hostname];
+								const { KeyringController } = this.datamodel.context;
+								const isUnlocked = KeyringController.isUnlocked();
+								const selectedAddress = this.datamodel.context.PreferencesController.state
+									.selectedAddress;
+								end(null, isUnlocked && isEnabled && selectedAddress ? [selectedAddress] : []);
 							}
-						},
-						{ network: '1', provider: { type: MAINNET } }
-					),
+						}
+					}),
 					new PhishingController(),
 					new PreferencesController(
 						{},


### PR DESCRIPTION
We weren't passing a `chainId` to the default provider config. This PR removes the inline provider config and just uses the default defined by the controller itself, which is Mainnet with a chain ID.