### PR TITLE
Hide Remember me strings

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2145,11 +2145,11 @@
     "unknownError": "Unknown error occurred"
   },
   "remember_me": {
-    "enable_remember_me": "Allow \"Remember me\"",
-    "enable_remember_me_description": "Turn on at your own risk. When \"Remember me\" is on, it gives anyone access to your MetaMask if they can access your phone."
+    "enable_remember_me": "Turn on Remember me",
+    "enable_remember_me_description": "When Remember me is on, anyone with access to your phone can access your MetaMask account."
   },
   "turn_off_remember_me": {
-    "title": "Enter your password to turn off the Remember me option",
+    "title": "Enter your password to turn off Remember me",
     "placeholder": "Password",
     "description": "If you turn this option off, you'll need your password to unlock MetaMask from now on.",
     "action": "Turn off Remember me"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2143,5 +2143,15 @@
   "download_files": {
     "error": "Failed to download attachment.",
     "unknownError": "Unknown error occurred"
+  },
+  "remember_me": {
+    "enable_remember_me": "Allow \"Remember me\"",
+    "enable_remember_me_description": "Turn on at your own risk. When \"Remember me\" is on, it gives anyone access to your MetaMask if they can access your phone."
+  },
+  "turn_off_remember_me": {
+    "title": "Enter your password to turn off the Remember me option",
+    "placeholder": "Password",
+    "description": "If you turn this option off, you'll need your password to unlock MetaMask from now on.",
+    "action": "Turn off Remember me"
   }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
- These are the strings for the [hide remember me PR](https://github.com/MetaMask/metamask-mobile/pull/4305/files#diff-c31c440a532cfa87d12df6a7c76ac83d0e80ee9b8b7fe38a274204000eaa0948)
_1. What is the reason for the change?_
- so we can ship these earlier and get the translations ASAP since this is such a sensitive change
_2. What is the improvement/solution?_
- adding the strings as a separate PR so we can ship it independently of the [fix](https://github.com/MetaMask/metamask-mobile/pull/4305/files#diff-c31c440a532cfa87d12df6a7c76ac83d0e80ee9b8b7fe38a274204000eaa0948)
- after this is merged I will rebase

The strings were agreed upon [here](https://www.figma.com/file/WJF8Tdwysm6dzabGkMYpJK/Mobile---Remove-%22Remember-me%22?node-id=0%3A1#235957544)

**Screenshots/Recordings**
these are the modal designs, we have no designs for the settings toggle
<img width="339" alt="Screen Shot 2022-08-02 at 12 54 40 PM" src="https://user-images.githubusercontent.com/22918444/182431242-59123b45-f1a4-4465-a18b-a79727aac9d2.png">


**Issue**

Progresses https://github.com/MetaMask/metamask-mobile/issues/4194

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
