### PR TITLE
Swaps: Add copy for 0% fee in quotes info modal

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -2139,12 +2139,11 @@ function SwapsQuotesView({
             <Text bold>{strings('swaps.fee_text.best_price')}</Text>{' '}
             {strings('swaps.fee_text.from_the')}{' '}
             <Text bold>{strings('swaps.fee_text.top_liquidity')}</Text>{' '}
-            {strings('swaps.fee_text.fee_is_applied', {
-              fee:
-                selectedQuote && selectedQuote?.fee
-                  ? `${selectedQuote.fee}%`
-                  : '0.875%',
-            })}
+            {selectedQuote && selectedQuote?.fee > 0
+              ? strings('swaps.fee_text.fee_is_applied', {
+                  fee: `${selectedQuote.fee}%`,
+                })
+              : strings('swaps.fee_text.fee_is_not_applied')}
           </Text>
         }
       />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1864,7 +1864,8 @@
       "best_price": "best price",
       "from_the": "from the",
       "top_liquidity": "top liquidity sources every time.",
-      "fee_is_applied": "A fee of {{fee}} is automatically factored into each quote, which supports ongoing development to make MetaMask even better."
+      "fee_is_applied": "A fee of {{fee}} is automatically factored into each quote, which supports ongoing development to make MetaMask even better.",
+      "fee_is_not_applied": "MetaMask does not include an additional fee in this quote."
     },
     "enable": {
       "this_will": "This will",


### PR DESCRIPTION

**Description**

This PR changes a hardcoded value being shown when the swaps quote had 0% MetaMask fee.


**Screenshots/Recordings**

Before  and After
<img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-06 at 13 27 29" src="https://user-images.githubusercontent.com/1024246/188711323-160700c2-4ef4-4f43-b520-e7871e2d7964.png" /> » <img  width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-06 at 13 19 21" src="https://user-images.githubusercontent.com/1024246/188711333-73a59b20-5e61-48ac-bda8-16ff177870e6.png" />

When the quote has a value it is correctly displayed: 
<img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-06 at 13 19 00" src="https://user-images.githubusercontent.com/1024246/188712186-a18a0c2f-20fb-46e4-b8d2-1b22d8a66c62.png" />

