### PR TITLE
Fix Estimated gas fee calculation on the tx detail page 

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -310,6 +310,12 @@ function getTransactionPropertiesFromGasEstimates(gasEstimateType, estimates) {
               .suggestedMaxPriorityFeePerGas,
         ),
       ),
+      estimatedBaseFee: addHexPrefix(
+        decGWEIToHexWEI(
+          estimates.estimatedBaseFee ||
+            estimates[DEFAULT_GAS_FEE_OPTION_FEE_MARKET].estimatedBaseFee,
+        ),
+      ),
     };
   }
 

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -714,7 +714,10 @@ function decodeSwapsTx(args) {
     );
   const cryptoSummaryTotalAmount =
     sourceToken.symbol === 'ETH'
-      ? `${Number(totalEthGas) + Number(decimalSourceAmount)} ${ticker}`
+      ? `${
+          Number(!isNaN(totalEthGas) ? totalEthGas : 0) +
+          Number(decimalSourceAmount)
+        } ${ticker}`
       : decimalSourceAmount
       ? `${decimalSourceAmount} ${sourceToken.symbol} + ${totalEthGas} ${ticker}`
       : `${totalEthGas} ${ticker}`;


### PR DESCRIPTION
## Description
- Fix Estimated gas fee calculation on the tx detail page for Swaps on EIP-1559 networks
- Fix NAN ETH in Total amount if estimated gas fee is < 0.00001 ETH

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/80175477/204524340-ce8cd230-e411-4981-8ce4-fb411e271b19.png)

After:
![image](https://user-images.githubusercontent.com/80175477/204524388-03cd12f5-48c0-4bb4-b8fc-c4cc68e73847.png)

Before:
![image](https://user-images.githubusercontent.com/80175477/204546201-4a8d977c-e133-4a0f-a7a3-2e86ef805a70.png)

After: 
![image](https://user-images.githubusercontent.com/80175477/204546236-ee04875a-9e1c-4d05-96ea-889115a699ee.png)
