### PR TITLE
Keystone Integration: fix transaction details not shown

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -253,9 +253,7 @@ const Main = (props) => {
 				{!forceReload ? <MainNavigator navigation={props.navigation} /> : renderLoader()}
 				<GlobalAlert />
 				<FadeOutOverlay />
-				<View>
-					<Notification navigation={props.navigation} />
-				</View>
+				<Notification navigation={props.navigation} />
 				<FiatOrders />
 				<SwapsLiveness />
 				<BackupAlert onDismiss={toggleRemindLater} navigation={props.navigation} />


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixed the issue that transaction details modal cannot be opened in Keystone Integration when clicked notification

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
