### PR TITLE
Line height is distributed unevenly when lineHeight <= fontSize

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -45,6 +45,8 @@ const styles = StyleSheet.create({
 		color: colors.fontPrimary,
 		fontSize: 20,
 		lineHeight: 20,
+		paddingTop: 4,
+		marginTop: -4,
 	},
 	desc: {
 		...fontStyles.normal,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

When lineHeight is less than the fontSize, Text shrinks the line's bounding box only by removing space from above the text, rather than distributing the space evenly above and below, as is done with extra line height.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
![image](https://user-images.githubusercontent.com/11713023/149733413-f870be25-86c2-4f89-9ecf-24c32fb509ff.png)
![image](https://user-images.githubusercontent.com/11713023/149733443-ca209a19-a80c-4b31-950d-30dda8caf064.png)


