### PR TITLE
[fix] Surface WalletConnect errors to user

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -201,6 +201,20 @@ class DeeplinkManager {
     });
   }
 
+  _handleWalletConnect(wcUri, redirectUrl, autosign, origin) {
+    if (!WalletConnect.isValidUri(wcUri)) return;
+    try {
+      WalletConnect.newSession(
+                  wcUri,
+                  redirectUrl,
+                  autosign,
+                  origin,
+                );
+    } catch (e) {
+        if (e) Alert.alert('Error connecting your wallet', e.toString());
+    }
+  }
+
   parse(url, { browserCallBack, origin, onHandled }) {
     const urlObj = new URL(
       url
@@ -242,12 +256,11 @@ class DeeplinkManager {
           if (action === ACTIONS.CONNECT) {
             Alert.alert(strings('dapp_connect.warning'));
           } else if (action === ACTIONS.WC && params?.uri) {
-            WalletConnect.newSession(
-              params.uri,
+            this._handleWalletConnect(
+              params?.uri,
               params.redirectUrl,
               false,
-              origin,
-            );
+              origin)
           } else if (action === ACTIONS.WC) {
             // This is called from WC just to open the app and it's not supposed to do anything
             return;
@@ -296,14 +309,11 @@ class DeeplinkManager {
         handled();
 
         wcCleanUrl = url.replace('wc://wc?uri=', '');
-        if (!WalletConnect.isValidUri(wcCleanUrl)) return;
-
-        WalletConnect.newSession(
-          wcCleanUrl,
-          params?.redirect,
-          params?.autosign,
-          origin,
-        );
+        this._handleWalletConnect(
+            wcCleanUrl,
+            params?.redirect,
+            params?.autosign,
+            origin)
         break;
 
       case PROTOCOLS.ETHEREUM:
@@ -328,16 +338,11 @@ class DeeplinkManager {
           Alert.alert(strings('dapp_connect.warning'));
         } else if (url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.WC}`)) {
           const cleanUrlObj = new URL(urlObj.query.replace('?uri=', ''));
-          const href = cleanUrlObj.href;
-
-          if (!WalletConnect.isValidUri(href)) return;
-
-          WalletConnect.newSession(
-            href,
+          this._handleWalletConnect(
+            cleanUrlObj.href,
             params?.redirect,
             params?.autosign,
-            origin,
-          );
+            origin)
         }
 
         break;


### PR DESCRIPTION


**Description**

Currently, there is no feedback for when a connection is broken/can't be connected to. For example, hitting a dead session currently has no feedback from Metamask, and users end up confused about what steps to take.
This shows an alert dialog to let users know potential next steps to take.

This also refactors the wallet connect code a little so that all 3 paths benefit from the error handling UI.
**Screenshots/Recordings**


<img width="412" alt="Screen Shot 2022-09-07 at 10 53 52 AM" src="https://user-images.githubusercontent.com/863461/188947235-870590b3-333c-4444-877b-6e5646129c44.png">

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
