### PR TITLE
[HOTFIX] ENS name being resolved correctly

### DIFF
--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -28,7 +28,7 @@ import StyledButton from '../../../UI/StyledButton';
 import { allowedToBuy } from '../../../UI/FiatOrders';
 import AnalyticsV2 from '../../../../util/analyticsV2';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
-import { doENSLookup, doENSReverseLookup } from '../../../../util/ENSUtils';
+import { doENSReverseLookup } from '../../../../util/ENSUtils';
 import { handleNetworkSwitch } from '../../../../util/networks';
 import { renderFromWei } from '../../../../util/number';
 import {
@@ -355,12 +355,10 @@ class SendFlow extends PureComponent {
   };
 
   validateToAddress = async () => {
-    const { toAccount } = this.state;
-    const { network } = this.props;
+    const { toAccount, toEnsAddressResolved } = this.state;
     let addressError;
     if (isENS(toAccount)) {
-      const resolvedAddress = await doENSLookup(toAccount, network);
-      if (!resolvedAddress) {
+      if (!toEnsAddressResolved) {
         addressError = strings('transaction.could_not_resolve_ens');
       }
     } else if (!isValidHexAddress(toAccount, { mixedCaseUseChecksum: true })) {
@@ -785,7 +783,15 @@ class SendFlow extends PureComponent {
                 containerStyle={styles.buttonNext}
                 onPress={this.onTransactionDirectionSet}
                 testID={ADDRESS_BOOK_NEXT_BUTTON}
-                disabled={!toSelectedAddressReady}
+                //To selectedAddressReady needs to be calculated on this component, needing a bigger refactor
+                //Will be here just to ensure that we don't break existing conditions
+                disabled={
+                  !(
+                    (isValidHexAddress(toEnsAddressResolved) ||
+                      isValidHexAddress(toAccount)) &&
+                    toSelectedAddressReady
+                  )
+                }
               >
                 {strings('address_book.next')}
               </StyledButton>


### PR DESCRIPTION
**Description**
When the user had a slower internet connection and it was really quick to press the confirm button, the button would be enabled but the address would not be ready yet. Because of that we only proceeded to the next screen with the ENS.

**Proposed Solution**
Now we ensure that we have on that screen the address of the ens to go to the amount screen.

**Technical**
This was due to a delay in the component state on the validation function that happens on pressing the confirm button. This hotfix's a solution but it's better that we refactor some of the validation logic of it.


**Test cases**
If you can slow down your internet, this could be done on browser stack or with the `Network Link Conditioner` on macos 
Case 1:
(Repeat this many times until it happens)
* Try ti send some USDC
* Write an ens on the address input of Send screen and try to hit Confirm as fast as you can (For me I needed to use the enter of the Keyboard)
* Then write an amount on the amount screen
* On confirm screen check if the address is 0x0000000 (if it is this address is incorrect)


**Issue**

Progresses #5128 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
