### PR TITLE
Fix: Lost original data when using wallet connect for erc20 token transaction

### DIFF
--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -474,6 +474,14 @@ class TransactionEditor extends PureComponent {
 		const to = opts.to ? opts.to : transaction.to;
 		const generateData = {
 			ERC20: () => {
+
+				// Use raw data when transaction with walletconnect. 
+				// Additional parameters can enrich the transaction information for ERC20, such as orders or goods.
+				// These additional parameters have been tested on the metamask-extension and Ethereum mainnet
+				if (transaction.data){
+					return transaction.data
+				}
+
 				const tokenAmountToSend = selectedAsset && value && value.toString(16);
 				return to && tokenAmountToSend
 					? generateTransferData('transfer', { toAddress: to, amount: tokenAmountToSend })


### PR DESCRIPTION

Ethereum transactions allow additional parameters. These parameters can be used to refer to a product or order. It has passed the test on Ethereum mainnet. The transaction is carried out as expected on metamask-extension and other mobile wallets.
The original data is lost due to recoding data when walletconnect is used for transactions.

**This is an example of additional parameters and correct execution**
[https://goerli.etherscan.io/tx/0x4b231f533eb0f7e0fd39838c94a4bcb577c15f90975afde0d040e5d029252115](https://goerli.etherscan.io/tx/0x4b231f533eb0f7e0fd39838c94a4bcb577c15f90975afde0d040e5d029252115)

![img_v2_85e574c2-07a3-49b1-b64b-5cbd264262ag](https://user-images.githubusercontent.com/32406183/132822517-ff11129f-40b5-45de-a770-9c7539332957.png)


