### PR TITLE
Enabling transaction with no conversion rate and exchange rate

### DIFF
--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -100,8 +100,6 @@ export const getEIP1559TransactionData = ({
       !gas ||
       !gasFeeEstimates ||
       !transactionState ||
-      !contractExchangeRates ||
-      !conversionRate ||
       !currentCurrency ||
       !nativeCurrency
     ) {


### PR DESCRIPTION
**Description**
I's not possible to complete a transaction with no conversion rate and no exchange rate

**Proposed Solution**
When there is no conversion rate and no exchange rate, the user should be able to complete the transaction

**Screenshots/Recordings**

|  ERC20 token on ethereum mainnet  |  ETH on ethereum mainnet |  Gnosis XDAI without conversion rate | Uniswap  | Sushiswap  |
|---|---|---|---|---|
|  <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/209814952-d1662179-087b-463e-9bcb-2d60c068f1c4.png"> |  <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/209817779-aea761e2-8dd5-4824-a02f-907dd0a2cc4c.png"> |  <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/209817923-5d9b80de-f4ad-467d-94d3-b126b460831b.png"> | <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/209819479-1bc8c1ad-e3a5-4f4b-9541-72477ead6592.png">  | <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/209821191-225ce457-006a-4f8d-9f96-51ddf7d65673.png">  |


**Test cases**
* Sendflow send eth (Ethereum mainnet)
* Sendflow send ERC20 (Ethereum mainnet)
* SendFlow send XDAi (Gnosis chain)
* SendFlow send avax (Avalanche)
* Swap xdai to GNO sushi swap (Gnosis chain)
* Swap uniswap eth to matic (Ethereum mainnet)
* Approve APE token uniswap (Ethereum mainnet)
* Swap APE token uniswap to eth (Ethereum mainnet)

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/549, https://github.com/MetaMask/metamask-mobile/issues/5387, https://github.com/MetaMask/metamask-mobile/issues/5427


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
