### PR TITLE
[Android] Changing the minSdkVersion version and default emulator version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
 	ext {
 		buildToolsVersion = "29.0.2"
-		minSdkVersion = 19
+		minSdkVersion = 26
         compileSdkVersion = 30
         targetSdkVersion = 30
 		kotlin_version = "1.3.50"

--- a/package.json
+++ b/package.json
@@ -283,7 +283,7 @@
         "build": "yarn start:android:e2e",
         "type": "android.emulator",
         "device": {
-          "avdName": "Pixel_3_API_29"
+          "avdName": "Pixel_3_API_30"
         }
       },
       "android.emu.release": {
@@ -291,7 +291,7 @@
         "build": "METAMASK_ENVIRONMENT='production' yarn build:android:release:e2e",
         "type": "android.emulator",
         "device": {
-          "avdName": "Pixel_3_API_29"
+          "avdName": "Pixel_3_API_30"
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

_Write a short description of the changes included in this pull request._

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Detox basically fails to start because of two things:
- the minSDK Version
-  the emulator version

This PR updates the sdk version and the emulator version. 