### PR TITLE
fixed description for apple pay to reflect the desc for card

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/components/OrderDetails.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/OrderDetails.tsx
@@ -160,7 +160,7 @@ const Stage: React.FC<PropsStage> = ({
               ? strings('fiat_on_ramp_aggregator.order_details.processing')
               : strings('transaction.submitted')}
           </Text>
-          {!paymentType?.includes('Credit') ? (
+          {paymentType?.includes('Bank') ? (
             <Text small centered style={styles.stageMessage}>
               {strings(
                 'fiat_on_ramp_aggregator.order_details.processing_bank_description',


### PR DESCRIPTION
Apple pay was previously showing the description for bank transactions in the order details screen. Fixed it to show the description for credit card

**Description**

_Write a short description of the changes included in this pull request._

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #???
