### PR TITLE
ci: temporarily downgrade ubuntu to 20.04

### DIFF
--- a/.github/workflows/bump-version-name.yml
+++ b/.github/workflows/bump-version-name.yml
@@ -7,7 +7,7 @@ on:
     types: [opened]
 jobs:
   bump-version-name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "contains(github.head_ref, 'release/')"
     permissions:
       contents: write  

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   CLABot:
     if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   create-release-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 


### PR DESCRIPTION
May be overly cautious but in order to rule this out completely for tomorrow (ubuntu 22.04+ ship vulnerable openssl versions while 20.04 does not)