### PR TITLE
Fix import of `isEIP1559Transaction`

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -24,10 +24,9 @@ import StatusText from '../../Base/StatusText';
 import DetailsModal from '../../Base/DetailsModal';
 import { isMainNet } from '../../../util/networks';
 import { weiHexToGweiDec } from '@metamask/controller-utils';
-import {
-  WalletDevice,
-  isEIP1559Transaction,
-} from '@metamask/transaction-controller';
+import { WalletDevice } from '@metamask/transaction-controller';
+// TODO: Update after this function has been exported from the package
+import { isEIP1559Transaction } from '@metamask/transaction-controller/dist/utils';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 
 const createStyles = (colors) =>

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -33,7 +33,8 @@ import { swapsUtils } from '@metamask/swaps-controller';
 import { isSwapsNativeAsset } from '../Swaps/utils';
 import { toLowerCaseEquals } from '../../../util/general';
 import Engine from '../../../core/Engine';
-import { isEIP1559Transaction } from '@metamask/transaction-controller';
+// TODO: Update after this function has been exported from the package
+import { isEIP1559Transaction } from '@metamask/transaction-controller/dist/utils';
 
 const { getSwapsContractAddress } = swapsUtils;
 

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -3,7 +3,8 @@ import { rawEncode, rawDecode } from 'ethereumjs-abi';
 import BigNumber from 'bignumber.js';
 import humanizeDuration from 'humanize-duration';
 import { query, isSmartContractCode } from '@metamask/controller-utils';
-import { isEIP1559Transaction } from '@metamask/transaction-controller';
+// TODO: Update after this function has been exported from the package
+import { isEIP1559Transaction } from '@metamask/transaction-controller/dist/utils';
 import { swapsUtils } from '@metamask/swaps-controller';
 import Engine from '../../core/Engine';
 import I18n, { strings } from '../../../locales/i18n';


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The import of `isEIP1559Transaction` was not working; that function was accidentally removed from the package exports in a recent update. It has been updated to import directly from the util files in the package instead.

This is a temporary solution. We will also update the `@metamask/transaction-controller` package to export this method, so we don't need to reference a file internal to the package. This is being fixed like this for now so that we don't have to wait for the package update, because the next package update will be a lot of work.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
