### PR TITLE
Browser Component Warning

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -61,14 +61,11 @@ class Browser extends PureComponent {
 	};
 	static navigationOptions = ({ navigation, route }) => getBrowserViewNavbarOptions(navigation, route);
 
-	constructor(props) {
-		super(props);
-
-		if (!props.tabs.length) {
+	componentDidMount() {
+		if (!this.props.tabs.length) {
 			this.newTab();
 		}
-	}
-	componentDidMount() {
+
 		const activeTab = this.props.tabs.find((tab) => tab.id === this.props.activeTab);
 		if (activeTab) {
 			this.switchToTab(activeTab);


### PR DESCRIPTION
**Description**

Fix for the warning displayed when loading the browser for the first time.
`Warning: Cannot update a component from inside the function body of a different component.
    in Browser (created by Connect(Browser))`

**Checklist**

* [NA] There is a related GitHub issue
* [NA] Tests are included if applicable
* [NA] Any added code is fully documented
