### PR TITLE
Fix "Text strings must be rendered within a <Text> component"

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -203,6 +203,7 @@ const styles = StyleSheet.create({
 	error: {
 		color: colors.red,
 		fontSize: 12,
+		lineHeight: 16,
 		...fontStyles.normal,
 		textAlign: 'center'
 	},

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -39,7 +39,7 @@ class TransactionReviewFeeCard extends PureComponent {
 		/**
 		 * Total transaction value in fiat
 		 */
-		totalFiat: PropTypes.object,
+		totalFiat: PropTypes.string,
 		/**
 		 * Transaction value in fiat before gas fee
 		 */
@@ -142,7 +142,7 @@ class TransactionReviewFeeCard extends PureComponent {
 					{!!totalFiat && this.renderIfGasEstimationReady(totalAmount)}
 				</Summary.Row>
 				<Summary.Row end last>
-					{this.renderIfGasEstimationReady(equivalentTotalAmount)}
+					{this.renderIfGasEstimationReady(<Text bold>{equivalentTotalAmount}</Text>)}
 				</Summary.Row>
 			</Summary>
 		);

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -39,7 +39,7 @@ class TransactionReviewFeeCard extends PureComponent {
 		/**
 		 * Total transaction value in fiat
 		 */
-		totalFiat: PropTypes.string,
+		totalFiat: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node, PropTypes.string]),
 		/**
 		 * Transaction value in fiat before gas fee
 		 */

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -106,6 +106,7 @@ const styles = StyleSheet.create({
 	error: {
 		color: colors.red,
 		fontSize: 12,
+		lineHeight: 16,
 		...fontStyles.normal,
 		textAlign: 'center'
 	},

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -203,6 +203,7 @@ const styles = StyleSheet.create({
 	error: {
 		color: colors.red,
 		fontSize: 12,
+		lineHeight: 16,
 		...fontStyles.normal,
 		textAlign: 'center'
 	},


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

There's an error when you try to do token transfer in a dapp

Before:

![image](https://user-images.githubusercontent.com/675259/106364940-455ffb00-6300-11eb-945f-18f241ccf37e.png)

After:

![image](https://user-images.githubusercontent.com/675259/106364980-822bf200-6300-11eb-9f96-ecfe5cc7417c.png)

Notes:

I actually broke this in https://github.com/MetaMask/metamask-mobile/pull/2076/files#diff-3b63689d21af01cd00a2246b982b5d0c8471f65049cd3693179c90bc05d4418cR145

I have to check a couple of other things out, it's odd that the `usd` is lower case here.

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #2179
