### PR TITLE
On-ramp: Add compact payment method selector

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/components/PaymentMethodModal.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/PaymentMethodModal.tsx
@@ -116,6 +116,7 @@ function PaymentMethodModal({
                           amountTier={amountTier}
                           paymentTypeIcon={getPaymentMethodIcon(paymentType)}
                           logo={logo}
+                          compact
                         />
                       </View>
                     ),

--- a/app/components/UI/FiatOnRampAggregator/components/PaymentOption.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/PaymentOption.tsx
@@ -24,6 +24,7 @@ interface Props {
   logo: Payment['logo'];
   onPress?: () => any;
   highlighted?: boolean;
+  compact?: boolean;
 }
 
 const createStyles = (colors: Colors) =>
@@ -35,6 +36,11 @@ const createStyles = (colors: Colors) =>
       borderRadius: 6,
       justifyContent: 'center',
       alignItems: 'center',
+    },
+    compactIconWrapper: {
+      width: 32,
+      height: 32,
+      borderRadius: 4.8,
     },
     icon: {
       color: colors.icon.default,
@@ -51,6 +57,10 @@ const createStyles = (colors: Colors) =>
       backgroundColor: colors.border.muted,
       height: 1,
       marginVertical: 12,
+    },
+    compactLine: {
+      height: 0,
+      marginVertical: 6,
     },
   });
 
@@ -112,6 +122,7 @@ const PaymentOption: React.FC<Props> = ({
   logo,
   onPress,
   highlighted,
+  compact,
 }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -120,10 +131,12 @@ const PaymentOption: React.FC<Props> = ({
     <Box onPress={onPress} highlighted={highlighted}>
       <ListItem.Content>
         <ListItem.Icon>
-          <View style={styles.iconWrapper}>
+          <View
+            style={[styles.iconWrapper, compact && styles.compactIconWrapper]}
+          >
             <PaymentIcon
               iconType={paymentTypeIcon}
-              size={16}
+              size={compact ? 13 : 16}
               style={styles.icon}
             />
           </View>
@@ -144,7 +157,7 @@ const PaymentOption: React.FC<Props> = ({
         </ListItem.Amounts>
       </ListItem.Content>
 
-      <View style={styles.line} />
+      <View style={[styles.line, compact && styles.compactLine]} />
 
       <Text primary small>
         <Feather name="clock" /> {renderTime(time)} •{' '}


### PR DESCRIPTION



**Description**

This PR adds a compact version for the on-ramp payment method selectors. These compact versions are used in the modal selectors.

**Screenshots/Recordings**

Before - After
<img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-13 at 20 12 44" src="https://user-images.githubusercontent.com/1024246/190036918-6a44ccb2-38bb-466a-8dbd-7110e602e10a.png" /> <img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-13 at 20 12 51" src="https://user-images.githubusercontent.com/1024246/190036923-496386e1-fbec-449d-9c1d-6701872bb0f8.png" />


