### PR TITLE
Swaps: Adjust Keypad size for medium and smaller devices

### DIFF
--- a/app/components/Base/Keypad/components.js
+++ b/app/components/Base/Keypad/components.js
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 	},
 	keypadButton: {
 		paddingHorizontal: 20,
-		paddingVertical: Device.isMediumDevice() ? (Device.isIphone5() ? 5 : 10) : 12,
+		paddingVertical: Device.isMediumDevice() ? (Device.isIphone5() ? 4 : 8) : 12,
 		flex: 1,
 		justifyContent: 'center',
 		alignItems: 'center'


### PR DESCRIPTION

**Description**

This PR squeezes keypad rows for medium and smaller devices.
Picture as reference:
![image](https://user-images.githubusercontent.com/1024246/109865018-558e3180-7c42-11eb-8049-cf9ec85d1b4c.png)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #2333
