### PR TITLE
Fixed error message with the name of the cryptocurrency

### DIFF
--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -883,8 +883,8 @@ class Confirm extends PureComponent {
       accounts,
       contractBalances,
       selectedAsset,
+      ticker,
       transactionState: {
-        ticker,
         transaction: { value },
       },
     } = this.props;


### PR DESCRIPTION

**Description**

_1. What is the reason for the change?_
This is a proposal fix for the CW4 of the release 5.4.0
The error message when we had insufficient funds was with the wrong name of the cryptocurrency

The technical problem was that the value of the ticker it was being searched on the wrong place.

_2. What is the improvement/solution?_
Error message updated to the proper cryptocurrency.

**Screenshots/Recordings**
Error:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/46944231/179109225-d7f919b5-76e2-461e-b4f5-173dd093292a.png">

Solution:
![simulator_screenshot_DDCD6324-FD18-4E8B-87EB-47C0F54E8247](https://user-images.githubusercontent.com/46944231/179108482-2331c012-fdf4-4d79-bc1b-c7ee1b6064b6.png)


**Issue**

Progresses #[316](https://github.com/MetaMask/mobile-planning/issues/316)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
