### PR TITLE
Fix order id retrieve in checkout

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -99,11 +99,12 @@ const CheckoutWebView = () => {
             // Most likely the user clicked the X in Wyre widget
             // @ts-expect-error navigation prop mismatch
             navigation.dangerouslyGetParent()?.pop();
-          } else {
-            throw new Error(
-              `Order ID could not be retrieved. Callback was ${navState?.url}`,
-            );
+            return;
           }
+
+          throw new Error(
+            `Order ID could not be retrieved. Callback was ${navState?.url}`,
+          );
         }
 
         const transformedOrder = await processAggregatorOrder(

--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -86,6 +86,14 @@ const CheckoutWebView = () => {
   const handleNavigationStateChange = async (navState: WebViewNavigation) => {
     if (navState?.url.startsWith(callbackBaseUrl)) {
       try {
+        const parsedUrl = parseUrl(navState?.url);
+        if (Object.keys(parsedUrl.query).length === 0) {
+          // There was no query params in the URL to parse
+          // Most likely the user clicked the X in Wyre widget
+          // @ts-expect-error navigation prop mismatch
+          navigation.dangerouslyGetParent()?.pop();
+          return;
+        }
         const orders = await SDK.orders();
         const orderId = await orders.getOrderIdFromCallback(
           params?.provider.id,
@@ -93,15 +101,6 @@ const CheckoutWebView = () => {
         );
 
         if (!orderId) {
-          const parsedUrl = parseUrl(navState?.url);
-          if (Object.keys(parsedUrl.query).length === 0) {
-            // There was no query params in the URL to parse
-            // Most likely the user clicked the X in Wyre widget
-            // @ts-expect-error navigation prop mismatch
-            navigation.dangerouslyGetParent()?.pop();
-            return;
-          }
-
           throw new Error(
             `Order ID could not be retrieved. Callback was ${navState?.url}`,
           );

--- a/app/components/UI/FiatOnRampAggregator/Views/GetQuotes.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetQuotes.tsx
@@ -31,7 +31,6 @@ import StyledButton from '../../StyledButton';
 import BaseListItem from '../../../Base/ListItem';
 import { getFiatOnRampAggNavbar } from '../../Navbar';
 
-import { callbackBaseUrl } from '../orderProcessor/aggregator';
 import useInterval from '../../../hooks/useInterval';
 import { strings } from '../../../../../locales/i18n';
 import Device from '../../../../util/device';
@@ -183,6 +182,7 @@ const GetQuotes = () => {
     selectedAddress,
     selectedFiatCurrencyId,
     appConfig,
+    callbackBaseUrl,
     sdkError,
   } = useFiatOnRampSDK();
 

--- a/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
+++ b/app/components/UI/FiatOnRampAggregator/orderProcessor/aggregator.ts
@@ -98,5 +98,3 @@ export async function processAggregatorOrder(
     return order;
   }
 }
-
-export const callbackBaseUrl = 'https://dummy.url.metamask.io';

--- a/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
+++ b/app/components/UI/FiatOnRampAggregator/sdk/index.tsx
@@ -57,6 +57,7 @@ export interface IFiatOnRampSDK {
   selectedChainId: string;
 
   appConfig: IFiatOnRampSDKConfig;
+  callbackBaseUrl: string;
 }
 
 interface IProviderProps<T> {
@@ -74,6 +75,10 @@ export const SDK = OnRampSdk.create(
     verbose: VERBOSE_SDK,
   },
 );
+
+export const callbackBaseUrl = isDevelopment
+  ? 'https://on-ramp-content.metaswap-dev.codefi.network/regions/fake-callback'
+  : 'https://on-ramp-content.metaswap.codefi.network/regions/fake-callback';
 
 const appConfig = {
   POLLING_INTERVAL: 20000,
@@ -180,6 +185,7 @@ export const FiatOnRampSDKProvider = ({
     selectedChainId,
 
     appConfig,
+    callbackBaseUrl,
   };
 
   return <SDKContext.Provider value={value || contextValue} {...props} />;

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-native-gesture-handler/**/cross-fetch": "3.1.5"
   },
   "dependencies": {
-    "@consensys/on-ramp-sdk": "^1.0.2",
+    "@consensys/on-ramp-sdk": "^1.0.3",
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@keystonehq/bc-ur-registry-eth": "^0.7.7",
     "@keystonehq/metamask-airgapped-keyring": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,10 +1104,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@consensys/on-ramp-sdk@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@consensys/on-ramp-sdk/-/on-ramp-sdk-1.0.2.tgz#b450227649cfa9084fd9c4b2d0e098c8f4bc2ca3"
-  integrity sha512-9hIuRrCsrifwVV+kPkuTw8wIJODAczZgNbWHvPdaWMGy3Qv1rQ0O9bmLHiO56Wrym/U+2bBpCdiwPtMiJiKUHA==
+"@consensys/on-ramp-sdk@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@consensys/on-ramp-sdk/-/on-ramp-sdk-1.0.3.tgz#92cc982d00cde4b3749ec5024ce67a4a74d5cbf2"
+  integrity sha512-1WRuInJ5WTt1NHFVejI7BgTCRhYAQAlOg0wd3l60dgD1NqS3KI3z6hUqve3EPZGq/R/0DbQ8vjxBPl/rRNNxDg==
   dependencies:
     async "^3.2.3"
     axios "^0.21.0"


### PR DESCRIPTION
This PR upgrades SDK to version 1.0.3. This fixes a bug where `getOrderIdFromCallback` was throwing a NotFoundException