### PR TITLE
Disable send NFT on IOS

### DIFF
--- a/app/components/UI/CollectibleModal/index.js
+++ b/app/components/UI/CollectibleModal/index.js
@@ -46,6 +46,7 @@ const CollectibleModal = (props) => {
   }, [contractName, collectible, newAssetTransaction, navigation]);
 
   const isTradable = useCallback(() => {
+    if (Device.isIos()) return false;
     // This might be deprecated
     const lowerAddress = collectible.address.toLowerCase();
     const tradable =

--- a/app/components/Views/CollectibleView/index.js
+++ b/app/components/Views/CollectibleView/index.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import collectiblesTransferInformation from '../../../util/collectibles-transfer';
 import { newAssetTransaction } from '../../../actions/transaction';
 import { ThemeContext, mockTheme } from '../../../util/theme';
-import Device from 'app/util/device';
+import Device from '../../../util/device';
 
 const createStyles = (colors) =>
   StyleSheet.create({

--- a/app/components/Views/CollectibleView/index.js
+++ b/app/components/Views/CollectibleView/index.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import collectiblesTransferInformation from '../../../util/collectibles-transfer';
 import { newAssetTransaction } from '../../../actions/transaction';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import Device from 'app/util/device';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -94,10 +95,12 @@ class CollectibleView extends PureComponent {
     const styles = createStyles(colors);
 
     const lowerAddress = collectible.address.toLowerCase();
-    const tradable =
-      lowerAddress in collectiblesTransferInformation
+    const isTradable = () => {
+      if (Device.isIos) return false;
+      return lowerAddress in collectiblesTransferInformation
         ? collectiblesTransferInformation[lowerAddress].tradable
         : true;
+    };
 
     return (
       <SafeAreaView style={styles.root}>
@@ -109,7 +112,7 @@ class CollectibleView extends PureComponent {
             />
           </View>
         </ScrollView>
-        {tradable && (
+        {isTradable() && (
           <View style={styles.buttons}>
             <StyledButton
               type={'confirm'}

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -1021,7 +1021,8 @@ class Amount extends PureComponent {
     if (!asset.tokenId) {
       return this.renderToken(asset, index);
     }
-    return this.renderCollectible(asset, index);
+
+    if (Device.isAndroid()) return this.renderCollectible(asset, index);
   };
 
   processCollectibles = () => {


### PR DESCRIPTION
NEED to be redirected to the branch _release/5.12.2_

**Description**
The NFT send feature need's to be disabled on IOS because of the new policy of the Apple store.

**Proposed Solution**
The NFT send feature is disabled when we press the NFT and do not render the NFTs on the amount screen of send flow on IOS.

**Test Case**
Case1:
* Go to wallet view
* Press the NFTs tab
* Press an NFT
* Should not have a send button if you are using IOS and should have if you are using android
Case 2:
* Press send on Wallet view
* Select a destination wallet address
* Press ETH
* Should not render the NFTs if you are using IOS and should have if you are using android

**Screenshots/Recordings**
https://recordit.co/LtuHuguLes

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #5384 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
