### PR TITLE
[5.2.0][FIX] Alignment of check icon with option on select component

### DIFF
--- a/app/components/UI/SelectComponent/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SelectComponent/__snapshots__/index.test.tsx.snap
@@ -161,8 +161,10 @@ exports[`SelectComponent should render correctly 1`] = `
               onPress={[Function]}
               style={
                 Object {
+                  "alignItems": "center",
                   "flexDirection": "row",
                   "height": 35,
+                  "justifyContent": "center",
                   "paddingHorizontal": 15,
                   "paddingVertical": 5,
                 }
@@ -188,8 +190,10 @@ exports[`SelectComponent should render correctly 1`] = `
               onPress={[Function]}
               style={
                 Object {
+                  "alignItems": "center",
                   "flexDirection": "row",
                   "height": 35,
+                  "justifyContent": "center",
                   "paddingHorizontal": 15,
                   "paddingVertical": 5,
                 }

--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -71,6 +71,8 @@ const createStyles = (colors) =>
       paddingHorizontal: 15,
       paddingVertical: 5,
       flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
       height: Device.isIos() ? ROW_HEIGHT : undefined,
     },
     optionLabel: {
@@ -81,7 +83,6 @@ const createStyles = (colors) =>
     },
     icon: {
       paddingHorizontal: 10,
-      marginTop: 5,
     },
     listWrapper: {
       flex: 1,


### PR DESCRIPTION
**Description**
The check icon was not aligned with the option on the options list of the languages available.

**Proposed Solution**
Align the option with the check icon on the options list.
That component it's used on different settings screens:
 - General Settings
 - Settings & Privacy
 - Advanced

**Code Impact**
Very low, just a style adjustment

**Test Cases**
General Settings:

- Currency Conversion
  - IOS - :white_check_mark:
  - Android - :white_check_mark:

- Current Language
  - IOS - :white_check_mark:
  - Android - :white_check_mark:

- Search Engine
  - IOS - :white_check_mark:
  - Android - :white_check_mark:

Security Settings:
 - Auto Lock
   - IOS - :white_check_mark:
   - Android - :white_check_mark:

Advanced Settings:
 - IPFS Gateway
   - IOS - :white_check_mark:
   - Android - no options to select

**Screenshots/Recordings**
Android Screenshot of IPFS Gateway:
![image](https://user-images.githubusercontent.com/46944231/169062410-6682d735-d072-4e16-bb6d-d9c98ba4c2a5.png)

IOS Simulator solution demo:
https://recordit.co/NuGiBlYblQ


**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/277
