### PR TITLE
Get selected address from provider state instead of old props

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -427,7 +427,8 @@ export const BrowserTab = (props) => {
 		// all user facing RPC calls not implemented by the provider
 		createAsyncMiddleware(async (req, res, next) => {
 			const getAccounts = async () => {
-				const { privacyMode, selectedAddress } = props;
+				const { privacyMode } = props;
+				const { selectedAddress } = getProviderState();
 				const isEnabled = !privacyMode || approvedHosts[hostname];
 
 				return isEnabled && selectedAddress ? [selectedAddress] : [];
@@ -471,7 +472,8 @@ export const BrowserTab = (props) => {
 				},
 				eth_requestAccounts: async () => {
 					const { params } = req;
-					const { privacyMode, selectedAddress } = props;
+					const { privacyMode } = props;
+					const { selectedAddress } = getProviderState();
 
 					if (!privacyMode || ((!params || !params.force) && approvedHosts[hostname])) {
 						res.result = [selectedAddress];

--- a/app/core/BackgroundBridge.js
+++ b/app/core/BackgroundBridge.js
@@ -141,6 +141,7 @@ export class BackgroundBridge extends EventEmitter {
 		const memState = this.getState();
 		return {
 			isUnlocked: this.isUnlocked(),
+			selectedAddress: memState.selectedAddress,
 			...this.getProviderNetworkState(memState),
 		};
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

A potential solution for the issue reported with `eth_accounts` not containing latest information.

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #3496
