### PR TITLE
Don't render swap router address in recents

### DIFF
--- a/app/components/UI/AddCustomCollectible/index.js
+++ b/app/components/UI/AddCustomCollectible/index.js
@@ -10,7 +10,7 @@ import { isSmartContractAddress } from '../../../util/transactions';
 import Device from '../../../util/Device';
 import { connect } from 'react-redux';
 import AnalyticsV2 from '../../../util/analyticsV2';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -169,7 +169,7 @@ class AddCustomCollectible extends PureComponent {
 		const { selectedAddress } = this.props;
 		try {
 			const owner = await AssetsContractController.getOwnerOf(address, tokenId);
-			return toLowerCaseCompare(owner, selectedAddress);
+			return toLowerCaseEquals(owner, selectedAddress);
 		} catch (e) {
 			return false;
 		}

--- a/app/components/UI/AssetSearch/index.js
+++ b/app/components/UI/AssetSearch/index.js
@@ -6,7 +6,7 @@ import { strings } from '../../../../locales/i18n';
 import contractMap from '@metamask/contract-metadata';
 import Fuse from 'fuse.js';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	searchSection: {
@@ -68,7 +68,7 @@ export default class AssetSearch extends PureComponent {
 	handleSearch = searchQuery => {
 		this.setState({ searchQuery });
 		const fuseSearchResult = fuse.search(searchQuery);
-		const addressSearchResult = contractList.filter(token => toLowerCaseCompare(token.address, searchQuery));
+		const addressSearchResult = contractList.filter(token => toLowerCaseEquals(token.address, searchQuery));
 		const results = [...addressSearchResult, ...fuseSearchResult];
 		this.props.onSearch({ searchQuery, results });
 	};

--- a/app/components/UI/CollectibleContractOverview/index.js
+++ b/app/components/UI/CollectibleContractOverview/index.js
@@ -10,7 +10,7 @@ import { toggleCollectibleContractModal } from '../../../actions/modals';
 import { connect } from 'react-redux';
 import collectiblesTransferInformation from '../../../util/collectibles-transfer';
 import { newAssetTransaction } from '../../../actions/transaction';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -86,7 +86,7 @@ class CollectibleContractOverview extends PureComponent {
 	onSend = () => {
 		const { collectibleContract, collectibles } = this.props;
 		const collectible = collectibles.find(collectible =>
-			toLowerCaseCompare(collectible.address, collectibleContract.address)
+			toLowerCaseEquals(collectible.address, collectibleContract.address)
 		);
 		this.props.newAssetTransaction(collectible);
 		this.props.navigation.navigate('SendFlowView');

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -12,7 +12,7 @@ import CollectibleModal from '../CollectibleModal';
 import { favoritesCollectiblesObjectSelector } from '../../../reducers/collectibles';
 import Text from '../../Base/Text';
 import AppConstants from '../../../core/AppConstants';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -97,7 +97,7 @@ const CollectibleContracts = ({ collectibleContracts, collectibles, navigation, 
 	const renderCollectibleContract = useCallback(
 		(item, index) => {
 			const contractCollectibles = collectibles?.filter(collectible =>
-				toLowerCaseCompare(collectible.address, item.address)
+				toLowerCaseEquals(collectible.address, item.address)
 			);
 			return (
 				<CollectibleContractElement

--- a/app/components/UI/EthInput/index.js
+++ b/app/components/UI/EthInput/index.js
@@ -25,7 +25,7 @@ import { getTicker, getNormalizedTxState } from '../../../util/transactions';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import Device from '../../../util/Device';
 import NetworkMainAssetLogo from '../NetworkMainAssetLogo';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	root: {
@@ -284,7 +284,7 @@ class EthInput extends PureComponent {
 				break;
 			case 'CONTRACT_COLLECTIBLE_TRANSACTION': {
 				const collectiblesToShow = collectibles.filter(collectible =>
-					toLowerCaseCompare(collectible.address, transaction.selectedAsset.address)
+					toLowerCaseEquals(collectible.address, transaction.selectedAsset.address)
 				);
 				this.setState({
 					assets: collectiblesToShow

--- a/app/components/UI/PaymentRequest/index.js
+++ b/app/components/UI/PaymentRequest/index.js
@@ -39,7 +39,7 @@ import Device from '../../../util/Device';
 import currencySymbols from '../../../util/currency-symbols.json';
 import { NetworksChainId } from '@metamask/controllers';
 import { getTicker } from '../../../util/transactions';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const KEYBOARD_OFFSET = 120;
 const styles = StyleSheet.create({
@@ -343,7 +343,7 @@ class PaymentRequest extends PureComponent {
 		}
 
 		const fuseSearchResult = fuse.search(searchInputValue);
-		const addressSearchResult = contractList.filter(token => toLowerCaseCompare(token.address, searchInputValue));
+		const addressSearchResult = contractList.filter(token => toLowerCaseEquals(token.address, searchInputValue));
 		const results = [...addressSearchResult, ...fuseSearchResult];
 		this.setState({ searchInputValue, results });
 	};

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -52,7 +52,7 @@ import useBalance from './utils/useBalance';
 import useGasPrice from './utils/useGasPrice';
 import { trackErrorAsAnalytics } from '../../../util/analyticsV2';
 import { decodeApproveData, getTicker } from '../../../util/transactions';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 import { swapsTokensSelector } from '../../../reducers/swaps';
 
 const POLLING_INTERVAL = AppConstants.SWAPS.POLLING_INTERVAL;
@@ -294,8 +294,8 @@ function SwapsQuotesView({
 	);
 
 	/* Get tokens from the tokens list */
-	const sourceToken = swapsTokens?.find(token => toLowerCaseCompare(token.address, sourceTokenAddress));
-	const destinationToken = swapsTokens?.find(token => toLowerCaseCompare(token.address, destinationTokenAddress));
+	const sourceToken = swapsTokens?.find(token => toLowerCaseEquals(token.address, sourceTokenAddress));
+	const destinationToken = swapsTokens?.find(token => toLowerCaseEquals(token.address, destinationTokenAddress));
 
 	const hasConversionRate =
 		Boolean(destinationToken) &&

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -49,7 +49,7 @@ import SlippageModal from './components/SlippageModal';
 import useBalance from './utils/useBalance';
 import useBlockExplorer from './utils/useBlockExplorer';
 import InfoModal from './components/InfoModal';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	screen: {
@@ -161,11 +161,11 @@ function SwapsAmountView({
 	const [isInitialLoadingTokens, setInitialLoadingTokens] = useState(false);
 	const [, setLoadingTokens] = useState(false);
 	const [isSourceSet, setIsSourceSet] = useState(() =>
-		Boolean(swapsTokens?.find(token => toLowerCaseCompare(token.address, initialSource)))
+		Boolean(swapsTokens?.find(token => toLowerCaseEquals(token.address, initialSource)))
 	);
 
 	const [sourceToken, setSourceToken] = useState(() =>
-		swapsTokens?.find(token => toLowerCaseCompare(token.address, initialSource))
+		swapsTokens?.find(token => toLowerCaseEquals(token.address, initialSource))
 	);
 	const [destinationToken, setDestinationToken] = useState(null);
 	const [hasDismissedTokenAlert, setHasDismissedTokenAlert] = useState(true);
@@ -192,7 +192,7 @@ function SwapsAmountView({
 					InteractionManager.runAfterInteractions(() => {
 						const parameters = {
 							source: initialSource === SWAPS_NATIVE_ADDRESS ? 'MainView' : 'TokenView',
-							activeCurrency: swapsTokens?.find(token => toLowerCaseCompare(token.address, initialSource))
+							activeCurrency: swapsTokens?.find(token => toLowerCaseEquals(token.address, initialSource))
 								?.symbol,
 							chain_id: chainId
 						};
@@ -248,7 +248,7 @@ function SwapsAmountView({
 	useEffect(() => {
 		if (!isSourceSet && initialSource && swapsTokens && !sourceToken) {
 			setIsSourceSet(true);
-			setSourceToken(swapsTokens.find(token => toLowerCaseCompare(token.address, initialSource)));
+			setSourceToken(swapsTokens.find(token => toLowerCaseEquals(token.address, initialSource)));
 		}
 	}, [initialSource, isSourceSet, sourceToken, swapsTokens]);
 

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -18,7 +18,7 @@ import contractMap from '@metamask/contract-metadata';
 import { safeToChecksumAddress } from '../../../util/address';
 import TransactionTypes from '../../../core/TransactionTypes';
 import { MAINNET } from '../../../constants/network';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -381,7 +381,7 @@ class TransactionEditor extends PureComponent {
 		const { selectedAddress } = this.props;
 		try {
 			const owner = await AssetsContractController.getOwnerOf(address, tokenId);
-			const isOwner = toLowerCaseCompare(owner, selectedAddress);
+			const isOwner = toLowerCaseEquals(owner, selectedAddress);
 			if (!isOwner) {
 				return strings('transaction.invalid_collectible_ownership');
 			}

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -25,7 +25,7 @@ import contractMap from '@metamask/contract-metadata';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { swapsUtils } from '@metamask/swaps-controller';
 import { isSwapsNativeAsset } from '../Swaps/utils';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const { getSwapsContractAddress } = swapsUtils;
 
@@ -139,7 +139,7 @@ function getCollectibleTransfer(args) {
 	let actionKey;
 	const [, tokenId] = decodeTransferData('transfer', data);
 	const ticker = getTicker(args.ticker);
-	const collectible = collectibleContracts.find(collectible => toLowerCaseCompare(collectible.address, to));
+	const collectible = collectibleContracts.find(collectible => toLowerCaseEquals(collectible.address, to));
 	if (collectible) {
 		actionKey = `${strings('transactions.sent')} ${collectible.name}`;
 	} else {
@@ -335,7 +335,7 @@ function decodeTransferFromTx(args) {
 		selectedAddress
 	} = args;
 	const [addressFrom, addressTo, tokenId] = decodeTransferData('transferFrom', data);
-	const collectible = collectibleContracts.find(collectible => toLowerCaseCompare(collectible.address, to));
+	const collectible = collectibleContracts.find(collectible => toLowerCaseEquals(collectible.address, to));
 	let actionKey = args.actionKey;
 	if (collectible) {
 		actionKey = `${strings('transactions.sent')} ${collectible.name}`;

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -11,7 +11,7 @@ import { getNetworkNavbarOptions } from '../../UI/Navbar';
 import Engine from '../../../core/Engine';
 import { safeToChecksumAddress } from '../../../util/address';
 import { addAccountTimeFlagFilter } from '../../../util/transactions';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -146,7 +146,7 @@ class Asset extends PureComponent {
 		) {
 			if (isTransfer)
 				return this.props.tokens.find(({ address }) =>
-					toLowerCaseCompare(address, transferInformation.contractAddress)
+					toLowerCaseEquals(address, transferInformation.contractAddress)
 				);
 			return true;
 		}

--- a/app/components/Views/Collectible/index.js
+++ b/app/components/Views/Collectible/index.js
@@ -10,7 +10,7 @@ import Engine from '../../../core/Engine';
 import Modal from 'react-native-modal';
 import CollectibleContractInformation from '../../UI/CollectibleContractInformation';
 import { toggleCollectibleContractModal } from '../../../actions/modals';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -76,7 +76,7 @@ class Collectible extends PureComponent {
 		const address = params.address;
 		const { collectibles } = this.props;
 		const filteredCollectibles = collectibles.filter(collectible =>
-			toLowerCaseCompare(collectible.address, address)
+			toLowerCaseEquals(collectible.address, address)
 		);
 		filteredCollectibles.map(collectible => {
 			if (!collectible.name || collectible.name === '') {

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -44,7 +44,7 @@ import ErrorBoundary from '../ErrorBoundary';
 import WarningExistingUserModal from '../../UI/WarningExistingUserModal';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { trackErrorAsAnalytics } from '../../../util/analyticsV2';
-import { tlc, toLowerCaseCompare } from '../../../util/general';
+import { tlc, toLowerCaseEquals } from '../../../util/general';
 
 const isTextDelete = text => tlc(text) === 'delete';
 const deviceHeight = Device.getDeviceHeight();
@@ -314,8 +314,8 @@ class Login extends PureComponent {
 			// Should we force people to enable passcode / biometrics?
 			const error = e.toString();
 			if (
-				toLowerCaseCompare(error, WRONG_PASSWORD_ERROR) ||
-				toLowerCaseCompare(error, WRONG_PASSWORD_ERROR_ANDROID)
+				toLowerCaseEquals(error, WRONG_PASSWORD_ERROR) ||
+				toLowerCaseEquals(error, WRONG_PASSWORD_ERROR_ANDROID)
 			) {
 				this.setState({ loading: false, error: strings('login.invalid_password') });
 
@@ -328,7 +328,7 @@ class Login extends PureComponent {
 					'In order to proceed, you need to turn Passcode on or any biometrics authentication method supported in your device (FaceID, TouchID or Fingerprint)'
 				);
 				this.setState({ loading: false });
-			} else if (toLowerCaseCompare(error, VAULT_ERROR)) {
+			} else if (toLowerCaseEquals(error, VAULT_ERROR)) {
 				this.setState({
 					loading: false,
 					error: CLEAN_VAULT_ERROR

--- a/app/components/Views/SendFlow/AddressList/index.js
+++ b/app/components/Views/SendFlow/AddressList/index.js
@@ -13,7 +13,7 @@ import {
 	TRANSFER_FROM_FUNCTION_SIGNATURE
 } from '../../../../util/transactions';
 import { swapsUtils } from '@metamask/swaps-controller';
-import { toLowerCaseCompare } from '../../../../util/general';
+import { toLowerCaseEquals } from '../../../../util/general';
 
 const styles = StyleSheet.create({
 	root: {
@@ -181,7 +181,7 @@ class AddressList extends PureComponent {
 				if (
 					!recents.includes(checksummedTo) &&
 					!Object.keys(identities).includes(checksummedTo) &&
-					!toLowerCaseCompare(checksummedTo, getSwapsContractAddress)
+					!toLowerCaseEquals(checksummedTo, getSwapsContractAddress)
 				) {
 					recents.push(checksummedTo);
 					if (this.networkAddressBook[checksummedTo]) {

--- a/app/components/Views/SendFlow/AddressList/index.js
+++ b/app/components/Views/SendFlow/AddressList/index.js
@@ -12,9 +12,8 @@ import {
 	TRANSFER_FUNCTION_SIGNATURE,
 	TRANSFER_FROM_FUNCTION_SIGNATURE
 } from '../../../../util/transactions';
-
-// MetaMask: Swap Router
-const MM_SWAP_ROUTER = '0x881D40237659C251811CEC9c364ef91dC08D300C';
+import { swapsUtils } from '@metamask/swaps-controller';
+import { toLowerCaseCompare } from '../../../../util/general';
 
 const styles = StyleSheet.create({
 	root: {
@@ -100,7 +99,11 @@ class AddressList extends PureComponent {
 		 * Whether it only has to render address book
 		 */
 		onlyRenderAddressBook: PropTypes.bool,
-		reloadAddressList: PropTypes.bool
+		reloadAddressList: PropTypes.bool,
+		/**
+		 * Chain id
+		 */
+		chainId: PropTypes.string
 	};
 
 	state = {
@@ -156,7 +159,7 @@ class AddressList extends PureComponent {
 	};
 
 	getRecentAddresses = inputSearch => {
-		const { transactions, network, identities, onAccountPress, onAccountLongPress } = this.props;
+		const { transactions, network, identities, onAccountPress, onAccountLongPress, chainId } = this.props;
 		const recents = [];
 		const parsedRecents = [];
 		if (!inputSearch) {
@@ -174,10 +177,11 @@ class AddressList extends PureComponent {
 				}
 				const checksummedTo = safeToChecksumAddress(to);
 				if (recents.length > 2) return;
+				const getSwapsContractAddress = swapsUtils.getSwapsContractAddress(chainId);
 				if (
 					!recents.includes(checksummedTo) &&
 					!Object.keys(identities).includes(checksummedTo) &&
-					checksummedTo !== MM_SWAP_ROUTER
+					!toLowerCaseCompare(checksummedTo, getSwapsContractAddress)
 				) {
 					recents.push(checksummedTo);
 					if (this.networkAddressBook[checksummedTo]) {
@@ -304,7 +308,8 @@ const mapStateToProps = state => ({
 	addressBook: state.engine.backgroundState.AddressBookController.addressBook,
 	identities: state.engine.backgroundState.PreferencesController.identities,
 	network: state.engine.backgroundState.NetworkController.network,
-	transactions: state.engine.backgroundState.TransactionController.transactions
+	transactions: state.engine.backgroundState.TransactionController.transactions,
+	chainId: state.engine.backgroundState.NetworkController.provider.chainId
 });
 
 export default connect(mapStateToProps)(AddressList);

--- a/app/components/Views/SendFlow/AddressList/index.js
+++ b/app/components/Views/SendFlow/AddressList/index.js
@@ -177,11 +177,11 @@ class AddressList extends PureComponent {
 				}
 				const checksummedTo = safeToChecksumAddress(to);
 				if (recents.length > 2) return;
-				const getSwapsContractAddress = swapsUtils.getSwapsContractAddress(chainId);
+				const swapsContractAddress = swapsUtils.getSwapsContractAddress(chainId);
 				if (
 					!recents.includes(checksummedTo) &&
 					!Object.keys(identities).includes(checksummedTo) &&
-					!toLowerCaseEquals(checksummedTo, getSwapsContractAddress)
+					!toLowerCaseEquals(checksummedTo, swapsContractAddress)
 				) {
 					recents.push(checksummedTo);
 					if (this.networkAddressBook[checksummedTo]) {

--- a/app/components/Views/SendFlow/AddressList/index.js
+++ b/app/components/Views/SendFlow/AddressList/index.js
@@ -13,6 +13,9 @@ import {
 	TRANSFER_FROM_FUNCTION_SIGNATURE
 } from '../../../../util/transactions';
 
+// MetaMask: Swap Router
+const MM_SWAP_ROUTER = '0x881D40237659C251811CEC9c364ef91dC08D300C';
+
 const styles = StyleSheet.create({
 	root: {
 		flex: 1,
@@ -171,7 +174,11 @@ class AddressList extends PureComponent {
 				}
 				const checksummedTo = safeToChecksumAddress(to);
 				if (recents.length > 2) return;
-				if (!recents.includes(checksummedTo) && !Object.keys(identities).includes(checksummedTo)) {
+				if (
+					!recents.includes(checksummedTo) &&
+					!Object.keys(identities).includes(checksummedTo) &&
+					checksummedTo !== MM_SWAP_ROUTER
+				) {
 					recents.push(checksummedTo);
 					if (this.networkAddressBook[checksummedTo]) {
 						parsedRecents.push(

--- a/app/components/Views/SendFlow/AddressList/index.test.js
+++ b/app/components/Views/SendFlow/AddressList/index.test.js
@@ -10,7 +10,10 @@ describe('AddressList', () => {
 			engine: {
 				backgroundState: {
 					NetworkController: {
-						network: '1'
+						network: '1',
+						provider: {
+							chainId: '1'
+						}
 					},
 					AddressBookController: {
 						addressBook: {

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -54,7 +54,7 @@ import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
 import dismissKeyboard from 'react-native/Libraries/Utilities/dismissKeyboard';
 import NetworkMainAssetLogo from '../../../UI/NetworkMainAssetLogo';
 import { isMainNet } from '../../../../util/networks';
-import { toLowerCaseCompare } from '../../../../util/general';
+import { toLowerCaseEquals } from '../../../../util/general';
 
 const { hexToBN, BNToHex } = util;
 
@@ -425,7 +425,7 @@ class Amount extends PureComponent {
 		} = this.props;
 		try {
 			const owner = await AssetsContractController.getOwnerOf(address, tokenId);
-			const isOwner = toLowerCaseCompare(owner, selectedAddress);
+			const isOwner = toLowerCaseEquals(owner, selectedAddress);
 			if (!isOwner) {
 				return strings('transaction.invalid_collectible_ownership');
 			}

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -8,7 +8,7 @@ import { showAlert } from '../../../actions/alert';
 import Transactions from '../../UI/Transactions';
 import { safeToChecksumAddress } from '../../../util/address';
 import { addAccountTimeFlagFilter } from '../../../util/transactions';
-import { toLowerCaseCompare } from '../../../util/general';
+import { toLowerCaseEquals } from '../../../util/general';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -52,7 +52,7 @@ const TransactionsView = ({
 			) {
 				if (isTransfer)
 					return tokens.find(({ address }) =>
-						toLowerCaseCompare(address, transferInformation.contractAddress)
+						toLowerCaseEquals(address, transferInformation.contractAddress)
 					);
 				return true;
 			}

--- a/app/reducers/swaps/index.js
+++ b/app/reducers/swaps/index.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import contractMetadata from '@metamask/contract-metadata';
 import { isMainnetByChainId } from '../../util/networks';
 import { safeToChecksumAddress } from '../../util/address';
-import { toLowerCaseCompare } from '../../util/general';
+import { toLowerCaseEquals } from '../../util/general';
 
 // * Constants
 export const SWAPS_SET_LIVENESS = 'SWAPS_SET_LIVENESS';
@@ -167,7 +167,7 @@ export const swapsTopAssetsSelector = createSelector(
 			return [];
 		}
 		const result = topAssets
-			.map(({ address }) => tokens?.find(token => toLowerCaseCompare(token.address, address)))
+			.map(({ address }) => tokens?.find(token => toLowerCaseEquals(token.address, address)))
 			.filter(Boolean);
 		return addMetadata(chainId, result);
 	}

--- a/app/store/migrations.js
+++ b/app/store/migrations.js
@@ -1,7 +1,7 @@
 import { NetworksChainId } from '@metamask/controllers';
 import AppConstants from '../core/AppConstants';
 import { getAllNetworks, isSafeChainId } from '../util/networks';
-import { toLowerCaseCompare } from '../util/general';
+import { toLowerCaseEquals } from '../util/general';
 
 export const migrations = {
 	// Needed after https://github.com/MetaMask/controllers/pull/152
@@ -22,7 +22,7 @@ export const migrations = {
 		const tokens = state.engine.backgroundState.AssetsController.tokens;
 		const migratedTokens = [];
 		tokens.forEach(token => {
-			if (token.symbol === 'DAI' && toLowerCaseCompare(token.address, AppConstants.SAI_ADDRESS)) {
+			if (token.symbol === 'DAI' && toLowerCaseEquals(token.address, AppConstants.SAI_ADDRESS)) {
 				token.symbol = 'SAI';
 			}
 			migratedTokens.push(token);

--- a/app/util/ENSUtils.js
+++ b/app/util/ENSUtils.js
@@ -1,7 +1,7 @@
 import Engine from '../core/Engine';
 import networkMap from 'ethjs-ens/lib/network-map.json';
 import ENS from 'ethjs-ens';
-import { toLowerCaseCompare } from '../util/general';
+import { toLowerCaseEquals } from '../util/general';
 
 /**
  * Utility class with the single responsibility
@@ -26,7 +26,7 @@ export async function doENSReverseLookup(address, network) {
 		try {
 			const name = await this.ens.reverse(address);
 			const resolvedAddress = await this.ens.lookup(name);
-			if (toLowerCaseCompare(address, resolvedAddress)) {
+			if (toLowerCaseEquals(address, resolvedAddress)) {
 				ENSCache.cache[address] = name;
 				return name;
 			}

--- a/app/util/general.js
+++ b/app/util/general.js
@@ -35,7 +35,7 @@ export function findRouteNameFromNavigatorState({ routes }) {
 }
 export const capitalize = str => (str && str.charAt(0).toUpperCase() + str.slice(1)) || false;
 
-export const toLowerCaseCompare = (a, b) => {
+export const toLowerCaseEquals = (a, b) => {
 	if (!a && !b) return false;
 	return tlc(a) === tlc(b);
 };

--- a/app/util/general.test.js
+++ b/app/util/general.test.js
@@ -1,4 +1,4 @@
-import { capitalize, tlc, toLowerCaseCompare } from './general';
+import { capitalize, tlc, toLowerCaseEquals } from './general';
 
 describe('capitalize', () => {
 	const my_string = 'string';
@@ -19,21 +19,21 @@ describe('tlc', () => {
 	});
 });
 
-describe('toLowerCaseCompare', () => {
+describe('toLowerCaseEquals', () => {
 	const o = {};
 	it('compares two things', () => {
-		expect(toLowerCaseCompare('A', 'A')).toEqual(true);
-		expect(toLowerCaseCompare('aBCDefH', 'abcdefh')).toEqual(true);
-		expect(toLowerCaseCompare('A', 'B')).toEqual(false);
-		expect(toLowerCaseCompare('aBCDefH', 'abcdefi')).toEqual(false);
+		expect(toLowerCaseEquals('A', 'A')).toEqual(true);
+		expect(toLowerCaseEquals('aBCDefH', 'abcdefh')).toEqual(true);
+		expect(toLowerCaseEquals('A', 'B')).toEqual(false);
+		expect(toLowerCaseEquals('aBCDefH', 'abcdefi')).toEqual(false);
 		// cases where a or b are undefined
-		expect(toLowerCaseCompare(o.p, 'A')).toEqual(false);
-		expect(toLowerCaseCompare('A', o.p)).toEqual(false);
-		expect(toLowerCaseCompare(undefined, 'A')).toEqual(false);
-		expect(toLowerCaseCompare('A', undefined)).toEqual(false);
+		expect(toLowerCaseEquals(o.p, 'A')).toEqual(false);
+		expect(toLowerCaseEquals('A', o.p)).toEqual(false);
+		expect(toLowerCaseEquals(undefined, 'A')).toEqual(false);
+		expect(toLowerCaseEquals('A', undefined)).toEqual(false);
 		// case where a and b are both undefined, null or false
-		expect(toLowerCaseCompare(undefined, undefined)).toEqual(false);
-		expect(toLowerCaseCompare(null, null)).toEqual(false);
-		expect(toLowerCaseCompare(false, false)).toEqual(false);
+		expect(toLowerCaseEquals(undefined, undefined)).toEqual(false);
+		expect(toLowerCaseEquals(null, null)).toEqual(false);
+		expect(toLowerCaseEquals(false, false)).toEqual(false);
 	});
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This makes it so we don't render the MetaMask Swaps contract router address in Recents. Perhaps we should also consider not rendering token contract addresses as well? but at least we do show warnings for those on send:

![image](https://user-images.githubusercontent.com/675259/122499923-c83bd680-cfbf-11eb-945c-edfa15c31aab.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #2822
