### PR TITLE
remove default from create-release-pr workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       base-branch:
         description: 'The base branch, tag, or SHA for git operations and the pull request.'
-        default: 'main'
         required: true
       semver-version:
         description: 'A semantic version. eg: x.x.x'


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This removed the default 'main' option for base branch which will make it harder to accidentally cut a release from main

before:

![image](https://user-images.githubusercontent.com/675259/168852260-7203be56-68e2-4bbc-b677-d77251f3fa76.png)

after:

![image](https://user-images.githubusercontent.com/675259/168852099-8c1b582e-4969-464c-bb16-ad92951f2a57.png)
