### PR TITLE
Fix overriding network and account for orders being processed

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -95,7 +95,7 @@ const CheckoutWebView = () => {
           aggregatorInitialFiatOrder({
             id: orderId,
             account: selectedAddress,
-            network: Number(selectedChainId),
+            network: selectedChainId,
           }),
         );
         // add the order to the redux global store

--- a/app/components/UI/FiatOnRampAggregator/containers/ApplePayButton.tsx
+++ b/app/components/UI/FiatOnRampAggregator/containers/ApplePayButton.tsx
@@ -22,8 +22,9 @@ const ApplePayButton = ({
 }) => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
-  const network = useSelector(
-    (state: any) => state.engine.backgroundState.NetworkController.network,
+  const chainId = useSelector(
+    (state: any) =>
+      state.engine.backgroundState.NetworkController.provider.chainId,
   );
   const [pay] = useApplePay(quote) as [() => Promise<Order | typeof ABORTED>];
   const lockTime = useSelector((state: any) => state.settings.lockTime);
@@ -46,7 +47,7 @@ const ApplePayButton = ({
         if (order) {
           const fiatOrder: FiatOrder = {
             ...aggregatorOrderToFiatOrder(order),
-            network,
+            network: chainId,
           };
           addOrder(fiatOrder);
           // @ts-expect-error pop is not defined
@@ -76,7 +77,7 @@ const ApplePayButton = ({
     addOrder,
     lockTime,
     navigation,
-    network,
+    chainId,
     pay,
     protectWalletModalVisible,
     quote.crypto?.symbol,

--- a/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
+++ b/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
@@ -34,7 +34,7 @@ const aggregatorOrderStateToFiatOrderState = (
 interface InitialAggregatorOrder {
   id: string;
   account: string;
-  network: number;
+  network: string;
 }
 
 export const aggregatorInitialFiatOrder = (
@@ -63,7 +63,9 @@ export const aggregatorOrderToFiatOrder = (aggregatorOrder: Order) => ({
   currency: aggregatorOrder.fiatCurrency?.symbol || '',
   currencySymbol: aggregatorOrder.fiatCurrency?.denomSymbol || '',
   cryptocurrency: aggregatorOrder.cryptoCurrency?.symbol || '',
-  network: aggregatorOrder.cryptoCurrency?.network?.chainId || '',
+  network:
+    aggregatorOrder.cryptoCurrency?.network?.chainId &&
+    String(aggregatorOrder.cryptoCurrency?.network?.chainId),
   state: aggregatorOrderStateToFiatOrderState(aggregatorOrder.status),
   account: aggregatorOrder.walletAddress,
   txHash: aggregatorOrder.txHash,

--- a/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
+++ b/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
@@ -65,7 +65,7 @@ export const aggregatorOrderToFiatOrder = (aggregatorOrder: Order) => ({
   cryptocurrency: aggregatorOrder.cryptoCurrency?.symbol || '',
   network:
     aggregatorOrder.cryptoCurrency?.network?.chainId &&
-    String(aggregatorOrder.cryptoCurrency?.network?.chainId),
+    String(aggregatorOrder.cryptoCurrency.network.chainId),
   state: aggregatorOrderStateToFiatOrderState(aggregatorOrder.status),
   account: aggregatorOrder.walletAddress,
   txHash: aggregatorOrder.txHash,


### PR DESCRIPTION
Orders being processed which did not contain network information were incorrectly overridden with a `''` network