### PR TITLE
Update new urls to redirect to zendesk

### DIFF
--- a/app/components/Views/ErrorBoundary/index.js
+++ b/app/components/Views/ErrorBoundary/index.js
@@ -225,7 +225,7 @@ class ErrorBoundary extends Component {
   };
 
   openTicket = () => {
-    const url = 'https://metamask.zendesk.com/hc/en-us/requests/new';
+    const url = 'https://metamask.zendesk.com/hc/en-us';
     Linking.openURL(url);
   };
 

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -155,7 +155,7 @@ export default class AppInformation extends PureComponent {
   };
 
   onContactUs = () => {
-    const url = 'https://metamask.zendesk.com/hc/en-us/requests/new';
+    const url = 'https://metamask.zendesk.com/hc/en-us';
     this.goTo(url, strings('drawer.metamask_support'));
   };
 


### PR DESCRIPTION

**Description**
Redirecting to https://metamask.zendesk.com/hc/en-us instead of https://metamask.zendesk.com/hc/en-us/requests/new on ErrorBoundary and on AppInformation
Requested on this [slack thread](https://consensys.slack.com/archives/G8RSKCNCD/p1659533656990339)

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
