### PR TITLE
Handle `eth_sign` like `personal_sign` for WalletConnect

### DIFF
--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -130,43 +130,7 @@ class WalletConnect {
 							error
 						});
 					}
-				} else if (payload.method === 'eth_sign') {
-					const { MessageManager } = Engine.context;
-					let rawSig = null;
-					try {
-						if (payload.params[2]) {
-							throw new Error('Autosign is not currently supported');
-							// Leaving this in case we want to enable it in the future
-							// once WCIP-4 is defined: https://github.com/WalletConnect/WCIPs/issues/4
-							// rawSig = await KeyringController.signPersonalMessage({
-							// 	data: payload.params[1],
-							// 	from: payload.params[0]
-							// });
-						} else {
-							const data = payload.params[1];
-							const from = payload.params[0];
-							rawSig = await MessageManager.addUnapprovedMessageAsync({
-								data,
-								from,
-								meta: {
-									title: meta && meta.name,
-									url: meta && meta.url,
-									icon: meta && meta.icons && meta.icons[0]
-								},
-								origin: WALLET_CONNECT_ORIGIN
-							});
-						}
-						this.walletConnector.approveRequest({
-							id: payload.id,
-							result: rawSig
-						});
-					} catch (error) {
-						this.walletConnector.rejectRequest({
-							id: payload.id,
-							error
-						});
-					}
-				} else if (payload.method === 'personal_sign') {
+				} else if (payload.method === 'personal_sign' || payload.method === 'eth_sign') {
 					const { PersonalMessageManager } = Engine.context;
 					let rawSig = null;
 					try {


### PR DESCRIPTION
**Description**

This PR changes how `eth_sign` WalletConnect requests are handled, so that they behave the same as `personal_sign`. The issue arises from MetaMask's `eth_sign` implementation where it accepts the hash of the message to sign instead of the actual message [as is expected by the Ethereum JSONRPC spec](https://eth.wiki/json-rpc/API#eth_sign). This is the [legacy `eth_sign` behaviour](https://docs.metamask.io/guide/signing-data.html#a-brief-history) that was kept this way [in order to maintain backwards compatibility with existing applications](https://github.com/MetaMask/metamask-extension/issues/9957#issuecomment-754826067).

This becomes somewhat of an issue with WalletConnect, however, where [`eth_sign` is expected to prefix and hash the message before signing](https://docs.walletconnect.org/json-rpc-api-methods/ethereum#example-1). This causes issues with DApps that want to use WalletConnect and need to add special handling when connected to a MetaMask mobile peer, since it does not follow the standard for `eth_sign`. As a result, when using MetaMask + WalletConnect with web3.js or Ethers.js, signing a message doesn't quite work (as they end up making `eth_sign` request instead of `personal_sign`).

This PR therefore makes `eth_sign` and `personal_sign` handling of WalletConnect requests behave identically:
- It follows the Ethereum JSONRPC and WalletConnect `eth_sign` standard
- Does not have the same legacy requirements as the MetaMask browser extension

**Issue**

Resolves #2522 
