### PR TITLE
[FIX] Prevent import account from auto switching accounts (5.7 Regression)

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -511,9 +511,11 @@ class ChoosePassword extends PureComponent {
     try {
       // Import imported accounts again
       for (let i = 0; i < importedAccounts.length; i++) {
-        await KeyringController.importAccountWithStrategy('privateKey', [
-          importedAccounts[i],
-        ]);
+        await KeyringController.importAccountWithStrategy(
+          'privateKey',
+          [importedAccounts[i]],
+          false,
+        );
       }
     } catch (e) {
       Logger.error(

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -485,9 +485,11 @@ class ResetPassword extends PureComponent {
     try {
       // Import imported accounts again
       for (let i = 0; i < importedAccounts.length; i++) {
-        await KeyringController.importAccountWithStrategy('privateKey', [
-          importedAccounts[i],
-        ]);
+        await KeyringController.importAccountWithStrategy(
+          'privateKey',
+          [importedAccounts[i]],
+          false,
+        );
       }
     } catch (e) {
       Logger.error(

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -685,9 +685,11 @@ class Engine {
     // Recreate imported accounts
     if (importedAccounts) {
       for (let i = 0; i < importedAccounts.length; i++) {
-        await KeyringController.importAccountWithStrategy('privateKey', [
-          importedAccounts[i],
-        ]);
+        await KeyringController.importAccountWithStrategy(
+          'privateKey',
+          [importedAccounts[i]],
+          false,
+        );
       }
     }
 

--- a/app/core/Vault.js
+++ b/app/core/Vault.js
@@ -73,9 +73,11 @@ export const recreateVaultWithSamePassword = async (
   try {
     // Import imported accounts again
     for (let i = 0; i < importedAccounts.length; i++) {
-      await KeyringController.importAccountWithStrategy('privateKey', [
-        importedAccounts[i],
-      ]);
+      await KeyringController.importAccountWithStrategy(
+        'privateKey',
+        [importedAccounts[i]],
+        false,
+      );
     }
   } catch (e) {
     Logger.error(e, 'error while trying to import accounts on recreate vault');

--- a/patches/@metamask+controllers+30.3.0.patch
+++ b/patches/@metamask+controllers+30.3.0.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/@metamask/controllers/dist/keyring/KeyringController.js b/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
+index 8b9d1ba..c67dcf6 100644
+--- a/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
++++ b/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
+@@ -264,7 +264,7 @@ class KeyringController extends BaseController_1.BaseController {
+      * @throws Will throw when passed an unrecognized strategy.
+      * @returns Promise resolving to current state when the import is complete.
+      */
+-    importAccountWithStrategy(strategy, args) {
++    importAccountWithStrategy(strategy, args, shouldAutoSwitchAccounts = true) {
+         return __awaiter(this, void 0, void 0, function* () {
+             let privateKey;
+             switch (strategy) {
+@@ -307,7 +307,7 @@ class KeyringController extends BaseController_1.BaseController {
+             const accounts = yield newKeyring.getAccounts();
+             const allAccounts = yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts();
+             this.updateIdentities(allAccounts);
+-            this.setSelectedAddress(accounts[0]);
++            shouldAutoSwitchAccounts && this.setSelectedAddress(accounts[0]);
+             return this.fullUpdate();
+         });
+     }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Video of killing/reopening app after importing two accounts, each using private key.

https://user-images.githubusercontent.com/10508597/190052314-b6ccb956-bc59-4e9b-bb16-b389c8f9c8d6.mov


Progresses [#386](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/issues/metamask/mobile-planning/386)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
