### PR TITLE
Pin git dependencies to SHA to be safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@exodus/react-native-payments/validator": "^13.7.0"
   },
   "dependencies": {
-    "@exodus/react-native-payments": "https://github.com/wachunei/react-native-payments.git#package-json-hack",
+    "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@metamask/contract-metadata": "^1.30.0",
     "@metamask/controllers": "^18.0.0",
     "@metamask/etherscan-link": "^2.0.0",
@@ -192,7 +192,7 @@
     "react-native-modal": "^11.5.6",
     "react-native-os": "^1.2.6",
     "react-native-progress": "3.5.0",
-    "react-native-push-notification": "git+https://github.com/MetaMask/react-native-push-notification.git#androidx",
+    "react-native-push-notification": "git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5",
     "react-native-qrcode-svg": "5.1.2",
     "react-native-randombytes": "^3.5.3",
     "react-native-reanimated": "^1.13.2",
@@ -204,7 +204,7 @@
     "react-native-sensors": "5.3.0",
     "react-native-share": "^5.2.2",
     "react-native-skeleton-placeholder": "^4.0.0",
-    "react-native-splash-screen": "git+https://github.com/MetaMask/react-native-splash-screen.git",
+    "react-native-splash-screen": "git+https://github.com/MetaMask/react-native-splash-screen.git#1f45c08c0824cd94fdc6fb699529688a73614fee",
     "react-native-step-indicator": "^1.0.3",
     "react-native-svg": "12.1.1",
     "react-native-swipe-gestures": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-native-modal": "^11.5.6",
     "react-native-os": "^1.2.6",
     "react-native-progress": "3.5.0",
-    "react-native-push-notification": "git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5",
+    "react-native-push-notification": "git+https://github.com/MetaMask/react-native-push-notification.git#975e0e6757c40e3dce2d1b6dd3d66fc91127ac4c",
     "react-native-qrcode-svg": "5.1.2",
     "react-native-randombytes": "^3.5.3",
     "react-native-reanimated": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11706,9 +11706,9 @@ react-native-progress@3.5.0:
   dependencies:
     prop-types "^15.5.8"
 
-"react-native-push-notification@git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5":
-  version "3.1.2"
-  resolved "git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5"
+"react-native-push-notification@git+https://github.com/MetaMask/react-native-push-notification.git#975e0e6757c40e3dce2d1b6dd3d66fc91127ac4c":
+  version "3.1.3"
+  resolved "git+https://github.com/MetaMask/react-native-push-notification.git#975e0e6757c40e3dce2d1b6dd3d66fc91127ac4c"
 
 react-native-qrcode-svg@5.1.2:
   version "5.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,9 +1221,9 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
-"@exodus/react-native-payments@https://github.com/wachunei/react-native-payments.git#package-json-hack":
+"@exodus/react-native-payments@git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5":
   version "1.5.0"
-  resolved "https://github.com/wachunei/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5"
+  resolved "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5"
   dependencies:
     es6-error "^4.0.2"
     uuid "3.3.2"
@@ -11706,9 +11706,9 @@ react-native-progress@3.5.0:
   dependencies:
     prop-types "^15.5.8"
 
-"react-native-push-notification@git+https://github.com/MetaMask/react-native-push-notification.git#androidx":
-  version "3.1.3"
-  resolved "git+https://github.com/MetaMask/react-native-push-notification.git#975e0e6757c40e3dce2d1b6dd3d66fc91127ac4c"
+"react-native-push-notification@git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5":
+  version "3.1.2"
+  resolved "git+https://github.com/MetaMask/react-native-push-notification.git#7adf4ade7d47ea7ed19169ce11ea8a70ef6869f5"
 
 react-native-qrcode-svg@5.1.2:
   version "5.1.2"
@@ -11792,7 +11792,7 @@ react-native-skeleton-placeholder@^4.0.0:
   resolved "https://registry.yarnpkg.com/react-native-skeleton-placeholder/-/react-native-skeleton-placeholder-4.0.0.tgz#8c982cd9e00ffc69d5193da94945b75191eaa7c4"
   integrity sha512-nX0NM6GhurCIgz8Yf+H9VYIaxSF2mbtdozLgaJNh/8QIH9mi+aJ2G9BVHSpjQ0o1fNdKYbGzrXDsC+6v4hmqAA==
 
-"react-native-splash-screen@git+https://github.com/MetaMask/react-native-splash-screen.git":
+"react-native-splash-screen@git+https://github.com/MetaMask/react-native-splash-screen.git#1f45c08c0824cd94fdc6fb699529688a73614fee":
   version "3.2.0"
   resolved "git+https://github.com/MetaMask/react-native-splash-screen.git#1f45c08c0824cd94fdc6fb699529688a73614fee"
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We had a few pinned git dependencies that were previously pinned to branches. In order to guarantee integrity we should be pinning to a fixed git SHA. this way we won't accidentally change what we're deploying in production