### PR TITLE
Feature/remove bitmask

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,0 +1,3 @@
+# improved-yarn-audit advisory exclusions
+GHSA-fwr7-v2mv-hh25
+GHSA-gff7-g5r8-mg8m

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@walletconnect/client": "^1.7.1",
     "@walletconnect/utils": "^1.7.1",
     "asyncstorage-down": "4.2.0",
-    "axios": "^0.25",
+    "axios": "^0.26.1",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
     "babel-plugin-transform-remove-console": "6.9.4",
     "base-64": "1.0.0",

--- a/scripts/yarn-audit.sh
+++ b/scripts/yarn-audit.sh
@@ -4,12 +4,13 @@ set -u
 set -o pipefail
 
 # use `improved-yarn-audit` since that allows for exclude
-yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude GHSA-fwr7-v2mv-hh25
-audit_status="$?"
+# exclusions are in .iyarc now
+yarn run improved-yarn-audit \
+    --ignore-dev-deps \
+    --min-severity moderate \
+    --fail-on-missing-exclusions
 
-# Use a bitmask to ignore INFO and LOW severity audit results
-# See here: https://yarnpkg.com/lang/en/docs/cli/audit/
-audit_status="$(( audit_status & 11100 ))"
+audit_status="$?"
 
 if [[ "$audit_status" != 0 ]]
 then

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,12 +4455,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.25:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
-    follow-redirects "^1.14.7"
+    follow-redirects "^1.14.8"
 
 babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
@@ -8773,10 +8773,10 @@ focus-lock@^0.10.1:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.14.7:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I noticed yesterday that a couple of high and critical vulns were being skipped somehow...

After further examination I realised that the bitmask we had here was unnecessary as it was meant to be used in conjunction with `yarn audit`. Running `improved-yarn-audit` with `--min-severity moderate` actually handles this for us and gives us the correct exit code `0` if there's only a `LOW` vulnerability.

To handle the advisories correctly I've skipped one that has no patched version: https://github.com/advisories/GHSA-gff7-g5r8-mg8m and bumped `axios` as well. The `axios` bump should be safe since it's `minor`.

I've also moved exclusions into `.iyarc` so they're a bit easier to manage.

Lastly, I added `--fail-on-missing-exclusions` to ensure that if we have any unessesairy exclusions ci will also fail in that case: https://www.npmjs.com/package/improved-yarn-audit#user-content-maintaining-advisory-exclusions