### PR TITLE
remove secret_phrase_video_subtitle key

### DIFF
--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -1771,10 +1771,6 @@
     "loading": "Φόρτωση...",
     "not_found": "Τα μέσα δεν βρέθηκαν"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "EL CC",
-    "language": "el"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Επιλογές για προχωρημένους",
     "gas_limit": "Όριο τέλους συναλλαγής",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -1771,10 +1771,6 @@
     "loading": "Chargement…",
     "not_found": "Média introuvable"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "FR CC",
-    "language": "fr"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Options avancées",
     "gas_limit": "Limite de gaz",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -1771,11 +1771,6 @@
     "loading": "लोड हो रहा है...",
     "not_found": "माध्यम नहीं मिला"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "HI CC",
-    "language": "hi",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-hi-in.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "एडवांस विकल्प",
     "gas_limit": "गैस की सीमा",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -1771,11 +1771,6 @@
     "loading": "Memuat...",
     "not_found": "Media tidak ditemukan"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "ID CC",
-    "language": "id",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-id-id.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Opsi lanjutan",
     "gas_limit": "Batas gas",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -1771,11 +1771,6 @@
     "loading": "読み込み中...",
     "not_found": "メディアが見つかりません"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "JA CC",
-    "language": "ja",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ja-jp.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "高度なオプション",
     "gas_limit": "ガス上限",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -1771,11 +1771,6 @@
     "loading": "로딩 중...",
     "not_found": "미디어가 확인되지 않음"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "KO CC",
-    "language": "ko",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ko-kr.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "고급 옵션",
     "gas_limit": "가스 한도",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -1771,11 +1771,6 @@
     "loading": "Carregando...",
     "not_found": "Mídia não encontrada"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "PT CC",
-    "language": "pt",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-pt-br.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Opções avançadas",
     "gas_limit": "Limite de Gas",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -1771,11 +1771,6 @@
     "loading": "Загрузка...",
     "not_found": "Медиа не найдено"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "RU CC",
-    "language": "ru",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-ru-ru.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Расширенные параметры",
     "gas_limit": "Лимит газа",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -1771,10 +1771,6 @@
     "loading": "Yükleniyor...",
     "not_found": "Ortam bulunamadı"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "TR CC",
-    "language": "tr"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Gelişmiş seçenekler",
     "gas_limit": "Gaz limiti",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -1771,11 +1771,6 @@
     "loading": "Đang tải...",
     "not_found": "Không tìm thấy phương tiện"
   },
-  "secret_phrase_video_subtitle": {
-    "title": "VI CC",
-    "language": "vi",
-    "uri": "https://github.com/MetaMask/metamask-mobile/blob/main/app/videos/subtitles/secretPhrase/subtitles-vi-vn.vtt?raw=true"
-  },
   "edit_gas_fee_eip1559": {
     "advanced_options": "Tùy chọn nâng cao",
     "gas_limit": "Giới hạn gas",


### PR DESCRIPTION
looks like these got added back in when `5.2.0` was merged in: https://github.com/MetaMask/metamask-mobile/pull/4341

this removes them again.