### PR TITLE
Fix subtitle mapping

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -209,7 +209,6 @@ class Settings extends PureComponent {
     if (language === this.state.currentLanguage) return;
     setLocale(language);
     this.setState({ currentLanguage: language });
-    setTimeout(() => this.props.navigation.navigate('Home'), 100);
   };
 
   selectSearchEngine = (searchEngine) => {

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -209,6 +209,7 @@ class Settings extends PureComponent {
     if (language === this.state.currentLanguage) return;
     setLocale(language);
     this.setState({ currentLanguage: language });
+    setTimeout(() => this.props.navigation.navigate('Home'), 100);
   };
 
   selectSearchEngine = (searchEngine) => {

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -1772,9 +1772,8 @@
     "not_found": "Medium nicht gefunden"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "DE CC",
+    "language": "de"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Erweiterte Optionen",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -1772,9 +1772,8 @@
     "not_found": "Τα μέσα δεν βρέθηκαν"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN υπότιτλοι",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "EL CC",
+    "language": "el"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Επιλογές για προχωρημένους",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -1772,9 +1772,8 @@
     "not_found": "Média introuvable"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "FR CC",
+    "language": "fr"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Options avancées",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -1772,9 +1772,9 @@
     "not_found": "माध्यम नहीं मिला"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "HI CC",
+    "language": "hi",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-hi-in.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "एडवांस विकल्प",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -1772,9 +1772,9 @@
     "not_found": "Media tidak ditemukan"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "ID CC",
+    "language": "id",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-id-id.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Opsi lanjutan",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -1772,9 +1772,9 @@
     "not_found": "メディアが見つかりません"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "JA CC",
+    "language": "ja",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ja-jp.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "高度なオプション",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -1772,9 +1772,9 @@
     "not_found": "미디어가 확인되지 않음"
   },
   "secret_phrase_video_subtitle": {
-    "title": "영어 CC",
-    "language": "영어",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "KO CC",
+    "language": "ko",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ko-kr.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "고급 옵션",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -1772,9 +1772,9 @@
     "not_found": "Mídia não encontrada"
   },
   "secret_phrase_video_subtitle": {
-    "title": "IN CC",
-    "language": "in",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "PT CC",
+    "language": "pt",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-pt.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Opções avançadas",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -1774,7 +1774,7 @@
   "secret_phrase_video_subtitle": {
     "title": "PT CC",
     "language": "pt",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-pt.vtt?raw=true"
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-pt-br.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Opções avançadas",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -1772,9 +1772,9 @@
     "not_found": "Медиа не найдено"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
+    "title": "RU CC",
     "language": "ru",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ru-ru.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Расширенные параметры",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -1772,9 +1772,8 @@
     "not_found": "Ortam bulunamadı"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "tr",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "TR CC",
+    "language": "tr"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Gelişmiş seçenekler",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -1772,9 +1772,9 @@
     "not_found": "Không tìm thấy phương tiện"
   },
   "secret_phrase_video_subtitle": {
-    "title": "EN CC",
-    "language": "en",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-en.vtt?raw=true"
+    "title": "VI CC",
+    "language": "vi",
+    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-vi-vn.vtt?raw=true"
   },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Tùy chọn nâng cao",


### PR DESCRIPTION
this broke partly because of #4157 and partly because we're using these keys for _not_ translations

this fixes it. I'll have to see if there's a way we can mark these keys to _not_ be translated