### PR TITLE
On-ramp: Fix multiple redirection handling

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -34,6 +34,7 @@ const CheckoutWebView = () => {
   const dispatch = useDispatch();
   const trackEvent = useAnalytics();
   const [error, setError] = useState('');
+  const [isRedirectionHandled, setIsRedirectionHandled] = useState(false);
   const [key, setKey] = useState(0);
   const navigation = useNavigation();
   // @ts-expect-error useRoute params error
@@ -106,6 +107,8 @@ const CheckoutWebView = () => {
       navState?.url.startsWith(callbackBaseUrl) &&
       navState.loading === false
     ) {
+      if (isRedirectionHandled) return;
+      setIsRedirectionHandled(true);
       try {
         const parsedUrl = parseUrl(navState?.url);
         if (Object.keys(parsedUrl.query).length === 0) {
@@ -198,6 +201,7 @@ const CheckoutWebView = () => {
             ctaOnPress={() => {
               setKey((prevKey) => prevKey + 1);
               setError('');
+              setIsRedirectionHandled(false);
             }}
             location={'Provider Webview'}
           />

--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -102,7 +102,10 @@ const CheckoutWebView = () => {
   }, [dispatch]);
 
   const handleNavigationStateChange = async (navState: WebViewNavigation) => {
-    if (navState?.url.startsWith(callbackBaseUrl)) {
+    if (
+      navState?.url.startsWith(callbackBaseUrl) &&
+      navState.loading === false
+    ) {
       try {
         const parsedUrl = parseUrl(navState?.url);
         if (Object.keys(parsedUrl.query).length === 0) {

--- a/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Checkout.tsx
@@ -104,10 +104,10 @@ const CheckoutWebView = () => {
 
   const handleNavigationStateChange = async (navState: WebViewNavigation) => {
     if (
+      !isRedirectionHandled &&
       navState?.url.startsWith(callbackBaseUrl) &&
       navState.loading === false
     ) {
-      if (isRedirectionHandled) return;
       setIsRedirectionHandled(true);
       try {
         const parsedUrl = parseUrl(navState?.url);


### PR DESCRIPTION


**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR fixes the multiple redirection handling at the on-ramp checkout, which causes multiple toasts and events to be fired wrongly.

**Screenshots/Recordings**

~~_If applicable, add screenshots and/or recordings to visualize the before and after of your change_~~

**Issue**

~~Progresses #???~~

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
