### PR TITLE
Bugfix/fix pre release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,9 @@ jobs:
           command: sdkmanager --licenses
       - run:
           name: build:pre-release
-          command:
-            |
+          command: |
+              jq 'del(.engines)' package.json > new.json && mv new.json package.json
+              node -v
               METAMASK_ENVIRONMENT='production' yarn build:android:pre-release:bundle
       - store_artifacts:
           path: android/app/build/outputs/bundle/release
@@ -181,7 +182,10 @@ jobs:
             cd ios && pod install && cd ..
       - run:
           name: pre-release
-          command: METAMASK_ENVIRONMENT='production' yarn build:ios:pre-release
+          command: |
+              jq 'del(.engines)' package.json > new.json && mv new.json package.json
+              node -v
+              METAMASK_ENVIRONMENT='production' yarn build:ios:pre-release
       - store_artifacts:
           path: sourcemaps/ios
           destination: sourcemaps-ios


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

It would appear adding `engines` to the `package.json` in #2343 broke `develop` CI.

[You can see that here.](https://circleci.com/gh/MetaMask/metamask-mobile/26009?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

I guess those jobs are just using latest, but I don't think we actually want that?

I am just using `jq` to update the `package.json` in CI which i think is fine for now since I mostly wanted to add this as a developer ergonomic

However, we should investigate getting the proper version of node on these builds

**Checklist**

* [x] Run release jobs on circle to see if this actually works

([You can see that here](https://app.circleci.com/pipelines/github/MetaMask/mm-test/18/workflows/c1eb0b7d-34ee-46d6-a19b-36178166cdba))
