### PR TITLE
Improve error message when we are unable to fetch gas prices

### DIFF
--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -412,19 +412,23 @@ class Approval extends PureComponent {
       to: safeToChecksumAddress(transaction.to),
     };
 
-    if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
-      transactionToSend.gas = EIP1559GasData.gasLimitHex;
-      transactionToSend.maxFeePerGas = addHexPrefix(
-        EIP1559GasData.suggestedMaxFeePerGasHex,
-      ); //'0x2540be400'
-      transactionToSend.maxPriorityFeePerGas = addHexPrefix(
-        EIP1559GasData.suggestedMaxPriorityFeePerGasHex,
-      ); //'0x3b9aca00';
-      transactionToSend.to = safeToChecksumAddress(transaction.to);
-      delete transactionToSend.gasPrice;
-    } else {
-      transactionToSend.gas = BNToHex(transaction.gas);
-      transactionToSend.gasPrice = BNToHex(transaction.gasPrice);
+    try {
+      if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
+        transactionToSend.gas = EIP1559GasData.gasLimitHex;
+        transactionToSend.maxFeePerGas = addHexPrefix(
+          EIP1559GasData.suggestedMaxFeePerGasHex,
+        ); //'0x2540be400'
+        transactionToSend.maxPriorityFeePerGas = addHexPrefix(
+          EIP1559GasData.suggestedMaxPriorityFeePerGasHex,
+        ); //'0x3b9aca00';
+        transactionToSend.to = safeToChecksumAddress(transaction.to);
+        delete transactionToSend.gasPrice;
+      } else {
+        transactionToSend.gas = BNToHex(transaction.gas);
+        transactionToSend.gasPrice = BNToHex(undefined);
+      }
+    } catch (error) {
+      throw new Error(strings('transactions.transaction_error_gas_price'));
     }
 
     return transactionToSend;
@@ -449,18 +453,22 @@ class Approval extends PureComponent {
       to: selectedAsset.address,
     };
 
-    if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
-      transactionToSend.gas = EIP1559GasData.gasLimitHex;
-      transactionToSend.maxFeePerGas = addHexPrefix(
-        EIP1559GasData.suggestedMaxFeePerGasHex,
-      ); //'0x2540be400'
-      transactionToSend.maxPriorityFeePerGas = addHexPrefix(
-        EIP1559GasData.suggestedMaxPriorityFeePerGasHex,
-      ); //'0x3b9aca00';
-      delete transactionToSend.gasPrice;
-    } else {
-      transactionToSend.gas = BNToHex(transaction.gas);
-      transactionToSend.gasPrice = BNToHex(transaction.gasPrice);
+    try {
+      if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
+        transactionToSend.gas = EIP1559GasData.gasLimitHex;
+        transactionToSend.maxFeePerGas = addHexPrefix(
+          EIP1559GasData.suggestedMaxFeePerGasHex,
+        ); //'0x2540be400'
+        transactionToSend.maxPriorityFeePerGas = addHexPrefix(
+          EIP1559GasData.suggestedMaxPriorityFeePerGasHex,
+        ); //'0x3b9aca00';
+        delete transactionToSend.gasPrice;
+      } else {
+        transactionToSend.gas = BNToHex(transaction.gas);
+        transactionToSend.gasPrice = BNToHex(transaction.gasPrice);
+      }
+    } catch (e) {
+      throw new Error(strings('transactions.transaction_error_gas_price'));
     }
 
     return transactionToSend;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1035,6 +1035,7 @@
     "hash_copied_to_clipboard": "Transaction hash copied to clipboard",
     "address_copied_to_clipboard": "Address copied to clipboard",
     "transaction_error": "Transaction error",
+    "transaction_error_gas_price": "We were unable to determine gas prices",
     "address_to_placeholder": "Search, public address (0x), or ENS",
     "address_from_balance": "Balance:",
     "status": "Status",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

When we cannot fetch a gas price for a specific network and while on transaction modal the user sees a generic javascript error message. 

_1. What is the reason for the change?_
Improve UX and DX by showing proper error messages.
_2. What is the improvement/solution?_
This PR improves this error message by showing user-friendly text. 

**Screenshots/Recordings**
Before:
<img width="468" alt="Screen Shot 2022-07-26 at 13 24 35" src="https://user-images.githubusercontent.com/575479/181026939-15136956-77cd-4e27-ba9f-bca8dea119ed.png">
After:
<img width="464" alt="Screen Shot 2022-07-26 at 15 04 56" src="https://user-images.githubusercontent.com/575479/181026933-df3510ac-2d2c-4c60-82fc-b4b021a2c90c.png">


_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #4390

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
