### PR TITLE
[FIX] Use V4 of eth_signTypedData when using WalletConnect.

### DIFF
--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -219,7 +219,7 @@ class WalletConnect {
 								},
 								origin: WALLET_CONNECT_ORIGIN
 							},
-							'V3'
+							'V4'
 						);
 
 						this.walletConnector.approveRequest({


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Uses v4 of eth_signTypedData, which supports recursive arrays and structs.

**Issue**

Resolves a silent failure in the app that occurs when message data passed to eth_signTypedData over WalletConnect contains an array.
