### PR TITLE
[FIX] Updating gas price

### DIFF
--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -205,8 +205,8 @@ export const useGasTransaction = ({
         suggestedGasLimit: gasObject?.legacyGasLimit || suggestedGasLimit,
         suggestedGasPrice:
           gasFeeEstimates[gasSelected] ||
-          gasFeeEstimates?.gasPrice ||
-          gasObject?.suggestedGasPrice,
+          gasObject?.suggestedGasPrice ||
+          gasFeeEstimates?.gasPrice,
       },
       contractExchangeRates,
       conversionRate,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
There's a bug with updating gas prices for legacy transaction. While calculating the gas fees, `gasFeeEstimates?.gasPrice` is used and not the updated gas price.

Step to QA:
1. For legacy transactions (BSC, OP)
2. Attempt to send token to an address
3. Tap on the estimated gas fee to edit gas price or gas limit
4a. Adjust the gas limit (Works)
4b. Adjust the gas price (Fixed in this PR)

**Screenshots/Recordings**
Before:
https://recordit.co/sS1rEY18DR

Now:
http://recordit.co/FldqSShztZ

**Issue**

Progresses https://github.com/MetaMask/metamask-mobile/issues/5397

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
