### PR TITLE
[FIX] Prevent add account from auto switching accounts (5.7.0 Regression)

### DIFF
--- a/patches/@metamask+controllers+30.3.0.patch
+++ b/patches/@metamask+controllers+30.3.0.patch
@@ -1,8 +1,33 @@
 diff --git a/node_modules/@metamask/controllers/dist/keyring/KeyringController.js b/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
-index 8b9d1ba..d342d7c 100644
+index 8b9d1ba..818792b 100644
 --- a/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
 +++ b/node_modules/@metamask/controllers/dist/keyring/KeyringController.js
-@@ -307,8 +307,8 @@ class KeyringController extends BaseController_1.BaseController {
+@@ -119,6 +119,7 @@ class KeyringController extends BaseController_1.BaseController {
+     }
+     /**
+      * Adds a new account to the default (first) HD seed phrase keyring.
++     * Patched to not auto switch accounts.
+      *
+      * @returns Promise resolving to current state when the account is added.
+      */
+@@ -129,16 +130,10 @@ class KeyringController extends BaseController_1.BaseController {
+             if (!primaryKeyring) {
+                 throw new Error('No HD keyring found');
+             }
+-            const oldAccounts = yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts();
+             yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").addNewAccount(primaryKeyring);
+             const newAccounts = yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts();
+             yield this.verifySeedPhrase();
+             this.updateIdentities(newAccounts);
+-            newAccounts.forEach((selectedAddress) => {
+-                if (!oldAccounts.includes(selectedAddress)) {
+-                    this.setSelectedAddress(selectedAddress);
+-                }
+-            });
+             return this.fullUpdate();
+         });
+     }
+@@ -307,8 +302,8 @@ class KeyringController extends BaseController_1.BaseController {
              const accounts = yield newKeyring.getAccounts();
              const allAccounts = yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts();
              this.updateIdentities(allAccounts);


### PR DESCRIPTION
**Description**

[#392](https://github.com/MetaMask/mobile-planning/issues/392)

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
