### PR TITLE
Only rely on setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: yarn lint
   audit:
     runs-on: ubuntu-20.04
-    needs: lint
+    needs: setup
     steps:
       - uses: actions/cache@v2
         id: restore-build
@@ -75,7 +75,7 @@ jobs:
       - run: yarn audit:ci
   tgz-check:
     runs-on: ubuntu-20.04
-    needs: audit
+    needs: setup
     steps:
       - uses: actions/cache@v2
         id: restore-build
@@ -93,7 +93,7 @@ jobs:
       - run: yarn test:tgz-check
   test:
     runs-on: ubuntu-20.04
-    needs: tgz-check
+    needs: setup
     steps:
       - uses: actions/cache@v2
         id: restore-build


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

I previously made these jobs rely on each other, but they all actually only need to wait for `setup`.

This should speed things up a tiny bit by making all subsequent jobs run immediately after `setup` instead of needlessly waiting on each other. For example `test`, our longest running job, will start up sooner now.

for additional context

this was the shape of the CI pipeline:

![image](https://user-images.githubusercontent.com/675259/169859502-ae562335-9ae7-4404-aabb-a5c715568469.png)

now, it looks like this:

![image](https://user-images.githubusercontent.com/675259/169859649-bc8977c7-0459-43dc-a4c3-e2c343c2c2d0.png)
