### PR TITLE
[IMPROVEMENT] Refactor "Screenshot Deterrent" for Android

### DIFF
--- a/app/components/UI/ScreenshotDeterrent/ScreenshotDeterrent.tsx
+++ b/app/components/UI/ScreenshotDeterrent/ScreenshotDeterrent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Alert, Linking } from 'react-native';
+import { View, Alert, Linking, InteractionManager } from 'react-native';
+import PreventScreenshot from '../../../core/PreventScreenshot';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import useScreenshotWarning from '../../hooks/useScreenshotWarning';
 import { SRP_GUIDE_URL } from '../../../constants/urls';
@@ -53,10 +54,18 @@ const ScreenshotDeterrent = ({
 
   const [enableScreenshotWarning] = useScreenshotWarning(showScreenshotAlert);
 
-  useEffect(
-    () => enableScreenshotWarning(enabled && !alertPresent),
-    [alertPresent, enableScreenshotWarning, enabled],
-  );
+  useEffect(() => {
+    enableScreenshotWarning(enabled && !alertPresent);
+    InteractionManager.runAfterInteractions(() => {
+      PreventScreenshot.forbid();
+    });
+
+    return () => {
+      InteractionManager.runAfterInteractions(() => {
+        PreventScreenshot.allow();
+      });
+    };
+  }, [alertPresent, enableScreenshotWarning, enabled]);
 
   return <View />;
 };

--- a/app/components/UI/ScreenshotDeterrent/ScreenshotDeterrent.tsx
+++ b/app/components/UI/ScreenshotDeterrent/ScreenshotDeterrent.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, Alert, Linking, InteractionManager } from 'react-native';
 import PreventScreenshot from '../../../core/PreventScreenshot';
 import AnalyticsV2 from '../../../util/analyticsV2';
-import useScreenshotWarning from '../../hooks/useScreenshotWarning';
+import useScreenshotDeterrent from '../../hooks/useScreenshotDeterrent';
 import { SRP_GUIDE_URL } from '../../../constants/urls';
 import { strings } from '../../../../locales/i18n';
 
@@ -52,7 +52,7 @@ const ScreenshotDeterrent = ({
     );
   }, [isSRP]);
 
