### PR TITLE
Fix typeface on login text field

### DIFF
--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -520,6 +520,7 @@ class Login extends PureComponent {
 						<View style={styles.field}>
 							<Text style={styles.label}>{strings('login.password')}</Text>
 							<OutlinedTextField
+								style={styles.input}
 								placeholder={'Password'}
 								testID={'login-password-input'}
 								returnKeyType={'done'}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Something small that was missed in #2375:

| Before        | After           |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/675259/116604194-cf1d6580-a8fb-11eb-8812-0ea6b32f13ac.png) | ![image](https://user-images.githubusercontent.com/675259/116604287-e9574380-a8fb-11eb-9819-859403ada304.png) |

the placeholder text is now the correct typeface.

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #???
