### PR TITLE
Handle PhishingController breaking changes

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -410,11 +410,11 @@ export const BrowserTab = (props) => {
     const { PhishingController } = Engine.context;
 
     // Update phishing configuration if it is out-of-date
-    const phishingListsAreOutOfDate = this.phishingController.isOutOfDate();
+    const phishingListsAreOutOfDate = PhishingController.isOutOfDate();
     if (phishingListsAreOutOfDate) {
       // This is async but we are not `await`-ing it here intentionally, so that we don't slow
       // down network requests. The configuration is updated for the next request.
-      this.phishingController.updatePhishingLists();
+      PhishingController.updatePhishingLists();
     }
 
     const phishingControllerTestResult = PhishingController.test(hostname);

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -408,6 +408,15 @@ export const BrowserTab = (props) => {
    */
   const isAllowedUrl = useCallback((hostname) => {
     const { PhishingController } = Engine.context;
+
+    // Update phishing configuration if it is out-of-date
+    const phishingListsAreOutOfDate = this.phishingController.isOutOfDate();
+    if (phishingListsAreOutOfDate) {
+      // This is async but we are not `await`-ing it here intentionally, so that we don't slow
+      // down network requests. The configuration is updated for the next request.
+      this.phishingController.updatePhishingLists();
+    }
+
     const phishingControllerTestResult = PhishingController.test(hostname);
 
     // Only assign the if the hostname is on the block list

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -233,6 +233,9 @@ class Engine {
           'https://gas-api.metaswap.codefi.network/networks/<chain_id>/suggestedGasFees',
       });
 
+      const phishingController = new PhishingController();
+      phishingController.updatePhishingLists();
+
       const additionalKeyrings = [QRHardwareKeyring];
 
       const controllers = [
@@ -323,7 +326,7 @@ class Engine {
         new PersonalMessageManager(),
         new MessageManager(),
         networkController,
-        new PhishingController(),
+        phishingController,
         preferencesController,
         new TokenBalancesController(
           {


### PR DESCRIPTION
The PhishingController was changed in v31 and v32 to no longer update the phishing configuration regularly in the background. Instead it has to be updated manually.

We now check for phishing configuration updates each time we're using it to test whether a URL is suspicious or not. This matches how the extension works. It should be roughly equivalent to how the Phishing Controller worked in past versions, except that now it will no longer be polling for updates when the browser is not in-use.

The phishing configuration is also explicitly updated once upon construction.

Note that this PR is pointing at #5200, so I have skipped most of the steps in the PR template because I am unsure how or whether they apply.