### PR TITLE
Remove autoDismiss prop to always display close button on notification

### DIFF
--- a/app/components/UI/Notification/BaseNotification/index.js
+++ b/app/components/UI/Notification/BaseNotification/index.js
@@ -115,14 +115,7 @@ const getDescription = (status, { amount = null }) => {
 /**
  * BaseNotification component used to render in-app notifications
  */
-const BaseNotification = ({
-	status,
-	data = null,
-	data: { description = null, title = null },
-	onPress,
-	onHide,
-	autoDismiss
-}) => (
+const BaseNotification = ({ status, data = null, data: { description = null, title = null }, onPress, onHide }) => (
 	<View style={baseStyles.flexGrow}>
 		<TouchableOpacity
 			style={styles.defaultFlashFloating}
@@ -138,7 +131,7 @@ const BaseNotification = ({
 				<Text style={styles.flashText}>{!description ? getDescription(status, data) : description}</Text>
 			</View>
 			<View>
-				{autoDismiss && (
+				{onHide && (
 					<TouchableOpacity style={styles.closeTouchable} onPress={onHide}>
 						<IonicIcon name="ios-close" size={36} style={styles.closeIcon} />
 					</TouchableOpacity>
@@ -152,12 +145,7 @@ BaseNotification.propTypes = {
 	status: PropTypes.string,
 	data: PropTypes.object,
 	onPress: PropTypes.func,
-	onHide: PropTypes.func,
-	autoDismiss: PropTypes.bool
-};
-
-BaseNotification.defaultProps = {
-	autoDismiss: false
+	onHide: PropTypes.func
 };
 
 export default BaseNotification;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This makes it so the close button is always displayed on notifications when an `onHide` is provided. The hope here is people can still dismiss this notification if it gets stuck.

![image](https://user-images.githubusercontent.com/675259/117038849-1af25500-acd6-11eb-9b97-cfff0f34591b.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
