### PR TITLE
exclude GHSA-xvch-5gv4-984h

### DIFF
--- a/scripts/yarn-audit.sh
+++ b/scripts/yarn-audit.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # use `improved-yarn-audit` since that allows for exclude
 # exclude `ws` until we can come up with a better solution
-yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude 1005099,1006820
+yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude GHSA-xvch-5gv4-984h
 audit_status="$?"
 
 # Use a bitmask to ignore INFO and LOW severity audit results


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

There's a vuln in our package json and it's causing the `audit:ci` job to fail: https://github.com/advisories/GHSA-xvch-5gv4-984h

This vuln affects CLI and should not affect the application itself.

Skipping for now as there appears to be no resolution currently. Also removing the other skips since it appears those aren't needed anymore :)
