### PR TITLE
[PS] move backup wallet reminder popup

### DIFF
--- a/app/components/UI/BackupAlert/index.js
+++ b/app/components/UI/BackupAlert/index.js
@@ -62,10 +62,10 @@ const createStyles = (colors) =>
       flexDirection: 'row',
     },
     modalViewInBrowserView: {
-      bottom: Device.isIphoneX() ? 90 : 80,
+      bottom: Device.isIphoneX() ? 180 : 170,
     },
     modalViewNotInBrowserView: {
-      bottom: Device.isIphoneX() ? 20 : 10,
+      bottom: Device.isIphoneX() ? 120 : 110,
     },
     buttonsWrapper: {
       flexDirection: 'row-reverse',


### PR DESCRIPTION
**Description**

Repositioning Backup Wallet toast remider so it does not block Bottom Navigation Bar.

**Screenshots/Recordings**

Before: 
<img width="300px" src="https://user-images.githubusercontent.com/1649425/207926265-b2fd2c66-6843-48e5-95f2-399c16ef2f02.png" /><img width="300px" src="https://user-images.githubusercontent.com/1649425/207926318-92d54980-9111-412e-9772-2ca7f4a5e096.png" />

After: 
<img width="300px" src="https://user-images.githubusercontent.com/1649425/207926363-80e0d9ef-1628-432e-a89d-a22af4e4e49f.png" /><img width="300px" src="https://user-images.githubusercontent.com/1649425/207926393-fcfb0eef-7188-4c77-9036-c173142a3bc9.png" />

**Issue**

Progresses #5276 
