### PR TITLE
Bump version 14 xcode for release signing

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -338,4 +338,4 @@ app:
           IOS_APP_LINK: ''
 meta:
     bitrise.io:
-        stack: osx-xcode-13.3.x
+        stack: osx-xcode-14.0.x


### PR DESCRIPTION
Bump version of Xcode to have the latest signing required for iOS 16.

<img width="847" alt="Screen Shot 2022-09-14 at 10 18 02 AM" src="https://user-images.githubusercontent.com/10342624/190245939-aacc05b6-7161-4e3c-a023-c63045579f04.png">
