### PR TITLE
[Improvement] Collect code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ buck-out/
 *.jsbundle
 
 # testing
-coverage
+tests
 
 # app-specific
 /android/app/src/main/assets/InpageBridgeWeb3.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,13 +10,10 @@ const config = {
 		'node_modules/(?!(@react-native|react-native|rn-fetch|redux-persist-filesystem|@react-navigation|@react-native-community|@react-native-masked-view|react-navigation|react-navigation-redux-helpers|@sentry))',
 	],
 	snapshotSerializers: ['enzyme-to-json/serializer'],
-	collectCoverage: false,
-	collectCoverageFrom: [
-		'<rootDir>/app/**/*.{js,jsx}',
-		'!<rootDir>/node_modules/',
-		'!<rootDir>/app/util/*.{js,jsx}',
-		'!<rootDir>/app/entry*.js',
-	],
+	collectCoverage: true,
+	coveragePathIgnorePatterns: ['/node_modules/', '__mocks__', '<rootDir>/e2e/'],
+	coverageReporters: ['text-summary', 'lcov'],
+	coverageDirectory: '<rootDir>/tests/coverage',
 };
 
 // eslint-disable-next-line import/no-commonjs

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,8 @@ const config = {
 		'node_modules/(?!(@react-native|react-native|rn-fetch|redux-persist-filesystem|@react-navigation|@react-native-community|@react-native-masked-view|react-navigation|react-navigation-redux-helpers|@sentry))',
 	],
 	snapshotSerializers: ['enzyme-to-json/serializer'],
-	collectCoverage: true,
+	// This is an environment variable that can be used to execute logic only in development
+	collectCoverage: process.env.NODE_ENV !== 'production',
 	coveragePathIgnorePatterns: ['/node_modules/', '__mocks__', '<rootDir>/e2e/'],
 	coverageReporters: ['text-summary', 'lcov'],
 	coverageDirectory: '<rootDir>/tests/coverage',


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

- Enable jest code coverage collection
- This is valuabe as a benchmark but also as a debug tool
<img width="692" alt="Screen Shot 2022-03-02 at 1 51 34 PM" src="https://user-images.githubusercontent.com/22918444/156428611-8e0b8d40-7ac2-4880-b756-f1623a9aa272.png">

<img width="1726" alt="Screen Shot 2022-03-02 at 1 57 56 PM" src="https://user-images.githubusercontent.com/22918444/156429590-deafa6c5-a93e-4245-94b4-f78fd350ec80.png">

- [We can configure this further if needed](https://jestjs.io/docs/configuration)
- this will create a local directory of the test coverage report that is git ignored for now but can be used as a developer tool

## Pros/Cons of adding this change
- the main con of collecting code coverage is that it slows down the speed that tests get ran
- In order to put a number on the cost of adding this I collected some test run times from `main` and this branch. Here is a summary of the data.
- Ran on my brand new Macbook pro m1 with 16Gb of ram (milage may vary 😆 )

#### With Cache
| Average run time without test coverage | Average run time with test coverage | Delta (%) |
|----------------------------------------|-------------------------------------|-----------|
| 42.6 seconds                           | 59.3 seconds                        | -39.2     |

#### Pre Cache
| Run time without test coverage | Run time with test coverage | Delta (%) |
|--------------------------------|-----------------------------|-----------|
| 81 seconds                     | 148 seconds                 | -82.7     |

I will leave a comment with my raw data/notes when I was doing this analysis so people can fact check if they like. 

#### Conclusion/Questions
For most day to day tasks involving running tests, the cached results are going to be what you are using due to the fact that you will most likely be running the tests many times. Even still the cached results are about 40% slower when collecting code coverage. The question then becomes `do we feel that having our test suite run 40% slower is worth measuring our test coverage/enforcing better testing in the future`?

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #???
