### PR TITLE
send nft on IOS disabled

### DIFF
--- a/app/components/UI/CollectibleModal/index.js
+++ b/app/components/UI/CollectibleModal/index.js
@@ -9,6 +9,7 @@ import CollectibleMedia from '../CollectibleMedia';
 import { baseStyles, colors as importedColors } from '../../../styles/common';
 import Device from '../../../util/device';
 import ReusableModal from '../ReusableModal';
+import { isIOSNftTradable } from '../../../util/featureFlag';
 
 const styles = StyleSheet.create({
   bottomModal: {
@@ -46,7 +47,7 @@ const CollectibleModal = (props) => {
   }, [contractName, collectible, newAssetTransaction, navigation]);
 
   const isTradable = useCallback(() => {
-    if (Device.isIos()) return false;
+    if (!isIOSNftTradable()) return false;
     // This might be deprecated
     const lowerAddress = collectible.address.toLowerCase();
     const tradable =

--- a/app/components/UI/CollectibleModal/index.js
+++ b/app/components/UI/CollectibleModal/index.js
@@ -46,6 +46,7 @@ const CollectibleModal = (props) => {
   }, [contractName, collectible, newAssetTransaction, navigation]);
 
   const isTradable = useCallback(() => {
+    if (Device.isIos()) return false;
     // This might be deprecated
     const lowerAddress = collectible.address.toLowerCase();
     const tradable =

--- a/app/components/Views/CollectibleView/index.js
+++ b/app/components/Views/CollectibleView/index.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import collectiblesTransferInformation from '../../../util/collectibles-transfer';
 import { newAssetTransaction } from '../../../actions/transaction';
 import { ThemeContext, mockTheme } from '../../../util/theme';
-import Device from '../../../util/device';
+import { isIOSNftTradable } from '../../../util/featureFlag';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -96,7 +96,7 @@ class CollectibleView extends PureComponent {
 
     const lowerAddress = collectible.address.toLowerCase();
     const isTradable = () => {
-      if (Device.isIos) return false;
+      if (!isIOSNftTradable()) return false;
       return lowerAddress in collectiblesTransferInformation
         ? collectiblesTransferInformation[lowerAddress].tradable
         : true;

--- a/app/components/Views/CollectibleView/index.js
+++ b/app/components/Views/CollectibleView/index.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import collectiblesTransferInformation from '../../../util/collectibles-transfer';
 import { newAssetTransaction } from '../../../actions/transaction';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import Device from '../../../util/device';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -94,10 +95,12 @@ class CollectibleView extends PureComponent {
     const styles = createStyles(colors);
 
     const lowerAddress = collectible.address.toLowerCase();
-    const tradable =
-      lowerAddress in collectiblesTransferInformation
+    const isTradable = () => {
+      if (Device.isIos) return false;
+      return lowerAddress in collectiblesTransferInformation
         ? collectiblesTransferInformation[lowerAddress].tradable
         : true;
+    };
 
     return (
       <SafeAreaView style={styles.root}>
@@ -109,7 +112,7 @@ class CollectibleView extends PureComponent {
             />
           </View>
         </ScrollView>
-        {tradable && (
+        {isTradable() && (
           <View style={styles.buttons}>
             <StyledButton
               type={'confirm'}

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -1021,7 +1021,7 @@ class Amount extends PureComponent {
     if (!asset.tokenId) {
       return this.renderToken(asset, index);
     }
-    return this.renderCollectible(asset, index);
+    if (Device.isAndroid()) return this.renderCollectible(asset, index);
   };
 
   processCollectibles = () => {

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -72,6 +72,7 @@ import {
 } from '../../../../reducers/collectibles';
 import { gte } from '../../../../util/lodash';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
+import { isIOSNftTradable } from '../../../../util/featureFlag';
 
 const { hexToBN, BNToHex } = util;
 
@@ -1021,7 +1022,7 @@ class Amount extends PureComponent {
     if (!asset.tokenId) {
       return this.renderToken(asset, index);
     }
-    if (Device.isAndroid()) return this.renderCollectible(asset, index);
+    return this.renderCollectible(asset, index);
   };
 
   processCollectibles = () => {
@@ -1031,6 +1032,7 @@ class Amount extends PureComponent {
       .sort((a, b) => a.address < b.address)
       .forEach((collectible) => {
         const address = collectible.address.toLowerCase();
+        if (!isIOSNftTradable()) return;
         const isTradable =
           !collectiblesTransferInformation[address] ||
           collectiblesTransferInformation[address].tradable;

--- a/app/util/featureFlag/index.ts
+++ b/app/util/featureFlag/index.ts
@@ -1,0 +1,9 @@
+import Device from '../device';
+
+const IS_IOS_NFT_SEND_ENABLED = false;
+
+// eslint-disable-next-line import/prefer-default-export
+export const isIOSNftTradable = () => {
+  if (Device.isIos()) return IS_IOS_NFT_SEND_ENABLED;
+  return true;
+};


### PR DESCRIPTION
NEED to be redirected to the branch _release/5.12.2_

**Description**
The NFT send feature need's to be disabled on IOS because of the new policy of the Apple store.

**Proposed Solution**
The NFT send feature is disabled when we press the NFT and do not render the NFTs on the amount screen of send flow on IOS.

**Test Case**
Case1:
* Go to wallet view
* Press the NFTs tab
* Press an NFT
* Should not have a send button if you are using IOS and should have if you are using android
Case 2:
* Press send on Wallet view
* Select a destination wallet address
* Press ETH
* Should not render the NFTs if you are using IOS and should have if you are using android

**Screenshots/Recordings**
https://recordit.co/LtuHuguLes

Polygon Network
<img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/207421821-b6134281-6977-46a8-b778-4a360d831b44.png">


_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #5384 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
