### PR TITLE
FIX: Use search on an URL object to replace an undefined query

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -185,9 +185,9 @@ class DeeplinkManager {
     let params;
     let wcCleanUrl;
 
-    if (urlObj.query.length) {
+    if (urlObj.search.length) {
       try {
-        params = qs.parse(urlObj.query.substring(1));
+        params = qs.parse(urlObj.search.substring(1));
       } catch (e) {
         if (e) Alert.alert(strings('deeplink.invalid'), e.toString());
       }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

A syntax error change, there is currently no `query` field on the URL object, so I think this should refer to the `search` field.

**Code Impact**

Low

**Screenshots/Recordings**

This URL API doc:
[https://developer.mozilla.org/en-US/docs/Web/API/URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)
