### PR TITLE
fix issues 2100

### DIFF
--- a/app/store/index.js
+++ b/app/store/index.js
@@ -50,17 +50,6 @@ const persistConfig = {
 	storage: MigratedStorage,
 	stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
 	migrate: createMigrate(migrations, { debug: false }),
-	/**
-	 * fix bug: https://github.com/MetaMask/metamask-mobile/issues/2100
-	 * 
-	 * reason: redux-persist load storage data by 'getItem' API with a timeout (5 seconds default) when app ’cold start',
-	 * on some old devices, I/O is slow and 'readfile' operation may take long time Occasionally, when this happened, timeout
-	 * will lead to redux-persist rehydrate state with undefined and an Error(https://github.com/rt2zz/redux-persist/blob/master/src/persistReducer.js#89).
-	 * 
-	 * solution: the easy way to fix is to set a big timeout on config, Go further, we could save 'keyring' etc some important
-	 * data to separate files or backup for this. the second way is not complicated, we could set
-	 * serialize and deserialize to false to get JSON object and modify setItem/getItem API to save/load data.
-	 */
 	timeout: 30000,
 	writeFailHandler: error => Logger.error(error, { message: 'Error persisting data' }) // Log error if saving state fails
 };

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -50,6 +50,18 @@ const persistConfig = {
 	storage: MigratedStorage,
 	stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
 	migrate: createMigrate(migrations, { debug: false }),
+	/**
+	 * fix bug: https://github.com/MetaMask/metamask-mobile/issues/2100
+	 * 
+	 * reason: redux-persist load storage data by 'getItem' API with a timeout (5 seconds default) when app ’cold start',
+	 * on some old devices, I/O is slow and 'readfile' operation may take long time Occasionally, when this happened, timeout
+	 * will lead to redux-persist rehydrate state with undefined and an Error(https://github.com/rt2zz/redux-persist/blob/master/src/persistReducer.js#89).
+	 * 
+	 * solution: the easy way to fix is to set a big timeout on config, Go further, we could save 'keyring' etc some important
+	 * data to separate files or backup for this. the second way is not complicated, we could set
+	 * serialize and deserialize to false to get JSON object and modify setItem/getItem API to save/load data.
+	 */
+	timeout: 30000,
 	writeFailHandler: error => Logger.error(error, { message: 'Error persisting data' }) // Log error if saving state fails
 };
 

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -31,6 +31,7 @@ import {
 } from '../confirm-tx';
 
 import humanizeDuration from 'humanize-duration';
+import Logger from '../../util/Logger';
 
 const { SAI_ADDRESS } = AppConstants;
 
@@ -653,7 +654,7 @@ export const calculateEIP1559Times = ({
 			timeEstimateId = AppConstants.GAS_TIMES.RANGE;
 		}
 	} catch (error) {
-		console.log('ERROR ESTIMATING TIME', error);
+		Logger.log('ERROR ESTIMATING TIME', error);
 	}
 
 	return { timeEstimate, timeEstimateColor, timeEstimateId };


### PR DESCRIPTION
       /**
	 * fix bug: https://github.com/MetaMask/metamask-mobile/issues/2100
	 * 
	 * reason: redux-persist load storage data by 'getItem' API with a timeout (5 seconds default) when app ’cold start',
	 * on some old devices, I/O is slow and 'readfile' operation may take long time Occasionally, when this happened, timeout
	 * will lead to redux-persist rehydrate state with undefined and an Error(https://github.com/rt2zz/redux-persist/blob/master/src/persistReducer.js#89).
	 * 
	 * solution: the easy way to fix is to set a big timeout on config, Go further, we could save 'keyring' etc some important
	 * data to separate files or backup for this. the second way is not complicated, we could set
	 * serialize and deserialize to false to get JSON object and modify setItem/getItem API to save/load data.
	 */
