### PR TITLE
[CD1] bugfix: duplicate networks when adding to the addToFrequentRPClist

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -449,7 +449,7 @@ class NetworkSettings extends PureComponent {
       // Remove trailing slashes
       const formattedHref = url.href.replace(/\/+$/, '');
       PreferencesController.addToFrequentRpcList(
-        formattedHref,
+        url.href,
         decimalChainId,
         ticker,
         nickname,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes https://github.com/MetaMask/mobile-planning/issues/307#issuecomment-1160859054

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**

Progresses #???
