### PR TITLE
[FIX] Remove TouchableOpacity from DeleteMetaMetricsData component

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
@@ -151,11 +151,9 @@ const DeleteMetaMetricsData = () => {
             <Text>
               {strings('app_settings.delete_metrics_description_part_three')}
             </Text>{' '}
-            <TouchableOpacity onPress={openPrivacyPolicy}>
-              <Text style={[styles.blueText]}>
-                {strings('app_settings.consensys_privacy_policy')}
-              </Text>
-            </TouchableOpacity>
+            <Text style={[styles.blueText]} onPress={openPrivacyPolicy}>
+              {strings('app_settings.consensys_privacy_policy')}
+            </Text>
           </>
         ) : (
           <>
@@ -166,11 +164,9 @@ const DeleteMetaMetricsData = () => {
             <Text>
               {strings('app_settings.delete_metrics_description_part_five')}
             </Text>{' '}
-            <TouchableOpacity onPress={openPrivacyPolicy}>
-              <Text style={[styles.blueText]}>
-                {strings('app_settings.consensys_privacy_policy')}
-              </Text>
-            </TouchableOpacity>
+            <Text style={[styles.blueText]} onPress={openPrivacyPolicy}>
+              {strings('app_settings.consensys_privacy_policy')}
+            </Text>
           </>
         )
       }

--- a/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Alert,
-  Linking,
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-} from 'react-native';
+import { Alert, Linking, Platform, StyleSheet, Text } from 'react-native';
 import Analytics from '../../../../../core/Analytics/Analytics';
 import {
   DeletionTaskStatus,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
_2. What is the improvement/solution?_

Removed the `TouchableOpacity` from the component since `Text` API also has a `onPress` prop.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

NA

**Issue**

Progresses #NA

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
