### PR TITLE
Metamask Mobile not EIP-55 Compliant - Update WalletConnect.js

### DIFF
--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -278,7 +278,7 @@ class WalletConnect {
   startSession = async (sessionData, existing) => {
     const chainId = Engine.context.NetworkController.state.provider.chainId;
     const selectedAddress =
-      Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
+      Engine.context.PreferencesController.state.selectedAddress;
     const approveData = {
       chainId: parseInt(chainId, 10),
       accounts: [selectedAddress],


### PR DESCRIPTION
Updated line 281 - removed `?.toLowerCase()` as this makes Matamask Mobile not EIP-55 compatible.

<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
When reporting the selected address to Wallet Connect, the address is set with the 'toLower()' function and address is returned in lowercase - see [WalletConnect.js](https://github.com/MetaMask/metamask-mobile/blob/fb7184c14f3afc42f8e77475f05dffd557383c47/app/core/WalletConnect.js#L281)

[EIP-55](https://eips.ethereum.org/EIPS/eip-55) validation will fail if the address is not returned mixed case.

Can be confirmed using Wallet Connect's test [site](https://example.walletconnect.org/) and test connect using different wallets. MetaMask mobile (Android or iOS) returns a lower case address whereas other wallets return a mixed case address.

This appears to be the cause of some other issues (such as https://github.com/MetaMask/metamask-mobile/issues/3937)

_1. What is the reason for the change? MetaMask Mobile v 5.3.0 is currently not compliant with EIP-55 because the wallet address is returned to Wallet Connect in lower case.
_2. What is the improvement/solution? Return the wallet address to MetaMask without adjusting the character case.

**Screenshots/Recordings**
Please see Issue#4672 for screen shots.

**Issue**
Issue #4672 (https://github.com/MetaMask/metamask-mobile/issues/4672)
Progresses #???

**Checklist**

* [ x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented

