### PR TITLE
[FIX] Confusables bug

### DIFF
--- a/app/components/Views/SendFlow/AddressInputs/index.js
+++ b/app/components/Views/SendFlow/AddressInputs/index.js
@@ -170,7 +170,7 @@ const AddressName = ({ toAddressName, confusableCollection = [] }) => {
   const { colors } = useAppThemeFromContext() || mockTheme;
   const styles = createStyles(colors);
   if (confusableCollection.length) {
-    const texts = toAddressName.split('').map((char, index) => {
+    const texts = toAddressName?.split('').map((char, index) => {
       // if text has a confusable highlight it red
       if (confusableCollection.includes(char)) {
         // if the confusable is zero width, replace it with `?`

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -440,15 +440,15 @@ class Confirm extends PureComponent {
 
   handleConfusables = () => {
     const { identities = undefined, transactionState } = this.props;
-    const { transactionToName = undefined } = transactionState;
+    const { ensRecipient } = transactionState;
     const accountNames =
       (identities &&
         Object.keys(identities).map((hash) => identities[hash].name)) ||
       [];
-    const isOwnAccount = accountNames.includes(transactionToName);
-    if (transactionToName && !isOwnAccount) {
+    const isOwnAccount = accountNames.includes(ensRecipient);
+    if (ensRecipient && !isOwnAccount) {
       this.setState({
-        confusableCollection: collectConfusables(transactionToName),
+        confusableCollection: collectConfusables(ensRecipient),
       });
     }
   };


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

The confusables check is being used for address instead of only ENS names, this PR ensures that the recipient name is an ENS before checking for confusables.

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

| BUG | FIX |
|------------|-----------|
|      <img src="https://user-images.githubusercontent.com/17601467/168404739-4cdbeaba-a942-4bff-a95e-9174e61ae9f9.png" alt="fix" width="300"/>      |     <img src="https://user-images.githubusercontent.com/17601467/168404654-972dc22e-065d-4d51-acdc-4db881acba1b.png" alt="fix" width="300"/>      |

**Issue**

Progresses #4313
