### PR TITLE
Use navigate instead of push

### DIFF
--- a/app/components/Views/Settings/index.js
+++ b/app/components/Views/Settings/index.js
@@ -39,37 +39,37 @@ class Settings extends PureComponent {
 
 	onPressGeneral = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_GENERAL));
-		this.props.navigation.push('GeneralSettings');
+		this.props.navigation.navigate('GeneralSettings');
 	};
 
 	onPressAdvanced = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_ADVANCED));
-		this.props.navigation.push('AdvancedSettings');
+		this.props.navigation.navigate('AdvancedSettings');
 	};
 
 	onPressSecurity = () => {
 		InteractionManager.runAfterInteractions(() =>
 			Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_SECURITY_AND_PRIVACY)
 		);
-		this.props.navigation.push('SecuritySettings');
+		this.props.navigation.navigate('SecuritySettings');
 	};
 
 	onPressNetworks = () => {
-		this.props.navigation.push('NetworksSettings');
+		this.props.navigation.navigate('NetworksSettings');
 	};
 
 	onPressExperimental = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_EXPERIMENTAL));
-		this.props.navigation.push('ExperimentalSettings');
+		this.props.navigation.navigate('ExperimentalSettings');
 	};
 
 	onPressInfo = () => {
 		InteractionManager.runAfterInteractions(() => Analytics.trackEvent(ANALYTICS_EVENT_OPTS.SETTINGS_ABOUT));
-		this.props.navigation.push('CompanySettings');
+		this.props.navigation.navigate('CompanySettings');
 	};
 
 	onPressContacts = () => {
-		this.props.navigation.push('ContactsSettings');
+		this.props.navigation.navigate('ContactsSettings');
 	};
 
 	render = () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Instead of #2122 I realised we should just be using `.navigate` instead of `.push`

> If you run this code, you'll notice that when you tap "Go to Details... again" that it doesn't do anything! This is because we are already on the Details route. The navigate function roughly means "go to this screen", and if you are already on that screen then it makes sense that it would do nothing.

there's likely a few other spots where we could make this same improvement 
