### PR TITLE
[FIX][5.2]Removes `metamask://dapp/` schema support until stable on Android

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -208,10 +208,9 @@ class DeeplinkManager {
           `${PROTOCOLS.DAPP}/${PROTOCOLS.HTTPS}://`,
           `${PROTOCOLS.DAPP}/`,
         )
-        .replace(`${PROTOCOLS.DAPP}/${PROTOCOLS.HTTP}://`, `${PROTOCOLS.DAPP}/`)
         .replace(
-          `${PROTOCOLS.METAMASK}://${PROTOCOLS.DAPP}/`,
-          `${PROTOCOLS.DAPP}://`,
+          `${PROTOCOLS.DAPP}/${PROTOCOLS.HTTP}://`,
+          `${PROTOCOLS.DAPP}/`,
         ),
     );
     let params;


### PR DESCRIPTION
**Description**

Removes `metamask://dapp/` schema support until it is stable on Android

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #???
