### PR TITLE
Include L1 fee in the Send flow and on the tx detail page for Optimism

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -5,6 +5,7 @@ import {
   InteractionManager,
   Linking,
 } from 'react-native';
+import Eth from 'ethjs-query';
 import ActionView from '../../UI/ActionView';
 import PropTypes from 'prop-types';
 import { getApproveNavbar } from '../../UI/Navbar';
@@ -43,7 +44,12 @@ import AppConstants from '../../../core/AppConstants';
 import { UINT256_HEX_MAX_VALUE } from '../../../constants/transaction';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
 import { withNavigation } from '@react-navigation/compat';
-import { isTestNet, isMainnetByChainId } from '../../../util/networks';
+import {
+  isTestNet,
+  isMainnetByChainId,
+  isMultiLayerFeeNetwork,
+  fetchEstimatedL1FeeOptimism,
+} from '../../../util/networks';
 import EditPermission from './EditPermission';
 import Logger from '../../../util/Logger';
 import InfoModal from '../Swaps/components/InfoModal';
@@ -63,6 +69,9 @@ import createStyles from './styles';
 const { hexToBN } = util;
 
 const { ORIGIN_DEEPLINK, ORIGIN_QR_CODE } = AppConstants.DEEPLINKS;
+const POLLING_INTERVAL_ESTIMATED_L1_FEE = 30000;
+
+let intervalIdForEstimatedL1Fee;
 
 /**
  * PureComponent that manages ERC20 approve from the dapp browser
@@ -228,6 +237,7 @@ class ApproveTransactionReview extends PureComponent {
     token: {},
     showGasTooltip: false,
     gasTransactionObject: {},
+    multiLayerL1FeeTotal: '0x0',
   };
 
   customSpendLimitInput = React.createRef();
@@ -238,7 +248,30 @@ class ApproveTransactionReview extends PureComponent {
   originIsMMSDKRemoteConn =
     this.props.transaction.origin?.startsWith(MM_SDK_REMOTE_ORIGIN);
 
+  fetchEstimatedL1Fee = async () => {
+    const { transaction, chainId } = this.props;
+    if (!transaction?.transaction) {
+      return;
+    }
+    try {
+      const eth = new Eth(Engine.context.NetworkController.provider);
+      const result = await fetchEstimatedL1FeeOptimism(eth, {
+        txParams: transaction.transaction,
+        chainId,
+      });
+      this.setState({
+        multiLayerL1FeeTotal: result,
+      });
+    } catch (e) {
+      Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
+      this.setState({
+        multiLayerL1FeeTotal: '0x0',
+      });
+    }
+  };
+
   componentDidMount = async () => {
+    const { chainId } = this.props;
     const {
       transaction: { origin, to, data },
       tokenList,
@@ -297,6 +330,17 @@ class ApproveTransactionReview extends PureComponent {
         );
       },
     );
+    if (isMultiLayerFeeNetwork(chainId)) {
+      this.fetchEstimatedL1Fee();
+      intervalIdForEstimatedL1Fee = setInterval(
+        this.fetchEstimatedL1Fee,
+        POLLING_INTERVAL_ESTIMATED_L1_FEE,
+      );
+    }
+  };
+
+  componentWillUnmount = async () => {
+    clearInterval(intervalIdForEstimatedL1Fee);
   };
 
   getAnalyticsParams = () => {
@@ -549,6 +593,7 @@ class ApproveTransactionReview extends PureComponent {
       spenderAddress,
       originalApproveAmount,
       customSpendAmount,
+      multiLayerL1FeeTotal,
     } = this.state;
     const {
       primaryCurrency,
@@ -691,6 +736,7 @@ class ApproveTransactionReview extends PureComponent {
                     }
                     updateTransactionState={updateTransactionState}
                     onlyGas
+                    multiLayerL1FeeTotal={multiLayerL1FeeTotal}
                   />
 
                   {gasError && (

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -48,7 +48,7 @@ import {
   isTestNet,
   isMainnetByChainId,
   isMultiLayerFeeNetwork,
-  fetchEstimatedL1FeeOptimism,
+  fetchEstimatedMultiLayerL1Fee,
 } from '../../../util/networks';
 import EditPermission from './EditPermission';
 import Logger from '../../../util/Logger';
@@ -255,7 +255,7 @@ class ApproveTransactionReview extends PureComponent {
     }
     try {
       const eth = new Eth(Engine.context.NetworkController.provider);
-      const result = await fetchEstimatedL1FeeOptimism(eth, {
+      const result = await fetchEstimatedMultiLayerL1Fee(eth, {
         txParams: transaction.transaction,
         chainId,
       });
@@ -263,7 +263,7 @@ class ApproveTransactionReview extends PureComponent {
         multiLayerL1FeeTotal: result,
       });
     } catch (e) {
-      Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
+      Logger.error(e, 'fetchEstimatedMultiLayerL1Fee call failed');
       this.setState({
         multiLayerL1FeeTotal: '0x0',
       });

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -74,7 +74,7 @@ import { trackErrorAsAnalytics } from '../../../util/analyticsV2';
 import { decodeApproveData, getTicker } from '../../../util/transactions';
 import { toLowerCaseEquals } from '../../../util/general';
 import { swapsTokensSelector } from '../../../reducers/swaps';
-import { decGWEIToHexWEI, sumHexWEIs } from '../../../util/conversions';
+import { decGWEIToHexWEI } from '../../../util/conversions';
 import FadeAnimationView from '../FadeAnimationView';
 import Logger from '../../../util/Logger';
 import { useTheme } from '../../../util/theme';

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -36,7 +36,7 @@ import {
 import {
   isMainnetByChainId,
   isMultiLayerFeeNetwork,
-  fetchEstimatedL1FeeOptimism,
+  fetchEstimatedMultiLayerL1Fee,
 } from '../../../util/networks';
 import {
   getErrorMessage,
@@ -403,7 +403,8 @@ function SwapsQuotesView({
   const [trackedError, setTrackedError] = useState(false);
   const [animateOnGasChange, setAnimateOnGasChange] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
-  const [multiLayerL1FeeTotal, setMultiLayerL1FeeTotal] = useState(null);
+  const [multiLayerL1ApprovalFeeTotal, setMultiLayerL1ApprovalFeeTotal] =
+    useState(null);
 
   /* Selected quote, initially topAggId (see effects) */
   const [selectedQuoteId, setSelectedQuoteId] = useState(null);
