### PR TITLE
[Force upgrade] fix useAppConfig test

### DIFF
--- a/app/components/hooks/AppConfig/useAppConfig.test.tsx
+++ b/app/components/hooks/AppConfig/useAppConfig.test.tsx
@@ -42,7 +42,7 @@ describe('useAppConfig', () => {
     const expected: AppConfig = {
       security: {
         minimumVersions: {
-          appMinimumBuild: 700,
+          appMinimumBuild: 1024,
           appleMinimumOS: 6,
           androidMinimumAPIVersion: 21,
         },

--- a/app/components/hooks/AppConfig/useAppConfig.test.tsx
+++ b/app/components/hooks/AppConfig/useAppConfig.test.tsx
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react-hooks';
-import AppConfig from './AppConfig';
 import useAppConfig from './useAppConfig';
 
 describe('useAppConfig', () => {

--- a/app/components/hooks/AppConfig/useAppConfig.test.tsx
+++ b/app/components/hooks/AppConfig/useAppConfig.test.tsx
@@ -39,17 +39,16 @@ describe('useAppConfig', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useAppConfig(hasGithubPermissions),
     );
-    const expected: AppConfig = {
-      security: {
-        minimumVersions: {
-          appMinimumBuild: 1024,
-          appleMinimumOS: 6,
-          androidMinimumAPIVersion: 21,
-        },
-      },
-    };
     await waitForNextUpdate();
     expect(result.all[1].type).toEqual('Success');
-    expect(result.all[1].data).toMatchObject(expected);
+    expect(
+      result.all[1].data.security.minimumVersions.appMinimumBuild,
+    ).toBeDefined();
+    expect(
+      result.all[1].data.security.minimumVersions.appleMinimumOS,
+    ).toBeDefined();
+    expect(
+      result.all[1].data.security.minimumVersions.androidMinimumAPIVersion,
+    ).toBeDefined();
   });
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- since we shipped a new minimum version [here](https://github.com/MetaMask/metamask-mobile/pull/5410), the test was failing so we need to update to the latest value.
_2. What is the improvement/solution?_

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
