### PR TITLE
Keystone: Fix swap transaction 

### DIFF
--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -79,6 +79,7 @@ export const TRANSACTION_TYPES = {
 const MULTIPLIER_HEX = 16;
 
 const { getSwapsContractAddress } = swapsUtils;
+
 /**
  * Utility class with the single responsibility
  * of caching CollectibleAddresses
@@ -1406,4 +1407,28 @@ export const minimumTokenAllowance = (tokenDecimals) => {
   return Math.pow(10, -1 * tokenDecimals)
     .toFixed(tokenDecimals)
     .toString(10);
+};
+
+export const isSwapTransaction = (transactionMeta, chainId) => {
+  const to = transactionMeta.transaction.to?.toLowerCase();
+  const { data } = transactionMeta.transaction;
+
+  // if approval data includes metaswap contract
+  // if destination address is metaswap contract
+  return (
+    transactionMeta.origin === process.env.MM_FOX_CODE &&
+    to &&
+    (swapsUtils.isValidContractAddress(chainId, to) ||
+      (data &&
+        data.substr(0, 10) === APPROVE_FUNCTION_SIGNATURE &&
+        decodeApproveData(data).spenderAddress?.toLowerCase() ===
+          swapsUtils.getSwapsContractAddress(chainId)))
+  );
+};
+
+export const isApproveTransaction = (transactionMeta) => {
+  const {
+    transaction: { data },
+  } = transactionMeta;
+  return data && data.substr(0, 10) === APPROVE_FUNCTION_SIGNATURE;
 };

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@tradle/react-native-http": "2.0.1",
     "@walletconnect/client": "^1.7.1",
     "@walletconnect/utils": "^1.7.1",
+    "async-mutex": "^0.3.2",
     "asyncstorage-down": "4.2.0",
     "axios": "^0.26.1",
     "babel-plugin-transform-inline-environment-variables": "0.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,13 @@ async-mutex@^0.3.1:
   dependencies:
     tslib "^2.1.0"
 
+async-mutex@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 async@0.2.x, async@~0.2.9:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
@@ -16773,6 +16780,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
This PR fixed the situation that when user want to swap assets but exceeded the spend limit, if user rejected the approve transaction, the swap transaction will still appears which is a lot of confusing. 

**Issue**

new dependency: async-mutex. 

I add this dependency because UI will handle the 2 incoming transactions immediately so it is impossible to block and cancel the second swap transaction in UI layer. So I add the mutex and check the state in transactionController to see whether the second transaction was canceled. 



