### PR TITLE
On boarding tour appears when protect your new wallet

### DIFF
--- a/app/components/Views/ManualBackupStep3/index.js
+++ b/app/components/Views/ManualBackupStep3/index.js
@@ -23,6 +23,7 @@ import Device from '../../../util/device';
 import Confetti from '../../UI/Confetti';
 import HintModal from '../../UI/HintModal';
 import { getTransparentOnboardingNavbarOptions } from '../../UI/Navbar';
+import setOnboardingWizardStep from '../../../actions/wizard';
 import {
   ONBOARDING_WIZARD,
   SEED_PHRASE_HINTS,
@@ -109,6 +110,10 @@ class ManualBackupStep3 extends PureComponent {
      * Object that represents the current route info like params passed to it
      */
     route: PropTypes.object,
+    /**
+     * Action to set onboarding wizard step
+     */
+    setOnboardingWizardStep: PropTypes.func,
   };
 
   updateNavBar = () => {
@@ -194,6 +199,7 @@ class ManualBackupStep3 extends PureComponent {
     if (onboardingWizard) {
       this.props.navigation.reset({ routes: [{ name: 'HomeNav' }] });
     } else {
+      this.props.setOnboardingWizardStep(1);
       this.props.navigation.reset({ routes: [{ name: 'HomeNav' }] });
     }
   };
@@ -273,6 +279,7 @@ ManualBackupStep3.contextType = ThemeContext;
 
 const mapDispatchToProps = (dispatch) => ({
   showAlert: (config) => dispatch(showAlert(config)),
+  setOnboardingWizardStep: (step) => dispatch(setOnboardingWizardStep(step)),
 });
 
 export default connect(null, mapDispatchToProps)(ManualBackupStep3);


### PR DESCRIPTION

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards]()
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
When we fresh installed the app and create a new wallet and we decide to protect it instead of skipping it, the onboarding tour possibility was not appearing
The onboarding only appears when it's fresh installed, when we skip the tutorial, it will not appear if we create a new wallet.

**Proposed Solution**
 The onboarding modal now appears when we complete all the 3 steps of creating a new wallet on the fresh installs
 

**Code impact**
Low

**Test cases**
Case1:
* Uninstall and install MM app
* Create a new wallet creating the secret recovery phrase
* See the onboarding tour modal
Case 2:
* Uninstall and install MM app
* Create a new wallet and skip creating the secret recovery phrase
* See the onboarding tour modal

**Screenshots/Recordings**
https://recordit.co/mw80xMldky

**Issue**

Progresses #https://github.com/metamask/mobile-planning/issues/389

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
