### PR TITLE
Fix crash on sign message popup

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -86,10 +86,11 @@ const RootRPCMethodsUI = (props) => {
 
 	const onUnapprovedMessage = (messageParams, type, origin) => {
 		setCurrentPageMeta(messageParams.meta);
-		delete messageParams.meta;
-		setSignMessageParams(messageParams);
+		const signMessageParams = { ...messageParams };
+		delete signMessageParams.meta;
+		setSignMessageParams(signMessageParams);
 		setSignType(type);
-		showPendingApprovalModal({ type: ApprovalTypes.SIGN_MESSAGE, origin: messageParams.origin });
+		showPendingApprovalModal({ type: ApprovalTypes.SIGN_MESSAGE, origin: signMessageParams.origin });
 	};
 
 	const initializeWalletConnect = () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Safely delete property on a new object instead of deleting the original one which further causes the object to be `undefined` and resulting in a crash.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
