### PR TITLE
bugfix/allow seedphrases when locked

### DIFF
--- a/app/components/Views/QRScanner/index.js
+++ b/app/components/Views/QRScanner/index.js
@@ -104,6 +104,13 @@ export default class QrScanner extends PureComponent {
 				this.props.navigation.goBack();
 			}
 		} else {
+			if (!failedSeedPhraseRequirements(content) && isValidMnemonic(content)) {
+				this.shouldReadBarCode = false;
+				data = { seed: content };
+				this.end(data, content);
+				return;
+			}
+
 			const { KeyringController } = Engine.context;
 			const isUnlocked = KeyringController.isUnlocked();
 
@@ -122,13 +129,6 @@ export default class QrScanner extends PureComponent {
 				this.mounted = false;
 				this.props.navigation.goBack();
 				this.props.navigation.state.params.onScanSuccess(data, content);
-				return;
-			}
-
-			if (!failedSeedPhraseRequirements(content) && isValidMnemonic(content)) {
-				this.shouldReadBarCode = false;
-				data = { seed: content };
-				this.end(data, content);
 				return;
 			}
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We need to be able to scan a seedphrase in case the user wants to import wallet in the onboarding flow

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
