### PR TITLE
Allows DApps to read URLs from QR codes

### DIFF
--- a/app/components/Views/QRScanner/index.tsx
+++ b/app/components/Views/QRScanner/index.tsx
@@ -44,6 +44,7 @@ export interface QRScannerParams {
   onScanError?: (error: string) => void;
   onStartScan?: (data: any) => Promise<void>;
   origin?: string;
+  followURL?: boolean = true;
 }
 
 export const createQRScannerNavDetails =
@@ -135,9 +136,10 @@ const QRScanner = () => {
 
       const contentProtocol = getURLProtocol(content);
       if (
-        contentProtocol === PROTOCOLS.HTTP ||
-        contentProtocol === PROTOCOLS.HTTPS
+        (contentProtocol === PROTOCOLS.HTTP || contentProtocol === PROTOCOLS.HTTPS) &&
+        followURL
       ) {
+        
         const redirect = await showAlertForURLRedirection(content);
 
         if (!redirect) {

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -492,10 +492,11 @@ export const getRpcMethodMiddleware = ({
         res.result = `MetaMask/${appVersion}/Mobile`;
       },
 
-      wallet_scanQRCode: () =>
-        new Promise<void>((resolve, reject) => {
+      wallet_scanQRCode: () => {
+        return new Promise<void>((resolve, reject) => {
           checkTabActive();
           navigation.navigate('QRScanner', {
+            followURL: false,
             onScanSuccess: (data: any) => {
               const regex = new RegExp(req.params[0]);
               if (regex && !regex.exec(data)) {
@@ -522,7 +523,8 @@ export const getRpcMethodMiddleware = ({
               throw ethErrors.rpc.internal(e.toString());
             },
           });
-        }),
+        })
+      },
 
       wallet_watchAsset: async () => {
         const {


### PR DESCRIPTION
**Description**

I have added followURL parameter to QRScanner component. This parameter controls behavior when scanning QR code. Default behavior is that when scanner detects URL it asks users for redirection. However this is not practical when DApp requests for scanning of QR code, because DApp may expect URLs to be scanned but unfortunately current QRScanner component will never return URL. DApp can bypass this by using HTML5 and Javascript libraries for accessing Camera but these libraries have their own issues.

Requires: `needs-dev-review`, `needs-qa`

**Issue**

Progresses  [#5141]

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
