### PR TITLE
Only get nonce from the network if the feature is enabled

### DIFF
--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -209,7 +209,8 @@ class TransactionReviewInformation extends PureComponent {
 	};
 
 	componentDidMount = async () => {
-		await this.setNetworkNonce();
+		const { showCustomNonce } = this.props;
+		showCustomNonce && (await this.setNetworkNonce());
 	};
 
 	setNetworkNonce = async () => {

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -368,9 +368,9 @@ class Confirm extends PureComponent {
 		// For analytics
 		AnalyticsV2.trackEvent(AnalyticsV2.ANALYTICS_EVENTS.SEND_TRANSACTION_STARTED, this.getAnalyticsParams());
 
-		const { navigation, providerType } = this.props;
+		const { showCustomNonce, navigation, providerType } = this.props;
 		await this.handleFetchBasicEstimates();
-		await this.setNetworkNonce();
+		showCustomNonce && (await this.setNetworkNonce());
 		navigation.setParams({ providerType });
 		this.parseTransactionData();
 		this.prepareTransaction();


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Looking more closely at the custom nonce work that was recently completed I realized we were getting the network nonce and then... not doing anything with it (even for users that have the feature disabled). this change ensures we only get the nonce from the network if the user has the `showCustomNonce` feature enabled.
