### PR TITLE
[5.2.0][FIX] M6 - Fixes double tab opening when using `metamask://dapp/` deep link schema

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -336,7 +336,10 @@ class DeeplinkManager {
           );
         } else if (url.startsWith('metamask://dapp/')) {
           try {
-            this._handleBrowserUrl(urlObj.href.split('metamask://dapp/')[1]);
+            this._handleBrowserUrl(
+              urlObj.href.split('metamask://dapp/')[1],
+              browserCallBack,
+            );
           } catch (e) {
             if (e) Alert.alert(strings('deeplink.invalid'), e.toString());
           }


### PR DESCRIPTION
**Description**

When I tap a `metamask://dapp/` deeplinks introduced in PR 4167 with MetaMask open in the background, then 2 tabs are opening

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Issue**

Progresses #M6
