### PR TITLE
[Force upgrade] only fetch minimum versions if permissions enabled

### DIFF
--- a/app/components/hooks/AppConfig/useAppConfig.test.tsx
+++ b/app/components/hooks/AppConfig/useAppConfig.test.tsx
@@ -4,18 +4,41 @@ import useAppConfig from './useAppConfig';
 
 describe('useAppConfig', () => {
   test('it should start with a state of "Loading"', () => {
-    const { result } = renderHook(() => useAppConfig());
+    const hasGithubPermissions = true;
+    const { result } = renderHook(() => useAppConfig(hasGithubPermissions));
     expect(result.current.type).toEqual('Loading');
   });
-
+  test('it should return an error when hasGithubPermissions is false', async () => {
+    const hasGithubPermissions = false;
+    const { result } = renderHook(() => useAppConfig(hasGithubPermissions));
+    expect(result.all[1].type).toEqual('Error');
+  });
+  test('it should not call fetch when hasGithubPermissions is false', async () => {
+    const hasGithubPermissions = false;
+    const spy = jest.spyOn(global, 'fetch');
+    renderHook(() => useAppConfig(hasGithubPermissions));
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+  test('it should call fetch when hasGithubPermissions is true', async () => {
+    const hasGithubPermissions = true;
+    const spy = jest.spyOn(global, 'fetch');
+    renderHook(() => useAppConfig(hasGithubPermissions));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
   test('it should return a state of "Success"', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAppConfig());
+    const hasGithubPermissions = true;
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppConfig(hasGithubPermissions),
+    );
     expect(result.current.type).toBe('Loading');
     await waitForNextUpdate();
     expect(result.all[1].type).toEqual('Success');
   });
   test('after a successful fetch, the AppConfig data should be available', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAppConfig());
+    const hasGithubPermissions = true;
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAppConfig(hasGithubPermissions),
+    );
     const expected: AppConfig = {
       security: {
         minimumVersions: {

--- a/app/components/hooks/MinimumVersions/useMinimumVersions.tsx
+++ b/app/components/hooks/MinimumVersions/useMinimumVersions.tsx
@@ -7,12 +7,12 @@ import { useNavigation } from '@react-navigation/native';
 import { InteractionManager } from 'react-native';
 
 const useMinimumVersions = () => {
-  const minimumValues = useAppConfig();
-  const currentBuildNumber = Number(getBuildNumber());
-  const navigation = useNavigation();
   const allowAutomaticSecurityChecks = useSelector(
     (state: any) => state.security.automaticSecurityChecksEnabled,
   );
+  const minimumValues = useAppConfig(allowAutomaticSecurityChecks);
+  const currentBuildNumber = Number(getBuildNumber());
+  const navigation = useNavigation();
   const shouldTriggerUpdateFlow = useMemo(
     () =>
       !!(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- I noticed that due to an oversight I made, we were making fetch calls to Github before the user granted persmission. Luckily this was not in production. 
_2. What is the improvement/solution?_
- this is a small change that checks if this permission is given before making the fetch. If not we will not fetch and return a state of Error for the useAppConfig.
- This fix patches a bug made in this [original PR](https://github.com/MetaMask/metamask-mobile/pull/4917)

**Screenshots/Recordings**


https://user-images.githubusercontent.com/22918444/205169106-7abbc9e4-5be9-409e-beeb-b13bc3d22d2c.mov



**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/505

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
