### PR TITLE
Update `crowdin/github-action`

### DIFF
--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: crowdin action
-      uses: crowdin/github-action@d0622816ed4f4744db27d04374b2cef6867f7bed
+      uses: crowdin/github-action@9237b4cb361788dfce63feb2e2f15c09e2fe7415
       with:
         upload_translations: true
         download_translations: true

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,6 @@
 "project_id_env": CROWDIN_PROJECT_ID
 "api_token_env": CROWDIN_PERSONAL_TOKEN
 "base_path" : "."
-"base_url" : "https://metamask.crowdin.com"
 
 "preserve_hierarchy": true
 


### PR DESCRIPTION
Update `crowdin/github-action` to `9237b4cb361788dfce63feb2e2f15c09e2fe7415` (latest)

This action was updated in our allow list and needs to be updated here as well.

same as: https://github.com/MetaMask/metamask-extension/pull/14381

Also removing `base_url` same as: https://github.com/MetaMask/metamask-extension/pull/14364