### PR TITLE
[Force upgrade] Automatic security checks settings

### DIFF
--- a/app/actions/security/index.ts
+++ b/app/actions/security/index.ts
@@ -3,6 +3,7 @@ import type { Action } from 'redux';
 
 export enum ActionType {
   SET_ALLOW_LOGIN_WITH_REMEMBER_ME = 'SET_ALLOW_LOGIN_WITH_REMEMBER_ME',
+  SET_AUTOMATIC_SECURITY_CHECKS = 'SET_AUTOMATIC_SECURITY_CHECKS',
 }
 
 export interface AllowLoginWithRememberMeUpdated
@@ -10,11 +11,23 @@ export interface AllowLoginWithRememberMeUpdated
   enabled: boolean;
 }
 
-export type Action = AllowLoginWithRememberMeUpdated;
+export interface AutomaticSecurityChecks
+  extends Action<ActionType.SET_AUTOMATIC_SECURITY_CHECKS> {
+  enabled: boolean;
+}
+
+export type Action = AllowLoginWithRememberMeUpdated | AutomaticSecurityChecks;
 
 export const setAllowLoginWithRememberMe = (
   enabled: boolean,
 ): AllowLoginWithRememberMeUpdated => ({
   type: ActionType.SET_ALLOW_LOGIN_WITH_REMEMBER_ME,
+  enabled,
+});
+
+export const setAutomaticSecurityChecks = (
+  enabled: boolean,
+): AutomaticSecurityChecks => ({
+  type: ActionType.SET_AUTOMATIC_SECURITY_CHECKS,
   enabled,
 });

--- a/app/actions/security/state.ts
+++ b/app/actions/security/state.ts
@@ -1,3 +1,4 @@
 export interface SecuritySettingsState {
   allowLoginWithRememberMe: boolean;
+  automaticSecurityChecks: boolean;
 }

--- a/app/components/Views/Settings/SecuritySettings/Sections/AutomaticSecurityChecks.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/AutomaticSecurityChecks.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+import { SecurityOptionToggle } from '../../../../UI/SecurityOptionToggle';
+import { strings } from '../../../../../../locales/i18n';
+import { useSelector, useDispatch } from 'react-redux';
+import { setAutomaticSecurityChecks } from '../../../../../actions/security';
+
+const AutomaticSecurityChecks = () => {
+  const dispatch = useDispatch();
+  const automaticSecurityChecksState = useSelector(
+    (state: any) => state.security.automaticSecurityChecks,
+  );
+
+  const toggleAutomaticSecurityChecks = useCallback(
+    (value: boolean) => {
+      dispatch(setAutomaticSecurityChecks(value));
+    },
+    [dispatch],
+  );
+  return (
+    <SecurityOptionToggle
+      title={strings(`automatic_security_checks.title`)}
+      description={strings(`automatic_security_checks.description`)}
+      value={automaticSecurityChecksState}
+      onOptionUpdated={toggleAutomaticSecurityChecks}
+    />
+  );
+};
+
+export default React.memo(AutomaticSecurityChecks);

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -66,6 +66,7 @@ import { LEARN_MORE_URL } from '../../../../constants/urls';
 import DeleteMetaMetricsData from './Sections/DeleteMetaMetricsData';
 import DeleteWalletData from './Sections/DeleteWalletData';
 import RememberMeOptionSection from './Sections/RememberMeOptionSection';
+import AutomaticSecurityChecks from './Sections/AutomaticSecurityChecks';
 
 const isIos = Device.isIos();
 
@@ -1151,6 +1152,7 @@ class Settings extends PureComponent {
           {this.renderApprovalModal()}
           {this.renderHistoryModal()}
           {this.isMainnet() && this.renderOpenSeaSettings()}
+          <AutomaticSecurityChecks />
           {this.renderHint()}
         </View>
       </ScrollView>

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -1152,7 +1152,7 @@ class Settings extends PureComponent {
           {this.renderApprovalModal()}
           {this.renderHistoryModal()}
           {this.isMainnet() && this.renderOpenSeaSettings()}
-          <AutomaticSecurityChecks />
+          {__DEV__ ? <AutomaticSecurityChecks /> : null}
           {this.renderHint()}
         </View>
       </ScrollView>

--- a/app/reducers/security/index.ts
+++ b/app/reducers/security/index.ts
@@ -4,6 +4,7 @@ import { SecuritySettingsState } from '../../actions/security/state';
 
 const initialState: Readonly<SecuritySettingsState> = {
   allowLoginWithRememberMe: false,
+  automaticSecurityChecks: true,
 };
 
 const securityReducer = (
@@ -13,7 +14,13 @@ const securityReducer = (
   switch (action.type) {
     case ActionType.SET_ALLOW_LOGIN_WITH_REMEMBER_ME:
       return {
+        ...state,
         allowLoginWithRememberMe: action.enabled,
+      };
+    case ActionType.SET_AUTOMATIC_SECURITY_CHECKS:
+      return {
+        ...state,
+        automaticSecurityChecks: action.enabled,
       };
     default:
       return state;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2161,5 +2161,9 @@
   "confirmation_modal": {
     "cancel_cta": "Cancel",
     "confirm_cta": "Confirm"
+  },
+  "automatic_security_checks": {
+    "title": "Automatic security checks",
+    "description": "Automatically checking for updates may expose your IP address to GitHub servers. This only indicates that your IP address is using MetaMask. No other information or account addresses are exposed."
   }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- we need a setting to enable/disable the automatic security checks as well as inform users that their IP will be sent to github
- this change allows for that setting to persist in global state
_2. What is the improvement/solution?_
- add some state to the existing security redux store
- add a toggle setting to settings/security
- this check will default to on
- this setting will only be visible in dev mode and will be hidden in release until we finish [this following ticket](https://github.com/MetaMask/mobile-planning/issues/232)

**Screenshots/Recordings**
![Simulator Screen Shot - iPhone 13 Pro - 2022-08-23 at 15 24 47](https://user-images.githubusercontent.com/22918444/186509868-a7b470fa-0727-4a48-827b-c8fa7c4ae47e.png)

**Issue**

Progresses https://github.com/MetaMask/metamask-mobile/issues/4812

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
