### PR TITLE
only run ci on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+    branches: main
   pull_request:
 jobs:
   setup:


### PR DESCRIPTION
I changed this thinking it would be handy to run CI on all pushes, but we've now hit a limitation because of the one job that uses `macos-12`... [Apparently you can only have 5 concurrent macOS jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)

If anybody _does_ need to run CI without opening a PR they can always temporarily change this line back or change it to their feature branch name to have CI run on `push` temporarily.