### PR TITLE
Updated new rpcUrl of gnosischain on test file

### DIFF
--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -5,7 +5,7 @@ const correctParams = {
   chainName: 'xDai',
   blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
   nativeCurrency: { symbol: 'xDai', decimals: 18 },
-  rpcUrls: ['https://rpc.xdaichain.com'],
+  rpcUrls: ['https://rpc.gnosischain.com'],
 };
 
 const otherOptions = {


### PR DESCRIPTION
**Description**
[rpc.xdaichain.com](http://rpc.xdaichain.com/) is no longer supported
https://twitter.com/gnosischain/status/1536766216689287168
And the tests to the wallet_addEthereumChain.test.js file are failing.

**Proposed solution**
Change the rpcUrl for the new one recommended by gnosischain [here](https://developers.gnosischain.com/for-developers/developer-resources/update-rpc-url)

**Code Impact**
The impact is low, just for the file wallet_addEthereumChain.test.js file continues to test the RPC method as expected

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #???
