### PR TITLE
Update default iOS simulator

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -172,13 +172,13 @@ buildAndroidRunE2E(){
 
 buildIosSimulator(){
 	prebuild_ios
-	SIM="${IOS_SIMULATOR:-"iPhone 11 Pro"}"
+	SIM="${IOS_SIMULATOR:-"iPhone 13 Pro"}"
 	react-native run-ios --simulator "$SIM"
 }
 
 buildIosSimulatorQA(){
 	prebuild_ios
-	SIM="${IOS_SIMULATOR:-"iPhone 11 Pro"}"
+	SIM="${IOS_SIMULATOR:-"iPhone 13 Pro"}"
 	react-native run-ios --simulator "$SIM" --scheme "MetaMask-QA"
 }
 


### PR DESCRIPTION
> latest Xcode upgrade does not ship with iPhone 11 Pro which is our default iOS simulator, maybe it is time to upgrade it?