### PR TITLE
[5.2.0][FIX] M3 - Warning on legit address

### DIFF
--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -364,6 +364,8 @@ class SendFlow extends PureComponent {
    * @returns
    */
   getAddressNameFromBookOrIdentities = (toSelectedAddress) => {
+    if (!toSelectedAddress) return;
+
     const { addressBook, network, identities } = this.props;
     const networkAddressBook = addressBook[network] || {};
 
@@ -493,6 +495,7 @@ class SendFlow extends PureComponent {
   };
 
   onToSelectedAddressChange = (toSelectedAddress) => {
+    //undefined
     const addressName =
       this.getAddressNameFromBookOrIdentities(toSelectedAddress);
 
@@ -508,7 +511,7 @@ class SendFlow extends PureComponent {
         toSelectedAddressName: addressName,
       });
     } else {
-      this.validateAddressOrENSFromInput(toSelectedAddress);
+      this.validateAddressOrENSFromInput(toSelectedAddress); //undefined
       /**
        * Because validateAddressOrENSFromInput is asynchronous function
        * we are setting the state here synchronously, so it does not block the UI

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -407,7 +407,7 @@ class SendFlow extends PureComponent {
         !identities[checksummedToSelectedAddress]
       ) {
         toAddressName = toSelectedAddress;
-        // If not in address book nor user accounts
+        // If not in the addressBook nor user accounts
         addToAddressToAddressBook = true;
       }
 

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -360,8 +360,8 @@ class SendFlow extends PureComponent {
   };
   /**
    * This returns the address name from the address book or user accounts if the selectedAddress exist there
-   * @param {String} toSelectedAddress - Represents the value of what user writes on toAddress input
-   * @returns {string | null} - String cointaining the address or null if it's not on the address book or identities
+   * @param {String} toSelectedAddress - Address input
+   * @returns {String | null} - Address or null if toSelectedAddress is not in the addressBook or identities array
    */
   getAddressNameFromBookOrIdentities = (toSelectedAddress) => {
     if (!toSelectedAddress) return;

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -492,7 +492,7 @@ class SendFlow extends PureComponent {
 
     /**
      * If the address is from addressBook or identities
-     * we do not need to validate since it was already validated before
+     * then validation is not necessary since it was already validated
      */
     if (addressName) {
       this.setState({

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -504,7 +504,7 @@ class SendFlow extends PureComponent {
     } else {
       this.validateAddressOrENSFromInput(toSelectedAddress);
       /**
-       * Because validateAddressOrENSFromInput is asynchronous function
+       * Because validateAddressOrENSFromInput is an asynchronous function
        * we are setting the state here synchronously, so it does not block the UI
        * */
       this.setState({

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -360,8 +360,8 @@ class SendFlow extends PureComponent {
   };
   /**
    * This returns the address name from the address book or user accounts if the selectedAddress exist there
-   * @param {*} toSelectedAddress - Represents the value of what user writes on toAddress input
-   * @returns
+   * @param {String} toSelectedAddress - Represents the value of what user writes on toAddress input
+   * @returns {string | null} - String cointaining the address or null if it's not on the address book or identities
    */
   getAddressNameFromBookOrIdentities = (toSelectedAddress) => {
     if (!toSelectedAddress) return;
@@ -369,21 +369,13 @@ class SendFlow extends PureComponent {
     const { addressBook, network, identities } = this.props;
     const networkAddressBook = addressBook[network] || {};
 
-    const checksummedToSelectedAddress = toChecksumAddress(toSelectedAddress);
+    const checksummedAddress = toChecksumAddress(toSelectedAddress);
 
-    if (
-      networkAddressBook[checksummedToSelectedAddress] ||
-      identities[checksummedToSelectedAddress]
-    ) {
-      return (
-        (networkAddressBook[checksummedToSelectedAddress] &&
-          networkAddressBook[checksummedToSelectedAddress].name) ||
-        (identities[checksummedToSelectedAddress] &&
-          identities[checksummedToSelectedAddress].name)
-      );
-    }
-
-    return null;
+    return networkAddressBook[checksummedAddress]
+      ? networkAddressBook[checksummedAddress].name
+      : identities[checksummedAddress]
+      ? identities[checksummedAddress].name
+      : null;
   };
 
   validateAddressOrENSFromInput = async (toSelectedAddress) => {

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -495,7 +495,6 @@ class SendFlow extends PureComponent {
   };
 
   onToSelectedAddressChange = (toSelectedAddress) => {
-    //undefined
     const addressName =
       this.getAddressNameFromBookOrIdentities(toSelectedAddress);
 
@@ -511,7 +510,7 @@ class SendFlow extends PureComponent {
         toSelectedAddressName: addressName,
       });
     } else {
-      this.validateAddressOrENSFromInput(toSelectedAddress); //undefined
+      this.validateAddressOrENSFromInput(toSelectedAddress);
       /**
        * Because validateAddressOrENSFromInput is asynchronous function
        * we are setting the state here synchronously, so it does not block the UI


### PR DESCRIPTION
**Description**
The warning of invalid address was showing before the address was verified but if it was on the address book was already verified.

**Proposed solution**
 Now the address that is on the address book will not be verified again, that way we will not have the delay of verifying the address again.

**Code Impact**
Low, the code will only affect how the SendTo screen works, it's the first screen of the send flow.

**Test Cases**
Case 1:
* In wallet view, press the send button
* In the Address to complete with (in mainnet):
  * ENS name
  * address
  * address from the address book
  * recents
  * from user accounts
* Press next and insert one amount
* In rinkeby network completed the transaction when the address was from
  *  insert normal address
  *  recent 
  *  address from the address book
Case 2:
 * Complete with an unknown address
 * Add the address to the Address book
Case 3:
 * Select the address from the address book
 * Clear address 
Case 4:
 * Select unkown address from recents (will appear the warning because needs to be verified)
 * Clear address
Case 5:
 * Write an unkown address  (will appear the warning because needs to be verified)
 * Clear address
Case 6:
* Write an ens name  (will appear the warning because needs to be verified)
* Clear ens name
Case 7:
* Scan address with QR code
* Clear address
* Scan again and do a transaction

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**
Solution without the orange warning:
https://recordit.co/FCljUjFoxQ

**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/278
