### PR TITLE
remove extra zero balance account potentially created from seeking ahead

### DIFF
--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -72,5 +72,11 @@ export default async () => {
     i++;
   }
 
+  // remove extra zero balance account potentially created from seeking ahead
+  if (accounts.length > 1 && lastBalance === '0x0') {
+    await KeyringController.removeAccount(accounts[accounts.length - 1]);
+    accounts = await KeyringController.getAccounts();
+  }
+
   updateIdentities(accounts);
 };

--- a/app/util/importAdditionalAccounts.js
+++ b/app/util/importAdditionalAccounts.js
@@ -73,7 +73,7 @@ export default async () => {
   }
 
   // remove extra zero balance account potentially created from seeking ahead
-  if (accounts.length > 1 && lastBalance === '0x0') {
+  if (accounts.length > 1 && lastBalance === ZERO_BALANCE) {
     await KeyringController.removeAccount(accounts[accounts.length - 1]);
     accounts = await KeyringController.getAccounts();
   }


### PR DESCRIPTION
This is to match functionality with: https://github.com/MetaMask/metamask-extension/pull/12074

Explanation:
 - A previous PR added 'seeking' to make sure that when users import their wallets with their seed, consecutive accounts with non-zero balances are automatically generated. However, the PR missed part of the logic: removing the final, zero balance extra account, if created. More motivation behind this PR described in issue https://github.com/MetaMask/metamask-extension/issue/12073.
 

| Before: | After |
| --- | ----------- |
| ![image](https://user-images.githubusercontent.com/675259/211072195-cef040c3-3b8a-4e0b-a9ac-8e42df9cf0f6.png) | ![image](https://user-images.githubusercontent.com/675259/211078311-6c9fa2fe-1e54-4555-bb2a-9d397b6f0f75.png)
| (account 3 is imported with zero eth) | (account 3 is removed immediately after import (matching extension functionality)) |