### PR TITLE
[FIX] Undefined address error

### DIFF
--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -24,15 +24,18 @@ export function renderFullAddress(address) {
 export const formatAddress = (rawAddress, type) => {
 	let formattedAddress = rawAddress;
 
-	if (isValidAddress(rawAddress)) {
-		if (type && type === 'short') {
-			formattedAddress = renderShortAddress(rawAddress);
-		} else if (type && type === 'mid') {
-			formattedAddress = renderSlightlyLongAddress(rawAddress);
-		} else {
-			formattedAddress = renderFullAddress(rawAddress);
-		}
+	if (!isValidAddress(rawAddress)) {
+		return rawAddress;
 	}
+
+	if (type && type === 'short') {
+		formattedAddress = renderShortAddress(rawAddress);
+	} else if (type && type === 'mid') {
+		formattedAddress = renderSlightlyLongAddress(rawAddress);
+	} else {
+		formattedAddress = renderFullAddress(rawAddress);
+	}
+
 	return formattedAddress.toLowerCase();
 };
 

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -21,7 +21,7 @@ describe('isENS', () => {
 describe('renderSlightlyLongAddress', () => {
 	const mockAddress = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
 	it('should return the address when the address do not exist', () => {
-		expect(renderSlightlyLongAddress(null)).toBe(null);
+		expect(renderSlightlyLongAddress(null)).toBeNull();
 	});
 	it('should return 5 characters before ellipsis and 4 final characters of the address after the ellipsis', () => {
 		expect(renderSlightlyLongAddress(mockAddress).split('.')[0].length).toBe(24);

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -1,4 +1,4 @@
-import { isENS, renderSlightlyLongAddress } from '.';
+import { isENS, renderSlightlyLongAddress, formatAddress } from '.';
 
 describe('isENS', () => {
 	it('should return false by default', () => {
@@ -30,5 +30,17 @@ describe('renderSlightlyLongAddress', () => {
 	it('should return 0xC4955 before ellipsis and 4D272 after the ellipsis', () => {
 		expect(renderSlightlyLongAddress(mockAddress, 5, 2).split('.')[0]).toBe('0xC4955');
 		expect(renderSlightlyLongAddress(mockAddress, 5, 0).split('.')[3]).toBe('4D272');
+	});
+});
+
+describe('formatAddress', () => {
+	const mockAddress = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
+	it('should return address formatted for short type', () => {
+		const expectedValue = '0xc495...d272';
+		expect(formatAddress(mockAddress, 'short')).toBe(expectedValue);
+	});
+	it('should return address formatted for mid type', () => {
+		const expectedValue = '0xc4955c0d639d99699bfd7e...d272';
+		expect(formatAddress(mockAddress, 'mid')).toBe(expectedValue);
 	});
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

There's an edge case in the address util method `formatAddress` where an `undefined` value would get passed and try to call `toLowerCase`.

`undefined is not an object (evaluating 'o.toLowerCase')`

Reference: https://sentry.io/organizations/metamask/issues/3215676712/?project=2299799&query=is%3Aunresolved+undefined+is+not+an+object+%28evaluating+%27o.toLowerCase%27%29&statsPeriod=14d

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Progresses #???
