### PR TITLE
Keystone Integration: fix iOS duplicate Keystone accounts issue

### DIFF
--- a/app/components/UI/QRHardware/withQRHardwareAwareness.tsx
+++ b/app/components/UI/QRHardware/withQRHardwareAwareness.tsx
@@ -21,15 +21,26 @@ const withQRHardwareAwareness = (
 			},
 		};
 
+		keyringState: any;
+
+		subscribeKeyringState = (value: any) => {
+			this.setState({
+				QRState: value,
+			});
+		};
+
 		componentDidMount() {
 			const { KeyringController } = Engine.context as any;
 			KeyringController.getQRKeyringState().then((store: any) => {
-				store.subscribe((value: any) => {
-					this.setState({
-						QRState: value,
-					});
-				});
+				this.keyringState = store;
+				this.keyringState.subscribe(this.subscribeKeyringState);
 			});
+		}
+
+		componentWillUnmount() {
+			if (this.keyringState) {
+				this.keyringState.unsubscribe(this.subscribeKeyringState);
+			}
 		}
 
 		render() {

--- a/app/components/Views/ConnectQRHardware/index.tsx
+++ b/app/components/Views/ConnectQRHardware/index.tsx
@@ -99,13 +99,22 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
 		});
 	}, [KeyringController]);
 
+	const subscribeKeyringState = useCallback((storeValue: any) => {
+		setQRState(storeValue);
+	}, []);
+
 	useEffect(() => {
-		KeyringController.getQRKeyringState().then((memstore: any) => {
-			memstore.subscribe((value: any) => {
-				setQRState(value);
-			});
+		let memStore: any;
+		KeyringController.getQRKeyringState().then((_memStore: any) => {
+			memStore = _memStore;
+			memStore.subscribe(subscribeKeyringState);
 		});
-	}, [KeyringController]);
+		return () => {
+			if (memStore) {
+				memStore.unsubscribe(subscribeKeyringState);
+			}
+		};
+	}, [KeyringController, subscribeKeyringState]);
 
 	useEffect(() => {
 		const unTrackedAccounts: string[] = [];

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -410,8 +410,8 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.12.1):
     - React-Core
-  - RNCCheckbox (0.4.2):
-    - React
+  - RNCCheckbox (0.5.12):
+    - React-Core
   - RNCClipboard (1.8.4):
     - React-Core
   - RNCMaskedView (0.2.6):
@@ -816,7 +816,7 @@ SPEC CHECKSUMS:
   ReactNativePayments: a4e3ac915256a4e759c8a04338b558494a63a0f5
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
-  RNCCheckbox: 357578d3b42652c78ee9a1bb9bcfc3195af6e161
+  RNCCheckbox: ed1b4ca295475b41e7251ebae046360a703b6eb5
   RNCClipboard: ddd4d291537f1667209c9c405aaa4307297e252e
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@react-native-clipboard/clipboard": "^1.8.4",
     "@react-native-community/async-storage": "1.12.1",
     "@react-native-community/blur": "^3.6.0",
-    "@react-native-community/checkbox": "^0.4.2",
+    "@react-native-community/checkbox": "^0.5.12",
     "@react-native-community/cookies": "^5.0.1",
     "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/viewpager": "3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,10 +2510,10 @@
   dependencies:
     prop-types "^15.5.10"
 
-"@react-native-community/checkbox@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.4.2.tgz#109214058610200fcbb97e8761cf0cba8df5abd5"
-  integrity sha512-vGetj36fOD+o3xCx8AGg56HqopetKQAWCEslD3oj8cs0xaGyRLQh3Febu13wMBOdaAQP85kITpaIET9DF4Apaw==
+"@react-native-community/checkbox@^0.5.12":
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.12.tgz#1f55a38bbcd5f10ca853db0c6a9f1c4beccc37af"
+  integrity sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ==
 
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0-rc.0"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes the issue that user can de-check Keystone accounts in select accounts page which will cause duplicated accounts in account list view. 
The root cause is the CheckBox library we use not implements disable prop on iOS (however it does have the disable prop), update the dependency can resolve this issue. 

Also this PR add some code to unsubscribe QRKeyring state change.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Resolves #???
