### PR TITLE
Add confusables explanation(s)

### DIFF
--- a/app/components/Views/SendFlow/AddressInputs/index.js
+++ b/app/components/Views/SendFlow/AddressInputs/index.js
@@ -8,7 +8,7 @@ import Identicon from '../../../UI/Identicon';
 import { renderShortAddress } from '../../../../util/address';
 import { strings } from '../../../../../locales/i18n';
 import Text from '../../../Base/Text';
-import { hasZeroWidthPoints } from '../../../../util/validators';
+import { hasZeroWidthPoints } from '../../../../util/confusables';
 import { useAppThemeFromContext, mockTheme } from '../../../../util/theme';
 
 const createStyles = (colors) =>

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -52,7 +52,7 @@ import { capitalize, shallowEqual, renderShortText } from '../../../../util/gene
 import { isMainNet, getNetworkName, getNetworkNonce, isMainnetByChainId } from '../../../../util/networks';
 import Text from '../../../Base/Text';
 import AnalyticsV2 from '../../../../util/analyticsV2';
-import { collectConfusables } from '../../../../util/validators';
+import { collectConfusables } from '../../../../util/confusables';
 import InfoModal from '../../../UI/Swaps/components/InfoModal';
 import { addHexPrefix, toChecksumAddress } from 'ethereumjs-util';
 import { removeFavoriteCollectible } from '../../../../actions/collectibles';

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -28,7 +28,7 @@ import { allowedToBuy } from '../../../UI/FiatOrders';
 import NetworkList from '../../../../util/networks';
 import Text from '../../../Base/Text';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { collectConfusables, getConfusablesExplanation, hasZeroWidthPoints } from '../../../../util/confusables';
