### PR TITLE
Fix: Use decimals rounding for items in apple pay

### DIFF
--- a/app/components/UI/FiatOrders/PaymentMethodApplePay/index.js
+++ b/app/components/UI/FiatOrders/PaymentMethodApplePay/index.js
@@ -244,7 +244,8 @@ function PaymentMethodApplePay({
 		try {
 			const order = await pay(
 				roundAmount,
-				quotation.fees[selectedCurrency] + quotation.fees.ETH / quotation.exchangeRate
+				quotation.fees[selectedCurrency] + quotation.fees.ETH / quotation.exchangeRate,
+				decimalSeparator ? 2 : 0 // TODO: retrieve decimals with useCurrency in the future
 			);
 			if (order !== ABORTED) {
 				if (order) {
@@ -294,6 +295,7 @@ function PaymentMethodApplePay({
 		setLockTime,
 		pay,
 		roundAmount,
+		decimalSeparator,
 		selectedCurrency,
 		ABORTED,
 		addOrder,

--- a/app/components/UI/FiatOrders/orderProcessor/wyreApplePay.js
+++ b/app/components/UI/FiatOrders/orderProcessor/wyreApplePay.js
@@ -676,10 +676,12 @@ export function useWyreOrderQuotation(network, amount, currency, address, countr
 
 export function useWyreApplePay(address, currency, network) {
 	const showRequest = useCallback(
-		async (amount, fee) => {
-			const total = (Number(amount) + Number(fee)).toFixed(2);
+		async (amount, fee, decimals) => {
+			const fixedAmount = Number(amount).toFixed(decimals);
+			const fixedFee = Number(fee).toFixed(decimals);
+			const total = (Number(amount) + Number(fee)).toFixed(decimals);
 			const methodData = getMethodData(currency, network);
-			const paymentDetails = getPaymentDetails(ETH_CURRENCY_CODE, currency, amount, fee, total);
+			const paymentDetails = getPaymentDetails(ETH_CURRENCY_CODE, currency, fixedAmount, fixedFee, total);
 			const paymentRequest = new PaymentRequest(methodData, paymentDetails, paymentOptions);
 			try {
 				const paymentResponse = await paymentRequest.show();


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
This PR fixes a crash for iOS 15 users. Apple Pay methods won't take care of currency decimal rounding anymore, a string with the correct decimals must be provided to `PKPaymentSummaryItem`
**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #3161 
