### PR TITLE
[FIX] Default spent limit value

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -26,7 +26,7 @@ import { ANALYTICS_EVENT_OPTS } from '../../../util/analytics';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import TransactionHeader from '../../UI/TransactionHeader';
 import AccountInfoCard from '../../UI/AccountInfoCard';
-import TransactionReviewDetailsCard from '../../UI/TransactionReview/TransactionReivewDetailsCard';
+import TransactionReviewDetailsCard from '../../UI/TransactionReview/TransactionReviewDetailsCard';
 import Device from '../../../util/device';
 import AppConstants from '../../../core/AppConstants';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
@@ -256,7 +256,7 @@ class ApproveTransactionReview extends PureComponent {
 		totalGasFiat: undefined,
 		tokenSymbol: undefined,
 		spendLimitUnlimitedSelected: true,
-		spendLimitCustomValue: undefined,
+		spendLimitCustomValue: MINIMUM_VALUE,
 		ticker: getTicker(this.props.ticker),
 		viewDetails: false,
 		spenderAddress: '0x...',
@@ -388,7 +388,7 @@ class ApproveTransactionReview extends PureComponent {
 	};
 
 	onPressSpendLimitUnlimitedSelected = () => {
-		this.setState({ spendLimitUnlimitedSelected: true, spendLimitCustomValue: undefined });
+		this.setState({ spendLimitUnlimitedSelected: true, spendLimitCustomValue: MINIMUM_VALUE });
 	};
 
 	onPressSpendLimitCustomSelected = () => {
@@ -489,14 +489,12 @@ class ApproveTransactionReview extends PureComponent {
 		const { host, spendLimitUnlimitedSelected, tokenSymbol, spendLimitCustomValue, originalApproveAmount } =
 			this.state;
 
-		const _spendLimitCustomValue = spendLimitCustomValue ?? MINIMUM_VALUE;
-
 		return (
 			<EditPermission
 				host={host}
 				spendLimitUnlimitedSelected={spendLimitUnlimitedSelected}
 				tokenSymbol={tokenSymbol}
-				spendLimitCustomValue={_spendLimitCustomValue}
+				spendLimitCustomValue={spendLimitCustomValue}
 				originalApproveAmount={originalApproveAmount}
 				onSetApprovalAmount={this.onEditPermissionSetAmount}
 				onSpendLimitCustomValueChange={this.onSpendLimitCustomValueChange}

--- a/app/components/UI/TransactionReview/TransactionReviewDetailsCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewDetailsCard/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
 import { strings } from '../../../../../locales/i18n';
 import Feather from 'react-native-vector-icons/Feather';
-import ConnectHeader from '../../../UI/ConnectHeader';
+import ConnectHeader from '../../ConnectHeader';
 
 const styles = StyleSheet.create({
 	uppercase: {


### PR DESCRIPTION
**Description**
Papercuts - During a transaction review, the user is able to select a "Custom spent limit" for a token. If the user select the custom limit without changing the value (i.e. use the default custom value), the app should show the default value as the limit.

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #3786 
