### PR TITLE
Updating design-tokens library to v1.5.1

### DIFF
--- a/app/components/Base/TabBar.js
+++ b/app/components/Base/TabBar.js
@@ -17,6 +17,9 @@ const createStyles = (colors) =>
 			...fontStyles.normal,
 			fontSize: 14,
 		},
+		tabBar: {
+			borderColor: colors.border.muted,
+		},
 	});
 
 function TabBar({ ...props }) {
@@ -31,6 +34,7 @@ function TabBar({ ...props }) {
 			backgroundColor={colors.background.default}
 			tabStyle={styles.tabStyle}
 			textStyle={styles.textStyle}
+			style={styles.tabBar}
 			{...props}
 		/>
 	);

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -20,7 +20,6 @@ import {
 } from '../../../util/number';
 import { safeToChecksumAddress } from '../../../util/address';
 import Device from '../../../util/device';
-import DefaultTabBar from 'react-native-scrollable-tab-view/DefaultTabBar';
 import TransactionReviewInformation from './TransactionReviewInformation';
 import TransactionReviewSummary from './TransactionReviewSummary';
 import TransactionReviewData from './TransactionReviewData';
@@ -294,22 +293,6 @@ class TransactionReview extends PureComponent {
 		const colors = this.context.colors || mockTheme.colors;
 		return createStyles(colors);
 	};
-
-	renderTabBar() {
-		const colors = this.context.colors || mockTheme.colors;
-		const styles = this.getStyles();
-
-		return (
-			<DefaultTabBar
-				underlineStyle={styles.tabUnderlineStyle}
-				activeTextColor={colors.primary.default}
-				inactiveTextColor={colors.text.muted}
-				backgroundColor={colors.background.default}
-				tabStyle={styles.tabStyle}
-				textStyle={styles.textStyle}
-			/>
-		);
-	}
 
 	toggleDataView = () => {
 		const { animate } = this.props;

--- a/app/components/Views/AddAsset/index.js
+++ b/app/components/Views/AddAsset/index.js
@@ -29,6 +29,9 @@ const createStyles = (colors) =>
 			height: 2,
 			backgroundColor: colors.primary.default,
 		},
+		tabBar: {
+			borderColor: colors.border.muted,
+		},
 		tabStyle: {
 			paddingBottom: 0,
 		},
@@ -102,6 +105,7 @@ class AddAsset extends PureComponent {
 				backgroundColor={colors.background.default}
 				tabStyle={styles.tabStyle}
 				textStyle={styles.textStyle}
+				style={styles.tabBar}
 			/>
 		);
 	}

--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -151,6 +151,9 @@ const createStyles = (colors) =>
 		revealModalText: {
 			marginBottom: 20,
 		},
+		tabBar: {
+			borderColor: colors.border.muted,
+		},
 	});
 
 const WRONG_PASSWORD_ERROR = 'error: Invalid password';
@@ -370,6 +373,7 @@ class RevealPrivateCredential extends PureComponent {
 				backgroundColor={colors.background.default}
 				tabStyle={styles.tabStyle}
 				textStyle={styles.textStyle}
+				style={styles.tabBar}
 			/>
 		);
 	}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -32,6 +32,9 @@ const createStyles = (colors: any) =>
 		tabStyle: {
 			paddingBottom: 0,
 		},
+		tabBar: {
+			borderColor: colors.border.muted,
+		},
 		textStyle: {
 			fontSize: 12,
 			letterSpacing: 0.5,
@@ -145,6 +148,7 @@ const Wallet = ({ navigation }: any) => {
 				backgroundColor={colors.background.default}
 				tabStyle={styles.tabStyle}
 				textStyle={styles.textStyle}
+				style={styles.tabBar}
 			/>
 		),
 		[styles, colors]

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
   "dependencies": {
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@metamask/contract-metadata": "^1.30.0",
-    "@metamask/design-tokens": "1.4.2",
     "@metamask/controllers": "27.0.0",
+    "@metamask/design-tokens": "^1.5.1",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/swaps-controller": "^6.6.0",
     "@react-native-clipboard/clipboard": "^1.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,10 +2238,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.3"
 
-"@metamask/design-tokens@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.4.2.tgz#023030f3eca181b10bf89c5813a9656f4e7e2852"
-  integrity sha512-kS63Tx+WOUloBTz4pDDG3DcisoXwaT+06/a2KTSDI0n1t3IQPLo1FCMsijqtYWFPfAI06tWOjtaslpFTB+dsAg==
+"@metamask/design-tokens@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.5.1.tgz#723f10bc5fe03ce14d47b1ad6190a835df62745a"
+  integrity sha512-HLXpuzQGnVPZHOvHpzOVQoe/1mvjNOTNxvAgR1na3BAUiO3NhnUxhYE2RzV0rpbc3UUUGbjVB+dceMZ4FtFfRw==
 
 "@metamask/eslint-config-typescript@^7.0.0":
   version "7.0.1"


### PR DESCRIPTION
**Description**
Updating `@metamask/design-tokens` library to `v.1.5.1` which includes
- background.default and background.alternative values have been swapped
- overlays have been updated from white to black

**Checklist**

* [x] There is a related GitHub issue
* [x] ~Tests are included if applicable~ NA
* [x] ~Any added code is fully documented~ NA

**Issue**

Resolves #3985

## Screencasts

### Before

https://user-images.githubusercontent.com/8112138/160887905-f4942787-48a7-4a49-9aa7-804f0fca301f.mp4

### After

https://user-images.githubusercontent.com/8112138/160887938-db84b130-d5b5-4519-9a0a-b42e2a63da03.mp4

![Screen Shot 2022-03-29 at 4 32 51 PM](https://user-images.githubusercontent.com/8112138/160887990-ab8f96cd-c7ad-4cb5-b15e-3365978f9805.png)
