### PR TITLE
Cal/5.4.0 rc fixes 2nd set

### DIFF
--- a/app/components/UI/AccountList/AccountElement/index.js
+++ b/app/components/UI/AccountList/AccountElement/index.js
@@ -109,8 +109,8 @@ class AccountElement extends PureComponent {
 
   onPress = () => {
     const { onPress } = this.props;
-    const { index } = this.props.item;
-    onPress && onPress(index);
+    const { address } = this.props.item;
+    onPress && onPress(address);
   };
 
   onLongPress = () => {

--- a/app/components/UI/AssetIcon/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AssetIcon/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`AssetIcon should render correctly 1`] = `
 <RemoteImage
   fadeIn={true}
+  key="https://s3.amazonaws.com/airswap-token-images/WBTC.png"
   placeholderStyle={
     Object {
       "backgroundColor": "#F2F4F6",

--- a/app/components/UI/AssetIcon/index.tsx
+++ b/app/components/UI/AssetIcon/index.tsx
@@ -61,6 +61,7 @@ const AssetIcon = memo((props: Props) => {
 
   return (
     <RemoteImage
+      key={props.logo}
       address={props.address}
       fadeIn
       placeholderStyle={styles.placeholder}

--- a/app/components/UI/NetworkInfo/InfoDescription/infoDescription.tsx
+++ b/app/components/UI/NetworkInfo/InfoDescription/infoDescription.tsx
@@ -69,6 +69,10 @@ const Description = (props: DescriptionProps) => {
       screen: 'SettingsFlow',
       params: {
         screen: 'AdvancedSettings',
+        params: {
+          scrollToBottom: true,
+          isFullScreenModal: true,
+        },
       },
     });
   }, [navigation, onClose]);

--- a/app/components/UI/NetworkInfo/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkInfo/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NetworkInfo should render correctly 1`] = `
 <NetworkInfo
   dispatch={[Function]}
-  isTokenDetectionEnabled={false}
+  isTokenDetectionEnabled={true}
   networkProvider={
     Object {
       "rpcTarget": "",

--- a/app/components/UI/NetworkInfo/index.tsx
+++ b/app/components/UI/NetworkInfo/index.tsx
@@ -246,7 +246,7 @@ const NetworkInfo = (props: NetworkInfoProps) => {
 
 const mapStateToProps = (state: any) => ({
   isTokenDetectionEnabled:
-    !state.engine.backgroundState.PreferencesController.useTokenDetection,
+    state.engine.backgroundState.PreferencesController.useTokenDetection,
   networkProvider: state.engine.backgroundState.NetworkController.provider,
 });
 

--- a/app/components/Views/DetectedTokens/index.tsx
+++ b/app/components/Views/DetectedTokens/index.tsx
@@ -157,6 +157,7 @@ const DetectedTokens = () => {
 
     navigation.navigate('DetectedTokensConfirmation', {
       onConfirm: () => dismissModalAndTriggerAction(true),
+      isHidingAll: true,
     });
     InteractionManager.runAfterInteractions(() =>
       AnalyticsV2.trackEvent(AnalyticsV2.ANALYTICS_EVENTS.TOKENS_HIDDEN, {

--- a/app/components/Views/DetectedTokensConfirmation/index.tsx
+++ b/app/components/Views/DetectedTokensConfirmation/index.tsx
@@ -50,13 +50,14 @@ const createStyles = (colors: any) =>
 interface Props {
   route: {
     params: {
+      isHidingAll?: boolean;
       onConfirm: () => void;
     };
   };
 }
 
 const DetectedTokensConfirmation = ({ route }: Props) => {
-  const { onConfirm } = route.params;
+  const { onConfirm, isHidingAll } = route.params;
   const modalRef = useRef<ReusableModalRef>(null);
   const { colors } = useAppThemeFromContext() || mockTheme;
   const styles = createStyles(colors);
@@ -69,13 +70,19 @@ const DetectedTokensConfirmation = ({ route }: Props) => {
 
   const renderHeader = () => (
     <Text style={styles.headerLabel}>
-      {strings('detected_tokens.confirm.title')}
+      {strings(
+        `detected_tokens.confirm.${
+          isHidingAll ? 'hide.title' : 'import.title'
+        }`,
+      )}
     </Text>
   );
 
   const renderDescription = () => (
     <Text style={styles.description}>
-      {strings('detected_tokens.confirm.desc')}
+      {strings(
+        `detected_tokens.confirm.${isHidingAll ? 'hide.desc' : 'import.desc'}`,
+      )}
     </Text>
   );
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -743,10 +743,16 @@
     "token_lists": "Token lists: {{listNames}}",
     "token_more": " + {{remainingListCount}} more",
     "confirm": {
-      "title": "Import selected tokens?",
-      "desc": "Only the tokens you've selected will appear in your wallet. You can always import hidden tokens later by searching for them.",
       "cancel_cta": "Cancel",
-      "confirm_cta": "Confirm"
+      "confirm_cta": "Confirm",
+      "import": {
+        "title": "Import selected tokens?",
+        "desc": "Only the tokens you've selected will appear in your wallet. You can always import hidden tokens later by searching for them."
+      },
+      "hide": {
+        "title": "Are you sure?",
+        "desc": "If you hide tokens, they will not be shown in your wallet. However, you can still add them by searching for them."
+      }
     },
     "address_copied_to_clipboard": "Token address copied to clipboard"
   },


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Fixes CD2, CD6, CD7, and CD8 listed here - https://github.com/MetaMask/mobile-planning/issues/316

CD2, CD6 - Removing imported account that has detected tokens should not cause post-delete account to retain any of the deleted account's detected tokens.
CD7 -  Network modal that shows up the first time when switching account should show correct message in the token detection section (verify that message is correct depending on token detection toggle). Accessing token detection toggle from this flow should result in the Advanced settings screen anchoring down to the token detection toggle.
CD8 - Issue was that token images had stale image data. Test - LINK.E on Avalanche should render properly when searching for tokens.

Also included:
Updated copy for confirmation modal that shows when hiding all detected tokens.
<img width="186" alt="image" src="https://user-images.githubusercontent.com/10508597/179825757-e6a2ccd9-36bb-443f-8487-bbf5288bb908.png">


**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
