### PR TITLE
Update React Native dependency links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ The code is built using React-Native and running code locally requires a Mac or 
 
     -   If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 
--   Install the shared React Native dependencies (`React Native CLI`, _not_ `Expo CLI`)
-
-    -   [macOS](https://facebook.github.io/react-native/docs/getting-started.html#installing-dependencies-1)
-    -   [Linux](https://facebook.github.io/react-native/docs/getting-started.html#installing-dependencies-2)
+-   Install the shared [React Native dependencies](https://reactnative.dev/docs/environment-setup#installing-dependencies) (`React Native CLI`, _not_ `Expo CLI`)
 
 -   Install [cocoapods](https://guides.cocoapods.org/using/getting-started.html) by running:
 


### PR DESCRIPTION
**Description**

Updating the React Native dependency links in README.md so they don't go to 404. Have removed specific OS links as it is a generalized page without 

**Checklist**

* [x] There is a related GitHub issue
* [ ] ~~Tests are included if applicable~~
* [ ] ~~Any added code is fully documented~~

**Issue**

Resolves #3256 

![before](https://user-images.githubusercontent.com/8112138/136299203-846297b7-26ed-4eb3-8e06-b2dafa2ebe33.png)
![after](https://user-images.githubusercontent.com/8112138/136299213-bc5110d5-ea81-4a3f-ba04-60eebcadd2eb.png)


