### PR TITLE
[FIX] Slow cold starts, fix unnecessary executions of useEffect

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -260,7 +260,7 @@ const App = ({ userLoggedIn }) => {
   }, []);
 
   useEffect(() => {
-    async function checkExsiting() {
+    async function checkExisting() {
       const existingUser = await AsyncStorage.getItem(EXISTING_USER);
       const route = !existingUser
         ? Routes.ONBOARDING.ROOT_NAV
@@ -270,15 +270,15 @@ const App = ({ userLoggedIn }) => {
         triggerCheckedAuth();
       }
     }
-
-    checkExsiting();
-  });
+    checkExisting();
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, []);
 
   useEffect(() => {
     async function startApp() {
       const existingUser = await AsyncStorage.getItem(EXISTING_USER);
       try {
-        const currentVersion = await getVersion();
+        const currentVersion = getVersion();
         const savedVersion = await AsyncStorage.getItem(CURRENT_APP_VERSION);
         if (currentVersion !== savedVersion) {
           if (savedVersion)


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
This PR fixes slow cold start. 
There is still a place for improvement since we have a lot of asynchronous functions running when bootstrapping the application, from my discoverings Analytics init and any reads from Async Storage tend to be slow but that's something that we explicitly need for the app to work.

Removed unnecessary use of `await`. 

_1. What is the reason for the change?_
useEffect is executing multiple times causing unnecessary reads from Async Storage.
_2. What is the improvement/solution?_
Force only one execution (onMount)

**Screenshots/Recordings**
Before: https://recordit.co/X1VFwVcQrh
After: https://recordit.co/R4OdM5QTM2

**Issue**

Progresses #5382 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
