### PR TITLE
fix generate-static-assets

### DIFF
--- a/scripts/metamask-bot-build-generate-static-assets.js
+++ b/scripts/metamask-bot-build-generate-static-assets.js
@@ -47,7 +47,7 @@ const main = async () => {
     const isBlacklisted = blacklistedLogos[token.logo];
     await fs.appendFileSync(
       imageModulesPath,
-      `\n\t${isBlacklisted ? '//' : ''}'${
+      `\n  ${isBlacklisted ? '//' : ''}'${
         token.logo
       }': require('metamask/node_modules/@metamask/contract-metadata/images/${
         token.logo


### PR DESCRIPTION
this fixes some static asset generation that is now tabbed incorrectly after: https://github.com/MetaMask/metamask-mobile/pull/4182