### PR TITLE
Display correct number of decimals for 'usd' fiat

### DIFF
--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -235,13 +235,14 @@ class Engine {
 			TokenRatesController
 		} = this.datamodel.context;
 		const { selectedAddress } = PreferencesController.state;
-		const { conversionRate } = CurrencyRateController.state;
+		const { conversionRate, currentCurrency } = CurrencyRateController.state;
 		const { accounts } = AccountTrackerController.state;
 		const { tokens } = AssetsController.state;
 		let ethFiat = 0;
 		let tokenFiat = 0;
 		if (accounts[selectedAddress]) {
-			ethFiat = weiToFiatNumber(accounts[selectedAddress].balance, conversionRate);
+			const decimalsToShow = currentCurrency === 'usd' && 2;
+			ethFiat = weiToFiatNumber(accounts[selectedAddress].balance, conversionRate, decimalsToShow);
 		}
 		if (tokens.length > 0) {
 			const { contractBalances: tokenBalances } = TokenBalancesController.state;
@@ -259,7 +260,7 @@ class Engine {
 		}
 
 		const total = ethFiat + tokenFiat;
-		return +total.toFixed(2);
+		return total;
 	};
 
 	/**

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -241,7 +241,7 @@ class Engine {
 		let ethFiat = 0;
 		let tokenFiat = 0;
 		if (accounts[selectedAddress]) {
-			const decimalsToShow = currentCurrency === 'usd' && 2;
+			const decimalsToShow = (currentCurrency === 'usd' && 2) || undefined;
 			ethFiat = weiToFiatNumber(accounts[selectedAddress].balance, conversionRate, decimalsToShow);
 		}
 		if (tokens.length > 0) {

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -259,7 +259,7 @@ class Engine {
 		}
 
 		const total = ethFiat + tokenFiat;
-		return total;
+		return +total.toFixed(2);
 	};
 
 	/**

--- a/app/util/number.js
+++ b/app/util/number.js
@@ -348,7 +348,7 @@ export function weiToFiat(wei, conversionRate, currencyCode, decimalsToShow = 5)
 		}
 		return `0.00 ${currencyCode}`;
 	}
-	decimalsToShow = currencyCode === 'usd' && 2;
+	decimalsToShow = (currencyCode === 'usd' && 2) || undefined;
 	const value = weiToFiatNumber(wei, conversionRate, decimalsToShow);
 	if (currencySymbols[currencyCode]) {
 		return `${currencySymbols[currencyCode]}${value}`;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I noticed we're not rounding fiat correctly in some instances:

**Before:**

<img src=https://user-images.githubusercontent.com/675259/111176622-e12b8a80-857f-11eb-82b7-9102e4114d38.png width=300 /><img src=https://user-images.githubusercontent.com/675259/111176664-eab4f280-857f-11eb-9459-86bf3fd86537.png width=300 />

**After:**

![image](https://user-images.githubusercontent.com/675259/111177273-73339300-8580-11eb-8d90-8b2738e74769.png)

<strike>This likely needs more work since I don't think adding `toFixed(2)` is an adequate enough solution</strike>. We could probably look at adding `Intl.NumberFormat` in the future.

<strike>Adding the `DONOTMERGE` label and moving this to Draft until we can land on a better solution.</strike>

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
