### PR TITLE
Deprecate snake case from feature flags

### DIFF
--- a/app/components/UI/Swaps/SwapsLiveness.js
+++ b/app/components/UI/Swaps/SwapsLiveness.js
@@ -23,7 +23,7 @@ function SwapLiveness({ isLive, chainId, setLiveness }) {
         AppConstants.SWAPS.CLIENT_ID,
       );
       const liveness =
-        typeof data === 'boolean' ? data : data?.mobile_active ?? false;
+        typeof data === 'boolean' ? data : data?.mobileActive ?? false;
       setLiveness(liveness, chainId);
     } catch (error) {
       Logger.error(error, 'Swaps: error while fetching swaps liveness');

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -231,7 +231,7 @@ function SwapsAmountView({
           AppConstants.SWAPS.CLIENT_ID,
         );
         const liveness =
-          typeof data === 'boolean' ? data : data?.mobile_active ?? false;
+          typeof data === 'boolean' ? data : data?.mobileActive ?? false;
         setLiveness(liveness, chainId);
         if (liveness) {
           // Triggered when a user enters the MetaMask Swap feature


### PR DESCRIPTION
**Description**

This change deprecates the use of snake case keys on feature flags on swaps.
For this the swaps-api has been updated to return both snake case and camel case values.

Once this PR and [a similar one on the extension](https://github.com/MetaMask/metamask-extension/pull/15994) are merged, snake case values can be safely removed from swaps api

**Screenshots/Recordings**

<img width="552" alt="Screenshot 2022-09-27 at 13 18 41" src="https://user-images.githubusercontent.com/8658960/192513092-97083098-5d46-475a-9659-8364a966d6fd.png">


**Issue**

See MMS-255

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
