### PR TITLE
Add wordd 'buy' to limit description

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1651,9 +1651,9 @@
       "hours": "hours",
       "business_day": "business day",
       "business_days": "business days",
-      "lowest_limit": "lowest limit",
-      "medium_limit": "medium limit",
-      "highest_limit": "highest limit",
+      "lowest_limit": "lowest buy limit",
+      "medium_limit": "medium buy limit",
+      "highest_limit": "highest buy limit",
       "apple_cash_not_supported": "Apple Cash is not supported.",
       "card_fees": "Check with your card provider to understand any fees they may charge you. For example, credit card purchases may incur cash advance fees.",
       "continue_to_amount": "Continue to amount"


### PR DESCRIPTION


**Description**

This PR adds the word 'buy' to Payment Methods

**Screenshots/Recordings**
Before/After
<img width="305" alt="Screen Shot 2022-07-20 at 14 54 57" src="https://user-images.githubusercontent.com/1024246/180070162-80593a43-b8f0-44fe-85a5-006e05a8e55c.png"><img width="299" alt="Screen Shot 2022-07-20 at 14 54 28" src="https://user-images.githubusercontent.com/1024246/180070168-d718ebf3-1e23-4315-a6f0-1f69eb7c5f8a.png">


**Issue**

Solves https://consensyssoftware.atlassian.net/browse/ONRAMP-88

