### PR TITLE
bump `actions/checkout` to `v3`

### DIFF
--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: crowdin action
       uses: crowdin/github-action@9237b4cb361788dfce63feb2e2f15c09e2fe7415


### PR DESCRIPTION
Right now the crowdin action is [failing](https://github.com/MetaMask/metamask-mobile/runs/6077450587?check_suite_focus=true) because of: https://github.com/actions/checkout/issues/760

This has been fixed here: https://github.com/devops-infra/action-pull-request/pull/74/files

Bumping to latest should bring in those changes and fix the failing job.

