### PR TITLE
fix: get Favicons from dedicated metamask.faviconkit.com subdomain

### DIFF
--- a/app/components/UI/WebsiteIcon/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/WebsiteIcon/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`WebsiteIcon should render correctly 1`] = `
       onError={[Function]}
       source={
         Object {
-          "uri": "https://api.faviconkit.com/url.com/64",
+          "uri": "https://metamask.faviconkit.com/url.com/64",
         }
       }
     />

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -69,7 +69,7 @@ export default class WebsiteIcon extends PureComponent {
 	 * Get image url from favicon api
 	 */
 	getIconUrl = (url) => {
-		const iconUrl = `https://api.faviconkit.com/${getHost(url)}/64`;
+		const iconUrl = `https://metamask.faviconkit.com/${getHost(url)}/64`;
 		return iconUrl;
 	};
 

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1149,7 +1149,7 @@ export const BrowserTab = (props) => {
 							contentDescription: `Launch ${name || url} on MetaMask`,
 							keywords: [name.split(' '), url, 'dapp'],
 							thumbnail: {
-								uri: icon.current || `https://api.faviconkit.com/${getHost(url)}/256`,
+								uri: icon.current || `https://metamask.faviconkit.com/${getHost(url)}/256`,
 							},
 						};
 						try {


### PR DESCRIPTION
We’re super proud to be MetaMask’s choice for favicons! To ensure continous uptime, we’re giving the project its own dedicated subdomain, and this MR updates the icon URLs to use its dedicated domain name: `metamask.faviconkit.com`

<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

We’ve changed occurrences of `https://api.faviconkit.com` to `https://metamask.faviconkit.com`

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] ~~Any added code is fully documented~~

**Issue**

#4058
