### PR TITLE
Approval error when insufficient balance 

### DIFF
--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -530,6 +530,8 @@ class Approve extends PureComponent {
   };
 
   updateTransactionState = (gas) => {
+    gas.error = this.validateGas(gas.totalMaxHex || gas.totalHex);
+
     this.setState({ eip1559GasTransaction: gas, legacyGasTransaction: gas });
   };
 

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -530,9 +530,13 @@ class Approve extends PureComponent {
   };
 
   updateTransactionState = (gas) => {
-    gas.error = this.validateGas(gas.totalMaxHex || gas.totalHex);
+    const gasError = this.validateGas(gas.totalMaxHex || gas.totalHex);
 
-    this.setState({ eip1559GasTransaction: gas, legacyGasTransaction: gas });
+    this.setState({
+      eip1559GasTransaction: gas,
+      legacyGasTransaction: gas,
+      gasError,
+    });
   };
 
   render = () => {
@@ -547,7 +551,7 @@ class Approve extends PureComponent {
       eip1559GasObject,
       eip1559GasTransaction,
       legacyGasObject,
-      legacyGasTransaction,
+      gasError,
     } = this.state;
 
     const {
@@ -626,9 +630,7 @@ class Approve extends PureComponent {
                 review={this.review}
               >
                 <ApproveTransactionReview
-                  gasError={
-                    eip1559GasTransaction.error || legacyGasTransaction.error
-                  }
+                  gasError={gasError}
                   onCancel={this.onCancel}
                   onConfirm={this.onConfirm}
                   over={over}


### PR DESCRIPTION
**Description**
The token approval modal was not showing the insufficient balance error and not disabling the button when a user requested token approval with insufficient balance.

**Proposed Solution**
When updating the transaction state with the gas properties, validate if there is enough balance and saving the error on the component state. 

**Screenshots/Recordings**
* With Coston Network with a non-funded wallet
https://recordit.co/F4kpmhXuYS
* With Ethereum mainnet with a funded wallet on Uniswap
https://recordit.co/4ZvJtI4HT5

**Test Cases**
Case1:
* [add conston network](https://docs.flare.network/dev/reference/network-configs/)
* Go to https://coston-explorer.flare.network/token/0x8048C36831d8F7e40365Cf11cff6Db66293ec9e9/write-contract
* Connect wallet
* Approve
* The expected behaviour it's opening a modal with the button confirmed disabled and an insufficient fund message

Case2:
* Change to ethereum mainnet
* Go to uniswap
* Try to swap a token to ETH like polygon or APE (Or another that you didn't approved already)
* The expected behaviour it's possible to approve if you are with a funded wallet


**Issue**

Progresses #5427 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