+import { collectConfusables, getConfusablesExplanations, hasZeroWidthPoints } from '../../../../util/confusables';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import addRecent from '../../../../actions/recents';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
@@ -615,7 +615,7 @@ class SendFlow extends PureComponent {
 		const displayConfusableWarning = !existingContact && confusableCollection && !!confusableCollection.length;
 		const displayAsWarning =
 			confusableCollection && confusableCollection.length && !confusableCollection.some(hasZeroWidthPoints);
-		const explanations = displayConfusableWarning && getConfusablesExplanation(confusableCollection);
+		const explanations = displayConfusableWarning && getConfusablesExplanations(confusableCollection);
 
 		return (
 			<SafeAreaView edges={['bottom']} style={styles.wrapper} testID={'send-screen'}>

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -28,12 +28,11 @@ import { allowedToBuy } from '../../../UI/FiatOrders';
 import NetworkList from '../../../../util/networks';
 import Text from '../../../Base/Text';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { collectConfusables, hasZeroWidthPoints } from '../../../../util/confusables';
+import { collectConfusables, getConfusablesExplanation, hasZeroWidthPoints } from '../../../../util/confusables';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import addRecent from '../../../../actions/recents';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import { ADD_ADDRESS_MODAL_CONTAINER_ID, ENTER_ALIAS_INPUT_BOX_ID } from '../../../../constants/test-ids';
-import confusablesMap from 'unicode-confusables/data/confusables.json';
 
 const { hexToBN } = util;
 const createStyles = (colors) =>
@@ -616,17 +615,7 @@ class SendFlow extends PureComponent {
 		const displayConfusableWarning = !existingContact && confusableCollection && !!confusableCollection.length;
 		const displayAsWarning =
 			confusableCollection && confusableCollection.length && !confusableCollection.some(hasZeroWidthPoints);
-		const explanations =
-			displayConfusableWarning &&
-			confusableCollection
-				.map((confusable) => {
-					const key = confusable;
-					const value = confusablesMap[confusable];
-					return hasZeroWidthPoints(key)
-						? strings('transaction.contains_zero_width')
-						: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
-				})
-				.reduce((unique, item) => (unique.includes(item) ? unique : [...unique, item]), []);
+		const explanations = displayConfusableWarning && getConfusablesExplanation(confusableCollection);
 
 		return (
 			<SafeAreaView edges={['bottom']} style={styles.wrapper} testID={'send-screen'}>

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -616,20 +616,17 @@ class SendFlow extends PureComponent {
 		const displayConfusableWarning = !existingContact && confusableCollection && !!confusableCollection.length;
 		const displayAsWarning =
 			confusableCollection && confusableCollection.length && !confusableCollection.some(hasZeroWidthPoints);
-		const confusableCollectionMap =
+		const explanations =
 			displayConfusableWarning &&
-			confusableCollection.map((confusable) => ({ [confusable]: confusablesMap[confusable] }));
-		const explanationsGuard = displayConfusableWarning && confusableCollectionMap.length;
-		let explanations =
-			explanationsGuard &&
-			confusableCollectionMap.map((confusableObj) => {
-				const [key, value] = Object.entries(confusableObj)[0];
-				return hasZeroWidthPoints(key)
-					? strings('transaction.contains_zero_width')
-					: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
-			});
-		// remove duplicates
-		explanations = explanationsGuard && explanations.filter((item, index) => explanations.indexOf(item) === index);
+			confusableCollection
+				.map((confusable) => {
+					const key = confusable;
+					const value = confusablesMap[confusable];
+					return hasZeroWidthPoints(key)
+						? strings('transaction.contains_zero_width')
+						: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
+				})
+				.reduce((unique, item) => (unique.includes(item) ? unique : [...unique, item]), []);
 
 		return (
 			<SafeAreaView edges={['bottom']} style={styles.wrapper} testID={'send-screen'}>

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -624,7 +624,9 @@ class SendFlow extends PureComponent {
 			explanationsGuard &&
 			confusableCollectionMap.map((confusableObj) => {
 				const [key, value] = Object.entries(confusableObj)[0];
-				return hasZeroWidthPoints(key) ? `contains zero width character` : `'${key}' is similar to '${value}'`;
+				return hasZeroWidthPoints(key)
+					? strings('transaction.contains_zero_width')
+					: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
 			});
 		// remove duplicates
 		explanations = explanationsGuard && explanations.filter((item, index) => explanations.indexOf(item) === index);

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -28,7 +28,7 @@ import { allowedToBuy } from '../../../UI/FiatOrders';
 import NetworkList from '../../../../util/networks';
 import Text from '../../../Base/Text';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { collectConfusables, hasZeroWidthPoints } from '../../../../util/validators';
+import { collectConfusables, hasZeroWidthPoints } from '../../../../util/confusables';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import addRecent from '../../../../actions/recents';
 import { ThemeContext, mockTheme } from '../../../../util/theme';

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -690,7 +690,7 @@ class SendFlow extends PureComponent {
 											{strings('transaction.confusable_title')}
 										</Text>
 										<Text style={styles.confusableMsg}>
-											{strings('transaction.confusable_msg')} {explanations.join(', ')}
+											{strings('transaction.confusable_msg')} {explanations.join(', ')}.
 										</Text>
 									</View>
 								</View>

--- a/app/util/confusables/index.js
+++ b/app/util/confusables/index.js
@@ -22,13 +22,14 @@ const zeroWidthPoints = new Set([
 
 export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);
 
-export const getConfusablesExplanation = (confusableCollection) =>
-	confusableCollection
-		.map((confusable) => {
+export const getConfusablesExplanation = (confusableCollection) => [
+	...new Set(
+		confusableCollection.map((confusable) => {
 			const key = confusable;
 			const value = confusablesMap[confusable];
 			return hasZeroWidthPoints(key)
 				? strings('transaction.contains_zero_width')
 				: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
 		})
-		.reduce((unique, item) => (unique.includes(item) ? unique : [...unique, item]), []);
+	),
+];

--- a/app/util/confusables/index.js
+++ b/app/util/confusables/index.js
@@ -1,4 +1,6 @@
 import { confusables } from 'unicode-confusables';
+import { strings } from '../../../locales/i18n';
+import confusablesMap from 'unicode-confusables/data/confusables.json';
 
 export const collectConfusables = (ensName) => {
 	const key = 'similarTo';
@@ -19,3 +21,14 @@ const zeroWidthPoints = new Set([
 ]);
 
 export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);
+
+export const getConfusablesExplanation = (confusableCollection) =>
+	confusableCollection
+		.map((confusable) => {
+			const key = confusable;
+			const value = confusablesMap[confusable];
+			return hasZeroWidthPoints(key)
+				? strings('transaction.contains_zero_width')
+				: `'${key}' ${strings('transaction.similar_to')} '${value}'`;
+		})
+		.reduce((unique, item) => (unique.includes(item) ? unique : [...unique, item]), []);

--- a/app/util/confusables/index.js
+++ b/app/util/confusables/index.js
@@ -24,9 +24,8 @@ export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);
 
 export const getConfusablesExplanations = (confusableCollection) => [
 	...new Set(
-		confusableCollection.map((confusable) => {
-			const key = confusable;
-			const value = confusablesMap[confusable];
+		confusableCollection.map((key) => {
+			const value = confusablesMap[key];
 			return hasZeroWidthPoints(key)
 				? strings('transaction.contains_zero_width')
 				: `'${key}' ${strings('transaction.similar_to')} '${value}'`;

--- a/app/util/confusables/index.js
+++ b/app/util/confusables/index.js
@@ -22,7 +22,7 @@ const zeroWidthPoints = new Set([
 
 export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);
 
-export const getConfusablesExplanation = (confusableCollection) => [
+export const getConfusablesExplanations = (confusableCollection) => [
 	...new Set(
 		confusableCollection.map((confusable) => {
 			const key = confusable;

--- a/app/util/confusables/index.js
+++ b/app/util/confusables/index.js
@@ -1,0 +1,21 @@
+import { confusables } from 'unicode-confusables';
+
+export const collectConfusables = (ensName) => {
+	const key = 'similarTo';
+	const collection = confusables(ensName).reduce(
+		(total, current) => (key in current ? [...total, current.point] : total),
+		[]
+	);
+	return collection;
+};
+
+const zeroWidthPoints = new Set([
+	'\u200b', // zero width space
+	'\u200c', // zero width non-joiner
+	'\u200d', // zero width joiner
+	'\ufeff', // zero width no-break space
+	'\u2028', // line separator
+	'\u2029', // paragraph separator,
+]);
+
+export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);

--- a/app/util/confusables/index.test.ts
+++ b/app/util/confusables/index.test.ts
@@ -1,0 +1,21 @@
+import { hasZeroWidthPoints, collectConfusables } from '.';
+
+describe('hasZeroWidthPoints', () => {
+	it('should detect zero-width unicode', () => {
+		expect('vita‍lik.eth'.split('').some(hasZeroWidthPoints)).toEqual(true);
+	});
+	it('should not detect zero-width unicode', () => {
+		expect('vitalik.eth'.split('').some(hasZeroWidthPoints)).toEqual(false);
+	});
+});
+
+describe('collectConfusables', () => {
+	it('should detect homoglyphic unicode points', () => {
+		expect(collectConfusables('vita‍lik.eth')).toHaveLength(1);
+		expect(collectConfusables('faceboоk.eth')).toHaveLength(1);
+	});
+
+	it('should detect multiple homoglyphic unicode points', () => {
+		expect(collectConfusables('ѕсоре.eth')).toHaveLength(5);
+	});
+});

--- a/app/util/confusables/index.test.ts
+++ b/app/util/confusables/index.test.ts
@@ -1,4 +1,4 @@
-import { hasZeroWidthPoints, collectConfusables } from '.';
+import { hasZeroWidthPoints, collectConfusables, getConfusablesExplanations } from '.';
 
 describe('hasZeroWidthPoints', () => {
 	it('should detect zero-width unicode', () => {
@@ -17,5 +17,12 @@ describe('collectConfusables', () => {
 
 	it('should detect multiple homoglyphic unicode points', () => {
 		expect(collectConfusables('ѕсоре.eth')).toHaveLength(5);
+	});
+});
+
+describe('getConfusablesExplanations', () => {
+	it('should get the right number of explanations', () => {
+		expect(getConfusablesExplanations(collectConfusables('ѕсоре.eth'))).toHaveLength(5);
+		expect(getConfusablesExplanations(collectConfusables('metamask.eth'))).toHaveLength(1);
 	});
 });

--- a/app/util/validators/index.js
+++ b/app/util/validators/index.js
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { confusables } from 'unicode-confusables';
 import Encryptor from '../../core/Encryptor';
 
 export const failedSeedPhraseRequirements = (seed) => {
@@ -34,23 +33,3 @@ export const parseVaultValue = async (password, vault) => {
 export const parseSeedPhrase = (seedPhrase) => (seedPhrase || '').trim().toLowerCase().match(/\w+/gu)?.join(' ') || '';
 
 export const { isValidMnemonic } = ethers.utils;
-
-export const collectConfusables = (ensName) => {
-	const key = 'similarTo';
-	const collection = confusables(ensName).reduce(
-		(total, current) => (key in current ? [...total, current.point] : total),
-		[]
-	);
-	return collection;
-};
-
-const zeroWidthPoints = new Set([
-	'\u200b', // zero width space
-	'\u200c', // zero width non-joiner
-	'\u200d', // zero width joiner
-	'\ufeff', // zero width no-break space
-	'\u2028', // line separator
-	'\u2029', // paragraph separator,
-]);
-
-export const hasZeroWidthPoints = (char) => zeroWidthPoints.has(char);

--- a/app/util/validators/index.test.ts
+++ b/app/util/validators/index.test.ts
@@ -1,4 +1,4 @@
-import { failedSeedPhraseRequirements, parseSeedPhrase, hasZeroWidthPoints, collectConfusables } from '.';
+import { failedSeedPhraseRequirements, parseSeedPhrase } from '.';
 
 const VALID_24 =
 	'verb middle giant soon wage common wide tool gentle garlic issue nut retreat until album recall expire bronze bundle live accident expect dry cook';
@@ -33,25 +33,5 @@ describe('parseSeedPhrase', () => {
 	});
 	it('Should handle uppercase', () => {
 		expect(parseSeedPhrase(`   ${String(VALID_12).toUpperCase()}`)).toEqual(VALID_12);
-	});
-});
-
-describe('hasZeroWidthPoints', () => {
-	it('should detect zero-width unicode', () => {
-		expect('vita‍lik.eth'.split('').some(hasZeroWidthPoints)).toEqual(true);
-	});
-	it('should not detect zero-width unicode', () => {
-		expect('vitalik.eth'.split('').some(hasZeroWidthPoints)).toEqual(false);
-	});
-});
-
-describe('collectConfusables', () => {
-	it('should detect homoglyphic unicode points', () => {
-		expect(collectConfusables('vita‍lik.eth')).toHaveLength(1);
-		expect(collectConfusables('faceboоk.eth')).toHaveLength(1);
-	});
-
-	it('should detect multiple homoglyphic unicode points', () => {
-		expect(collectConfusables('ѕсоре.eth')).toHaveLength(5);
 	});
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -761,6 +761,8 @@
 		"gas_education_learn_more": "Learn more about gas fees",
 		"confusable_title": "Check the recipient address",
 		"confusable_msg": "We have detected a confusable character in the ENS name. Check the ENS name to avoid a potential scam.",
+		"similar_to": "is similar to",
+		"contains_zero_width": "contains zero width character",
 		"dapp_suggested_gas": "This gas fee has been suggested by %{origin}. It’s using legacy gas estimation which may be inaccurate. However, editing this gas fee may cause a problem with your transaction. Please reach out to %{origin} if you have questions.",
 		"dapp_suggested_eip1559_gas": "This gas fee has been suggested by %{origin}. Overriding this may cause a problem with your transaction. Please reach out to %{origin} if you have questions."
 	},


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

First swing at adding an explanation to the ens warning so users know why `m` is getting flagged (and other single characters like `0` and `1` get flagged):

![image](https://user-images.githubusercontent.com/675259/158658115-9a13d72f-654e-4d88-9738-c250b00e88da.png)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**Issue**

Resolves #3799  
