### PR TITLE
[FIX] NFT asset display error, probably a cache issue. #3406

### DIFF
--- a/app/components/UI/AccountList/index.js
+++ b/app/components/UI/AccountList/index.js
@@ -166,7 +166,7 @@ class AccountList extends PureComponent {
 
 	onAccountChange = async (newIndex) => {
 		const previousIndex = this.state.selectedAccountIndex;
-		const { PreferencesController } = Engine.context;
+		const { PreferencesController, CollectiblesController } = Engine.context;
 		const { keyrings, accounts } = this.props;
 
 		requestAnimationFrame(async () => {
@@ -185,6 +185,7 @@ class AccountList extends PureComponent {
 					return;
 				}
 
+				CollectiblesController.update(CollectiblesController.defaultState);
 				PreferencesController.setSelectedAddress(accountsOrdered[newIndex]);
 
 				this.props.onAccountChange();


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

ref: https://github.com/MetaMask/metamask-mobile/issues/3406

I have noticed that the controller repository has been updated to 19.0, but Metamask-mobile is still using 18.0. I think the best thing to do is to modify the `AssetsDetectionController.detectAssets` method and update the `collectibleContracts` and `collectibles` attr according to the changing of address. But the current solution is also acceptable.

**Checklist**

*  - [x] Fix NFT display error when account changed.

**Issue**

Resolves #3406