-  const [enableScreenshotWarning] = useScreenshotWarning(showScreenshotAlert);
+  const [enableScreenshotWarning] = useScreenshotDeterrent(showScreenshotAlert);
 
   useEffect(() => {
     enableScreenshotWarning(enabled && !alertPresent);

--- a/app/components/Views/ImportPrivateKey/index.js
+++ b/app/components/Views/ImportPrivateKey/index.js
@@ -6,7 +6,6 @@ import {
   TextInput,
   Text,
   View,
-  InteractionManager,
   Platform,
 } from 'react-native';
 
@@ -19,7 +18,6 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { strings } from '../../../../locales/i18n';
 import Device from '../../../util/device';
 import { importAccountFromPrivateKey } from '../../../util/address';
-import PreventScreenshot from '../../../core/PreventScreenshot';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { createStyles } from './styles';
 import generateTestId from '../../../../wdio/utils/generateTestId';
@@ -54,12 +52,10 @@ export default class ImportPrivateKey extends PureComponent {
       setTimeout(() => {
         this.mounted && this.setState({ inputWidth: '100%' });
       }, 100);
-    InteractionManager.runAfterInteractions(() => PreventScreenshot.forbid());
   };
 
   componentWillUnmount = () => {
     this.mounted = false;
-    InteractionManager.runAfterInteractions(() => PreventScreenshot.allow());
   };
 
   goNext = async () => {

--- a/app/components/Views/ImportPrivateKeySuccess/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportPrivateKeySuccess/__snapshots__/index.test.tsx.snap
@@ -119,5 +119,9 @@ exports[`ImportPrivateKeySuccess should render correctly 1`] = `
       </View>
     </View>
   </ScrollView>
+  <ScreenshotDeterrent
+    enabled={true}
+    isSRP={false}
+  />
 </View>
 `;

--- a/app/components/Views/ImportPrivateKeySuccess/index.js
+++ b/app/components/Views/ImportPrivateKeySuccess/index.js
@@ -15,7 +15,7 @@ import Icon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { strings } from '../../../../locales/i18n';
 import Device from '../../../util/device';
-import PreventScreenshot from '../../../core/PreventScreenshot';
+import { ScreenshotDeterrent } from '../../UI/ScreenshotDeterrent';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import {
@@ -90,14 +90,12 @@ class ImportPrivateKeySuccess extends PureComponent {
 
   componentDidMount = () => {
     InteractionManager.runAfterInteractions(() => {
-      PreventScreenshot.forbid();
       BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
     });
   };
 
   componentWillUnmount = () => {
     InteractionManager.runAfterInteractions(() => {
-      PreventScreenshot.allow();
       BackHandler.removeEventListener(
         'hardwareBackPress',
         this.handleBackPress,
@@ -156,6 +154,7 @@ class ImportPrivateKeySuccess extends PureComponent {
             </View>
           </View>
         </ScrollView>
+        <ScreenshotDeterrent enabled isSRP={false} />
       </View>
     );
   }

--- a/app/components/Views/ManualBackupStep1/index.js
+++ b/app/components/Views/ManualBackupStep1/index.js
@@ -20,7 +20,6 @@ import OnboardingProgress from '../../UI/OnboardingProgress';
 import { strings } from '../../../../locales/i18n';
 import ActionView from '../../UI/ActionView';
 import Engine from '../../../core/Engine';
-import PreventScreenshot from '../../../core/PreventScreenshot';
 import SecureKeychain from '../../../core/SecureKeychain';
 import { getOnboardingNavbarOptions } from '../../UI/Navbar';
 import { ScreenshotDeterrent } from '../../UI/ScreenshotDeterrent';
@@ -88,7 +87,6 @@ const ManualBackupStep1 = ({ route, navigation, appTheme }) => {
     getSeedphrase();
     setWords(route.params?.words ?? []);
     setReady(true);
-    InteractionManager.runAfterInteractions(() => PreventScreenshot.forbid());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/app/components/Views/RevealPrivateCredential/index.js
+++ b/app/components/Views/RevealPrivateCredential/index.js
@@ -7,7 +7,6 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  InteractionManager,
   Linking,
   Platform,
 } from 'react-native';
@@ -35,7 +34,6 @@ import {
 import ClipboardManager from '../../../core/ClipboardManager';
 import { useTheme } from '../../../util/theme';
 import Engine from '../../../core/Engine';
-import PreventScreenshot from '../../../core/PreventScreenshot';
 import SecureKeychain from '../../../core/SecureKeychain';
 import { BIOMETRY_CHOICE } from '../../../constants/storage';
 import AnalyticsV2 from '../../../util/analyticsV2';
@@ -46,7 +44,6 @@ import AppConstants from '../../../core/AppConstants';
 import { createStyles } from './styles';
 
 const PRIVATE_KEY = 'private_key';
-// const SEED_PHRASE = 'seed_phrase';
 
 /**
  * View that displays private account information as private key or seed phrase
@@ -163,15 +160,6 @@ const RevealPrivateCredential = ({
     };
 
     unlockWithBiometrics();
-    InteractionManager.runAfterInteractions(() => {
-      PreventScreenshot.forbid();
-    });
-
-    return () => {
-      InteractionManager.runAfterInteractions(() => {
-        PreventScreenshot.allow();
-      });
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/app/components/hooks/useScreenshotDeterrent.ts
+++ b/app/components/hooks/useScreenshotDeterrent.ts
@@ -3,7 +3,7 @@ import { NativeModules, NativeEventEmitter } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import Device from '../../util/device';
 
-const useScreenshotWarning = (warning: () => void) => {
+const useScreenshotDeterrent = (warning: () => void) => {
   const [enabled, setEnabled] = useState<boolean>(false);
 
   const screenshotDetect = NativeModules.ScreenshotDetect;
@@ -54,4 +54,4 @@ const useScreenshotWarning = (warning: () => void) => {
   return [setEnabled];
 };
 
-export default useScreenshotWarning;
+export default useScreenshotDeterrent;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off
-->

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
Both solutions for "Screenshot Deterrent" on iOS and Android have some inconsistencies regarding the screens it's activated. This refactor aims to improve this issue.

_2. What is the improvement/solution?_
Refactor the hook `useScreenshotDeterrent` to include Android's "Prevent Screenshot" solution.

**Screenshots/Recordings**

Recording of Android behaviour after the refactor. The screen is black during screen share and/or recordings when it's displaying sensitive data (Android privacy feature).

https://user-images.githubusercontent.com/17601467/210476906-dc442c4f-6267-47d0-9fd2-d05a9d9c4e71.mov

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/227

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
