### PR TITLE
Upgrade on-ramp-sdk to >=0.0.15

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.js
+++ b/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.js
@@ -102,7 +102,8 @@ const AmountToBuy = () => {
 	const [{ data: dataTokens, error: errorDataTokens, isFetching: isFetchingDataTokens }] = useSDKMethod(
 		'getCryptoCurrencies',
 		{ countryId: selectedCountry?.id, regionId: selectedRegion?.id },
-		selectedPaymentMethod
+		selectedPaymentMethod,
+		selectedFiatCurrencyId
 	);
 
 	const [{ data: defaultCurrnecy, error: errorDefaultCurrnecy, isFetching: isFetchingDefaultCurrency }] =

--- a/app/components/UI/FiatOnRampAggregator/Views/GetQuotes.js
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetQuotes.js
@@ -4,7 +4,7 @@ import ScreenLayout from '../components/ScreenLayout';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { useFiatOnRampSDK, useSDKMethod } from '../sdk';
 import LoadingAnimation from '../components/LoadingAnimation';
-import Quotes from '../components/Quotes';
+import Quote from '../components/Quote';
 import { strings } from '../../../../../locales/i18n';
 import Text from '../../../Base/Text';
 import { getFiatOnRampAggNavbar } from '../../Navbar';
@@ -92,14 +92,8 @@ const GetQuotes = () => {
 							.filter(({ error }) => !error)
 							.map((quote) => (
 								<View key={quote.providerId} style={styles.row}>
-									<Quotes
-										providerName={quote.providerName}
-										amountOut={quote.amountOut}
-										crypto={quote.crypto}
-										fiat={quote.fiat}
-										networkFee={quote.netwrokFee}
-										processingFee={quote.providerFee}
-										amountIn={quote.amountIn}
+									<Quote
+										quote={quote}
 										onPress={() => handleOnPress(quote)}
 										onPressBuy={() => handleOnPressBuy(quote)}
 										highlighted={quote.providerId === providerId}

--- a/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
@@ -99,7 +99,7 @@ const Quote: React.FC<Props> = ({ quote, onPress, onPressBuy, highlighted }: Pro
 				</ListItem.Body>
 				<ListItem.Amounts>
 					<Text small right>
-						≈ {fiat?.denomSymbol} {renderFiat(price, fiat.symbol, fiat.decimals)}
+						≈ {fiat.denomSymbol} {renderFiat(price, fiat.symbol, fiat.decimals)}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
@@ -112,7 +112,7 @@ const Quote: React.FC<Props> = ({ quote, onPress, onPressBuy, highlighted }: Pro
 				</ListItem.Body>
 				<ListItem.Amounts>
 					<Text black small right>
-						{fiat?.denomSymbol} {renderFiat(totalFees, fiat.symbol, fiat.decimals)}
+						{fiat.denomSymbol} {renderFiat(totalFees, fiat.symbol, fiat.decimals)}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>

--- a/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
@@ -5,6 +5,7 @@ import Feather from 'react-native-vector-icons/Feather';
 import CustomText from '../../../Base/Text';
 import BaseListItem from '../../../Base/ListItem';
 import StyledButton from '../../StyledButton';
+import { renderFiat, renderFromTokenMinimalUnit, toTokenMinimalUnit } from '../../../../util/number';
 
 // TODO: Convert into typescript and correctly type optionals
 const Text = CustomText as any;
@@ -20,30 +21,55 @@ const styles = StyleSheet.create({
 });
 
 interface Props {
-	amountIn: number;
-	amountOut: number;
-	crypto: string;
-	fiat: string;
-	networkFee: number;
-	processingFee: number;
-	providerName: string;
+	quote: {
+		providerId: string;
+		providerName: string;
+		providerLogos: {
+			light: string;
+			dark: string;
+		};
+		providerLinks: string[];
+		providerHQ: string;
+		description: string;
+		crypto: {
+			id: string;
+			network: string;
+			symbol: string;
+			logo: string;
+			decimals: number;
+			address: string;
+			name: string;
+		};
+		cryptoId: string;
+		fiat: {
+			id: string;
+			symbol: string;
+			name: string;
+			decimals: number;
+			denomSymbol: string;
+		};
+		fiatId: string;
+		networkFee: number;
+		providerFee: number;
+		amountIn: number;
+		amountOut: number;
+		buyURL?: string;
+		status?: number;
+		message?: string;
+		error?: boolean;
+		paymentMethod?: any;
+		receiver?: string;
+		getApplePayRequestInfo?: () => any;
+		purchaseWithApplePay?: () => Promise<any>;
+	};
 	onPress?: () => any;
 	onPressBuy?: () => any;
 	highlighted?: boolean;
 }
-const Quotes: React.FC<Props> = ({
-	amountIn,
-	amountOut,
-	crypto,
-	fiat,
-	networkFee,
-	processingFee,
-	providerName,
-	onPress,
-	onPressBuy,
-	highlighted,
-}: Props) => {
-	const totalFees = networkFee + processingFee;
+
+const Quote: React.FC<Props> = ({ quote, onPress, onPressBuy, highlighted }: Props) => {
+	const { networkFee, providerFee, amountIn, amountOut, fiat, providerName, crypto } = quote;
+	const totalFees = networkFee + providerFee;
 	const price = amountIn - totalFees;
 
 	return (
@@ -57,21 +83,23 @@ const Quotes: React.FC<Props> = ({
 					</ListItem.Title>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text big primary bold>
-						{amountOut.toFixed(7)} {crypto}
+					<Text big primary bold right>
+						{renderFromTokenMinimalUnit(
+							toTokenMinimalUnit(amountOut, crypto.decimals).toString(),
+							crypto.decimals
+						)}{' '}
+						{crypto.symbol}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
 
 			<ListItem.Content>
 				<ListItem.Body>
-					<Text black small>
-						Price {fiat}
-					</Text>
+					<Text small>Price {fiat?.symbol}</Text>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text black small>
-						≈ ${price}
+					<Text small right>
+						≈ {fiat?.denomSymbol} {renderFiat(price, fiat.symbol, fiat.decimals)}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
@@ -83,31 +111,36 @@ const Quotes: React.FC<Props> = ({
 					</Text>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text black small>
-						${totalFees}
+					<Text black small right>
+						{fiat?.denomSymbol} {renderFiat(totalFees, fiat.symbol, fiat.decimals)}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
 
 			<ListItem.Content>
 				<ListItem.Body>
-					<Text small style={styles.fee}>
+					<Text grey small style={styles.fee}>
 						Processing fee
 					</Text>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text small>${processingFee}</Text>
+					<Text grey small right>
+						{fiat.denomSymbol} {renderFiat(providerFee, fiat.symbol, fiat.decimals)}
+					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
 
 			<ListItem.Content>
 				<ListItem.Body>
-					<Text small style={styles.fee}>
+					<Text grey small style={styles.fee}>
 						Network fee
 					</Text>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text small>${networkFee}</Text>
+					<Text grey small right>
+						{fiat.denomSymbol}
+						{renderFiat(networkFee, fiat.symbol, fiat.decimals)}
+					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
 
@@ -118,9 +151,8 @@ const Quotes: React.FC<Props> = ({
 					</Text>
 				</ListItem.Body>
 				<ListItem.Amounts>
-					<Text black small>
-						${amountIn}
-						{amountOut % 1 !== 0 && '.00'}
+					<Text black small right>
+						{fiat.denomSymbol} {renderFiat(amountIn, fiat.symbol, fiat.decimals)}
 					</Text>
 				</ListItem.Amounts>
 			</ListItem.Content>
@@ -136,4 +168,4 @@ const Quotes: React.FC<Props> = ({
 	);
 };
 
-export default Quotes;
+export default Quote;

--- a/app/components/UI/FiatOnRampAggregator/components/Quotes.stories.js
+++ b/app/components/UI/FiatOnRampAggregator/components/Quotes.stories.js
@@ -1,5 +1,4 @@
-/* eslint-disable react-native/no-color-literals */
-import Quotes from './Quotes';
+import Quote from './Quote';
 import React from 'react';
 import { SafeAreaView } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
@@ -8,7 +7,7 @@ storiesOf('FiatOnRamp / Quotes', module)
 	.addDecorator((getStory) => getStory())
 	.add('Default', () => (
 		<SafeAreaView>
-			<Quotes
+			<Quote
 				providerName="Transak"
 				amountOut={0.06878071}
 				crypto="ETH"
@@ -18,7 +17,7 @@ storiesOf('FiatOnRamp / Quotes', module)
 				amountIn={300.0}
 			/>
 
-			<Quotes
+			<Quote
 				providerName="Wyre"
 				amountOut={0.06878071}
 				crypto="ETH"

--- a/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
+++ b/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, createContext, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { OnRampSdk, IOnRampSdk, Environment } from '@chingiz-mardanov/on-ramp-sdk';
+import { OnRampSdk, IOnRampSdk, Environment, Context } from '@chingiz-mardanov/on-ramp-sdk';
 import {
 	fiatOrdersCountrySelectorAgg,
 	setFiatOrdersCountryAGG,
@@ -33,13 +33,16 @@ interface IProviderProps<T> {
 	children?: React.ReactNode | undefined;
 }
 
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const VERBOSE_SDK = isDevelopment;
+
 const SDKContext = createContext<IFiatOnRampSDK | undefined>(undefined);
 
 export const FiatOnRampSDKProvider = ({ value, ...props }: IProviderProps<IFiatOnRampSDK>) => {
 	const [sdkModule, setSdkModule] = useState<IOnRampSdk | undefined>(undefined);
 	useEffect(() => {
 		(async () => {
-			setSdkModule(await OnRampSdk.getSDK(Environment.Staging));
+			setSdkModule(await OnRampSdk.getSDK(Environment.Staging, Context.Mobile, VERBOSE_SDK));
 		})();
 	}, []);
 

--- a/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
+++ b/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
@@ -42,8 +42,17 @@ export const FiatOnRampSDKProvider = ({ value, ...props }: IProviderProps<IFiatO
 	const [sdkModule, setSdkModule] = useState<IOnRampSdk | undefined>(undefined);
 	useEffect(() => {
 		(async () => {
-			setSdkModule(await OnRampSdk.getSDK(Environment.Staging, Context.Mobile, VERBOSE_SDK));
+			setSdkModule(
+				await OnRampSdk.getSDK(Environment.Staging, Context.Mobile, {
+					verbose: VERBOSE_SDK,
+					maxInstanceCount: 2,
+				})
+			);
 		})();
+
+		return () => {
+			OnRampSdk.destructInstance();
+		};
 	}, []);
 
 	const sdk: IOnRampSdk | undefined = useMemo(() => sdkModule, [sdkModule]);

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -135,7 +135,7 @@ export function fromTokenMinimalUnitString(minimalInput, decimals) {
  * Converts some unit to token minimal unit
  *
  * @param {number|string|BN} tokenValue - Value to convert
- * @param {string} decimals - Unit to convert from, ether by default
+ * @param {number} decimals - Unit to convert from, ether by default
  * @returns {Object} - BN instance containing the new number
  */
 export function toTokenMinimalUnit(tokenValue, decimals) {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "**/minimist": "1.2.6"
   },
   "dependencies": {
-    "@chingiz-mardanov/on-ramp-sdk": "^0.0.15",
+    "@chingiz-mardanov/on-ramp-sdk": "^0.0.16",
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@metamask/contract-metadata": "^1.30.0",
     "@metamask/controllers": "27.0.0",

--- a/package.json
+++ b/package.json
@@ -101,11 +101,11 @@
     "**/minimist": "1.2.6"
   },
   "dependencies": {
-    "@chingiz-mardanov/on-ramp-sdk": "^0.0.12",
+    "@chingiz-mardanov/on-ramp-sdk": "^0.0.15",
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@metamask/contract-metadata": "^1.30.0",
-    "@metamask/design-tokens": "1.4.2",
     "@metamask/controllers": "27.0.0",
+    "@metamask/design-tokens": "1.4.2",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/swaps-controller": "^6.6.0",
     "@react-native-clipboard/clipboard": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "**/minimist": "1.2.6"
   },
   "dependencies": {
-    "@chingiz-mardanov/on-ramp-sdk": "^0.0.16",
+    "@chingiz-mardanov/on-ramp-sdk": "^0.0.17",
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@metamask/contract-metadata": "^1.30.0",
     "@metamask/controllers": "27.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chingiz-mardanov/on-ramp-sdk@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.15.tgz#a9f6ef649847fe35c1ffc3932e2b6765dd8ce9a4"
-  integrity sha512-JUXFMLq/ugayOQ6TANerxJm9SryvCV2zoxXJcn7uU8whoRS9Jhrrj1PxWfdEC7IkeJbewQjhqEuJ204k3pi9Gg==
+"@chingiz-mardanov/on-ramp-sdk@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.16.tgz#42b571602b7f4c0199322cb38712c9bd6831909c"
+  integrity sha512-14nC2WdRQjJziAoEPxt6B4JH5714oDaZRY1/Jcw2XECNd/V9+ir8u92wqncbvaR8/XYwXYbzl01zBPP9JgT4Yg==
   dependencies:
     async "^3.2.3"
     axios "^0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chingiz-mardanov/on-ramp-sdk@^0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.12.tgz#08c35b4554f83bc64ef352671449cf138293f7b9"
-  integrity sha512-u1npt1dR3L4m41EmEfLii8Gb2V0kCl7TzMy8cWvItRHO8/bIBeRd7wz6gYnckdVazKzZzcjzRXybnjqNCcJfXQ==
+"@chingiz-mardanov/on-ramp-sdk@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.15.tgz#a9f6ef649847fe35c1ffc3932e2b6765dd8ce9a4"
+  integrity sha512-JUXFMLq/ugayOQ6TANerxJm9SryvCV2zoxXJcn7uU8whoRS9Jhrrj1PxWfdEC7IkeJbewQjhqEuJ204k3pi9Gg==
   dependencies:
     async "^3.2.3"
     axios "^0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chingiz-mardanov/on-ramp-sdk@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.16.tgz#42b571602b7f4c0199322cb38712c9bd6831909c"
-  integrity sha512-14nC2WdRQjJziAoEPxt6B4JH5714oDaZRY1/Jcw2XECNd/V9+ir8u92wqncbvaR8/XYwXYbzl01zBPP9JgT4Yg==
+"@chingiz-mardanov/on-ramp-sdk@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@chingiz-mardanov/on-ramp-sdk/-/on-ramp-sdk-0.0.17.tgz#6f0f22d8e59ac501db0106e2ec49c94f67203d6b"
+  integrity sha512-sICMvU6enq0pZ3YdIO3oK4cQCAxSK7VyPJTmXXGxbnPgTO374LxhwlsXglHnHGtN8uky2doNIyvOwGXbbzUhvQ==
   dependencies:
     async "^3.2.3"
     axios "^0.21.0"


### PR DESCRIPTION
This PR upgrades On-ramp SDK to version 0.0.15.
There are Breaking changes that need to be addressed.

- [x] `getCryptoCurrencies` takes a fiat currency as third argument. ADDED https://github.com/MetaMask/metamask-mobile/blob/7552d74d9428e598776926d7826c8d9bd18ed20b/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.js#L102-L107
- [ ] `Quotes` component needs to adapt to new API interface. Breaking change is `crypto` and `fiat` are now objects.

```ts
export interface QuoteResponse {
  providerId?: string;
  providerName?: string;
  providerLogos?: Logos;
  providerLinks?: Link;
  providerHQ?: string;
  description?: string;
  crypto?: CryptoCurrency | string;
  cryptoId?: string;
  fiat?: FiatCurrency | string;
  fiatId?: string;
  networkFee?: number;
  providerFee?: number;
  amountIn?: number;
  amountOut?: number;
  buyURL?: string;
  status?: number;
  message?: string;
  error?: boolean;
  paymentMethod?: any;
  receiver?: string;
  getApplePayRequestInfo?(setup: IApplePaySetup): ApplePayPaymentInfo;
  purchaseWithApplePay?(
    paymentDetails: PaymentDetailsIOS
  ): Promise<ApplePayPurchaseResult>;
}
```
