### PR TITLE
bump crowdin/github-action

### DIFF
--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: crowdin action
-      uses: crowdin/github-action@9237b4cb361788dfce63feb2e2f15c09e2fe7415
+      uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
       with:
         upload_translations: true
         download_translations: true


### PR DESCRIPTION
after landing: https://github.com/MetaMask/metamask-mobile/pull/4127 It would appear we also need to update the action itself. 

This does that.