### PR TITLE
Split CI into multiple jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,26 @@
-name: CI
+name: ci
 on: [push,pull_request]
 jobs:
-  build-lint-audit-test:
-    name: Build, Lint, Audit, and Test
+  setup:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - name: Get Node.js version
+        id: nvm
+        run: |
+          VERSION=$(cat .nvmrc)
+          echo ::set-output name=NODE_VERSION::$VERSION
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Get Yarn cache directory
         run: |
           YARN_CACHE_DIR=$(yarn cache dir)
-          echo $YARN_CACHE_DIR
           echo "::set-output name=YARN_CACHE_DIR::$YARN_CACHE_DIR"
         id: yarn-cache-dir
-      - name: Get Node version
-        run: |
-          node -v
       - name: Get Yarn version
         run: |
           YARN_VERSION=$(yarn --version)
-          echo $YARN_VERSION
           echo "::set-output name=YARN_VERSION::$YARN_VERSION"
         id: yarn-version
       - name: Cache yarn dependencies
@@ -34,14 +29,86 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn setup
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+  lint:
+    runs-on: ubuntu-20.04
+    needs: setup
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Get Node.js version
+        id: nvm
+        run: |
+          VERSION=$(cat .nvmrc)
+          echo ::set-output name=NODE_VERSION::$VERSION
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn lint
+  audit:
+    runs-on: ubuntu-20.04
+    needs: lint
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Get Node.js version
+        id: nvm
+        run: |
+          VERSION=$(cat .nvmrc)
+          echo ::set-output name=NODE_VERSION::$VERSION
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn audit:ci
+  tgz-check:
+    runs-on: ubuntu-20.04
+    needs: audit
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Get Node.js version
+        id: nvm
+        run: |
+          VERSION=$(cat .nvmrc)
+          echo ::set-output name=NODE_VERSION::$VERSION
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn test:tgz-check
+  test:
+    runs-on: ubuntu-20.04
+    needs: tgz-check
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Get Node.js version
+        id: nvm
+        run: |
+          VERSION=$(cat .nvmrc)
+          echo ::set-output name=NODE_VERSION::$VERSION
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: NODE_OPTIONS=--max_old_space_size=20480 yarn test:unit --forceExit --silent
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04
-    needs:
-      - build-lint-audit-test
+    needs: [setup, lint, audit, tgz-check, test]
     steps:
       - run: echo "Great success!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
-on: [push,pull_request]
+on:
+  push:
+    branches: main
+  pull_request:
 jobs:
   setup:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This splits our previously single job into _multiple_ jobs. we do this by caching `yarn setup` in the first `setup` job and then utilise that cache in downstream jobs.

Additionally, I've made one small tweak where the node version used in the action containers is plucked from the `.npmrc` file in the project. if/when we upgrade nodejs we won't have to update the fixed version here.

new pipeline looks like this: 
![image](https://user-images.githubusercontent.com/675259/160708666-a774d804-1250-4b71-b6c9-f67f0171d6c6.png)

you can also look at the last workflow run for this pull request :)