### PR TITLE
Remove Picker deprecation warning

### DIFF
--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView, StyleSheet, Text, View, TouchableOpacity, Picker } from 'react-native';
+import { ScrollView, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { Picker } from '@react-native-community/picker';
 import { fontStyles, colors, baseStyles } from '../../../styles/common';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import Modal from 'react-native-modal';

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@react-native-community/cookies": "^4.0.1",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "6.0.0",
+    "@react-native-community/picker": "^1.8.1",
     "@react-native-community/viewpager": "^3.3.0",
     "@rnhooks/keyboard": "^0.0.3",
     "@sentry/integrations": "6.3.1",

--- a/patches/react-native+0.63.4.patch
+++ b/patches/react-native+0.63.4.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js b/node_modules/react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
+index a4e0cc0..4f4c9ea 100644
+--- a/node_modules/react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
++++ b/node_modules/react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
+@@ -10,7 +10,8 @@
+ 'use strict';
+
+ const React = require('react');
+-const {NativeModules, Picker, View} = require('react-native');
++const {NativeModules, View} = require('react-native');
++const {Picker} = require('@react-native-community/picker');
+ const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+ const {Recording: RecordingModule} = NativeModules;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.0.tgz#2a4d7190b508dd0c2293656c9c1aa068f6f60a71"
   integrity sha512-Z9M8VGcF2IZVOo2x+oUStvpCW/8HjIRi4+iQCu5n+PhC7OqCQX58KYAzdBr///alIfRXiu6oMb+lK+rXQH1FvQ==
 
+"@react-native-community/picker@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/picker/-/picker-1.8.1.tgz#94f14f0aad98fa7592967b941be97deec95c3805"
+  integrity sha512-Sj9DzX1CSnmYiuEQ5fQhExoo4XjSKoZkqLPAAybycq6RHtCuWppf+eJXRMCOJki25BlKSSt+qVqg0fIe//ujNQ==
+
 "@react-native-community/viewpager@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-2.0.2.tgz#622b190294b1310c4825c98daeaee1c8443f7124"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This removes the deprecation error (previously it was a warning) for Picker. It requires a patch to react-native, but I am sure we can get rid of that once we upgrade.


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
