### PR TITLE
Just being able to navigate to on ramp if the networks are supported

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -60,6 +60,7 @@ import withQRHardwareAwareness from '../QRHardware/withQRHardwareAwareness';
 import QRSigningDetails from '../QRHardware/QRSigningDetails';
 import Routes from '../../../constants/navigation/Routes';
 import formatNumber from '../../../util/formatNumber';
+import { allowedToBuy } from '../FiatOrders';
 
 const { hexToBN } = util;
 const createStyles = (colors) =>
@@ -675,6 +676,7 @@ class ApproveTransactionReview extends PureComponent {
     } = this.props;
     const styles = this.getStyles();
     const isTestNetwork = isTestNet(network);
+
     const originIsDeeplink =
       origin === ORIGIN_DEEPLINK || origin === ORIGIN_QR_CODE;
     const errorPress = isTestNetwork ? this.goToFaucet : this.buyEth;
@@ -826,17 +828,26 @@ class ApproveTransactionReview extends PureComponent {
 
                   {gasError && (
                     <View style={styles.errorWrapper}>
-                      <TouchableOpacity onPress={errorPress}>
+                      {isTestNetwork || allowedToBuy(network) ? (
+                        <TouchableOpacity onPress={errorPress}>
+                          <Text reset style={styles.error}>
+                            {gasError}
+                          </Text>
+
+                          {over && (
+                            <Text
+                              reset
+                              style={[styles.error, styles.underline]}
+                            >
+                              {errorLinkText}
+                            </Text>
+                          )}
+                        </TouchableOpacity>
+                      ) : (
                         <Text reset style={styles.error}>
                           {gasError}
                         </Text>
-
-                        {over && (
-                          <Text reset style={[styles.error, styles.underline]}>
-                            {errorLinkText}
-                          </Text>
-                        )}
-                      </TouchableOpacity>
+                      )}
                     </View>
                   )}
                   {!gasError && (

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -41,6 +41,7 @@ import { ThemeContext, mockTheme } from '../../../../util/theme';
 import Routes from '../../../../constants/navigation/Routes';
 import AppConstants from '../../../../core/AppConstants';
 import WarningMessage from '../../../Views/SendFlow/WarningMessage';
+import { allowedToBuy } from '../../FiatOrders';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -616,7 +617,6 @@ class TransactionReviewInformation extends PureComponent {
     const styles = createStyles(colors);
 
     const isTestNetwork = isTestNet(network);
-
     const errorPress = isTestNetwork ? this.goToFaucet : this.buyEth;
     const errorLinkText = isTestNetwork
       ? strings('transaction.go_to_faucet')
@@ -656,14 +656,18 @@ class TransactionReviewInformation extends PureComponent {
         )}
         {!!error && (
           <View style={styles.errorWrapper}>
-            <TouchableOpacity onPress={errorPress}>
+            {isTestNetwork || allowedToBuy(network) ? (
+              <TouchableOpacity onPress={errorPress}>
+                <Text style={styles.error}>{error}</Text>
+                {over && (
+                  <Text style={[styles.error, styles.underline]}>
+                    {errorLinkText}
+                  </Text>
+                )}
+              </TouchableOpacity>
+            ) : (
               <Text style={styles.error}>{error}</Text>
-              {over && (
-                <Text style={[styles.error, styles.underline]}>
-                  {errorLinkText}
-                </Text>
-              )}
-            </TouchableOpacity>
+            )}
           </View>
         )}
         {!!warningGasPriceHigh && (

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -84,6 +84,7 @@ import { KEYSTONE_TX_CANCELED } from '../../../../constants/error';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import Routes from '../../../../constants/navigation/Routes';
 import WarningMessage from '../WarningMessage';
+import { allowedToBuy } from '../../../UI/FiatOrders';
 
 const EDIT = 'edit';
 const EDIT_NONCE = 'edit_nonce';
@@ -382,7 +383,6 @@ class Confirm extends PureComponent {
     fromAccountModalVisible: false,
     warningModalVisible: false,
     mode: REVIEW,
-    over: false,
     gasSelected: AppConstants.GAS_OPTIONS.MEDIUM,
     gasSelectedTemp: AppConstants.GAS_OPTIONS.MEDIUM,
     EIP1559TransactionData: {},
@@ -1376,7 +1376,6 @@ class Confirm extends PureComponent {
       warningGasPriceHigh,
       confusableCollection,
       mode,
-      over,
       warningModalVisible,
       LegacyTransactionData,
       isAnimating,
@@ -1421,6 +1420,7 @@ class Confirm extends PureComponent {
       );
 
     const isTestNetwork = isTestNet(network);
+
     const errorPress = isTestNetwork ? this.goToFaucet : this.buyEth;
     const errorLinkText = isTestNetwork
       ? strings('transaction.go_to_faucet')
@@ -1545,14 +1545,16 @@ class Confirm extends PureComponent {
 
           {errorMessage && (
             <View style={styles.errorWrapper}>
-              <TouchableOpacity onPress={errorPress}>
-                <Text style={styles.error}>{errorMessage}</Text>
-                {over ? (
+              {isTestNetwork || allowedToBuy(network) ? (
+                <TouchableOpacity onPress={errorPress}>
+                  <Text style={styles.error}>{errorMessage}</Text>
                   <Text style={[styles.error, styles.underline]}>
                     {errorLinkText}
                   </Text>
-                ) : null}
-              </TouchableOpacity>
+                </TouchableOpacity>
+              ) : (
+                <Text style={styles.error}>{errorMessage}</Text>
+              )}
             </View>
           )}
           {!!warningGasPriceHigh && (


### PR DESCRIPTION
**Description**
Was being able to go to on-ramp (Buy Cryptocurrency with fiat) when the network was not supported

**Proposed Solution**
Just be able to go to on-ramp if the network is supported 
Case Ethereum mainnet:
<img src="https://user-images.githubusercontent.com/46944231/174998479-2fbfb22d-2c33-4afd-86eb-908d6d191c18.png" width="150" height="280">

Case Palm:
<img src="https://user-images.githubusercontent.com/46944231/174998631-66f20f6e-5d1e-457f-94b1-5e8e08394503.png" width="150" height="280">



**Code Impact**
Low


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

**Screenshots/Recordings**

_If applicable, add screenshots or recordings to visualize the changes_

**Issue**
[CD5](https://github.com/MetaMask/mobile-planning/issues/307#issuecomment-1160890654)
Progresses #https://github.com/MetaMask/mobile-planning/issues/307 
