### PR TITLE
[Improve] Automatic security checks metrics

### DIFF
--- a/app/components/UI/EnableAutomaticSecurityChecksModal/EnableAutomaticSecurityChecksModal.tsx
+++ b/app/components/UI/EnableAutomaticSecurityChecksModal/EnableAutomaticSecurityChecksModal.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../../wdio/features/testIDs/Screens/EnableAutomaticSecurityChecksScreen.testIds';
 
 import generateTestId from '../../../../wdio/utils/generateTestId';
+import generateDeviceAnalyticsMetaData from '../../../util/metrics';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 const onboardingDeviceImage = require('../../../images/swaps_onboard_device.png');
@@ -48,8 +49,11 @@ const EnableAutomaticSecurityChecksModal = () => {
     modalRef?.current?.dismissModal(cb);
 
   useEffect(() => {
+    AnalyticsV2.trackEvent(
+      AnalyticsV2.ANALYTICS_EVENTS.AUTOMATIC_SECURITY_CHECKS_PROMPT_VIEWED,
+      generateDeviceAnalyticsMetaData(),
+    );
     dispatch(setAutomaticSecurityChecksModalOpen(true));
-
     return () => {
       dispatch(setAutomaticSecurityChecksModalOpen(false));
     };
@@ -61,7 +65,7 @@ const EnableAutomaticSecurityChecksModal = () => {
         AnalyticsV2.trackEvent(
           AnalyticsV2.ANALYTICS_EVENTS
             .AUTOMATIC_SECURITY_CHECKS_DISABLED_FROM_PROMPT,
-          { platform: Platform.OS },
+          generateDeviceAnalyticsMetaData(),
         );
         dispatch(userSelectedAutomaticSecurityChecksOptions());
       }),
@@ -73,7 +77,7 @@ const EnableAutomaticSecurityChecksModal = () => {
       AnalyticsV2.trackEvent(
         AnalyticsV2.ANALYTICS_EVENTS
           .AUTOMATIC_SECURITY_CHECKS_ENABLED_FROM_PROMPT,
-        { platform: Platform.OS },
+        generateDeviceAnalyticsMetaData(),
       );
       dispatch(userSelectedAutomaticSecurityChecksOptions());
       dispatch(setAutomaticSecurityChecks(true));

--- a/app/components/UI/UpdateNeeded/UpdateNeeded.tsx
+++ b/app/components/UI/UpdateNeeded/UpdateNeeded.tsx
@@ -17,8 +17,8 @@ import { ButtonSize } from '../../../component-library/components/Buttons/Button
 import ButtonPrimary from '../../../component-library/components/Buttons/Button/variants/ButtonPrimary';
 import { MM_APP_STORE_LINK, MM_PLAY_STORE_LINK } from '../../../constants/urls';
 import AnalyticsV2 from '../../../util/analyticsV2';
-import { getBuildNumber, getVersion, getBrand } from 'react-native-device-info';
 import { ScrollView } from 'react-native-gesture-handler';
+import generateDeviceAnalyticsMetaData from '../../../util/metrics';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 const onboardingDeviceImage = require('../../../images/swaps_onboard_device.png');
@@ -28,31 +28,15 @@ export const createUpdateNeededNavDetails = createNavigationDetails(
   Routes.MODAL.UPDATE_NEEDED,
 );
 
-interface DeviceMetaData {
-  platform: string;
-  currentBuildNumber: string;
-  applicationVersion: string;
-  operatingSystemVersion: string;
-  deviceBrand: string;
-}
-
 const UpdateNeeded = () => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const modalRef = useRef<ReusableModalRef | null>(null);
 
-  const generateAnalyticsMetaData = (): DeviceMetaData => ({
-    platform: Platform.OS,
-    currentBuildNumber: getBuildNumber(),
-    applicationVersion: getVersion(),
-    operatingSystemVersion: Platform.Version.toString(),
-    deviceBrand: getBrand(),
-  });
-
   useEffect(() => {
     AnalyticsV2.trackEvent(
-      AnalyticsV2.ANALYTICS_EVENTS.FORCE_UPGRADE_UPDATED_NEEDED_PROMPT_VIEWED,
-      generateAnalyticsMetaData(),
+      AnalyticsV2.ANALYTICS_EVENTS.FORCE_UPGRADE_UPDATE_NEEDED_PROMPT_VIEWED,
+      generateDeviceAnalyticsMetaData(),
     );
   }, []);
 
@@ -63,7 +47,7 @@ const UpdateNeeded = () => {
     dismissModal(() => {
       AnalyticsV2.trackEvent(
         AnalyticsV2.ANALYTICS_EVENTS.FORCE_UPGRADE_REMIND_ME_LATER_CLICKED,
-        generateAnalyticsMetaData(),
+        generateDeviceAnalyticsMetaData(),
       );
     });
 
@@ -72,7 +56,7 @@ const UpdateNeeded = () => {
     AnalyticsV2.trackEvent(
       AnalyticsV2.ANALYTICS_EVENTS
         .FORCE_UPGRADE_UPDATE_TO_THE_LATEST_VERSION_CLICKED,
-      { ...generateAnalyticsMetaData(), link },
+      { ...generateDeviceAnalyticsMetaData(), link },
     );
     Linking.canOpenURL(link).then(
       (supported) => {

--- a/app/util/analyticsV2.js
+++ b/app/util/analyticsV2.js
@@ -185,7 +185,7 @@ export const ANALYTICS_EVENTS_V2 = {
   ONRAMP_ERROR: generateOpt('On-ramp Error'),
 
   // force upgrade/automatic security checks
-  FORCE_UPGRADE_UPDATED_NEEDED_PROMPT_VIEWED: generateOpt(
+  FORCE_UPGRADE_UPDATE_NEEDED_PROMPT_VIEWED: generateOpt(
     'Force Upgrade Update Needed Prompt Viewed',
   ),
   FORCE_UPGRADE_UPDATE_TO_THE_LATEST_VERSION_CLICKED: generateOpt(
@@ -193,6 +193,10 @@ export const ANALYTICS_EVENTS_V2 = {
   ),
   FORCE_UPGRADE_REMIND_ME_LATER_CLICKED: generateOpt(
     'Force Upgrade Clicked Remind Me Later',
+  ),
+
+  AUTOMATIC_SECURITY_CHECKS_PROMPT_VIEWED: generateOpt(
+    'Automatic Security Checks Prompt Viewed',
   ),
 
   AUTOMATIC_SECURITY_CHECKS_ENABLED_FROM_PROMPT: generateOpt(

--- a/app/util/metrics/DeviceAnalyticsMetaData/DeviceAnalyticsMetaData.types.ts
+++ b/app/util/metrics/DeviceAnalyticsMetaData/DeviceAnalyticsMetaData.types.ts
@@ -1,0 +1,7 @@
+export interface DeviceMetaData {
+  platform: string;
+  currentBuildNumber: string;
+  applicationVersion: string;
+  operatingSystemVersion: string;
+  deviceBrand: string;
+}

--- a/app/util/metrics/DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData.ts
+++ b/app/util/metrics/DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData.ts
@@ -1,0 +1,13 @@
+import { Platform } from 'react-native';
+import { getBuildNumber, getVersion, getBrand } from 'react-native-device-info';
+import { DeviceMetaData } from './DeviceAnalyticsMetaData.types';
+
+const generateDeviceAnalyticsMetaData = (): DeviceMetaData => ({
+  platform: Platform.OS,
+  currentBuildNumber: getBuildNumber(),
+  applicationVersion: getVersion(),
+  operatingSystemVersion: Platform.Version.toString(),
+  deviceBrand: getBrand(),
+});
+
+export default generateDeviceAnalyticsMetaData;

--- a/app/util/metrics/index.ts
+++ b/app/util/metrics/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData';


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- When I initially write the metrics in [this PR](https://github.com/MetaMask/metamask-mobile/pull/4917) I missed an event to count the amount of times the `EnableAutomaticSecurityChecksModal` was viewed. this PR adds that event
_2. What is the improvement/solution?_
- add a new event for `Automatic Security Checks Prompt Viewed`
- add it to the use effect of `EnableAutomaticSecurityChecksModal`
- make the metadata function a util function and call it from both `EnableAutomaticSecurityChecksModal` and `UpdateNeeded`

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
