### PR TITLE
fix(sendflow): limit use max value to 5 decimal digits

### DIFF
--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -37,6 +37,7 @@ import {
 	handleWeiNumber,
 	fromTokenMinimalUnitString,
 	toHexadecimal,
+	renderNumber,
 } from '../../../../util/number';
 import { getTicker, generateTransferData, getEther, calculateEIP1559GasFeeHexes } from '../../../../util/transactions';
 import { GAS_ESTIMATE_TYPES, util } from '@metamask/controllers';
@@ -693,7 +694,7 @@ class Amount extends PureComponent {
 			const realMaxValue = balanceBN.sub(estimatedTotalGas);
 			const maxValue = balanceBN.isZero() || realMaxValue.isNeg() ? new BN(0) : realMaxValue;
 			if (internalPrimaryCurrencyIsCrypto) {
-				input = fromWei(maxValue);
+				input = renderNumber(fromWei(maxValue));
 			} else {
 				input = `${weiToFiatNumber(maxValue, conversionRate)}`;
 				this.setState({ maxFiatInput: `${weiToFiatNumber(maxValue, conversionRate, 12)}` });


### PR DESCRIPTION
**Description**

_This Pull Request removes the excess amount of decimals when using `USE MAX` button on the send flow. It formats the value to 5 fixed decimal digits without rounding. This only applies to ETH assets_

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #3876 
