### PR TITLE
On-ramp: allow amount formatting on android

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/AmountToBuy.tsx
@@ -46,11 +46,11 @@ import ErrorView from '../components/ErrorView';
 
 import { getFiatOnRampAggNavbar } from '../../Navbar';
 import { useTheme } from '../../../../util/theme';
-import Device from '../../../../util/device';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { Colors } from '../../../../util/theme/models';
 import { NATIVE_ADDRESS, NETWORKS_NAMES } from '../../../../constants/on-ramp';
+import { formatAmount } from '../utils';
 
 // TODO: Convert into typescript and correctly type
 const Text = BaseText as any;
@@ -352,18 +352,6 @@ const AmountToBuy = () => {
       defaultFiatCurrency;
     return currency;
   }, [fiatCurrencies, defaultFiatCurrency, selectedFiatCurrencyId]);
-
-  /**
-   * Format the amount for display (iOS only)
-   */
-  const displayAmount = useMemo(() => {
-    if (Device.isIos() && Intl && Intl?.NumberFormat) {
-      return amountFocused
-        ? amount
-        : new Intl.NumberFormat().format(amountNumber);
-    }
-    return amount;
-  }, [amount, amountFocused, amountNumber]);
 
   const amountIsBelowMinimum = useMemo(
     () => amountNumber !== 0 && limits && amountNumber < limits.minAmount,
@@ -752,25 +740,25 @@ const AmountToBuy = () => {
                 highlighted={amountFocused}
                 label={strings('fiat_on_ramp_aggregator.amount')}
                 currencySymbol={currentFiatCurrency?.denomSymbol}
-                amount={displayAmount}
+                amount={amountFocused ? amount : formatAmount(amountNumber)}
                 highlightedError={!amountIsValid}
                 currencyCode={currentFiatCurrency?.symbol}
                 onPress={onAmountInputPress}
                 onCurrencyPress={handleFiatSelectorPress}
               />
             </View>
-            {amountIsBelowMinimum && (
+            {amountIsBelowMinimum && limits && (
               <Text red small>
                 {strings('fiat_on_ramp_aggregator.minimum')}{' '}
                 {currentFiatCurrency?.denomSymbol}
-                {limits?.minAmount}
+                {formatAmount(limits.minAmount)}
               </Text>
             )}
-            {amountIsAboveMaximum && (
+            {amountIsAboveMaximum && limits && (
               <Text red small>
                 {strings('fiat_on_ramp_aggregator.maximum')}{' '}
                 {currentFiatCurrency?.denomSymbol}
-                {limits?.maxAmount}
+                {formatAmount(limits.maxAmount)}
               </Text>
             )}
           </ScreenLayout.Content>

--- a/app/components/UI/FiatOnRampAggregator/utils/index.test.ts
+++ b/app/components/UI/FiatOnRampAggregator/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { timeToDescription, TimeDescriptions } from '.';
+import { timeToDescription, TimeDescriptions, formatAmount } from '.';
 describe('timeToDescription', () => {
   it('should return a function', () => {
     expect(timeToDescription).toBeInstanceOf(Function);
@@ -18,4 +18,30 @@ describe('timeToDescription', () => {
       expect(timeToDescription([lower, upper])).toStrictEqual(result);
     },
   );
+});
+
+describe('formatAmount', () => {
+  it('should format amount', () => {
+    jest.spyOn(Intl, 'NumberFormat').mockImplementation(
+      () =>
+        ({
+          format: jest.fn().mockImplementation(() => '123,123'),
+        } as any),
+    );
+    expect(formatAmount(123123)).toBe('123,123');
+    jest.spyOn(Intl, 'NumberFormat').mockClear();
+  });
+
+  it('should return input amount as string if Intl throws', () => {
+    jest.spyOn(Intl, 'NumberFormat').mockImplementation(
+      () =>
+        ({
+          format: jest.fn().mockImplementation(() => {
+            throw Error();
+          }),
+        } as any),
+    );
+    expect(formatAmount(123123)).toBe('123123');
+    jest.spyOn(Intl, 'NumberFormat').mockClear();
+  });
 });

--- a/app/components/UI/FiatOnRampAggregator/utils/index.ts
+++ b/app/components/UI/FiatOnRampAggregator/utils/index.ts
@@ -91,3 +91,12 @@ export const formatId = (id: string) => {
 
   return id.startsWith('/') ? id : '/' + id;
 };
+
+export function formatAmount(amount: number) {
+  try {
+    if (Intl?.NumberFormat) return new Intl.NumberFormat().format(amount);
+    return String(amount);
+  } catch (e) {
+    return String(amount);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR adds a number format to Android in the Amount to Buy screen. This feature was present in iOS.


**Screenshots/Recordings**

Before - After
<img width="300" alt="Screenshot_20221125_111507" src="https://user-images.githubusercontent.com/1024246/204031880-42aa98c8-de71-4201-96d2-0e6ea081aecf.png" /> <img width="300" alt="Screenshot_20221125_111440" src="https://user-images.githubusercontent.com/1024246/204031839-a6f9dd4d-737c-442d-98ba-33e9b4b08a94.png" />


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
