### PR TITLE
Fix WalletConnect Icon on connect screen

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -491,8 +491,9 @@ const RootRPCMethodsUI = (props) => {
           onCancel={onWalletConnectSessionRejected}
           onConfirm={onWalletConnectSessionApproval}
           currentPageInformation={{
-            title: meta && meta.name,
-            url: meta && meta.url,
+            title: meta?.name,
+            url: meta?.url,
+            icon: meta?.icons?.[0],
           }}
           walletConnectRequest
         />


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Use WalletConnect icon field on connect screen

How to test: Test multiple websites that use WalletConnect, they all should work and they all should show an Icon on the connect modal