### PR TITLE
Swaps: fix Use Max by adding `fromTokenMinimalUnitString`

### DIFF
--- a/app/components/UI/Swaps/components/QuotesModal.js
+++ b/app/components/UI/Swaps/components/QuotesModal.js
@@ -7,7 +7,7 @@ import IonicIcon from 'react-native-vector-icons/Ionicons';
 import { connect } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import {
-	fromTokenMinimalUnit,
+	fromTokenMinimalUnitString,
 	renderFromTokenMinimalUnit,
 	renderFromWei,
 	toWei,
@@ -258,7 +258,7 @@ function QuotesModal({
 									<View style={styles.detailsRow}>
 										<Text small>{strings('swaps.guaranteed_amount')}</Text>
 										<Text primary>
-											{fromTokenMinimalUnit(
+											{fromTokenMinimalUnitString(
 												selectedDetailsQuote.destinationAmount,
 												destinationToken.decimals
 											)}{' '}

--- a/app/components/UI/Swaps/components/TransactionsEditionModal.js
+++ b/app/components/UI/Swaps/components/TransactionsEditionModal.js
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
 import Modal from 'react-native-modal';
-import { fromTokenMinimalUnit, hexToBN, toTokenMinimalUnit } from '../../../../util/number';
+import { fromTokenMinimalUnitString, hexToBN, toTokenMinimalUnit } from '../../../../util/number';
 import CustomGas from '../../CustomGas';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import EditPermission from '../../ApproveTransactionReview/EditPermission';
@@ -84,7 +84,7 @@ function TransactionsEditionModal({
 		if (originalApprovalTransaction) {
 			const approvalTransactionAmount = decodeApproveData(originalApprovalTransaction.data).encodedAmount;
 			const amountDec = hexToBN(approvalTransactionAmount).toString();
-			setApprovalTransactionAmount(fromTokenMinimalUnit(amountDec, sourceToken.decimals));
+			setApprovalTransactionAmount(fromTokenMinimalUnitString(amountDec, sourceToken.decimals));
 		}
 	}, [originalApprovalTransaction, sourceToken.decimals, setApprovalTransaction]);
 	return (

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -7,7 +7,7 @@ import { View as AnimatableView } from 'react-native-animatable';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
 import Logger from '../../../util/Logger';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { balanceToFiat, fromTokenMinimalUnit, toTokenMinimalUnit, weiToFiat } from '../../../util/number';
+import { balanceToFiat, fromTokenMinimalUnitString, toTokenMinimalUnit, weiToFiat } from '../../../util/number';
 import { swapsUtils } from '@estebanmino/controllers';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
 
@@ -326,7 +326,7 @@ function SwapsAmountView({
 		if (!sourceToken || !balanceAsUnits) {
 			return;
 		}
-		setAmount(fromTokenMinimalUnit(balanceAsUnits.toString(), sourceToken.decimals));
+		setAmount(fromTokenMinimalUnitString(balanceAsUnits.toString(), sourceToken.decimals));
 	}, [balanceAsUnits, sourceToken]);
 
 	const handleSlippageChange = useCallback(value => {

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -75,8 +75,7 @@ export function fromTokenMinimalUnitString(minimalInput, decimals) {
 	const tokenFormat = ethersUtils.formatUnits(minimalInput, decimals);
 	const isInteger = Boolean(INTEGER_REGEX.exec(tokenFormat));
 
-	// eslint-disable-next-line prefer-const
-	let [integerPart, decimalPart] = tokenFormat.split('.');
+	const [integerPart, decimalPart] = tokenFormat.split('.');
 	if (isInteger) {
 		return integerPart;
 	}

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -2,6 +2,7 @@
  * Collection of utility functions for consistent formatting and conversion
  */
 import { addHexPrefix, BN } from 'ethereumjs-util';
+import { utils as ethersUtils } from 'ethers';
 import convert from 'ethjs-unit';
 import { util } from '@metamask/controllers';
 import numberToBN from 'number-to-bn';
@@ -55,6 +56,31 @@ export function fromTokenMinimalUnit(minimalInput, decimals) {
 		value = '-' + value;
 	}
 	return value;
+}
+
+const INTEGER_REGEX = /^-?\d*(\.0+|\.)?$/;
+
+/**
+ * Converts token minimal unit to readable string value
+ *
+ * @param {string} minimalInput - Token minimal unit to convert
+ * @param {number} decimals - Token decimals to convert
+ * @returns {string} - String containing the new number
+ */
+export function fromTokenMinimalUnitString(minimalInput, decimals) {
+	if (typeof minimalInput !== 'string') {
+		throw new TypeError('minimalInput must be a string');
+	}
+
+	const tokenFormat = ethersUtils.formatUnits(minimalInput, decimals);
+	const isInteger = Boolean(INTEGER_REGEX.exec(tokenFormat));
+
+	// eslint-disable-next-line prefer-const
+	let [integerPart, decimalPart] = tokenFormat.split('.');
+	if (isInteger) {
+		return integerPart;
+	}
+	return `${integerPart}.${decimalPart}`;
 }
 
 /**

--- a/app/util/number.test.js
+++ b/app/util/number.test.js
@@ -3,6 +3,7 @@ import {
 	BNToHex,
 	fromWei,
 	fromTokenMinimalUnit,
+	fromTokenMinimalUnitString,
 	toTokenMinimalUnit,
 	renderFromTokenMinimalUnit,
 	renderFromWei,
@@ -66,6 +67,88 @@ describe('Number utils :: fromTokenMinimalUnit', () => {
 		expect(fromTokenMinimalUnit(1e2, 6)).toEqual('0.0001');
 		expect(fromTokenMinimalUnit(1e16, 6)).toEqual('10000000000');
 		expect(fromTokenMinimalUnit(1e18, 18)).toEqual('1');
+	});
+});
+
+describe('Number utils :: fromTokenMinimalUnitString', () => {
+	it('fromTokenMinimalUnit using number', () => {
+		expect(() => fromTokenMinimalUnitString(1337, 6)).toThrow();
+		expect(() => fromTokenMinimalUnitString(1337, 0)).toThrow();
+		expect(() => fromTokenMinimalUnitString(1337, 18)).toThrow();
+	});
+
+	it('fromTokenMinimalUnitString using string', () => {
+		expect(fromTokenMinimalUnitString('1337', 6)).toEqual('0.001337');
+		expect(fromTokenMinimalUnitString('1337', 0)).toEqual('1337');
+		expect(fromTokenMinimalUnitString('1337', 18)).toEqual('0.000000000000001337');
+		expect(fromTokenMinimalUnitString('1234560000000000000', 18)).toEqual('1.23456');
+		expect(fromTokenMinimalUnitString('1000000000000000000', 18)).toEqual('1');
+		expect(fromTokenMinimalUnitString('1', 18)).toEqual('0.000000000000000001');
+		expect(fromTokenMinimalUnitString('0', 18)).toEqual('0');
+		expect(fromTokenMinimalUnitString('123456789', 5)).toEqual('1234.56789');
+		expect(fromTokenMinimalUnitString('1234567890000000000987654321', 18)).toEqual('1234567890.000000000987654321');
+		expect(fromTokenMinimalUnitString('10000000000000000000000000000001', 18)).toEqual(
+			'10000000000000.000000000000000001'
+		);
+		expect(fromTokenMinimalUnitString('10000000000000000000000000000000', 18)).toEqual('10000000000000');
+		expect(fromTokenMinimalUnitString('3900229504248293869', 18)).toEqual('3.900229504248293869');
+		expect(fromTokenMinimalUnitString('92836465327282987373728723', 18)).toEqual('92836465.327282987373728723');
+		expect(fromTokenMinimalUnitString('6123512631253', 16)).toEqual('0.0006123512631253');
+		expect(fromTokenMinimalUnitString('92836465327282987373728723', 0)).toEqual('92836465327282987373728723');
+		expect(fromTokenMinimalUnitString('9283646532728212312312312312312987373728723', 32)).toEqual(
+			'92836465327.28212312312312312312987373728723'
+		);
+		expect(fromTokenMinimalUnitString('-1234560000000000000', 18)).toEqual('-1.23456');
+		expect(fromTokenMinimalUnitString('-1000000000000000000', 18)).toEqual('-1');
+		expect(fromTokenMinimalUnitString('-1', 18)).toEqual('-0.000000000000000001');
+		expect(fromTokenMinimalUnitString('-0', 18)).toEqual('0');
+		expect(fromTokenMinimalUnitString('-123456789', 5)).toEqual('-1234.56789');
+		expect(fromTokenMinimalUnitString('-1234567890000000000987654321', 18)).toEqual(
+			'-1234567890.000000000987654321'
+		);
+		expect(fromTokenMinimalUnitString('-10000000000000000000000000000001', 18)).toEqual(
+			'-10000000000000.000000000000000001'
+		);
+		expect(fromTokenMinimalUnitString('-10000000000000000000000000000000', 18)).toEqual('-10000000000000');
+		expect(fromTokenMinimalUnitString('-3900229504248293869', 18)).toEqual('-3.900229504248293869');
+		expect(fromTokenMinimalUnitString('-92836465327282987373728723', 18)).toEqual('-92836465.327282987373728723');
+		expect(fromTokenMinimalUnitString('-6123512631253', 16)).toEqual('-0.0006123512631253');
+		expect(fromTokenMinimalUnitString('-92836465327282987373728723', 0)).toEqual('-92836465327282987373728723');
+		expect(fromTokenMinimalUnitString('-9283646532728212312312312312312987373728723', 32)).toEqual(
+			'-92836465327.28212312312312312312987373728723'
+		);
+	});
+
+	it('fromTokenMinimalUnitString using BN number', () => {
+		expect(fromTokenMinimalUnitString(new BN('1337').toString(10), 6)).toEqual('0.001337');
+		expect(fromTokenMinimalUnitString(new BN('1337').toString(10), 0)).toEqual('1337');
+		expect(fromTokenMinimalUnitString(new BN('1337').toString(10), 18)).toEqual('0.000000000000001337');
+		expect(fromTokenMinimalUnitString(new BN('123456').toString(), 5)).toEqual('1.23456');
+		expect(fromTokenMinimalUnitString(new BN('123456').toString(), 5)).toEqual('1.23456');
+		expect(fromTokenMinimalUnitString(new BN('1234560000000000000').toString(), 18)).toEqual('1.23456');
+		expect(fromTokenMinimalUnitString(new BN('1000000000000000000').toString(), 18)).toEqual('1');
+		expect(fromTokenMinimalUnitString(new BN('1').toString(), 18)).toEqual('0.000000000000000001');
+		expect(fromTokenMinimalUnitString(new BN('0').toString(), 18)).toEqual('0');
+		expect(fromTokenMinimalUnitString(new BN('123456789').toString(), 5)).toEqual('1234.56789');
+		expect(fromTokenMinimalUnitString(new BN('1234567890000000000987654321').toString(), 18)).toEqual(
+			'1234567890.000000000987654321'
+		);
+		expect(fromTokenMinimalUnitString(new BN('10000000000000000000000000000001').toString(), 18)).toEqual(
+			'10000000000000.000000000000000001'
+		);
+		expect(fromTokenMinimalUnitString(new BN('10000000000000000000000000000000').toString(), 18)).toEqual(
+			'10000000000000'
+		);
+		expect(fromTokenMinimalUnitString(new BN('3900229504248293869').toString(), 18)).toEqual(
+			'3.900229504248293869'
+		);
+		expect(fromTokenMinimalUnitString(new BN('92836465327282987373728723').toString(), 18)).toEqual(
+			'92836465.327282987373728723'
+		);
+		expect(fromTokenMinimalUnitString(new BN('6123512631253').toString(), 16)).toEqual('0.0006123512631253');
+		expect(fromTokenMinimalUnitString(new BN('92836465327282987373728723').toString(), 0)).toEqual(
+			'92836465327282987373728723'
+		);
 	});
 });
 


### PR DESCRIPTION


**Description**

This PR adds a working function to parse minimal units into token format depending on the decimal places of the currency. This makes <kbd>Use Max</kbd> work as expected.

* **Previous wrong behavior**, present in Send Flow (notice balance on the left and value on the right don't match) 
![image](https://user-images.githubusercontent.com/1024246/107300628-a9996200-6a58-11eb-8f6f-749bd036de1d.png)

* **Swaps behavior (values match)**
![image](https://user-images.githubusercontent.com/1024246/107300653-b3bb6080-6a58-11eb-83f6-50f2ab1bde33.png)


**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #2206 
