### PR TITLE
Swaps: Add wETH as swaps autoSign tx

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -64,6 +64,8 @@ import Analytics from '../../../core/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
 import BigNumber from 'bignumber.js';
 import { setInfuraAvailabilityBlocked, setInfuraAvailabilityNotBlocked } from '../../../actions/infuraAvailability';
+import { isSwapsContract } from '../../UI/Swaps/utils';
+import { toLowerCaseCompare } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	flex: {
@@ -318,11 +320,13 @@ const Main = props => {
 			// if destination address is metaswap contract
 			if (
 				to &&
-				(to === swapsUtils.getSwapsContractAddress(props.chainId) ||
+				// TODO: replace with wETH contract once swaps-controller exposes the variable
+				((toLowerCaseCompare(to, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2') &&
+					transactionMeta.origin === process.env.MM_FOX_CODE) ||
+					isSwapsContract(to, props.chainId) ||
 					(data &&
 						data.substr(0, 10) === APPROVE_FUNCTION_SIGNATURE &&
-						decodeApproveData(data).spenderAddress?.toLowerCase() ===
-							swapsUtils.getSwapsContractAddress(props.chainId)))
+						isSwapsContract(decodeApproveData(data).spenderAddress?.toLowerCase(), props.chainId)))
 			) {
 				if (transactionMeta.origin === process.env.MM_FOX_CODE) {
 					autoSign(transactionMeta);

--- a/app/components/UI/Swaps/utils/index.js
+++ b/app/components/UI/Swaps/utils/index.js
@@ -22,6 +22,11 @@ export function isSwapsNativeAsset(token) {
 	return Boolean(token) && token?.address === swapsUtils.NATIVE_SWAPS_TOKEN_ADDRESS;
 }
 
+export function isSwapsContract(contract, chainId) {
+	if (!contract) return false;
+	return contract === swapsUtils.getSwapsContractAddress(chainId);
+}
+
 /**
  * Sets required parameters for Swaps Quotes View
  * @param {string} sourceTokenAddress Token contract address used as swaps source


### PR DESCRIPTION
**Description**

This PR allows trades with wETH contract address as target to be handled a Swaps transaction

**Checklist**


* [x] Add wETH contract address as Swaps
* [ ] upgrade swaps-controller
* [ ] use wETH contract address variable from swapscontroller
* [ ] Review Transaction Item rendering 


