### PR TITLE
remove jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 	}
 	repositories {
 		google()
-		jcenter()
+		gradlePluginPortal()
 	}
 
 	dependencies {
@@ -46,8 +46,9 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 		google()
-        jcenter()
-        maven { url 'https://www.jitpack.io' }
+		mavenCentral()
+		maven { url 'https://www.jitpack.io' }
+		gradlePluginPortal()
 	}
 
 	subprojects {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Today when building the project I ran into:

```
* What went wrong:
Could not determine the dependencies of task ':app:mergeDebugAssets'.
> Could not resolve all task dependencies for configuration ':app:debugRuntimeClasspath'.
   > Could not resolve org.webkit:android-jsc:+.
     Required by:
         project :app
      > Failed to list versions for org.webkit:android-jsc.
         > Unable to load Maven meta-data from https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml.
            > Could not HEAD 'https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml'.
               > Read timed out
```
then I noticed that jcenter urls were 403'ing `https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml`

As it turns out jcenter has been sunset: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This PR gets things working with `gradlePluginPortal()` and `mavenCentral()`
