### PR TITLE
Fix undefined gas price crash

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -245,7 +245,7 @@ const RootRPCMethodsUI = (props) => {
 				} = transactionMeta;
 				const { AssetsContractController } = Engine.context;
 				transactionMeta.transaction.gas = hexToBN(gas);
-				transactionMeta.transaction.gasPrice = gasPrice && hexToBN(gasPrice);
+				transactionMeta.transaction.gasPrice = hexToBN(gasPrice);
 				if (
 					(value === '0x0' || !value) &&
 					data &&


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Fix wrong condition that further causes a crash when transaction gas price is `undefined`.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
