### PR TITLE
Swaps: Sort quotes by asc fees when destination amount is the same

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -320,7 +320,15 @@ function SwapsQuotesView({
 
 		const orderedAggregators = hasConversionRate
 			? Object.values(quoteValues).sort((a, b) => Number(b.overallValueOfQuote) - Number(a.overallValueOfQuote))
-			: Object.values(quotes).sort((a, b) => new BigNumber(b.destinationAmount).comparedTo(a.destinationAmount));
+			: Object.values(quotes).sort((a, b) => {
+					const comparison = new BigNumber(b.destinationAmount).comparedTo(a.destinationAmount);
+					if (comparison === 0) {
+						// If the  destination amount is the same, we sort by fees ascending
+						return Number(quoteValues[a.aggregator].ethFee) - Number(quoteValues[b.aggregator].ethFee);
+					}
+					return comparison;
+					// eslint-disable-next-line no-mixed-spaces-and-tabs
+			  });
 
 		return orderedAggregators.map(quoteValue => quotes[quoteValue.aggregator]);
 	}, [hasConversionRate, quoteValues, quotes]);

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -324,7 +324,9 @@ function SwapsQuotesView({
 					const comparison = new BigNumber(b.destinationAmount).comparedTo(a.destinationAmount);
 					if (comparison === 0) {
 						// If the  destination amount is the same, we sort by fees ascending
-						return Number(quoteValues[a.aggregator].ethFee) - Number(quoteValues[b.aggregator].ethFee);
+						return (
+							Number(quoteValues[a.aggregator]?.ethFee) - Number(quoteValues[b.aggregator]?.ethFee) || 0
+						);
 					}
 					return comparison;
 					// eslint-disable-next-line no-mixed-spaces-and-tabs

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -7,7 +7,6 @@ import { View as AnimatableView } from 'react-native-animatable';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
 import numberToBN from 'number-to-bn';
 import Logger from '../../../util/Logger';
-import { toChecksumAddress } from 'ethereumjs-util';
 import {
 	balanceToFiat,
 	fromTokenMinimalUnitString,
@@ -15,6 +14,7 @@ import {
 	toTokenMinimalUnit,
 	weiToFiat
 } from '../../../util/number';
+import { safeToChecksumAddress } from '../../../util/address';
 import { swapsUtils } from '@estebanmino/controllers';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
 
@@ -251,7 +251,7 @@ function SwapsAmountView({
 	}, [destinationToken]);
 
 	const isTokenInBalances =
-		sourceToken && !isSwapsETH(sourceToken) ? toChecksumAddress(sourceToken.address) in balances : false;
+		sourceToken && !isSwapsETH(sourceToken) ? safeToChecksumAddress(sourceToken.address) in balances : false;
 
 	useEffect(() => {
 		(async () => {
@@ -311,7 +311,7 @@ function SwapsAmountView({
 		if (isSwapsETH(sourceToken)) {
 			balanceFiat = weiToFiat(toTokenMinimalUnit(amount, sourceToken?.decimals), conversionRate, currentCurrency);
 		} else {
-			const sourceAddress = toChecksumAddress(sourceToken.address);
+			const sourceAddress = safeToChecksumAddress(sourceToken.address);
 			const exchangeRate = sourceAddress in tokenExchangeRates ? tokenExchangeRates[sourceAddress] : undefined;
 			balanceFiat = balanceToFiat(amount, conversionRate, exchangeRate, currentCurrency);
 		}


### PR DESCRIPTION


**Description**

When no rate is available, quotes are sorted by destination token amount. This PRs sorts by ascending fees if the destination token amount is the same

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

