### PR TITLE
Add fiat on ramp modal close button extra hit area

### DIFF
--- a/app/components/UI/FiatOrders/components/PaymentMethod/Modal.js
+++ b/app/components/UI/FiatOrders/components/PaymentMethod/Modal.js
@@ -77,7 +77,7 @@ const PaymentMethodModal = ({ isVisible, title, dismiss, children }) => (
 		<SafeAreaView style={styles.modalView}>
 			<View style={styles.title}>
 				<Title>{title}</Title>
-				<TouchableOpacity onPress={dismiss}>
+				<TouchableOpacity onPress={dismiss} hitSlop={{ top: 20, right: 20, bottom: 20, left: 20 }}>
 					<CloseIcon />
 				</TouchableOpacity>
 			</View>


### PR DESCRIPTION
**Description**

Add fiat on ramp modal close button extra hit area

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #2172
