### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/bump-version-name.yml
+++ b/.github/workflows/bump-version-name.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write  
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Bump script
       env:
         HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,13 @@ jobs:
   setup:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Node.js version
         id: nvm
         run: |
           VERSION=$(cat .nvmrc)
           echo ::set-output name=NODE_VERSION::$VERSION
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Get Yarn cache directory
@@ -57,7 +57,7 @@ jobs:
         run: |
           VERSION=$(cat .nvmrc)
           echo ::set-output name=NODE_VERSION::$VERSION
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn ${{ matrix['scripts'] }}
@@ -82,7 +82,7 @@ jobs:
         run: |
           VERSION=$(cat .nvmrc)
           echo ::set-output name=NODE_VERSION::$VERSION
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn test:unit:${{ matrix['units'] }} --forceExit --silent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get Node.js version
         id: nvm
-        run: |
-          VERSION=$(cat .nvmrc)
-          echo ::set-output name=NODE_VERSION::$VERSION
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Get Yarn cache directory
-        run: |
-          YARN_CACHE_DIR=$(yarn cache dir)
-          echo "::set-output name=YARN_CACHE_DIR::$YARN_CACHE_DIR"
+        run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_OUTPUT
         id: yarn-cache-dir
       - name: Get Yarn version
-        run: |
-          YARN_VERSION=$(yarn --version)
-          echo "::set-output name=YARN_VERSION::$YARN_VERSION"
+        run: echo "YARN_VERSION=$(yarn --version)" >> $GITHUB_OUTPUT
         id: yarn-version
       - name: Cache yarn dependencies
         uses: actions/cache@v2
@@ -54,9 +48,7 @@ jobs:
           key: ${{ github.sha }}
       - name: Get Node.js version
         id: nvm
-        run: |
-          VERSION=$(cat .nvmrc)
-          echo ::set-output name=NODE_VERSION::$VERSION
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
@@ -79,9 +71,7 @@ jobs:
           key: ${{ github.sha }}
       - name: Get Node.js version
         id: nvm
-        run: |
-          VERSION=$(cat .nvmrc)
-          echo ::set-output name=NODE_VERSION::$VERSION
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
         run: echo "YARN_VERSION=$(yarn --version)" >> $GITHUB_OUTPUT
         id: yarn-version
       - name: Cache yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn setup
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*
@@ -41,7 +41,7 @@ jobs:
           - audit:ci
           - test:tgz-check
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*
@@ -64,7 +64,7 @@ jobs:
           - components-remaining
     needs: setup
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.base-branch }}
       - name: Get Node.js version
         id: nvm
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # This is to guarantee that the most recent tag is fetched.
           # This can be configured to a more reasonable value by consumers.
@@ -31,7 +31,7 @@ jobs:
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Set Versions


### PR DESCRIPTION
This PR bumps the GitHub actions that we we use to the latest version, removing deprecation notices from our CI.

Similar to https://github.com/MetaMask/snaps-monorepo/pull/853