@@ -479,16 +480,16 @@ function SwapsQuotesView({
     [allQuotes, selectedQuoteId],
   );
   const selectedQuoteValue = useMemo(() => {
-    if (!quoteValues[selectedQuoteId] || multiLayerL1FeeTotal === null) {
+    if (!quoteValues[selectedQuoteId] || !multiLayerL1ApprovalFeeTotal) {
       return quoteValues[selectedQuoteId];
     }
     const fees = {
       ethFee: calculateEthFeeForMultiLayer({
-        multiLayerL1FeeTotal,
+        multiLayerL1FeeTotal: multiLayerL1ApprovalFeeTotal,
         ethFee: quoteValues[selectedQuoteId].ethFee,
       }),
       maxEthFee: calculateEthFeeForMultiLayer({
-        multiLayerL1FeeTotal,
+        multiLayerL1FeeTotal: multiLayerL1ApprovalFeeTotal,
         ethFee: quoteValues[selectedQuoteId].maxEthFee,
       }),
     };
@@ -499,7 +500,7 @@ function SwapsQuotesView({
   }, [
     // eslint-disable-next-line react-hooks/exhaustive-deps
     quoteValues[selectedQuoteId],
-    multiLayerL1FeeTotal,
+    multiLayerL1ApprovalFeeTotal,
     quoteValues,
     selectedQuoteId,
   ]);
@@ -1596,40 +1597,30 @@ function SwapsQuotesView({
   }, [error, handleQuotesErrorMetric, trackedError]);
 
   useEffect(() => {
-    if (!multiLayerFeeNetwork || !selectedQuote?.trade) {
+    if (!multiLayerFeeNetwork) {
       return;
     }
-    const getEstimatedL1Fee = async () => {
+    const getEstimatedL1ApprovalFee = async () => {
       try {
         const eth = new Eth(Engine.context.NetworkController.provider);
-        const l1TradeFeeTotal = await fetchEstimatedL1FeeOptimism(eth, {
-          txParams: selectedQuote.trade,
-          chainId,
-        });
         let l1ApprovalFeeTotal = '0x0';
         if (approvalTransaction) {
-          l1ApprovalFeeTotal = await fetchEstimatedL1FeeOptimism(eth, {
+          l1ApprovalFeeTotal = await fetchEstimatedMultiLayerL1Fee(eth, {
             txParams: {
               ...approvalTransaction,
               value: '0x0', // For approval txs we need to use "0x0" here.
             },
             chainId,
           });
+          setMultiLayerL1ApprovalFeeTotal(l1ApprovalFeeTotal);
         }
-        const l1FeeTotal = sumHexWEIs([l1TradeFeeTotal, l1ApprovalFeeTotal]);
-        setMultiLayerL1FeeTotal(l1FeeTotal);
       } catch (e) {
-        Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
-        setMultiLayerL1FeeTotal(null);
+        Logger.error(e, 'fetchEstimatedMultiLayerL1Fee call failed');
+        setMultiLayerL1ApprovalFeeTotal(null);
       }
     };
-    getEstimatedL1Fee();
-  }, [
-    selectedQuote?.trade,
-    multiLayerFeeNetwork,
-    approvalTransaction,
-    chainId,
-  ]);
+    getEstimatedL1ApprovalFee();
+  }, [multiLayerFeeNetwork, approvalTransaction, chainId]);
 
   const openLinkAboutGas = () =>
     Linking.openURL(
@@ -2246,7 +2237,7 @@ function SwapsQuotesView({
         selectedQuote={selectedQuoteId}
         showOverallValue={hasConversionRate}
         ticker={getTicker(ticker)}
-        multiLayerL1FeeTotal={multiLayerL1FeeTotal}
+        multiLayerL1ApprovalFeeTotal={multiLayerL1ApprovalFeeTotal}
       />
 
       <ApprovalTransactionEditionModal

--- a/app/components/UI/Swaps/components/QuotesModal.js
+++ b/app/components/UI/Swaps/components/QuotesModal.js
@@ -146,7 +146,7 @@ function QuotesModal({
   quoteValues,
   showOverallValue,
   ticker,
-  multiLayerL1FeeTotal,
+  multiLayerL1ApprovalFeeTotal,
 }) {
   const bestOverallValue =
     quoteValues?.[quotes[0].aggregator]?.overallValueOfQuote ?? 0;
@@ -225,10 +225,13 @@ function QuotesModal({
     }
   }, [displayDetails, selectedDetailsQuote]);
 
-  const selectedDetailsQuoteValuesEthFee = calculateEthFeeForMultiLayer({
-    multiLayerL1FeeTotal,
-    ethFee: selectedDetailsQuoteValues?.ethFee,
-  });
+  let selectedDetailsQuoteValuesEthFee = selectedDetailsQuoteValues?.ethFee;
+  if (multiLayerL1ApprovalFeeTotal) {
+    selectedDetailsQuoteValuesEthFee = calculateEthFeeForMultiLayer({
+      multiLayerL1FeeTotal: multiLayerL1ApprovalFeeTotal,
+      ethFee: selectedDetailsQuoteValuesEthFee,
+    });
+  }
 
   return (
     <Modal
@@ -393,10 +396,13 @@ function QuotesModal({
                       const { aggregator } = quote;
                       const isSelected = aggregator === selectedQuote;
                       const quoteValue = quoteValues[aggregator];
-                      const quoteEthFee = calculateEthFeeForMultiLayer({
-                        multiLayerL1FeeTotal,
-                        ethFee: quoteValue?.ethFee,
-                      });
+                      let quoteEthFee = quoteValue?.ethFee;
+                      if (multiLayerL1ApprovalFeeTotal) {
+                        quoteEthFee = calculateEthFeeForMultiLayer({
+                          multiLayerL1FeeTotal: multiLayerL1ApprovalFeeTotal,
+                          ethFee: quoteEthFee,
+                        });
+                      }
                       return (
                         <TouchableOpacity
                           key={aggregator}
@@ -515,7 +521,7 @@ QuotesModal.propTypes = {
   ticker: PropTypes.string,
   quoteValues: PropTypes.object,
   showOverallValue: PropTypes.bool,
-  multiLayerL1FeeTotal: PropTypes.string,
+  multiLayerL1ApprovalFeeTotal: PropTypes.string,
 };
 
 const mapStateToProps = (state) => ({

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -162,11 +162,13 @@ class TransactionDetails extends PureComponent {
       return;
     }
     try {
-      let { l1Fee: l1HexGasTotal } = await this.fetchTxReceipt(transactionHash);
-      if (!l1HexGasTotal) {
-        l1HexGasTotal = '0x0'; // Sets it to 0 if it's not available in a txReceipt yet.
+      let { l1Fee: multiLayerL1FeeTotal } = await this.fetchTxReceipt(
+        transactionHash,
+      );
+      if (!multiLayerL1FeeTotal) {
+        multiLayerL1FeeTotal = '0x0'; // Sets it to 0 if it's not available in a txReceipt yet.
       }
-      transactionObject.transaction.l1HexGasTotal = l1HexGasTotal;
+      transactionObject.transaction.multiLayerL1FeeTotal = multiLayerL1FeeTotal;
       const decodedTx = await decodeTransaction({
         tx: transactionObject,
         selectedAddress,

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -12,6 +12,7 @@ import {
   addCurrencySymbol,
   toBN,
   BNToHex,
+  limitToMaximumDecimalPlaces,
 } from '../../../util/number';
 import { strings } from '../../../../locales/i18n';
 import {
@@ -715,12 +716,18 @@ function decodeSwapsTx(args) {
         : swapTransaction.destinationAmount,
       swapTransaction.destinationToken.decimals,
     );
+  let totalAmountForEthSourceTokenFormatted;
+  if (sourceToken.symbol === 'ETH') {
+    const totalAmountForEthSourceToken =
+      Number(!isNaN(totalEthGas) ? totalEthGas : 0) +
+      Number(decimalSourceAmount);
+    totalAmountForEthSourceTokenFormatted = `${limitToMaximumDecimalPlaces(
+      totalAmountForEthSourceToken,
+    )} ${ticker}`;
+  }
   const cryptoSummaryTotalAmount =
     sourceToken.symbol === 'ETH'
-      ? `${
-          Number(!isNaN(totalEthGas) ? totalEthGas : 0) +
-          Number(decimalSourceAmount)
-        } ${ticker}`
+      ? totalAmountForEthSourceTokenFormatted
       : decimalSourceAmount
       ? `${decimalSourceAmount} ${sourceToken.symbol} + ${totalEthGas} ${ticker}`
       : `${totalEthGas} ${ticker}`;

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -45,7 +45,7 @@ function calculateTotalGas(transaction) {
     estimatedBaseFee,
     maxPriorityFeePerGas,
     maxFeePerGas,
-    l1HexGasTotal,
+    multiLayerL1FeeTotal,
   } = transaction;
   if (isEIP1559Transaction(transaction)) {
     const eip1559GasHex = calculateEIP1559GasFeeHexes({
@@ -66,8 +66,8 @@ function calculateTotalGas(transaction) {
   if (isBN(gasBN) && isBN(gasPriceBN)) {
     totalGas = gasBN.mul(gasPriceBN);
   }
-  if (l1HexGasTotal) {
-    totalGas = hexToBN(sumHexWEIs([BNToHex(totalGas), l1HexGasTotal]));
+  if (multiLayerL1FeeTotal) {
+    totalGas = hexToBN(sumHexWEIs([BNToHex(totalGas), multiLayerL1FeeTotal]));
   }
   return totalGas;
 }

--- a/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
+++ b/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
@@ -35,6 +35,7 @@ const TransactionReviewEIP1559Update = ({
   gasObject,
   onlyGas,
   updateTransactionState,
+  multiLayerL1FeeTotal,
 }: TransactionEIP1559UpdateProps) => {
   const [showLearnMoreModal, setShowLearnMoreModal] = useState(false);
   const [
@@ -55,6 +56,7 @@ const TransactionReviewEIP1559Update = ({
     gasSelected,
     legacy: !!legacy,
     gasObject,
+    multiLayerL1FeeTotal,
   });
 
   const {

--- a/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/types.ts
+++ b/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/types.ts
@@ -67,6 +67,7 @@ export interface TransactionEIP1559UpdateProps {
    */
   updateTransactionState: any;
   onlyGas: boolean;
+  multiLayerL1FeeTotal?: string;
 }
 
 export interface SkeletonProps {

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -28,6 +28,7 @@ import {
   calculateEthEIP1559,
   calculateERC20EIP1559,
 } from '../../../../util/transactions';
+import { sumHexWEIs } from '../../../../util/conversions';
 import Analytics from '../../../../core/Analytics/Analytics';
 import { ANALYTICS_EVENT_OPTS } from '../../../../util/analytics';
 import { getNetworkNonce, isTestNet } from '../../../../util/networks';
@@ -208,6 +209,7 @@ class TransactionReviewInformation extends PureComponent {
      */
     originWarning: PropTypes.bool,
     gasSelected: PropTypes.string,
+    multiLayerL1FeeTotal: PropTypes.string,
   };
 
   state = {
@@ -577,10 +579,15 @@ class TransactionReviewInformation extends PureComponent {
       onUpdatingValuesEnd,
       animateOnChange,
       isAnimating,
+      multiLayerL1FeeTotal,
     } = this.props;
 
-    const totalGas =
+    let totalGas =
       isBN(gas) && isBN(gasPrice) ? gas.mul(gasPrice) : hexToBN('0x0');
+    if (multiLayerL1FeeTotal) {
+      totalGas = hexToBN(sumHexWEIs([BNToHex(totalGas), multiLayerL1FeeTotal]));
+    }
+
     const totalGasFiat = weiToFiat(totalGas, conversionRate, currentCurrency);
     const totalGasEth = `${renderFromWei(totalGas)} ${getTicker(ticker)}`;
     const [totalFiat, totalValue] = this.getRenderTotals(

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -10,7 +10,7 @@ import {
 import Eth from 'ethjs-query';
 import {
   isMultiLayerFeeNetwork,
-  fetchEstimatedL1FeeOptimism,
+  fetchEstimatedMultiLayerL1Fee,
 } from '../../../util/networks';
 import Engine from '../../../core/Engine';
 import Logger from '../../../util/Logger';
@@ -247,7 +247,7 @@ class TransactionReview extends PureComponent {
     }
     try {
       const eth = new Eth(Engine.context.NetworkController.provider);
-      const result = await fetchEstimatedL1FeeOptimism(eth, {
+      const result = await fetchEstimatedMultiLayerL1Fee(eth, {
         txParams: transaction.transaction,
         chainId,
       });
@@ -255,7 +255,7 @@ class TransactionReview extends PureComponent {
         multiLayerL1FeeTotal: result,
       });
     } catch (e) {
-      Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
+      Logger.error(e, 'fetchEstimatedMultiLayerL1Fee call failed');
       this.setState({
         multiLayerL1FeeTotal: '0x0',
       });

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -7,6 +7,13 @@ import {
   Animated,
   ScrollView,
 } from 'react-native';
+import Eth from 'ethjs-query';
+import {
+  isMultiLayerFeeNetwork,
+  fetchEstimatedL1FeeOptimism,
+} from '../../../util/networks';
+import Engine from '../../../core/Engine';
+import Logger from '../../../util/Logger';
 import { fontStyles } from '../../../styles/common';
 import { connect } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
@@ -41,6 +48,10 @@ import withQRHardwareAwareness from '../QRHardware/withQRHardwareAwareness';
 import QRSigningDetails from '../QRHardware/QRSigningDetails';
 import { withNavigation } from '@react-navigation/compat';
 import { MM_SDK_REMOTE_ORIGIN } from '../../../core/SDKConnect';
+
+const POLLING_INTERVAL_ESTIMATED_L1_FEE = 30000;
+
+let intervalIdForEstimatedL1Fee;
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -226,6 +237,29 @@ class TransactionReview extends PureComponent {
     assetAmount: undefined,
     conversionRate: undefined,
     fiatValue: undefined,
+    multiLayerL1FeeTotal: '0x0',
+  };
+
+  fetchEstimatedL1Fee = async () => {
+    const { transaction, chainId } = this.props;
+    if (!transaction?.transaction) {
+      return;
+    }
+    try {
+      const eth = new Eth(Engine.context.NetworkController.provider);
+      const result = await fetchEstimatedL1FeeOptimism(eth, {
+        txParams: transaction.transaction,
+        chainId,
+      });
+      this.setState({
+        multiLayerL1FeeTotal: result,
+      });
+    } catch (e) {
+      Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
+      this.setState({
+        multiLayerL1FeeTotal: '0x0',
+      });
+    }
   };
 
   componentDidMount = async () => {
@@ -269,6 +303,17 @@ class TransactionReview extends PureComponent {
     InteractionManager.runAfterInteractions(() => {
       Analytics.trackEvent(ANALYTICS_EVENT_OPTS.TRANSACTIONS_CONFIRM_STARTED);
     });
+    if (isMultiLayerFeeNetwork(chainId)) {
+      this.fetchEstimatedL1Fee();
+      intervalIdForEstimatedL1Fee = setInterval(
+        this.fetchEstimatedL1Fee,
+        POLLING_INTERVAL_ESTIMATED_L1_FEE,
+      );
+    }
+  };
+
+  componentWillUnmount = async () => {
+    clearInterval(intervalIdForEstimatedL1Fee);
   };
 
   async componentDidUpdate(prevProps) {
@@ -400,6 +445,7 @@ class TransactionReview extends PureComponent {
       conversionRate,
       fiatValue,
       approveTransaction,
+      multiLayerL1FeeTotal,
     } = this.state;
     const currentPageInformation = { url: this.getUrlFromBrowser() };
     const styles = this.getStyles();
@@ -463,6 +509,7 @@ class TransactionReview extends PureComponent {
                       onUpdatingValuesEnd={onUpdatingValuesEnd}
                       animateOnChange={animateOnChange}
                       isAnimating={isAnimating}
+                      multiLayerL1FeeTotal={multiLayerL1FeeTotal}
                     />
                   </View>
                 </ScrollView>

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -62,7 +62,7 @@ import {
   getNetworkNonce,
   isMainnetByChainId,
   isMultiLayerFeeNetwork,
-  fetchEstimatedL1FeeOptimism,
+  fetchEstimatedMultiLayerL1Fee,
 } from '../../../../util/networks';
 import Text from '../../../Base/Text';
 import AnalyticsV2 from '../../../../util/analyticsV2';
@@ -328,7 +328,7 @@ class Confirm extends PureComponent {
     }
     try {
       const eth = new Eth(Engine.context.NetworkController.provider);
-      const result = await fetchEstimatedL1FeeOptimism(eth, {
+      const result = await fetchEstimatedMultiLayerL1Fee(eth, {
         txParams: transaction.transaction,
         chainId,
       });
@@ -336,7 +336,7 @@ class Confirm extends PureComponent {
         multiLayerL1FeeTotal: result,
       });
     } catch (e) {
-      Logger.error(e, 'fetchEstimatedL1FeeOptimism call failed');
+      Logger.error(e, 'fetchEstimatedMultiLayerL1Fee call failed');
       this.setState({
         multiLayerL1FeeTotal: '0x0',
       });

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -248,7 +248,6 @@ class Confirm extends PureComponent {
     EIP1559GasObject: {},
     legacyGasObject: {},
     legacyGasTransaction: {},
-    multiLayerFeeNetwork: false,
     multiLayerL1FeeTotal: '0x0',
   };
 
@@ -324,8 +323,7 @@ class Confirm extends PureComponent {
 
   fetchEstimatedL1Fee = async () => {
     const { transaction, chainId } = this.props;
-    const { multiLayerFeeNetwork } = this.state;
-    if (!multiLayerFeeNetwork || !transaction?.transaction) {
+    if (!transaction?.transaction) {
       return;
     }
     try {
@@ -353,7 +351,6 @@ class Confirm extends PureComponent {
     const pollToken = await startGasPolling(this.state.pollToken);
     this.setState({
       pollToken,
-      multiLayerFeeNetwork: isMultiLayerFeeNetwork(chainId),
     });
     // For analytics
     AnalyticsV2.trackEvent(
@@ -369,9 +366,10 @@ class Confirm extends PureComponent {
     this.parseTransactionDataHeader();
     if (isMultiLayerFeeNetwork(chainId)) {
       this.fetchEstimatedL1Fee();
-      intervalIdForEstimatedL1Fee = setInterval(() => {
-        this.fetchEstimatedL1Fee();
-      }, POLLING_INTERVAL_ESTIMATED_L1_FEE);
+      intervalIdForEstimatedL1Fee = setInterval(
+        this.fetchEstimatedL1Fee,
+        POLLING_INTERVAL_ESTIMATED_L1_FEE,
+      );
     }
   };
 

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -33,6 +33,7 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import Networks, {
   isMainnetByChainId,
   getDecimalChainId,
+  fetchEstimatedMultiLayerL1Fee,
 } from '../util/networks';
 import AppConstants from './AppConstants';
 import { store } from '../store';
@@ -361,6 +362,7 @@ class Engine {
         new SwapsController(
           {
             fetchGasFeeEstimates: () => gasFeeController.fetchGasFeeEstimates(),
+            fetchEstimatedMultiLayerL1Fee,
           },
           {
             clientId: AppConstants.SWAPS.CLIENT_ID,

--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -144,6 +144,7 @@ export const getLegacyTransactionData = ({
   ticker,
   gas,
   onlyGas,
+  multiLayerL1FeeTotal,
 }: LegacyProps) => {
   const parsedTransationData = parseTransactionLegacy(
     {
@@ -155,6 +156,7 @@ export const getLegacyTransactionData = ({
       selectedGasFee: {
         ...gas,
       },
+      multiLayerL1FeeTotal,
     },
     { onlyGas },
   );
@@ -171,6 +173,7 @@ export const useGasTransaction = ({
   gasSelected,
   legacy,
   gasObject,
+  multiLayerL1FeeTotal,
 }: UseGasTransactionProps) => {
   const [gasEstimateTypeChange, updateGasEstimateTypeChange] =
     useState<string>('');
@@ -214,6 +217,7 @@ export const useGasTransaction = ({
       transactionState,
       ticker,
       onlyGas,
+      multiLayerL1FeeTotal,
     });
   }
 

--- a/app/core/GasPolling/types.ts
+++ b/app/core/GasPolling/types.ts
@@ -114,6 +114,7 @@ export interface UseGasTransactionProps extends GasTransactionProps {
    */
   gasSelected: string | null;
   onlyGas?: boolean;
+
   /**
    * The type of transaction (EIP1559, legacy)
    */
@@ -132,6 +133,8 @@ export interface UseGasTransactionProps extends GasTransactionProps {
     suggestedMaxFeePerGas: string;
     suggestedMaxPriorityFeePerGas: string;
   };
+
+  multiLayerL1FeeTotal?: string;
 }
 
 export interface TransactionSharedProps {
@@ -212,4 +215,5 @@ export interface LegacyProps {
   suggestedGasPrice: any;
   suggestedGasLimit: string;
   onlyGas?: boolean;
+  multiLayerL1FeeTotal?: string;
 }

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -294,13 +294,14 @@ const buildOVMGasPriceOracleContract = (eth) => {
 };
 
 /**
- * It returns an estimated L1 fee for the Optimism network.
+ * It returns an estimated L1 fee for a multi layer network.
+ * Currently only for the Optimism network, but can be extended to other networks.
  *
  * @param {Object} eth
  * @param {Object} txMeta
  * @returns {String}
  */
-export const fetchEstimatedL1FeeOptimism = async (eth, txMeta) => {
+export const fetchEstimatedMultiLayerL1Fee = async (eth, txMeta) => {
   const contract = buildOVMGasPriceOracleContract(eth);
   const serializedTransaction =
     buildUnserializedTransaction(txMeta).serialize();

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -252,6 +252,20 @@ export function renderFiatAddition(
 }
 
 /**
+ * Limits a number to a max decimal places.
+ * @param {number} num
+ * @param {number} maxDecimalPlaces
+ * @returns {string}
+ */
+export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
+  if (isNaN(num) || isNaN(maxDecimalPlaces)) {
+    return num;
+  }
+  const base = Math.pow(10, maxDecimalPlaces);
+  return (Math.round(num * base) / base).toString();
+}
+
+/**
  * Converts fiat number as human-readable fiat string to token miniml unit expressed as a BN
  *
  * @param {number|string} fiat - Fiat number

--- a/app/util/number/index.test.ts
+++ b/app/util/number/index.test.ts
@@ -26,6 +26,7 @@ import {
   isNumber,
   isNumberScientificNotationWhenString,
   calculateEthFeeForMultiLayer,
+  limitToMaximumDecimalPlaces,
 } from '.';
 
 describe('Number utils :: BNToHex', () => {
@@ -757,5 +758,19 @@ describe('Number utils :: calculateEthFeeForMultiLayer', () => {
         ethFee: 0.000001,
       }),
     ).toBe('0.000227739');
+  });
+});
+
+describe('Number utils :: limitToMaximumDecimalPlaces', () => {
+  it('limits a num to a max decimal places (5)', () => {
+    expect(limitToMaximumDecimalPlaces(0.001050172)).toBe('0.00105');
+  });
+
+  it('limits a num to 3 decimal places', () => {
+    expect(limitToMaximumDecimalPlaces(0.001000172)).toBe('0.001');
+  });
+
+  it('does not add any decimal places for a whole number', () => {
+    expect(limitToMaximumDecimalPlaces(5)).toBe('5');
   });
 });

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -31,6 +31,7 @@ import {
   decGWEIToHexWEI,
   getValueFromWeiHex,
   formatETHFee,
+  sumHexWEIs,
 } from '../conversions';
 import {
   addEth,
@@ -1175,15 +1176,21 @@ export const parseTransactionLegacy = (
     },
     ticker,
     selectedGasFee,
+    multiLayerL1FeeTotal,
   },
   { onlyGas } = {},
 ) => {
   const gasLimit = new BN(selectedGasFee.suggestedGasLimit);
   const gasLimitHex = BNToHex(new BN(selectedGasFee.suggestedGasLimit));
 
-  const weiTransactionFee =
+  let weiTransactionFee =
     gasLimit &&
     gasLimit.mul(hexToBN(decGWEIToHexWEI(selectedGasFee.suggestedGasPrice)));
+  if (multiLayerL1FeeTotal) {
+    weiTransactionFee = hexToBN(
+      sumHexWEIs([BNToHex(weiTransactionFee), multiLayerL1FeeTotal]),
+    );
+  }
 
   const suggestedGasPriceHex = decGWEIToHexWEI(
     selectedGasFee.suggestedGasPrice,

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@metamask/design-tokens": "^1.9.0",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/sdk-communication-layer": "^0.0.1-beta.3",
-    "@metamask/swaps-controller": "^6.7.2",
+    "@metamask/swaps-controller": "git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d",
     "@ngraveio/bc-ur": "^1.1.6",
     "@react-native-async-storage/async-storage": "1.17.10",
     "@react-native-clipboard/clipboard": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@metamask/design-tokens": "^1.9.0",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/sdk-communication-layer": "^0.0.1-beta.3",
-    "@metamask/swaps-controller": "git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d",
+    "@metamask/swaps-controller": "^6.8.0",
     "@ngraveio/bc-ur": "^1.1.6",
     "@react-native-async-storage/async-storage": "1.17.10",
     "@react-native-clipboard/clipboard": "^1.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,10 +4052,9 @@
     socket.io-client "^4.5.1"
     uuid "^8.3.2"
 
-"@metamask/swaps-controller@^6.7.2":
+"@metamask/swaps-controller@git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d":
   version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@metamask/swaps-controller/-/swaps-controller-6.7.2.tgz#c999e55d449d36f8e948409c21d5362db93cc4cf"
-  integrity sha512-p3Czoqx7YANZX2GjW8apTio5rs3RkAGaIvoRd97fVza72R6VKXcRZ/pw9XB1o2z9beYdXqEn7+Q3v69yTUOu7A==
+  resolved "git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d"
   dependencies:
     "@metamask/controllers" "^26.0.0"
     abort-controller "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,9 +4052,10 @@
     socket.io-client "^4.5.1"
     uuid "^8.3.2"
 
-"@metamask/swaps-controller@git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d":
-  version "6.7.2"
-  resolved "git+https://github.com/MetaMask/swaps-controller.git#f8127fbdacc71d9f02b3c907844f3170ab9f472d"
+"@metamask/swaps-controller@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@metamask/swaps-controller/-/swaps-controller-6.8.0.tgz#c2c43173dc1101fab9ec918e7f7853f14072740b"
+  integrity sha512-BWuALQXWxk2Sw2+djZSIvbIhUDxwX99IE+Mq/c4FMFgNe80BSFMNeAScnhjKvH8xFs47ur7TDmS9bukZpm9rmA==
   dependencies:
     "@metamask/controllers" "^26.0.0"
     abort-controller "^3.0.0"


### PR DESCRIPTION
## Description
This PR:
- Includes Optimism's L1 fee in the Send flow, transaction detail page, dapp approval and tx confirmation modals and in all quotes in Swaps (not only in the selected one).

TODOs:
- Once QA is finished, I will merge new code into the swaps-controller, publish it on npm and use it here in package.json. Currently it's pointing to a GitHub commit in the swaps-controller repo for testing purposes.

## Testing
- Switch to the Optimism network
- See correct fees in the Send flow, transaction detail page and in Swaps (including a list of quotes). Try to submit a tx and compare estimated gas fee vs the real one.
- For dapp testing, open e.g. Uniswap in MetaMask app's browser section and try to do a swap with a token that needs an approval and with another one that doesn't. MetaMask's modal windows for approval and tx confirmation will show up with correct estimations. If an approval is needed, an estimated gas fee is higher for a few cents (at this time).