### PR TITLE
Add missing required prop in tests

### DIFF
--- a/app/components/Views/Approval/index.test.js
+++ b/app/components/Views/Approval/index.test.js
@@ -5,6 +5,9 @@ import { shallow } from 'enzyme';
 import { ROPSTEN } from '../../../constants/network';
 
 const mockStore = configureMockStore();
+const navigation = { state: { params: { address: '0x1' } } };
+// noop
+navigation.setParams = params => ({ ...params });
 
 describe('Approval', () => {
 	it('should render correctly', () => {
@@ -39,7 +42,7 @@ describe('Approval', () => {
 			}
 		};
 
-		const wrapper = shallow(<Approval />, {
+		const wrapper = shallow(<Approval navigation={navigation} />, {
 			context: { store: mockStore(initialState) }
 		});
 		expect(wrapper.dive()).toMatchSnapshot();


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Just something small I noticed in one of our tests:

```
Warning: Failed prop type: The prop `navigation` is marked as required in `Approval`, but its value is `undefined`.
```

and the `noop` is to avoid this TypeError:

```
TypeError: navigation.setParams is not a function
```
