### PR TITLE
Show newlines when signing message

### DIFF
--- a/app/components/UI/PersonalSign/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/PersonalSign/__snapshots__/index.test.tsx.snap
@@ -39,7 +39,10 @@ exports[`PersonalSign should render correctly 1`] = `
             },
           ]
         }
-      />
+      >
+        
+
+      </Text>
     </Text>
   </View>
 </Connect(SignatureRequest)>

--- a/app/components/UI/PersonalSign/index.js
+++ b/app/components/UI/PersonalSign/index.js
@@ -143,6 +143,7 @@ export default class PersonalSign extends PureComponent {
 			.map((line, i) => (
 				<Text key={`txt_${i}`} style={[styles.messageText, !showExpandedMessage ? styles.textLeft : null]}>
 					{line}
+					{!showExpandedMessage && '\n'}
 				</Text>
 			));
 		let messageText;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Message signature section was not rendering newlines. We can test by going to login.xyz and clicking on "Sign-in with Ethereum"
