### PR TITLE
Setup CI to read developer preview builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,18 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - name: Determine whether the current PR is a draft
+        id: set-is-draft
+        if: github.event_name == 'pull_request' && github.event.pull_request.number
+        run: echo "IS_DRAFT=$(gh pr view --json isDraft --jq '.isDraft' ${PR_NUMBER})" >> "$GITHUB_OUTPUT"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup registry config for using package previews on draft PRs
+        if: github.event_name == 'pull_request' && steps.set-is-draft.outputs.IS_DRAFT == 'true'
+        run: printf '%s\n\n%s' '@metamask:registry=https://npm.pkg.github.com' "//npm.pkg.github.com/:_authToken=${PACKAGE_READ_TOKEN}" > .npmrc
+        env:
+          PACKAGE_READ_TOKEN: ${{ secrets.PACKAGE_READ_TOKEN }}
       - run: yarn setup
       - uses: actions/cache@v3
         id: restore-build


### PR DESCRIPTION
Setup CI to read developer preview builds from the GitHub Packages registry on draft PRs.