### PR TITLE
Unable to Speedup/Cancel legacy transactions

### DIFF
--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -480,13 +480,13 @@ class Transactions extends PureComponent {
     });
   };
 
-  speedUpTransaction = async (EIP1559TransactionData) => {
+  speedUpTransaction = async (transactionObject) => {
     try {
       await Engine.context.TransactionController.speedUpTransaction(
         this.speedUpTxId,
-        EIP1559TransactionData?.suggestedMaxFeePerGasHex && {
-          maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
-          maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
+        transactionObject?.suggestedMaxFeePerGasHex && {
+          maxFeePerGas: `0x${transactionObject?.suggestedMaxFeePerGasHex}`,
+          maxPriorityFeePerGas: `0x${transactionObject?.suggestedMaxPriorityFeePerGasHex}`,
         },
       );
       this.onSpeedUpCompleted();
@@ -505,13 +505,13 @@ class Transactions extends PureComponent {
     await Engine.context.TransactionController.cancelTransaction(tx.id);
   };
 
-  cancelTransaction = async (EIP1559TransactionData) => {
+  cancelTransaction = async (transactionObject) => {
     try {
       await Engine.context.TransactionController.stopTransaction(
         this.cancelTxId,
-        EIP1559TransactionData?.suggestedMaxFeePerGasHex && {
-          maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
-          maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
+        transactionObject?.suggestedMaxFeePerGasHex && {
+          maxFeePerGas: `0x${transactionObject?.suggestedMaxFeePerGasHex}`,
+          maxPriorityFeePerGas: `0x${transactionObject?.suggestedMaxPriorityFeePerGasHex}`,
         },
       );
       this.onCancelCompleted();

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -482,19 +482,13 @@ class Transactions extends PureComponent {
 
   speedUpTransaction = async (EIP1559TransactionData) => {
     try {
-      if (EIP1559TransactionData?.suggestedMaxFeePerGasHex) {
-        await Engine.context.TransactionController.speedUpTransaction(
-          this.speedUpTxId,
-          {
-            maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
-            maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
-          },
-        );
-      } else {
-        await Engine.context.TransactionController.speedUpTransaction(
-          this.speedUpTxId,
-        );
-      }
+      await Engine.context.TransactionController.speedUpTransaction(
+        this.speedUpTxId,
+        EIP1559TransactionData?.suggestedMaxFeePerGasHex && {
+          maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
+          maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
+        },
+      );
       this.onSpeedUpCompleted();
     } catch (e) {
       this.handleSpeedUpTransactionFailure(e);
@@ -513,19 +507,13 @@ class Transactions extends PureComponent {
 
   cancelTransaction = async (EIP1559TransactionData) => {
     try {
-      if (EIP1559TransactionData?.suggestedMaxFeePerGasHex) {
-        await Engine.context.TransactionController.stopTransaction(
-          this.cancelTxId,
-          {
-            maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
-            maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
-          },
-        );
-      } else {
-        await Engine.context.TransactionController.stopTransaction(
-          this.cancelTxId,
-        );
-      }
+      await Engine.context.TransactionController.stopTransaction(
+        this.cancelTxId,
+        EIP1559TransactionData?.suggestedMaxFeePerGasHex && {
+          maxFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxFeePerGasHex}`,
+          maxPriorityFeePerGas: `0x${EIP1559TransactionData?.suggestedMaxPriorityFeePerGasHex}`,
+        },
+      );
       this.onCancelCompleted();
     } catch (e) {
       this.handleCancelTransactionFailure(e);

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -482,7 +482,7 @@ class Transactions extends PureComponent {
 
   speedUpTransaction = async (EIP1559TransactionData) => {
     try {
-      if (EIP1559TransactionData) {
+      if (EIP1559TransactionData?.suggestedMaxFeePerGasHex) {
         await Engine.context.TransactionController.speedUpTransaction(
           this.speedUpTxId,
           {
@@ -513,7 +513,7 @@ class Transactions extends PureComponent {
 
   cancelTransaction = async (EIP1559TransactionData) => {
     try {
-      if (EIP1559TransactionData) {
+      if (EIP1559TransactionData?.suggestedMaxFeePerGasHex) {
         await Engine.context.TransactionController.stopTransaction(
           this.cancelTxId,
           {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**
Non-EIP1559 transactions breaks when a user tries to speed up transaction. This test was done using BNB network and also applies to Optimism.

**Screenshots/Recordings**
https://recordit.co/1sIbNiNrfA

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/380

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
