### PR TITLE
[5.2.0][FIX] Text alignment for other languages

### DIFF
--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -589,23 +589,21 @@ class RevealPrivateCredential extends PureComponent {
     return (
       <Text style={styles.normalText}>
         {strings('reveal_credential.seed_phrase_explanation')[0]}
-        <TouchableOpacity onPress={() => Linking.openURL(SRP_URL)}>
-          <Text style={[styles.blueText, styles.link]}>
+       
+          <Text onPress={() => Linking.openURL(SRP_URL)} accessibilityElementsHidden style={[styles.blueText, styles.link]}>
             {strings('reveal_credential.seed_phrase_explanation')[1]}
           </Text>
-        </TouchableOpacity>
+
         {strings('reveal_credential.seed_phrase_explanation')[2]}
         <Text style={styles.boldText}>
-          {strings('reveal_credential.seed_phrase_explanation')[3]}
+          { strings('reveal_credential.seed_phrase_explanation')[3]}
         </Text>
         {strings('reveal_credential.seed_phrase_explanation')[4]}
-        <TouchableOpacity
-          onPress={() => Linking.openURL(NON_CUSTODIAL_WALLET_URL)}
-        >
-          <Text style={[styles.blueText, styles.link]}>
+       
+          <Text onPress={() => Linking.openURL(NON_CUSTODIAL_WALLET_URL)} style={[styles.blueText, styles.link]}>
             {strings('reveal_credential.seed_phrase_explanation')[5]}
           </Text>
-        </TouchableOpacity>
+      
         {strings('reveal_credential.seed_phrase_explanation')[6]}
         <Text style={styles.boldText}>
           {strings('reveal_credential.seed_phrase_explanation')[7]}

--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -589,21 +589,28 @@ class RevealPrivateCredential extends PureComponent {
     return (
       <Text style={styles.normalText}>
         {strings('reveal_credential.seed_phrase_explanation')[0]}
-       
-          <Text onPress={() => Linking.openURL(SRP_URL)} accessibilityElementsHidden style={[styles.blueText, styles.link]}>
-            {strings('reveal_credential.seed_phrase_explanation')[1]}
-          </Text>
+
+        <Text
+          onPress={() => Linking.openURL(SRP_URL)}
+          accessibilityElementsHidden
+          style={[styles.blueText, styles.link]}
+        >
+          {strings('reveal_credential.seed_phrase_explanation')[1]}
+        </Text>
 
         {strings('reveal_credential.seed_phrase_explanation')[2]}
         <Text style={styles.boldText}>
-          { strings('reveal_credential.seed_phrase_explanation')[3]}
+          {strings('reveal_credential.seed_phrase_explanation')[3]}
         </Text>
         {strings('reveal_credential.seed_phrase_explanation')[4]}
-       
-          <Text onPress={() => Linking.openURL(NON_CUSTODIAL_WALLET_URL)} style={[styles.blueText, styles.link]}>
-            {strings('reveal_credential.seed_phrase_explanation')[5]}
-          </Text>
-      
+
+        <Text
+          onPress={() => Linking.openURL(NON_CUSTODIAL_WALLET_URL)}
+          style={[styles.blueText, styles.link]}
+        >
+          {strings('reveal_credential.seed_phrase_explanation')[5]}
+        </Text>
+
         {strings('reveal_credential.seed_phrase_explanation')[6]}
         <Text style={styles.boldText}>
           {strings('reveal_credential.seed_phrase_explanation')[7]}

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -599,13 +599,13 @@
     "done": "Fertig",
     "confirm": "Weiter",
     "seed_phrase_explanation": [
-      "Die",
+      "Die ",
       "Geheime Wiederherstellungsphrase (Englisch: Secret Recovery Phrase, SRP)",
-      "gibt",
+      " gibt ",
       "vollen Zugriff auf Ihr Wallet, Ihr Guthaben und Ihre Konten.\n\n",
-      "MetaMask ist ein",
+      "MetaMask ist ein ",
       "verwaltungsloses Wallet",
-      ". Das bedeutet,",
+      ". Das bedeutet, ",
       "dass Sie der Besitzer Ihrer SRP sind."
     ],
     "private_key_explanation": "Speichern Sie diese an einem sicheren und geheimen Ort.",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -599,13 +599,13 @@
     "done": "Hecho",
     "confirm": "Siguiente",
     "seed_phrase_explanation": [
-      "La",
+      "La ",
       "Frase secreta de recuperación (SRP)",
-      "otorga",
+      " otorga ",
       "acceso completo a su billetera, fondos y cuentas.\n\n",
-      "MetaMask es una",
+      "MetaMask es una ",
       "billetera no custodiada",
-      "Eso significa que,",
+      ". Eso significa que, ",
       "usted es el dueño de su SRP."
     ],
     "private_key_explanation": "Guárdela en un lugar seguro y secreto.",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -599,13 +599,13 @@
     "done": "Terminé",
     "confirm": "Suivant",
     "seed_phrase_explanation": [
-      "La",
+      "La ",
       "phrase secrète de récupération (PSR)",
-      "donne",
+      " donne ",
       "un accès complet à votre portefeuille, vos fonds et vos comptes.\n\n",
-      "MetaMask est un",
+      "MetaMask est un ",
       "portefeuille non dépositaire",
-      "Cela signifie que",
+      ". Cela signifie que ",
       "vous êtes le responsable exclusif de votre PSR."
     ],
     "private_key_explanation": "Conservez-la dans un endroit sûr et secret.",


### PR DESCRIPTION
**Description**
The text was not align in the _Reveal Secret Recovery Phrase_ screen and some languages needed some changes in the translation file.

**Proposed Solution**
Edited the language files (german, spanish and french) to have the translations with the spaces missing and improved the _RevealPrivateCredential_ component for the text be aligned.

**Code Impact**
Very low, will only change the phrase in that screen.

**Test Cases**
Case1:
 - Phrase in Portuguese - Brazil
 - Phrase in German
 - Phrase in Spanish
 - Phrase in French

**Screenshots/Recordings**
SS in german:
![simulator_screenshot_63276760-1DE0-47E1-A795-8E89FCE662D2](https://user-images.githubusercontent.com/46944231/169315469-45de317d-40e9-47ed-add0-f963aa73c974.png)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #[277](https://github.com/MetaMask/mobile-planning/issues/277)
