### PR TITLE
Log warning for empty code

### DIFF
--- a/app/components/Views/Root/index.js
+++ b/app/components/Views/Root/index.js
@@ -32,7 +32,7 @@ export default class Root extends PureComponent {
 	constructor(props) {
 		super(props);
 		if (props.foxCode === '') {
-			Logger.log('Error: foxCode is an empty string');
+			Logger.error('WARN - foxCode is an empty string');
 		}
 		SecureKeychain.init(props.foxCode);
 		// Init EntryScriptWeb3 asynchronously on the background


### PR DESCRIPTION
**Description**

Log a warning to notice when the `foxCode` is an empty string.
