### PR TITLE
[FIX] - audit dependency exclusion

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,3 +1,4 @@
 # improved-yarn-audit advisory exclusions
 GHSA-fwr7-v2mv-hh25
 GHSA-gff7-g5r8-mg8m
+GHSA-7gc6-qh9x-w6h8


### PR DESCRIPTION
- added yarn audit exclusion 
- doesn't seem to impact the code base
- the issue references a patch for `node-fetch: 2.6.7` which we have in the resolutions in the package.json