### PR TITLE
json-rpc-engine@6.1.0

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -55,7 +55,7 @@ import OnboardingWizard from '../../UI/OnboardingWizard';
 import DrawerStatusTracker from '../../../core/DrawerStatusTracker';
 import { resemblesAddress } from '../../../util/address';
 
-import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware';
+import { createAsyncMiddleware } from 'json-rpc-engine';
 import { ethErrors } from 'eth-json-rpc-errors';
 
 import EntryScriptWeb3 from '../../../core/EntryScriptWeb3';

--- a/app/core/BackgroundBridge.js
+++ b/app/core/BackgroundBridge.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-commonjs */
 import URL from 'url-parse';
 import { NetworksChainId } from '@metamask/controllers';
+import { JsonRpcEngine } from 'json-rpc-engine';
 import { JS_POST_MESSAGE_TO_PROVIDER, JS_IFRAME_POST_MESSAGE_TO_PROVIDER } from '../util/browserScripts';
 import MobilePortStream from './MobilePortStream';
 import { setupMultiplex } from '../util/streams';
@@ -10,7 +11,6 @@ import { getAllNetworks } from '../util/networks';
 import Logger from '../util/Logger';
 import AppConstants from './AppConstants';
 
-const RpcEngine = require('json-rpc-engine');
 const createEngineStream = require('json-rpc-middleware-stream/engineStream');
 const createFilterMiddleware = require('eth-json-rpc-filters');
 const createSubscriptionManager = require('eth-json-rpc-filters/subscriptionManager');
@@ -178,7 +178,7 @@ export class BackgroundBridge extends EventEmitter {
 	setupProviderEngine() {
 		const origin = this.hostname;
 		// setup json rpc engine stack
-		const engine = new RpcEngine();
+		const engine = new JsonRpcEngine();
 		const provider = this.provider;
 
 		const blockTracker = this.blockTracker;

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "fuse.js": "3.4.4",
     "https-browserify": "0.0.1",
     "is-url": "^1.2.4",
-    "json-rpc-engine": "5.1.5",
+    "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "2.1.1",
     "lottie-react-native": "git+https://github.com/MetaMask/lottie-react-native.git#7ce6a78ac4ac7b9891bc513cb3f12f8b9c9d9106",
     "multihashes": "0.4.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,7 +5275,7 @@ eth-json-rpc-errors@^1.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-errors@^2.0.0, eth-json-rpc-errors@^2.0.2:
+eth-json-rpc-errors@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
   integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
@@ -8194,16 +8194,6 @@ json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
-json-rpc-engine@5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.1.5.tgz#a5f9915356ea916d5305716354080723c63dede7"
-  integrity sha512-HTT9HixG4j8vHYrmJIckgbISW9Q8tCkySv7x7Q8zjMpcw10wSe/dZSQ0w08VkDm3y195K4074UlvD3hxaznvlw==
-  dependencies:
-    async "^2.0.1"
-    eth-json-rpc-errors "^2.0.0"
-    promise-to-callback "^1.0.0"
-    safe-event-emitter "^1.0.1"
 
 json-rpc-engine@^5.1.3, json-rpc-engine@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
New major version of `json-rpc-engine`. It's been used in the extension for some time. Single use of the package has been updated.