### PR TITLE
[FIX] Add margin and check to AssetActionButton text

### DIFF
--- a/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`AssetActionButtons should render type receive correctly 1`] = `
     underline={false}
     upper={false}
   >
-    receive receive
+    receive...
   </Text>
 </TouchableOpacity>
 `;

--- a/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
@@ -51,12 +51,15 @@ exports[`AssetActionButtons should render correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;
 
@@ -125,12 +128,15 @@ exports[`AssetActionButtons should render type add correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;
 
@@ -199,12 +205,15 @@ exports[`AssetActionButtons should render type information correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;
 
@@ -285,12 +294,15 @@ exports[`AssetActionButtons should render type receive correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;
 
@@ -359,12 +371,15 @@ exports[`AssetActionButtons should render type send correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;
 
@@ -439,11 +454,14 @@ exports[`AssetActionButtons should render type swap correctly 1`] = `
       Object {
         "color": "#037DD6",
         "fontSize": 14,
+        "marginHorizontal": 3,
         "marginTop": 8,
       }
     }
     underline={false}
     upper={false}
-  />
+  >
+    mock text
+  </Text>
 </TouchableOpacity>
 `;

--- a/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AssetActionButton/__snapshots__/index.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`AssetActionButtons should render type receive correctly 1`] = `
     underline={false}
     upper={false}
   >
-    mock text
+    receive receive
   </Text>
 </TouchableOpacity>
 `;

--- a/app/components/UI/AssetActionButton/index.js
+++ b/app/components/UI/AssetActionButton/index.js
@@ -127,7 +127,7 @@ function AssetActionButton({ onPress, icon, label, disabled }) {
       </View>
       <Text centered style={styles.buttonText} numberOfLines={1}>
         {label.size > maxStringLength
-          ? `${label[(0, maxStringLength - 3)]}...`
+          ? `${label.substring(0, maxStringLength - 3)}...`
           : label}
       </Text>
     </TouchableOpacity>

--- a/app/components/UI/AssetActionButton/index.js
+++ b/app/components/UI/AssetActionButton/index.js
@@ -126,7 +126,7 @@ function AssetActionButton({ onPress, icon, label, disabled }) {
         {icon && (typeof icon === 'string' ? getIcon(icon) : icon)}
       </View>
       <Text centered style={styles.buttonText} numberOfLines={1}>
-        {label.size > maxStringLength
+        {label.length > maxStringLength
           ? `${label.substring(0, maxStringLength - 3)}...`
           : label}
       </Text>

--- a/app/components/UI/AssetActionButton/index.js
+++ b/app/components/UI/AssetActionButton/index.js
@@ -38,6 +38,7 @@ const createStyles = (colors) =>
     },
     buttonText: {
       marginTop: 8,
+      marginHorizontal: 3,
       color: colors.primary.default,
       fontSize: 14,
     },
@@ -59,6 +60,8 @@ const createStyles = (colors) =>
 function AssetActionButton({ onPress, icon, label, disabled }) {
   const { colors } = useAppThemeFromContext() || mockTheme;
   const styles = createStyles(colors);
+
+  const maxStringLength = 10;
 
   const getIcon = (type) => {
     switch (type) {
@@ -123,7 +126,9 @@ function AssetActionButton({ onPress, icon, label, disabled }) {
         {icon && (typeof icon === 'string' ? getIcon(icon) : icon)}
       </View>
       <Text centered style={styles.buttonText} numberOfLines={1}>
-        {label}
+        {label.size > maxStringLength
+          ? `${label[(0, maxStringLength - 3)]}...`
+          : label}
       </Text>
     </TouchableOpacity>
   );

--- a/app/components/UI/AssetActionButton/index.test.tsx
+++ b/app/components/UI/AssetActionButton/index.test.tsx
@@ -3,28 +3,33 @@ import { shallow } from 'enzyme';
 import AssetActionButton from './';
 
 describe('AssetActionButtons', () => {
+  const mockText = 'mock text';
   it('should render correctly', () => {
-    const wrapper = shallow(<AssetActionButton />);
+    const wrapper = shallow(<AssetActionButton label={mockText} />);
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type send correctly', () => {
-    const wrapper = shallow(<AssetActionButton icon="send" />);
+    const wrapper = shallow(<AssetActionButton icon="send" label={mockText} />);
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type receive correctly', () => {
-    const wrapper = shallow(<AssetActionButton icon="receive" />);
+    const wrapper = shallow(
+      <AssetActionButton icon="receive" label={mockText} />,
+    );
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type add correctly', () => {
-    const wrapper = shallow(<AssetActionButton icon="add" />);
+    const wrapper = shallow(<AssetActionButton icon="add" label={mockText} />);
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type information correctly', () => {
-    const wrapper = shallow(<AssetActionButton icon="information" />);
+    const wrapper = shallow(
+      <AssetActionButton icon="information" label={mockText} />,
+    );
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type swap correctly', () => {
-    const wrapper = shallow(<AssetActionButton icon="swap" />);
+    const wrapper = shallow(<AssetActionButton icon="swap" label={mockText} />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/app/components/UI/AssetActionButton/index.test.tsx
+++ b/app/components/UI/AssetActionButton/index.test.tsx
@@ -13,9 +13,9 @@ describe('AssetActionButtons', () => {
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type receive correctly', () => {
-    const wrapper = shallow(
-      <AssetActionButton icon="receive" label={mockText} />,
-    );
+    // String with more than 10 characters
+    const text = 'receive receive';
+    const wrapper = shallow(<AssetActionButton icon="receive" label={text} />);
     expect(wrapper).toMatchSnapshot();
   });
   it('should render type add correctly', () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

The `AssetActionButton` component wasn't handling long string. This PR add a margin and a 10 character max check to the component to avoid UI issues

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

| BUG | FIX |
|-----|-----|
| ![Bug](https://user-images.githubusercontent.com/17601467/169755943-60ab86ba-24cc-4655-bfc5-f671f78cb787.png) | ![Fix](https://user-images.githubusercontent.com/17601467/169755890-8bb2383a-09ae-4d13-86fb-35ea624e0291.png) |

**Issue**



Progresses [Issue Reference](https://github.com/MetaMask/mobile-planning/issues/278#issuecomment-1131975445)
