### PR TITLE
On-Ramp: Add scrolling to payment methods and make logo property optional

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/PaymentMethod.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/PaymentMethod.tsx
@@ -212,17 +212,21 @@ const PaymentMethod = () => {
       </ScreenLayout.Body>
       <ScreenLayout.Footer>
         <ScreenLayout.Content>
-          <View style={styles.row}>
-            <Text small grey centered>
-              {currentPaymentMethod?.paymentType === PaymentType.ApplePay &&
-                strings(
-                  'fiat_on_ramp_aggregator.payment_method.apple_cash_not_supported',
-                )}
-              {currentPaymentMethod?.paymentType ===
-                PaymentType.DebitCreditCard &&
-                strings('fiat_on_ramp_aggregator.payment_method.card_fees')}
-            </Text>
-          </View>
+          {(currentPaymentMethod?.paymentType === PaymentType.ApplePay ||
+            currentPaymentMethod?.paymentType ===
+              PaymentType.DebitCreditCard) && (
+            <View style={styles.row}>
+              <Text small grey centered>
+                {currentPaymentMethod?.paymentType === PaymentType.ApplePay &&
+                  strings(
+                    'fiat_on_ramp_aggregator.payment_method.apple_cash_not_supported',
+                  )}
+                {currentPaymentMethod?.paymentType ===
+                  PaymentType.DebitCreditCard &&
+                  strings('fiat_on_ramp_aggregator.payment_method.card_fees')}
+              </Text>
+            </View>
+          )}
           <View style={styles.row}>
             <StyledButton
               type={'confirm'}

--- a/app/components/UI/FiatOnRampAggregator/Views/PaymentMethod.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/PaymentMethod.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { PaymentType } from '@consensys/on-ramp-sdk';
 import BaseText from '../../../Base/Text';
@@ -185,28 +185,30 @@ const PaymentMethod = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
-        <ScreenLayout.Content>
-          {filteredPaymentMethods?.map(
-            ({ id, name, delay, amountTier, paymentType, logo }) => (
-              <View key={id} style={styles.row}>
-                <PaymentOption
-                  highlighted={id === selectedPaymentMethodId}
-                  title={name}
-                  time={delay}
-                  id={id}
-                  onPress={
-                    id === selectedPaymentMethodId
-                      ? undefined
-                      : () => handlePaymentMethodPress(id)
-                  }
-                  amountTier={amountTier}
-                  paymentTypeIcon={getPaymentMethodIcon(paymentType)}
-                  logo={logo}
-                />
-              </View>
-            ),
-          )}
-        </ScreenLayout.Content>
+        <ScrollView>
+          <ScreenLayout.Content>
+            {filteredPaymentMethods?.map(
+              ({ id, name, delay, amountTier, paymentType, logo }) => (
+                <View key={id} style={styles.row}>
+                  <PaymentOption
+                    highlighted={id === selectedPaymentMethodId}
+                    title={name}
+                    time={delay}
+                    id={id}
+                    onPress={
+                      id === selectedPaymentMethodId
+                        ? undefined
+                        : () => handlePaymentMethodPress(id)
+                    }
+                    amountTier={amountTier}
+                    paymentTypeIcon={getPaymentMethodIcon(paymentType)}
+                    logo={logo}
+                  />
+                </View>
+              ),
+            )}
+          </ScreenLayout.Content>
+        </ScrollView>
       </ScreenLayout.Body>
       <ScreenLayout.Footer>
         <ScreenLayout.Content>

--- a/app/components/UI/FiatOnRampAggregator/components/PaymentOption.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/PaymentOption.tsx
@@ -148,13 +148,15 @@ const PaymentOption: React.FC<Props> = ({
             </Text>
           </ListItem.Title>
         </ListItem.Body>
-        <ListItem.Amounts>
-          <ListItem.Amount>
-            <View style={styles.cardIcons}>
-              <PaymentTypeIcon style={styles.cardIcon} logosByTheme={logo} />
-            </View>
-          </ListItem.Amount>
-        </ListItem.Amounts>
+        {logo && (
+          <ListItem.Amounts>
+            <ListItem.Amount>
+              <View style={styles.cardIcons}>
+                <PaymentTypeIcon style={styles.cardIcon} logosByTheme={logo} />
+              </View>
+            </ListItem.Amount>
+          </ListItem.Amounts>
+        )}
       </ListItem.Content>
 
       <View style={[styles.line, compact && styles.compactLine]} />


### PR DESCRIPTION
**Description**
This PR allows the `logo` object (top right images) of payment methods to be optional using by conditionally rendering them and fixes the scrolling in the Payment Method View, which was static and not scrolling (see screenshot)

**Screenshots/Recordings**
Before - After
<img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-14 at 17 42 44" src="https://user-images.githubusercontent.com/1024246/190275722-70f6e929-c4e0-41d2-83e4-4cba816b5898.png" /> <img width="300" alt="Simulator Screen Shot - iPhone 11 Pro - 2022-09-14 at 17 41 51" src="https://user-images.githubusercontent.com/1024246/190275728-2e85f222-c0ac-45dc-aa35-c813c690c12e.png" />


