### PR TITLE
Remove swap navigation action

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -288,7 +288,7 @@ const App = ({ userLoggedIn }) => {
 						routingInstrumentation.registerNavigationContainer(navigator);
 					}}
 				>
-					<Stack.Navigator route={route} initialRouteName={route}>
+					<Stack.Navigator route={route} initialRouteName={route} screenOptions={{ gestureEnabled: false }}>
 						<Stack.Screen name="Login" component={Login} options={{ headerShown: false }} />
 						<Stack.Screen
 							name="OnboardingRootNav"

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
 
 const WalletTabHome = () => (
 	<Stack.Navigator initialRouteName={'WalletView'}>
-		<Stack.Screen name="WalletView" component={Wallet} />
+		<Stack.Screen name="WalletView" component={Wallet} options={{ gestureEnabled: false }} />
 		<Stack.Screen name="Asset" component={Asset} options={Asset.navigationOptions} />
 		<Stack.Screen name="AddAsset" component={AddAsset} options={AddAsset.navigationOptions} />
 

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -288,7 +288,6 @@ const Main = (props) => {
 			try {
 				TransactionController.hub.once(`${transactionMeta.id}:finished`, (transactionMeta) => {
 					if (transactionMeta.status === 'submitted') {
-						props.navigation.pop?.();
 						NotificationManager.watchSubmittedTransaction({
 							...transactionMeta,
 							assetType: transactionMeta.transaction.assetType,
@@ -313,7 +312,7 @@ const Main = (props) => {
 				Logger.error(error, 'error while trying to send transaction (Main)');
 			}
 		},
-		[props.navigation, props.swapsTransactions, trackSwaps]
+		[props.swapsTransactions, trackSwaps]
 	);
 
 	const onUnapprovedTransaction = useCallback(

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { RefreshControl, ScrollView, InteractionManager, ActivityIndicator, StyleSheet, View } from 'react-native';
+import {
+	RefreshControl,
+	ScrollView,
+	InteractionManager,
+	ActivityIndicator,
+	StyleSheet,
+	View,
+	BackHandler,
+} from 'react-native';
 import { useSelector } from 'react-redux';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import DefaultTabBar from 'react-native-scrollable-tab-view/DefaultTabBar';
@@ -86,6 +94,12 @@ const Wallet = ({ navigation }: any) => {
 	 * Current onboarding wizard step
 	 */
 	const wizardStep = useSelector((state: any) => state.wizard.step);
+
+	// Prevent Android back handler
+	useEffect(() => {
+		const backHandler = BackHandler.addEventListener('hardwareBackPress', () => true);
+		return () => backHandler.remove();
+	}, []);
 
 	useEffect(() => {
 		navigation.setOptions(getWalletNavbarOptions('wallet.title', navigation));


### PR DESCRIPTION
### **Description**

As reported by @cortisiko in RC v3.8.0

ISSUE 1
After performing a swap on a custom network (I used matic) I am logged out of the app:
http://recordit.co/NS0JnkXA0U

To reproduce:
1. Add Matic 
2. Go to swaps
3. Swap any token. 
4. Upon submitting the transaction you are logged out

### **Technical Details**

- There is an extra navigation action that triggers from a txn finished event
- We need to remove this nav action from the `Main` file

### **Acceptance Criteria**

- Same scenario in the description should be fixed

### **References**

- [Slack discussion](https://consensys.slack.com/archives/C02NZ42SJ4W/p1638839930029400)
