### PR TITLE
[FIX] isTestNetwork not callable

### DIFF
--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -389,7 +389,7 @@ class TransactionReviewInformation extends PureComponent {
           renderableTotalMaxNative,
           renderableTotalMaxConversion,
         ] = calculateEthEIP1559({
-          nativeCurrency: this.isTestNetwork ? ticker : nativeCurrency,
+          nativeCurrency: this.isTestNetwork() ? ticker : nativeCurrency,
           currentCurrency,
           totalMinNative,
           totalMinConversion,
@@ -475,7 +475,7 @@ class TransactionReviewInformation extends PureComponent {
           renderableTotalMaxNative,
           renderableTotalMaxConversion,
         ] = calculateEthEIP1559({
-          nativeCurrency: this.isTestNetwork ? ticker : nativeCurrency,
+          nativeCurrency: this.isTestNetwork() ? ticker : nativeCurrency,
           currentCurrency,
           totalMinNative,
           totalMinConversion,
@@ -622,8 +622,8 @@ class TransactionReviewInformation extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
 
-    const errorPress = this.isTestNetwork ? this.goToFaucet : this.buyEth;
-    const errorLinkText = this.isTestNetwork
+    const errorPress = this.isTestNetwork() ? this.goToFaucet : this.buyEth;
+    const errorLinkText = this.isTestNetwork()
       ? strings('transaction.go_to_faucet')
       : strings('transaction.buy_more');
 
@@ -661,7 +661,7 @@ class TransactionReviewInformation extends PureComponent {
         )}
         {!!error && (
           <View style={styles.errorWrapper}>
-            {this.isTestNetwork || allowedToBuy(network) ? (
+            {this.isTestNetwork() || allowedToBuy(network) ? (
               <TouchableOpacity onPress={errorPress}>
                 <Text style={styles.error}>{error}</Text>
                 {over && (


### PR DESCRIPTION
**Description**
When the warning with not enough funds and we are on the Polygon Mainnet, will appear _Go To Faucet_ instead of _Buy Now_ to redirect to swaps
We also are always showing the Ticket instead of the native currency on the Transaction Review Information Modal

**Proposed Solution**
The function now is being called.

**Code Impact**
Low -> It only affect the transaction Review Information Modal UI

**Screenshots/Recordings**
error:
<img width=250  src=https://user-images.githubusercontent.com/46944231/186966478-bec762f4-3e99-49b8-8dc4-ddf83b5d44b2.png />


solution:
<img width=250  src=https://user-images.githubusercontent.com/46944231/186966294-4c25ce2b-618e-4ac7-9083-42532f599bb8.png />



**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
