### PR TITLE
add e2e coverage for automatic security update screen

### DIFF
--- a/app/components/UI/EnableAutomaticSecurityChecksModal/EnableAutomaticSecurityChecksModal.tsx
+++ b/app/components/UI/EnableAutomaticSecurityChecksModal/EnableAutomaticSecurityChecksModal.tsx
@@ -21,6 +21,12 @@ import {
 } from '../../../actions/security';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import { ScrollView } from 'react-native-gesture-handler';
+import {
+  ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID,
+  ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON,
+} from '../../../../wdio/features/testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds';
+
+import generateTestId from '../../../../wdio/utils/generateTestId';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 const onboardingDeviceImage = require('../../../images/swaps_onboard_device.png');
@@ -68,7 +74,13 @@ const EnableAutomaticSecurityChecksModal = () => {
   return (
     <ReusableModal ref={modalRef} style={styles.screen}>
       <ScrollView contentContainerStyle={styles.content}>
-        <View style={styles.images}>
+        <View
+          style={styles.images}
+          {...generateTestId(
+            Platform,
+            ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID,
+          )}
+        >
           <Image source={onboardingDeviceImage} />
         </View>
         <Text variant={TextVariants.lHeadingLG} style={styles.title}>
@@ -89,6 +101,10 @@ const EnableAutomaticSecurityChecksModal = () => {
         <ButtonTertiary
           label={strings(
             'enable_automatic_security_check_modal.secondary_action',
+          )}
+          {...generateTestId(
+            Platform,
+            ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON,
           )}
           size={ButtonSize.Md}
           onPress={triggerCloseAndDisableAutomaticSecurityChecks}

--- a/e2e/pages/EnableAutomaticSecurityChecksView.js
+++ b/e2e/pages/EnableAutomaticSecurityChecksView.js
@@ -1,0 +1,23 @@
+import TestHelpers from '../helpers';
+
+import {
+  ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID,
+  ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON,
+} from '../../wdio/features/testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds';
+
+export default class EnableAutomaticSecurityChecksView {
+  static async tapNoThanks() {
+    await TestHelpers.tap(ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON);
+  }
+
+  static async isVisible() {
+    await TestHelpers.checkIfVisible(
+      ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID,
+    );
+  }
+  static async isNotVisible() {
+    await TestHelpers.checkIfNotVisible(
+      ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID,
+    );
+  }
+}

--- a/e2e/specs/add-custom-rpc.spec.js
+++ b/e2e/specs/add-custom-rpc.spec.js
@@ -20,7 +20,7 @@ import SkipAccountSecurityModal from '../pages/modals/SkipAccountSecurityModal';
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import ProtectYourWalletModal from '../pages/modals/ProtectYourWalletModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
-
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 const GORELI = 'Goerli Test Network';
 const XDAI_URL = 'https://rpc.gnosischain.com';
 const MAINNET = 'Ethereum Main Network';
@@ -56,6 +56,13 @@ describe('Custom RPC Tests', () => {
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on "Got it" to dimiss the whats new modal', async () => {

--- a/e2e/specs/add-custom-rpc.spec.js
+++ b/e2e/specs/add-custom-rpc.spec.js
@@ -59,7 +59,6 @@ describe('Custom RPC Tests', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/addressbook-tests.spec.js
+++ b/e2e/specs/addressbook-tests.spec.js
@@ -62,7 +62,6 @@ describe('Addressbook Tests', () => {
     await WalletView.isVisible();
   });
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/addressbook-tests.spec.js
+++ b/e2e/specs/addressbook-tests.spec.js
@@ -20,6 +20,8 @@ import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import ProtectYourWalletModal from '../pages/modals/ProtectYourWalletModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
 
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
+
 import TestHelpers from '../helpers';
 
 const INVALID_ADDRESS = '0xB8B4EE5B1b693971eB60bDa15211570df2dB221L';
@@ -58,6 +60,12 @@ describe('Addressbook Tests', () => {
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
+  });
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on the close button to dismiss the whats new modal', async () => {

--- a/e2e/specs/browser-tests.spec.js
+++ b/e2e/specs/browser-tests.spec.js
@@ -10,6 +10,7 @@ import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
 import DrawerView from '../pages/Drawer/DrawerView';
 import { BROWSER_SCREEN_ID, Browser } from '../pages/Drawer/Browser';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import ConnectModal from '../pages/modals/ConnectModal';
 import SkipAccountSecurityModal from '../pages/modals/SkipAccountSecurityModal';
@@ -54,6 +55,13 @@ describe('Browser Tests', () => {
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(2500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on the close button to dismiss the whats new modal', async () => {

--- a/e2e/specs/browser-tests.spec.js
+++ b/e2e/specs/browser-tests.spec.js
@@ -58,8 +58,7 @@ describe('Browser Tests', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
-    await TestHelpers.delay(2500);
+    await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();
   });

--- a/e2e/specs/contract-nickname.spec.js
+++ b/e2e/specs/contract-nickname.spec.js
@@ -9,6 +9,8 @@ import SendView from '../pages/SendView';
 import DrawerView from '../pages/Drawer/DrawerView';
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
+import LoginView from '../pages/LoginView';
 
 import AddContactView from '../pages/Drawer/Settings/Contacts/AddContactView';
 import ContactsView from '../pages/Drawer/Settings/Contacts/ContactsView';
@@ -19,16 +21,17 @@ import NetworkListModal from '../pages/modals/NetworkListModal';
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import NetworkEducationModal from '../pages/modals/NetworkEducationModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
+import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 
 import TestHelpers from '../helpers';
 
 const SECRET_RECOVERY_PHRASE =
   'fold media south add since false relax immense pause cloth just raven';
 const PASSWORD = `12345678`;
-const RINKEBY = 'Rinkeby Test Network';
 const APPROVAL_DEEPLINK_URL =
-  'https://metamask.app.link/send/0x01BE23585060835E02B77ef475b0Cc51aA1e0709@4/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=5e8';
+  'https://metamask.app.link/send/0x326C977E6efc84E512bB9C30f76E30c160eD06FB@5/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=5e8';
 const CONTRACT_NICK_NAME_TEXT = 'Ace RoMaIn';
+const GOERLI = 'Goerli Test Network';
 
 /* BROKEN. We need to revisit. Deep linking to a contract address does not work on a sim. */
 
@@ -51,11 +54,16 @@ describe('Adding Contract Nickname', () => {
   });
 
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
-    await ImportWalletView.toggleRememberMe();
     await ImportWalletView.enterSecretRecoveryPhrase(SECRET_RECOVERY_PHRASE);
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on "Got it" Button in the whats new modal', async () => {
@@ -81,11 +89,11 @@ describe('Adding Contract Nickname', () => {
     }
   });
 
-  it('should switch to rinkeby', async () => {
+  it('should switch to GOERLI', async () => {
     await WalletView.tapNetworksButtonOnNavBar();
-    await NetworkListModal.changeNetwork(RINKEBY);
+    await NetworkListModal.changeNetwork(GOERLI);
 
-    await WalletView.isNetworkNameVisible(RINKEBY);
+    await WalletView.isNetworkNameVisible(GOERLI);
     await TestHelpers.delay(1500);
   });
 
@@ -94,12 +102,41 @@ describe('Adding Contract Nickname', () => {
     await NetworkEducationModal.tapGotItButton();
     await NetworkEducationModal.isNotVisible();
   });
+  it('should go to the Privacy and settings view', async () => {
+    await WalletView.tapDrawerButton(); // tapping burger menu
 
+    await DrawerView.isVisible();
+    await DrawerView.tapSettings();
+
+    await SettingsView.tapSecurityAndPrivacy();
+
+    await SecurityAndPrivacy.scrollToTurnOnRememberMe();
+    TestHelpers.delay(3000);
+  });
+
+  it('should enable remember me', async () => {
+    await SecurityAndPrivacy.isRememberMeToggleOff();
+    await SecurityAndPrivacy.tapTurnOnRememberMeToggle();
+    await SecurityAndPrivacy.isRememberMeToggleOn();
+
+    TestHelpers.delay(1500);
+  });
+
+  it('should relaunch the app then enable remember me', async () => {
+    // Relaunch app
+    await TestHelpers.relaunchApp();
+    await LoginView.isVisible();
+    await LoginView.toggleRememberMe();
+
+    await LoginView.enterPassword(PASSWORD);
+    await WalletView.isVisible();
+  });
   it('should deep link to the approval modal', async () => {
     await TestHelpers.openDeepLink(APPROVAL_DEEPLINK_URL);
     await TestHelpers.delay(3000);
     await ApprovalModal.isVisible();
   });
+
   it('should add a nickname to the contract', async () => {
     await ApprovalModal.tapAddNickName();
 

--- a/e2e/specs/deeplinks.spec.js
+++ b/e2e/specs/deeplinks.spec.js
@@ -75,7 +75,6 @@ describe('Deep linking Tests', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/deeplinks.spec.js
+++ b/e2e/specs/deeplinks.spec.js
@@ -19,6 +19,7 @@ import NetworkView from '../pages/Drawer/Settings/NetworksView';
 import SettingsView from '../pages/Drawer/Settings/SettingsView';
 import LoginView from '../pages/LoginView';
 import TransactionConfirmationView from '../pages/TransactionConfirmView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 
@@ -71,6 +72,13 @@ describe('Deep linking Tests', () => {
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on the close button in the whats new modal', async () => {

--- a/e2e/specs/delete-wallet.spec.js
+++ b/e2e/specs/delete-wallet.spec.js
@@ -20,6 +20,7 @@ import ChangePasswordView from '../pages/Drawer/Settings/SecurityAndPrivacy/Chan
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import DeleteWalletModal from '../pages/modals/DeleteWalletModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 const SECRET_RECOVERY_PHRASE =
   'ketchup width ladder rent cheap eye torch employ quantum evidence artefact render protect delay wrap identify valley umbrella yard ridge wool swap differ kidney';
@@ -49,7 +50,12 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
   });
-
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
+  });
   it('should tap on "Got it" to dimiss the whats new modal', async () => {
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);

--- a/e2e/specs/delete-wallet.spec.js
+++ b/e2e/specs/delete-wallet.spec.js
@@ -51,11 +51,11 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
     await ImportWalletView.reEnterPassword(PASSWORD);
   });
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
+
   it('should tap on "Got it" to dimiss the whats new modal', async () => {
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);

--- a/e2e/specs/import-seed-phrase.spec.js
+++ b/e2e/specs/import-seed-phrase.spec.js
@@ -12,6 +12,7 @@ import ImportWalletView from '../pages/Onboarding/ImportWalletView';
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
 import LoginView from '../pages/LoginView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 //import DrawerView from '../pages/Drawer/DrawerView';
 //import SettingsView from '../pages/Drawer/Settings/SettingsView';
@@ -74,6 +75,12 @@ describe('Import seedphrase flow', () => {
     await WalletView.isVisible();
   });
 
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
+  });
   it('should tap on the close button in the whats new modal', async () => {
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);

--- a/e2e/specs/import-seed-phrase.spec.js
+++ b/e2e/specs/import-seed-phrase.spec.js
@@ -76,11 +76,11 @@ describe('Import seedphrase flow', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
+
   it('should tap on the close button in the whats new modal', async () => {
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);

--- a/e2e/specs/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding-wizard-opt-in.spec.js
@@ -55,8 +55,7 @@ describe('Onboarding wizard opt-in, metametrics opt out from settings', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
-    await TestHelpers.delay(2500);
+    await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();
   });

--- a/e2e/specs/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding-wizard-opt-in.spec.js
@@ -8,6 +8,7 @@ import CreatePasswordView from '../pages/Onboarding/CreatePasswordView';
 
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import DrawerView from '../pages/Drawer/DrawerView';
 
@@ -51,6 +52,13 @@ describe('Onboarding wizard opt-in, metametrics opt out from settings', () => {
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(2500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on "Got it" Button in the whats new modal', async () => {

--- a/e2e/specs/request-token-flow.spec.js
+++ b/e2e/specs/request-token-flow.spec.js
@@ -10,6 +10,7 @@ import RequestPaymentView from '../pages/RequestPaymentView';
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
 import DrawerView from '../pages/Drawer/DrawerView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import SkipAccountSecurityModal from '../pages/modals/SkipAccountSecurityModal';
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
@@ -51,6 +52,13 @@ describe('Request Token Flow', () => {
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on the close button in the whats new modal', async () => {

--- a/e2e/specs/request-token-flow.spec.js
+++ b/e2e/specs/request-token-flow.spec.js
@@ -55,7 +55,6 @@ describe('Request Token Flow', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/start-exploring.spec.js
+++ b/e2e/specs/start-exploring.spec.js
@@ -80,16 +80,6 @@ describe('Start Exploring', () => {
     await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
-  it('Should skip backup check', async () => {
-    // Check that we are on the Secure your wallet screen
-    await ProtectYourWalletView.isVisible();
-    await ProtectYourWalletView.tapOnRemindMeLaterButton();
-
-    await SkipAccountSecurityModal.tapIUnderstandCheckBox();
-    await SkipAccountSecurityModal.tapSkipButton();
-    await WalletView.isVisible();
-  });
-
   it('should tap on the close button in the whats new modal', async () => {
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);

--- a/e2e/specs/start-exploring.spec.js
+++ b/e2e/specs/start-exploring.spec.js
@@ -9,6 +9,7 @@ import CreatePasswordView from '../pages/Onboarding/CreatePasswordView';
 
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import { Browser } from '../pages/Drawer/Browser';
 
@@ -61,6 +62,13 @@ describe('Start Exploring', () => {
     await CreatePasswordView.reEnterPassword(PASSWORD);
     await CreatePasswordView.tapIUnderstandCheckBox();
     await CreatePasswordView.tapCreatePasswordButton();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('Should skip backup check', async () => {

--- a/e2e/specs/start-exploring.spec.js
+++ b/e2e/specs/start-exploring.spec.js
@@ -65,7 +65,6 @@ describe('Start Exploring', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/start-exploring.spec.js
+++ b/e2e/specs/start-exploring.spec.js
@@ -64,6 +64,16 @@ describe('Start Exploring', () => {
     await CreatePasswordView.tapCreatePasswordButton();
   });
 
+  it('Should skip backup check', async () => {
+    // Check that we are on the Secure your wallet screen
+    await ProtectYourWalletView.isVisible();
+    await ProtectYourWalletView.tapOnRemindMeLaterButton();
+
+    await SkipAccountSecurityModal.tapIUnderstandCheckBox();
+    await SkipAccountSecurityModal.tapSkipButton();
+    await WalletView.isVisible();
+  });
+
   it('Should dismiss Automatic Security checks screen', async () => {
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -65,7 +65,6 @@ describe('Wallet Tests', () => {
   });
 
   it('Should dismiss Automatic Security checks screen', async () => {
-    // Check that we are on the Secure your wallet screen
     await TestHelpers.delay(3500);
     await EnableAutomaticSecurityChecksView.isVisible();
     await EnableAutomaticSecurityChecksView.tapNoThanks();

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -9,6 +9,7 @@ import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
 import AccountListView from '../pages/AccountListView';
 import ImportAccountView from '../pages/ImportAccountView';
+import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
 import DrawerView from '../pages/Drawer/DrawerView';
 import SendView from '../pages/SendView';
@@ -61,6 +62,13 @@ describe('Wallet Tests', () => {
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
     await WalletView.isVisible();
+  });
+
+  it('Should dismiss Automatic Security checks screen', async () => {
+    // Check that we are on the Secure your wallet screen
+    await TestHelpers.delay(3500);
+    await EnableAutomaticSecurityChecksView.isVisible();
+    await EnableAutomaticSecurityChecksView.tapNoThanks();
   });
 
   it('should tap on the close button to dismiss the whats new modal', async () => {

--- a/wdio/features/LockResetWallet.feature
+++ b/wdio/features/LockResetWallet.feature
@@ -11,6 +11,7 @@ Feature: Lock and Reset Wallet
         And I type <password> in new password field
         And I type <password> in confirm password field
         And I tap "Import"
+        And I tap No Thanks on the Enable security check screen
         Then "Welcome to your new wallet!" is displayed
         Examples:
             | SRP                                                                   | password      |

--- a/wdio/features/NetworkFlow.feature
+++ b/wdio/features/NetworkFlow.feature
@@ -1,103 +1,104 @@
 @androidApp
 Feature: Networks
-              A user should be able to add a custom network via the popular network flow
-              A user should also have the ability to a add custom network via the custom network flow.
-              A user should be able to add a custom network via a Dapp.
+  A user should be able to add a custom network via the popular network flow
+  A user should also have the ability to a add custom network via the custom network flow.
+  A user should be able to add a custom network via a Dapp.
 
-        Scenario: Adding a network via the new popular network flow
-            Given I import wallet using seed phrase "fold media south add since false relax immense pause cloth just raven"
-              And I tap No thanks on the onboarding welcome tutorial
-             When I tap on the navbar network title button
-              And I tap on the Add a Network button
-             Then "POPULAR" tab is displayed on networks screen
-              And "CUSTOM NETWORKS" tab is displayed on networks screen
-              And I am on the Popular network view
-             When I tap on network "<Network>" to add it
-             Then the network approval modal should appear
-             When I select approve
-             Then the network approval modal has button "Switch Network" displayed
-              And the network approval modal has button "Close" displayed
-             When I tap on Switch network
-             Then I should see the added network name "<Network>" in the top navigation bar
-        #       And my token balance shows up correctly with token "ll"
-              And I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-             Then "<Network>" should be visible below the Custom Networks section
-             When I tap on the Add Network button
-             Then "<Network>" is not visible in the Popular Networks section
-              And I navigate back to the main wallet view
-        Examples:
-                  | Network |
-                  | Palm    |
+  Scenario: Adding a network via the new popular network flow
+    Given I import wallet using seed phrase "fold media south add since false relax immense pause cloth just raven"
+    And I tap No Thanks on the Enable security check screen
+    And I tap No thanks on the onboarding welcome tutorial
+    When I tap on the navbar network title button
+    And I tap on the Add a Network button
+    Then "POPULAR" tab is displayed on networks screen
+    And "CUSTOM NETWORKS" tab is displayed on networks screen
+    And I am on the Popular network view
+    When I tap on network "<Network>" to add it
+    Then the network approval modal should appear
+    When I select approve
+    Then the network approval modal has button "Switch Network" displayed
+    And the network approval modal has button "Close" displayed
+    When I tap on Switch network
+    Then I should see the added network name "<Network>" in the top navigation bar
+    #       And my token balance shows up correctly with token "ll"
+    And I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    Then "<Network>" should be visible below the Custom Networks section
+    When I tap on the Add Network button
+    Then "<Network>" is not visible in the Popular Networks section
+    And I navigate back to the main wallet view
+    Examples:
+      | Network |
+      | Palm    |
 
-        Scenario: Adding a network via the custom network flow
-            Given I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-              And I tap on the Add Network button
-             Then "POPULAR" tab is displayed on networks screen
-              And "CUSTOM NETWORKS" tab is displayed on networks screen
-             When I tap on the "CUSTOM NETWORKS" tab
-             Then Add button is disabled
-             When I type "<Network>" into Network name field
-              And I type "<rpcUrl>" into the RPC url field
-              And I type "<ChainID>" into the Chain ID field
-              And I type "<Network>" into the Network symbol field
-             When I tap on the Add button
-             Then I should see the added network name "<Network>" in the top navigation bar
-        Examples:
-                  | Network | rpcUrl                                | ChainID | Symbol |
-                  | Gnosis  | https://xdai-rpc.gateway.pokt.network | 100     | xDAI   |
+  Scenario: Adding a network via the custom network flow
+    Given I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    And I tap on the Add Network button
+    Then "POPULAR" tab is displayed on networks screen
+    And "CUSTOM NETWORKS" tab is displayed on networks screen
+    When I tap on the "CUSTOM NETWORKS" tab
+    Then Add button is disabled
+    When I type "<Network>" into Network name field
+    And I type "<rpcUrl>" into the RPC url field
+    And I type "<ChainID>" into the Chain ID field
+    And I type "<Network>" into the Network symbol field
+    When I tap on the Add button
+    Then I should see the added network name "<Network>" in the top navigation bar
+    Examples:
+      | Network | rpcUrl                                | ChainID | Symbol |
+      | Gnosis  | https://xdai-rpc.gateway.pokt.network | 100     | xDAI   |
 
 
-        Scenario: I can remove a custom network that was added via the popular network flow
-            Given I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-              And I tap on the Add Network button
-             Then "POPULAR" tab is displayed on networks screen
-              And "CUSTOM NETWORKS" tab is displayed on networks screen
-             When I tap on the "POPULAR" tab
-              And I tap on network "<Network>" to add it
-              And I select approve
-             Then the network approval modal has button "Switch Network" displayed
-              And the network approval modal has button "Close" displayed
-             When I tap on Switch network
-             Then I should see the added network name "<Network>" in the top navigation bar
-             When I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-              And I tap and hold network "<Network>"
-             Then I should see an alert window with the text "Do you want to remove this network?"
-              And I click "Remove" on remove network modal
-             Then "<Network>" should be removed from the list of RPC networks
-              And I go back to the main wallet screen
-        Examples:
-                  | Network  |
-                  | Optimism |
+  Scenario: I can remove a custom network that was added via the popular network flow
+    Given I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    And I tap on the Add Network button
+    Then "POPULAR" tab is displayed on networks screen
+    And "CUSTOM NETWORKS" tab is displayed on networks screen
+    When I tap on the "POPULAR" tab
+    And I tap on network "<Network>" to add it
+    And I select approve
+    Then the network approval modal has button "Switch Network" displayed
+    And the network approval modal has button "Close" displayed
+    When I tap on Switch network
+    Then I should see the added network name "<Network>" in the top navigation bar
+    When I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    And I tap and hold network "<Network>"
+    Then I should see an alert window with the text "Do you want to remove this network?"
+    And I click "Remove" on remove network modal
+    Then "<Network>" should be removed from the list of RPC networks
+    And I go back to the main wallet screen
+    Examples:
+      | Network  |
+      | Optimism |
 
-        Scenario: I can remove a custom network that was added via the custom network flow
-            Given I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-              And I tap on the Add Network button
-             Then "POPULAR" tab is displayed on networks screen
-              And "CUSTOM NETWORKS" tab is displayed on networks screen
-             When I tap on the "CUSTOM NETWORKS" tab
-             Then Add button is disabled
-             When I type "<Network>" into Network name field
-              And I type "<rpcUrl>" into the RPC url field
-              And I type "<ChainID>" into the Chain ID field
-              And I type "<Symbol>" into the Network symbol field
-             When I tap on the Add button
-             Then I should see the added network name "<Network>" in the top navigation bar
-             When I tap on the burger menu
-              And I tap on "Settings" in the menu
-              And In settings I tap on "Networks"
-             When I tap on network "<Network>" on networks screen
-             When I tap the "Delete" button
-             Then "<Network>" should be removed from the list of RPC networks
-        Examples:
-                  | Network            | rpcUrl                           | ChainID | Symbol |
-                  | Optimism on Gnosis | https://optimism.gnosischain.com | 300     | xDAI   |
+  Scenario: I can remove a custom network that was added via the custom network flow
+    Given I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    And I tap on the Add Network button
+    Then "POPULAR" tab is displayed on networks screen
+    And "CUSTOM NETWORKS" tab is displayed on networks screen
+    When I tap on the "CUSTOM NETWORKS" tab
+    Then Add button is disabled
+    When I type "<Network>" into Network name field
+    And I type "<rpcUrl>" into the RPC url field
+    And I type "<ChainID>" into the Chain ID field
+    And I type "<Symbol>" into the Network symbol field
+    When I tap on the Add button
+    Then I should see the added network name "<Network>" in the top navigation bar
+    When I tap on the burger menu
+    And I tap on "Settings" in the menu
+    And In settings I tap on "Networks"
+    When I tap on network "<Network>" on networks screen
+    When I tap the "Delete" button
+    Then "<Network>" should be removed from the list of RPC networks
+    Examples:
+      | Network            | rpcUrl                           | ChainID | Symbol |
+      | Optimism on Gnosis | https://optimism.gnosischain.com | 300     | xDAI   |

--- a/wdio/features/screen-objects/EnableSecurityChecksScreen.js
+++ b/wdio/features/screen-objects/EnableSecurityChecksScreen.js
@@ -1,0 +1,24 @@
+import Gestures from "../helpers/Gestures";
+import Selectors from "../helpers/Selectors";
+import { ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON,ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID } from "../testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds";
+
+class EnableAutomaticSecurityChecksScreen {
+get noThanksButton(){
+        return Selectors.getElementByPlatform(ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON);
+    }
+    get enableAutomaticSecurityChecksScreen(){
+        return Selectors.getElementByPlatform(ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID);
+    }
+
+    async tapNoThanksButton(){
+        await Gestures.waitAndTap(this.noThanksButton)
+    }
+    
+    async isVisible() {
+        await expect(this.enableAutomaticSecurityChecksScreen).toBeDisplayed();
+      }
+      async notVisible() {
+        await expect(this.enableAutomaticSecurityChecksScreen).not.toBeDisplayed();
+      }
+}
+export default new EnableAutomaticSecurityChecksScreen();

--- a/wdio/features/step-definitions/enable-automatic-security-checks.js
+++ b/wdio/features/step-definitions/enable-automatic-security-checks.js
@@ -1,0 +1,10 @@
+import { When, Then } from '@wdio/cucumber-framework';
+import EnableAutomaticSecurityChecksScreen from '../screen-objects/EnableSecurityChecksScreen';
+
+When(/^I tap No Thanks on the Enable security check screen/, async () => {
+    await EnableAutomaticSecurityChecksScreen.tapNoThanksButton();
+});
+
+// Then(/^I should no longer see the security check screen"/, async () => {
+//     await EnableAutomaticSecurityChecksScreen.notVisible();
+//   });

--- a/wdio/features/testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds.js
+++ b/wdio/features/testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds.js
@@ -1,0 +1,2 @@
+export const ENABLE_AUTOMATIC_SECURITY_CHECK_NO_THANKS_BUTTON = 'no-thanks-button';
+export const ENABLE_AUTOMATIC_SECURITY_CHECK_CONTAINER_ID = 'enable-automatic-checks-screen-container-image';


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR adds e2e test coverage in appium and detox for the automatic security update screen

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
