### PR TITLE
[FIX] android build cMake

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,1 +1,2 @@
 # improved-yarn-audit advisory exclusions
+GHSA-qm95-pgcg-qqfq

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -438,7 +438,7 @@ PODS:
     - React-Core
   - RNOS (1.2.6):
     - React
-  - RNReanimated (2.10.0):
+  - RNReanimated (2.11.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -854,7 +854,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
-  RNReanimated: f9055ab75a49358b30f99155637f95d77727e7dc
+  RNReanimated: 0a4de6844119f4f1c3a46e6e7958ee7425ab4d0f
   RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce
   RNSensors: c363d486c879e181905dea84a2535e49af1c2d25
   RNSentry: e86fb2e2fec0365644f4b582938bf66be515acce

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "react-native-push-notification": "git+https://github.com/MetaMask/react-native-push-notification.git#975e0e6757c40e3dce2d1b6dd3d66fc91127ac4c",
     "react-native-qrcode-svg": "5.1.2",
     "react-native-randombytes": "^3.5.3",
-    "react-native-reanimated": "2.10.0",
+    "react-native-reanimated": "2.11.0",
     "react-native-redash": "16.2.2",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19494,10 +19494,10 @@ react-native-randombytes@^3.5.3:
     buffer "^4.9.1"
     sjcl "^1.0.3"
 
-react-native-reanimated@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.10.0.tgz#ed53be66bbb553b5b5e93e93ef4217c87b8c73db"
-  integrity sha512-jKm3xz5nX7ABtHzzuuLmawP0pFWP77lXNdIC6AWOceBs23OHUaJ29p4prxr/7Sb588GwTbkPsYkDqVFaE3ezNQ==
+react-native-reanimated@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.11.0.tgz#415ef668440d1b7d8b2b36a20342b1035432dd80"
+  integrity sha512-/QnujrXSNyXasv7v8K3eu5Z4XGRYMPRa0+x0RjNr6Z5/KEuPHwrg1Xm7UZ2YSm6jCF2b1BW6ceqP/1d626gvhQ==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
React reanimated was upgraded to 2.10.0 which forced a specific version of cMake to be used when building. This broke many of our pipelines and automation effort. It has been upgraded to 2.11.0 which does not have that requirement and resolve pipeline and build issues. 

**Checklist**

* [NA] There is a related GitHub issue
* [NA] Tests are included if applicable
* [NA] Any added code is fully documented
