### PR TITLE
Implement kill all WalletConnect sessions button

### DIFF
--- a/app/components/Views/Settings/ExperimentalSettings/index.js
+++ b/app/components/Views/Settings/ExperimentalSettings/index.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, ScrollView, View } from 'react-native';
+import { Alert, StyleSheet, Text, ScrollView, View } from 'react-native';
 import { connect } from 'react-redux';
 import StyledButton from '../../../UI/StyledButton';
 import { colors, fontStyles } from '../../../../styles/common';
 import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import { strings } from '../../../../../locales/i18n';
+import WalletConnect from '../../../../core/WalletConnect';
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -53,6 +54,14 @@ class ExperimentalSettings extends PureComponent {
 		this.props.navigation.navigate('WalletConnectSessionsView');
 	};
 
+	killAllWalletConnectSessions = async () => {
+		await WalletConnect.killAllSessions();
+		Alert.alert(
+			strings('walletconnect_sessions.wallet_connect_all_sessions_ended_title'),
+			strings('walletconnect_sessions.wallet_connect_all_sessions_ended_desc')
+		);
+	};
+
 	render = () => (
 		<ScrollView style={styles.wrapper}>
 			<View style={styles.setting}>
@@ -65,6 +74,13 @@ class ExperimentalSettings extends PureComponent {
 						containerStyle={styles.clearHistoryConfirm}
 					>
 						{strings('experimental_settings.wallet_connect_dapps_cta')}
+					</StyledButton>
+					<StyledButton
+						type="normal"
+						onPress={this.killAllWalletConnectSessions}
+						containerStyle={styles.clearHistoryConfirm}
+					>
+						{strings('experimental_settings.wallet_connect_kill_all')}
 					</StyledButton>
 				</View>
 			</View>

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -382,6 +382,18 @@ const instance = {
 		// 3) Persist the list
 		await persistSessions();
 	},
+	killAllSessions: async () => {
+		// 1) First kill all sessions
+		for (const connectorToKill in connectors) {
+			if (connectorToKill && connectorToKill.walletConnector) {
+				await connectorToKill.killSession();
+			}
+		}
+		// 2) Remove everything from the list of connectors
+		connectors = [];
+		// 3) Persist the list
+		await persistSessions();
+	},
 	hub,
 	shutdown() {
 		Engine.context.TransactionController.hub.removeAllListeners();

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1267,6 +1267,9 @@
 		"wallet_connect_dapps": "WalletConnect Sessions",
 		"wallet_connect_dapps_desc": "View the list of active WalletConnect sessions",
 		"wallet_connect_dapps_cta": "VIEW SESSIONS",
+		"wallet_connect_kill_all": "KILL ALL SESSIONS",
+		"wallet_connect_all_sessions_ended_title": "All Sessions Ended",
+		"wallet_connect_all_sessions_ended_desc": "All sessions have been terminated",
 		"network_not_supported": "Current network not supported",
 		"switch_network": "Please switch to mainnet or rinkeby"
 	},


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR adds a button for killing all WalletConnect sessions. I really miss this feature, because during development I end up creating many sessions, to the point where Metamask becomes unresponsive, and killing them one by end is far from desirable.

