### PR TITLE
Fix issue #2829 - Lack of full ENS namespace support

### DIFF
--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -3,6 +3,7 @@ import Engine from '../../core/Engine';
 import AppConstants from '../../core/AppConstants';
 import { strings } from '../../../locales/i18n';
 import { tlc } from '../general';
+import punycode from 'punycode/punycode';
 
 const { supportedTLDs } = AppConstants;
 
@@ -70,10 +71,20 @@ export async function importAccountFromPrivateKey(private_key) {
  * @returns {boolean} - Returns a boolean indicating if it is valid
  */
 export function isENS(name) {
+	if (!name) return false;
+
+	const match = punycode
+		.toASCII(name)
+		.toLowerCase()
+		// Checks that the domain consists of at least one valid domain pieces separated by periods, followed by a tld
+		// Each piece of domain name has only the characters a-z, 0-9, and a hyphen (but not at the start or end of chunk)
+		// A chunk has minimum length of 1, but minimum tld is set to 2 for now (no 1-character tlds exist yet)
+		.match(/^(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+[a-z0-9][-a-z0-9]*[a-z0-9]$/u);
+
 	const OFFSET = 1;
 	const index = name && name.lastIndexOf('.');
 	const tld = index && index >= OFFSET && tlc(name.substr(index + OFFSET, name.length - OFFSET));
-	if (index && tld && supportedTLDs.includes(tld)) return true;
+	if (index && tld && !!match) return true;
 	return false;
 }
 

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -1,11 +1,8 @@
 import { toChecksumAddress } from 'ethereumjs-util';
 import Engine from '../../core/Engine';
-import AppConstants from '../../core/AppConstants';
 import { strings } from '../../../locales/i18n';
 import { tlc } from '../general';
 import punycode from 'punycode/punycode';
-
-const { supportedTLDs } = AppConstants;
 
 /**
  * Returns full checksummed address

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -4,8 +4,8 @@ describe('isENS', () => {
 	it('should return false by default', () => {
 		expect(isENS()).toBe(false);
 	});
-	it('should return false for normal domain', () => {
-		expect(isENS('ricky.codes')).toBe(false);
+	it('should return true for normal domain', () => {
+		expect(isENS('ricky.codes')).toBe(true);
 	});
 	it('should return true for ens', () => {
 		expect(isENS('rickycodes.eth')).toBe(true);

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "prop-types": "15.7.2",
     "pubnub": "4.27.3",
     "pump": "3.0.0",
+    "punycode": "^2.1.1",
     "qs": "6.7.0",
     "query-string": "^6.12.1",
     "react": "17.0.2",
@@ -236,8 +237,8 @@
     "through2": "3.0.1",
     "unicode-confusables": "^0.1.1",
     "url": "0.11.0",
-    "uuid": "^8.3.2",
     "url-parse": "1.5.9",
+    "uuid": "^8.3.2",
     "valid-url": "1.0.9",
     "vm-browserify": "1.1.2",
     "zxcvbn": "4.4.2"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

The ENS name verification was hardcoded and in metamask-extension they have an ens verification already implemented that fix this with a regex expression

Now we can find an account with the name "brantly.art" 

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**https://github.com/MetaMask/metamask-mobile/issues/2829**

Resolves # 

