### PR TITLE
Fix go to ens domain when coming from qr code

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -571,7 +571,7 @@ export const BrowserTab = (props) => {
 			}
 
 			if (isAllowedUrl(hostname)) {
-				if (initialCall) {
+				if (initialCall || !firstUrlLoaded) {
 					setInitialUrl(urlToGo);
 					setFirstUrlLoaded(true);
 				} else {
@@ -584,7 +584,7 @@ export const BrowserTab = (props) => {
 			handleNotAllowedUrl(urlToGo);
 			return null;
 		},
-		[handleIpfsContent, isAllowedUrl, isHomepage, props.defaultProtocol]
+		[firstUrlLoaded, handleIpfsContent, isAllowedUrl, isHomepage, props.defaultProtocol]
 	);
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Fix go to ens domain when coming from QR Code

How to test:
Reach out to @andrepimenta for an example link and QR Code

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
