### PR TITLE
Migrate to new CurrencyRateController

### DIFF
--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -145,7 +145,7 @@ export class NetworkList extends PureComponent {
 			this.props.onClose(false);
 			InteractionManager.runAfterInteractions(() => {
 				const { NetworkController, CurrencyRateController } = Engine.context;
-				CurrencyRateController.configure({ nativeCurrency: 'ETH' });
+				CurrencyRateController.setNativeCurrency('ETH');
 				NetworkController.setProviderType(type);
 				this.props.thirdPartyApiMode &&
 					setTimeout(() => {
@@ -185,7 +185,7 @@ export class NetworkList extends PureComponent {
 			return;
 		}
 
-		CurrencyRateController.configure({ nativeCurrency: ticker });
+		CurrencyRateController.setNativeCurrency(ticker);
 		NetworkController.setRpcTarget(rpcUrl, chainId, ticker, nickname);
 
 		AnalyticsV2.trackEvent(AnalyticsV2.ANALYTICS_EVENTS.NETWORK_SWITCHED, {

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -348,7 +348,7 @@ class Send extends PureComponent {
 		if (rpc) {
 			const { rpcUrl, chainId, ticker, nickname } = rpc;
 			const { NetworkController, CurrencyRateController } = Engine.context;
-			CurrencyRateController.configure({ nativeCurrency: ticker });
+			CurrencyRateController.setNativeCurrency(ticker);
 			NetworkController.setRpcTarget(rpcUrl, chainId, ticker, nickname);
 			this.props.showAlert({
 				isVisible: true,

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -173,7 +173,7 @@ class Settings extends PureComponent {
 
 	selectCurrency = async currency => {
 		const { CurrencyRateController } = Engine.context;
-		CurrencyRateController.configure({ currentCurrency: currency });
+		CurrencyRateController.setCurrentCurrency(currency);
 	};
 
 	selectLanguage = language => {

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -264,7 +264,7 @@ class NetworkSettings extends PureComponent {
 			const url = new URL(rpcUrl);
 			const decimalChainId = this.getDecimalChainId(chainId);
 			!isprivateConnection(url.hostname) && url.set('protocol', 'https:');
-			CurrencyRateController.configure({ nativeCurrency: ticker });
+			CurrencyRateController.setNativeCurrency(ticker);
 			PreferencesController.addToFrequentRpcList(url.href, decimalChainId, ticker, nickname, {
 				blockExplorerUrl
 			});

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -105,7 +105,7 @@ class NetworksSettings extends PureComponent {
 
 	switchToMainnet = () => {
 		const { NetworkController, CurrencyRateController } = Engine.context;
-		CurrencyRateController.configure({ nativeCurrency: 'ETH' });
+		CurrencyRateController.setNativeCurrency('ETH');
 		NetworkController.setProviderType(MAINNET);
 		this.props.thirdPartyApiMode &&
 			setTimeout(() => {

--- a/app/components/Views/Wallet/index.js
+++ b/app/components/Views/Wallet/index.js
@@ -123,7 +123,7 @@ class Wallet extends PureComponent {
 			const actions = [
 				AssetsDetectionController.detectAssets(),
 				AccountTrackerController.refresh(),
-				CurrencyRateController.poll(),
+				CurrencyRateController.start(),
 				TokenRatesController.poll()
 			];
 			await Promise.all(actions);

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -4,6 +4,7 @@ import {
 	AssetsContractController,
 	AssetsController,
 	AssetsDetectionController,
+	ControllerMessenger,
 	ComposableController,
 	CurrencyRateController,
 	KeyringController,
@@ -60,11 +61,6 @@ class Engine {
 	 */
 	constructor(initialState = {}) {
 		if (!Engine.instance) {
-			const { nativeCurrency, currentCurrency } = initialState.CurrencyRateController || {
-				nativeCurrency: 'eth',
-				currentCurrency: 'usd'
-			};
-
 			const preferencesController = new PreferencesController(
 				{},
 				{
@@ -107,10 +103,12 @@ class Engine {
 				getAssetSymbol: assetsContractController.getAssetSymbol.bind(assetsContractController),
 				getCollectibleTokenURI: assetsContractController.getCollectibleTokenURI.bind(assetsContractController)
 			});
+			this.controllerMessenger = new ControllerMessenger();
 			const currencyRateController = new CurrencyRateController({
-				nativeCurrency,
-				currentCurrency
+				messenger: this.controllerMessenger,
+				state: initialState.CurrencyRateController
 			});
+			currencyRateController.start();
 
 			const controllers = [
 				new KeyringController(
@@ -159,7 +157,8 @@ class Engine {
 				),
 				new TokenRatesController({
 					onAssetsStateChange: listener => assetsController.subscribe(listener),
-					onCurrencyRateStateChange: listener => currencyRateController.subscribe(listener)
+					onCurrencyRateStateChange: listener =>
+						this.controllerMessenger.subscribe(`${currencyRateController.name}:stateChange`, listener)
 				}),
 				new TransactionController({
 					getNetworkState: () => networkController.state,
@@ -179,13 +178,16 @@ class Engine {
 			// TODO: Pass initial state into each controller constructor instead
 			// This is being set post-construction for now to ensure it's functionally equivalent with
 			// how the `ComponsedController` used to set initial state.
+			//
+			// The check for `controller.subscribe !== undefined` is to filter out BaseControllerV2
+			// controllers. They should be initialized via the constructor instead.
 			for (const controller of controllers) {
-				if (initialState[controller.name]) {
+				if (initialState[controller.name] && controller.subscribe !== undefined) {
 					controller.update(initialState[controller.name]);
 				}
 			}
 
-			this.datamodel = new ComposableController(controllers, initialState);
+			this.datamodel = new ComposableController(controllers, this.controllerMessenger);
 			this.context = controllers.reduce((context, controller) => {
 				context[controller.name] = controller;
 				return context;
@@ -492,6 +494,9 @@ let instance;
 export default {
 	get context() {
 		return instance && instance.context;
+	},
+	get controllerMessenger() {
+		return instance && instance.controllerMessenger;
 	},
 	get state() {
 		const {

--- a/app/core/RPCMethods/wallet_addEthereumChain.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.js
@@ -126,7 +126,7 @@ const wallet_addEthereumChain = async ({
 			throw ethErrors.provider.userRejectedRequest();
 		}
 
-		CurrencyRateController.configure({ nativeCurrency: existingNetwork.ticker });
+		CurrencyRateController.setNativeCurrency(existingNetwork.ticker);
 		NetworkController.setRpcTarget(
 			existingNetwork.rpcUrl,
 			chainIdDecimal,
@@ -269,7 +269,7 @@ const wallet_addEthereumChain = async ({
 
 	if (!switchCustomNetworkApprove) throw ethErrors.provider.userRejectedRequest();
 
-	CurrencyRateController.configure({ nativeCurrency: ticker });
+	CurrencyRateController.setNativeCurrency(ticker);
 	NetworkController.setRpcTarget(firstValidRPCUrl, chainIdDecimal, ticker, _chainName);
 
 	res.result = null;

--- a/app/reducers/engine/index.js
+++ b/app/reducers/engine/index.js
@@ -39,7 +39,7 @@ function initalizeEngine(state = {}) {
 		store.dispatch({ type: 'UPDATE_BG_STATE', key: 'AssetsDetectionController' });
 	});
 
-	Engine.context.CurrencyRateController.subscribe(() => {
+	Engine.controllerMessenger.subscribe(`${Engine.context.CurrencyRateController.name}:stateChange`, () => {
 		store.dispatch({ type: 'UPDATE_BG_STATE', key: 'CurrencyRateController' });
 	});
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@exodus/react-native-payments": "https://github.com/wachunei/react-native-payments.git#package-json-hack",
     "@metamask/contract-metadata": "^1.23.0",
-    "@metamask/controllers": "^8.0.0",
+    "@metamask/controllers": "^9.0.0",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/swaps-controller": "^4.0.0",
     "@react-native-community/async-storage": "1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,7 +1539,7 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.23.0.tgz#c70be7f3eaeeb791651ce793b7cdc230e9780b18"
   integrity sha512-oTUqL9dtXtbng60DZMRsBmZ5HiOUUfEsZjuswOJ0yHO24YsW0ktCcgCJVYPv1HcOsF0SVrRtG4rtrvOl4nY+HA==
 
-"@metamask/contract-metadata@^1.24.0":
+"@metamask/contract-metadata@^1.24.0", "@metamask/contract-metadata@^1.25.0":
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.25.0.tgz#442ace91fb40165310764b68d8096d0017bb0492"
   integrity sha512-yhmYB9CQPv0dckNcPoWDcgtrdUp0OgK0uvkRE5QIBv4b3qENI1/03BztvK2ijbTuMlORUpjPq7/1MQDUPoRPVw==
@@ -1556,6 +1556,38 @@
     eth-ens-namehash "^2.0.8"
     eth-json-rpc-infura "^5.1.0"
     eth-keyring-controller "^6.1.0"
+    eth-method-registry "1.1.0"
+    eth-phishing-detect "^1.1.13"
+    eth-query "^2.1.2"
+    eth-rpc-errors "^4.0.0"
+    eth-sig-util "^3.0.0"
+    ethereumjs-tx "^1.3.7"
+    ethereumjs-util "^6.1.0"
+    ethereumjs-wallet "^1.0.1"
+    ethjs-util "^0.1.6"
+    human-standard-collectible-abi "^1.0.2"
+    human-standard-token-abi "^2.0.0"
+    immer "^8.0.1"
+    isomorphic-fetch "^3.0.0"
+    jsonschema "^1.2.4"
+    nanoid "^3.1.12"
+    single-call-balance-checker-abi "^1.0.0"
+    uuid "^8.3.2"
+    web3 "^0.20.7"
+    web3-provider-engine "^16.0.1"
+
+"@metamask/controllers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-9.0.0.tgz#b8661f6fad246b20b92f684a63ab268b0e5248a7"
+  integrity sha512-qj6sKw5j7a542i+EnN/XJW2JsZZzYbj5j8NjYBiRE70kNsyTQ7iXaaEdyXO6re+OAI5M1ULuWgTULoFlWiuHcA==
+  dependencies:
+    "@metamask/contract-metadata" "^1.25.0"
+    "@types/uuid" "^8.3.0"
+    async-mutex "^0.2.6"
+    babel-runtime "^6.26.0"
+    eth-ens-namehash "^2.0.8"
+    eth-json-rpc-infura "^5.1.0"
+    eth-keyring-controller "^6.2.1"
     eth-method-registry "1.1.0"
     eth-phishing-detect "^1.1.13"
     eth-query "^2.1.2"
@@ -5266,6 +5298,17 @@ eth-hd-keyring@^3.5.0:
     events "^1.1.1"
     xtend "^4.0.1"
 
+eth-hd-keyring@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-3.6.0.tgz#6835d30aa411b8d3ef098e82f6427b5325082abb"
+  integrity sha512-n2CwE9VNXsxLrXQa6suv0Umt4NT6+HtoahKgWx3YviXx4rQFwVT5nDwZfjhwrT31ESuoXYNIeJgz5hKLD96QeQ==
+  dependencies:
+    bip39 "^2.2.0"
+    eth-sig-util "^3.0.1"
+    eth-simple-keyring "^4.2.0"
+    ethereumjs-util "^7.0.9"
+    ethereumjs-wallet "^1.0.1"
+
 eth-json-rpc-errors@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz#148377ef55155585981c21ff574a8937f9d6991f"
@@ -5354,6 +5397,21 @@ eth-keyring-controller@^6.1.0:
     loglevel "^1.5.0"
     obs-store "^4.0.3"
 
+eth-keyring-controller@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.2.1.tgz#61901071fc74059ed37cb5ae93870fdcae6e3781"
+  integrity sha512-x2gTM1iHp2Kbvdtd9Eslysw0qzVZiqOzpVB3AU/ni2Xiit+rlcv2H80zYKjrEwlfWFDj4YILD3bOqlnEMmRJOA==
+  dependencies:
+    bip39 "^2.4.0"
+    bluebird "^3.5.0"
+    browser-passworder "^2.0.3"
+    eth-hd-keyring "^3.6.0"
+    eth-sig-util "^3.0.1"
+    eth-simple-keyring "^4.2.0"
+    ethereumjs-util "^7.0.9"
+    loglevel "^1.5.0"
+    obs-store "^4.0.3"
+
 eth-method-registry@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eth-method-registry/-/eth-method-registry-1.1.0.tgz#3cc01bd23dcf513428d14a0bb19910652cc5cac0"
@@ -5429,6 +5487,16 @@ eth-sig-util@^3.0.0:
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"
 
+eth-sig-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.1.tgz#8753297c83a3f58346bd13547b59c4b2cd110c96"
+  integrity sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==
+  dependencies:
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.0"
+
 eth-simple-keyring@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-3.5.0.tgz#c7fa285ca58d31ef44bc7db678b689f9ffd7b453"
@@ -5440,6 +5508,16 @@ eth-simple-keyring@^3.5.0:
     ethereumjs-wallet "^0.6.0"
     events "^1.1.1"
     xtend "^4.0.1"
+
+eth-simple-keyring@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-4.2.0.tgz#c197a4bd4cce7d701b5f3607d0b843112ddb17e3"
+  integrity sha512-lBxFObXJTBjktDkQszXrqoB317wghEUYATQ3W19vLAjaznrmbdy1lccPhXIRMT9bHIUgNKOJQkLohNZiT9tO8Q==
+  dependencies:
+    eth-sig-util "^3.0.1"
+    ethereumjs-util "^7.0.9"
+    ethereumjs-wallet "^1.0.1"
+    events "^1.1.1"
 
 eth-url-parser@1.0.2:
   version "1.0.2"
@@ -5501,7 +5579,7 @@ ethereumjs-abi@0.6.6:
     bn.js "^4.10.0"
     ethereumjs-util "^5.0.0"
 
-ethereumjs-abi@^0.6.5, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.5, ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:
@@ -5610,7 +5688,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0:
     rlp "^2.2.3"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@^7.0.10:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.9:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
@@ -13019,7 +13097,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-tweetnacl@^1.0.0:
+tweetnacl@^1.0.0, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==


### PR DESCRIPTION
**Description**

The CurrencyRateController has been migrated to the BaseControllerV2 API, which includes various API changes. These changes include:
* The constructor now expects to be passed a `RestrictedControllerMessenger`.
* State changes are subscribed to via the `ControllerMessenger` now, rather than via a `subscribe` function.
* The state and configuration are passed in as one "options" object, rather than as two separate parameters
* The polling needs to be started explicitly by calling `start`. It can be stopped and started on-demand now as well.
* Changing the current currency or native currency will now throw an error if we fail to update the conversion rate.

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented