### PR TITLE
Add authentication type to login metrics

### DIFF
--- a/app/constants/userProperties.ts
+++ b/app/constants/userProperties.ts
@@ -1,0 +1,9 @@
+enum AUTHENTICATION_TYPE {
+	BIOMETRIC = 'biometrics',
+	PASSCODE = 'device_passcode',
+	REMEMBER_ME = 'remember_me',
+	PASSWORD = 'password',
+	UNKNOWN = 'unknown',
+}
+
+export default AUTHENTICATION_TYPE;

--- a/app/core/Analytics.js
+++ b/app/core/Analytics.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { METRICS_OPT_IN, AGREED, DENIED } from '../constants/storage';
+import AUTHENTICATION_TYPE from '../constants/userProperties';
 import { NativeModules } from 'react-native';
 import DefaultPreference from 'react-native-default-preference';
 import Logger from '../util/Logger';
@@ -14,6 +15,7 @@ const USER_PROFILE_PROPERTY = {
 
 	ON: 'ON',
 	OFF: 'OFF',
+	AUTHENTICATION_TYPE: 'Authentication Type',
 };
 
 /**
@@ -153,6 +155,45 @@ class Analytics {
 	};
 
 	/**
+	 * Apply User Property
+	 *
+	 * @param {string} property - A string representing the login method of the user. One of biometrics, device_passcode, remember_me, password, unknown
+	 */
+	applyUserProperty = (property) => {
+		switch (property) {
+			case AUTHENTICATION_TYPE.BIOMETRIC:
+				RCTAnalytics.setUserProfileProperty(
+					USER_PROFILE_PROPERTY.AUTHENTICATION_TYPE,
+					AUTHENTICATION_TYPE.BIOMETRIC
+				);
+				break;
+			case AUTHENTICATION_TYPE.PASSCODE:
+				RCTAnalytics.setUserProfileProperty(
+					USER_PROFILE_PROPERTY.AUTHENTICATION_TYPE,
+					AUTHENTICATION_TYPE.PASSCODE
+				);
+				break;
+			case AUTHENTICATION_TYPE.REMEMBER_ME:
+				RCTAnalytics.setUserProfileProperty(
+					USER_PROFILE_PROPERTY.AUTHENTICATION_TYPE,
+					AUTHENTICATION_TYPE.REMEMBER_ME
+				);
+				break;
+			case AUTHENTICATION_TYPE.PASSWORD:
+				RCTAnalytics.setUserProfileProperty(
+					USER_PROFILE_PROPERTY.AUTHENTICATION_TYPE,
+					AUTHENTICATION_TYPE.PASSWORD
+				);
+				break;
+			default:
+				RCTAnalytics.setUserProfileProperty(
+					USER_PROFILE_PROPERTY.AUTHENTICATION_TYPE,
+					AUTHENTICATION_TYPE.UNKOWN
+				);
+		}
+	};
+
+	/**
 	 * Track event with value
 	 *
 	 * @param {object} event - Object containing event category, action and name
@@ -254,6 +295,9 @@ export default {
 	},
 	trackEvent(event, anonymously) {
 		return instance && instance.trackEvent(event, anonymously);
+	},
+	applyUserProperty(property) {
+		return instance && instance.applyUserProperty(property);
 	},
 	trackEventWithParameters(event, parameters, anonymously) {
 		return instance && instance.trackEventWithParameters(event, parameters, anonymously);

--- a/app/core/SecureKeychain.js
+++ b/app/core/SecureKeychain.js
@@ -24,7 +24,8 @@ const defaultOptions = {
 	fingerprintPromptDesc: strings('authentication.fingerprint_prompt_desc'),
 	fingerprintPromptCancel: strings('authentication.fingerprint_prompt_cancel'),
 };
-
+import Analytics from '../core/Analytics';
+import AUTHENTICATION_TYPE from '../constants/userProperties';
 /**
  * Class that wraps Keychain from react-native-keychain
  * abstracting metamask specific functionality and settings
@@ -102,11 +103,15 @@ export default {
 
 		if (type === this.TYPES.BIOMETRICS) {
 			authOptions.accessControl = Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET;
+			Analytics.applyUserProperty(AUTHENTICATION_TYPE.BIOMETRIC);
 		} else if (type === this.TYPES.PASSCODE) {
 			authOptions.accessControl = Keychain.ACCESS_CONTROL.DEVICE_PASSCODE;
+			Analytics.applyUserProperty(AUTHENTICATION_TYPE.PASSCODE);
 		} else if (type === this.TYPES.REMEMBER_ME) {
+			Analytics.applyUserProperty(AUTHENTICATION_TYPE.REMEMBER_ME);
 			//Don't need to add any parameter
 		} else {
+			Analytics.applyUserProperty(AUTHENTICATION_TYPE.PASSWORD);
 			// Setting a password without a type does not save it
 			return await this.resetGenericPassword();
 		}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

- Add login method as a metric we are tracking on login
- This is a precursor to removing `remember me` as we need track how many clients will be impacted

**🎩 Does it work?**

<img width="311" alt="Screen Shot 2022-03-14 at 4 24 41 PM" src="https://user-images.githubusercontent.com/22918444/158394369-c96597e8-2f6b-4f15-a0fb-0a07df2e9a52.png">
<img width="331" alt="Screen Shot 2022-03-14 at 4 23 12 PM" src="https://user-images.githubusercontent.com/22918444/158394373-fd2495e8-f1ab-48fc-8cbf-12d689ee9ccd.png">

As you can see this property has been successfully [added in mix panel](https://mixpanel.com/project/1979229/view/3052429/app/lexicon#transformations/profile-properties/user-profiles/Authentication%20Type)

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/mobile-planning/issues/170
