### PR TITLE
do not track rpc_url in metrics

### DIFF
--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -237,7 +237,6 @@ export class NetworkList extends PureComponent {
     NetworkController.setRpcTarget(rpcUrl, chainId, ticker, nickname);
 
     AnalyticsV2.trackEvent(AnalyticsV2.ANALYTICS_EVENTS.NETWORK_SWITCHED, {
-      rpc_url: rpcUrl,
       chain_id: chainId,
       source: 'Settings',
       symbol: ticker,

--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -214,13 +214,7 @@ export class NetworkList extends PureComponent {
     const { frequentRpcList } = this.props;
     const { NetworkController, CurrencyRateController } = Engine.context;
     const rpc = frequentRpcList.find(({ rpcUrl }) => rpcUrl === rpcTarget);
-    const {
-      rpcUrl,
-      chainId,
-      ticker,
-      nickname,
-      rpcPrefs: { blockExplorerUrl },
-    } = rpc;
+    const { rpcUrl, chainId, ticker, nickname } = rpc;
     const useRpcName = nickname || sanitizeUrl(rpcUrl);
     const useTicker = ticker || PRIVATENETWORK;
     this.handleNetworkSelected(useRpcName, useTicker, sanitizeUrl(rpcUrl));
@@ -240,7 +234,6 @@ export class NetworkList extends PureComponent {
       chain_id: chainId,
       source: 'Settings',
       symbol: ticker,
-      block_explorer_url: blockExplorerUrl,
       network_name: 'rpc',
     });
   };

--- a/app/components/UI/NetworkModal/index.tsx
+++ b/app/components/UI/NetworkModal/index.tsx
@@ -170,7 +170,6 @@ const NetworkModals = (props: NetworkProps) => {
         chain_id: decimalChainId,
         source: 'Popular network list',
         symbol: ticker,
-        block_explorer_url: blockExplorerUrl,
         network_name: nickname,
       };
 

--- a/app/components/UI/NetworkModal/index.tsx
+++ b/app/components/UI/NetworkModal/index.tsx
@@ -154,7 +154,6 @@ const NetworkModals = (props: NetworkProps) => {
 
     if (validUrl) {
       const url = new URLPARSE(rpcUrl);
-      const sanitizedUrl = sanitizeUrl(url.href);
       const decimalChainId = getDecimalChainId(chainId);
       !isprivateConnection(url.hostname) && url.set('protocol', 'https:');
       PreferencesController.addToFrequentRpcList(
@@ -168,7 +167,6 @@ const NetworkModals = (props: NetworkProps) => {
       );
 
       const analyticsParamsAdd = {
-        rpc_url: sanitizedUrl,
         chain_id: decimalChainId,
         source: 'Popular network list',
         symbol: ticker,

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -487,7 +487,6 @@ class NetworkSettings extends PureComponent {
         chain_id: decimalChainId,
         source: 'Custom network form',
         symbol: ticker,
-        block_explorer_url: blockExplorerUrl,
         network_name: nickname || RPC,
       };
       AnalyticsV2.trackEvent(

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -484,7 +484,6 @@ class NetworkSettings extends PureComponent {
       );
 
       const analyticsParamsAdd = {
-        rpc_url: formattedHref,
         chain_id: decimalChainId,
         source: 'Custom network form',
         symbol: ticker,

--- a/app/core/RPCMethods/wallet_addEthereumChain.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.js
@@ -128,7 +128,6 @@ const wallet_addEthereumChain = async ({
       chain_id: _chainId,
       source: 'Custom Network API',
       symbol: existingNetwork?.ticker,
-      block_explorer_url: existingNetwork?.blockExplorerUrl,
       network_name: 'rpc',
       ...analytics,
     };
@@ -265,7 +264,6 @@ const wallet_addEthereumChain = async ({
     chain_id: chainIdDecimal,
     source: 'Custom Network API',
     symbol: ticker,
-    block_explorer_url: firstValidBlockExplorerUrl,
     network_name: 'rpc',
     ...analytics,
   };

--- a/app/core/RPCMethods/wallet_addEthereumChain.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.js
@@ -125,7 +125,6 @@ const wallet_addEthereumChain = async ({
     }
 
     const analyticsParams = {
-      rpc_url: existingNetwork?.rpcUrl,
       chain_id: _chainId,
       source: 'Custom Network API',
       symbol: existingNetwork?.ticker,
@@ -263,7 +262,6 @@ const wallet_addEthereumChain = async ({
   requestData.alert = alert;
 
   const analyticsParamsAdd = {
-    rpc_url: firstValidRPCUrl,
     chain_id: chainIdDecimal,
     source: 'Custom Network API',
     symbol: ticker,

--- a/app/core/RPCMethods/wallet_switchEthereumChain.js
+++ b/app/core/RPCMethods/wallet_switchEthereumChain.js
@@ -82,7 +82,6 @@ const wallet_switchEthereumChain = async ({
       analyticsParams = {
         ...analyticsParams,
         symbol: existingNetworkRPC?.ticker,
-        block_explorer_url: existingNetworkRPC?.blockExplorerUrl,
         network_name: 'rpc',
       };
     } else {

--- a/app/core/RPCMethods/wallet_switchEthereumChain.js
+++ b/app/core/RPCMethods/wallet_switchEthereumChain.js
@@ -81,7 +81,6 @@ const wallet_switchEthereumChain = async ({
       };
       analyticsParams = {
         ...analyticsParams,
-        rpc_url: existingNetworkRPC?.rpcUrl,
         symbol: existingNetworkRPC?.ticker,
         block_explorer_url: existingNetworkRPC?.blockExplorerUrl,
         network_name: 'rpc',


### PR DESCRIPTION
**Description**
Removes rpc_url and block_explorer_url from event payloads to protect privacy. 
**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**
Fixes #5302 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
