### PR TITLE
Add accesible false to pressable group preventing VoiceOver interaction

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.tsx
@@ -709,7 +709,11 @@ const AmountToBuy = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
-        <Pressable onPress={handleKeypadDone} style={styles.viewContainer}>
+        <Pressable
+          onPress={handleKeypadDone}
+          style={styles.viewContainer}
+          accessible={false}
+        >
           <ScreenLayout.Content>
             <View style={[styles.selectors, styles.row]}>
               <AccountSelector />


### PR DESCRIPTION
A `Pressable` wrapper was preventing individually selecting UI elements within. This disables its grouping at accessibility layer, unlocking nested UI elements to be accessible.