### PR TITLE
pin nvm to @1.3.0

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,7 +9,7 @@ workflows:
             - activate-ssh-key@4:
                   run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
             - git-clone@4: {}
-            - nvm@1:
+            - nvm@1.3.0:
                   inputs:
                       - node_version: '14'
     code_setup_cache:


### PR DESCRIPTION
this job is currently broken because bitrise shipped a broken version `@1.3.1` : https://github.com/Almouro/bitrise-nvm-step/issues/16

there's a fix for `@1.3.2` but it's not out yet : https://github.com/bitrise-io/bitrise-steplib/pull/3553

for now we should pin to this version to fix the build.