### PR TITLE
Mount SeedPhraseVideo Video Player after transition

### DIFF
--- a/app/components/UI/SeedPhraseVideo/index.js
+++ b/app/components/UI/SeedPhraseVideo/index.js
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const SeedPhraseVideo = ({ style, onClose }) => {
+const SeedPhraseVideo = ({ style, onClose, showVideo }) => {
   const language = I18n.locale.substr(0, 2);
   const subtitle_source_tracks = [
     {
@@ -30,15 +30,18 @@ const SeedPhraseVideo = ({ style, onClose }) => {
       uri: getSubtitleUri(language),
     },
   ];
+
   return (
     <View style={styles.videoContainer}>
-      <MediaPlayer
-        onClose={onClose}
-        uri={video_source_uri}
-        style={[styles.mediaPlayer, style]}
-        textTracks={subtitle_source_tracks}
-        selectedTextTrack={{ type: 'index', value: 0 }}
-      />
+      {showVideo ? (
+        <MediaPlayer
+          onClose={onClose}
+          uri={video_source_uri}
+          style={[styles.mediaPlayer, style]}
+          textTracks={subtitle_source_tracks}
+          selectedTextTrack={{ type: 'index', value: 0 }}
+        />
+      ) : null}
     </View>
   );
 };
@@ -46,6 +49,7 @@ const SeedPhraseVideo = ({ style, onClose }) => {
 SeedPhraseVideo.propTypes = {
   style: PropTypes.object,
   onClose: PropTypes.func,
+  showVideo: PropTypes.bool,
 };
 
 export default SeedPhraseVideo;

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -310,6 +310,7 @@ class Settings extends PureComponent {
     passcodeChoice: false,
     showHint: false,
     hintText: '',
+    showVideo: false,
   };
 
   autolockOptions = [
@@ -405,6 +406,10 @@ class Settings extends PureComponent {
         hintText: manualBackup,
       });
     }
+
+    InteractionManager.runAfterInteractions(() => {
+      this.setState({ showVideo: true });
+    });
 
     if (this.props.route?.params?.scrollToBottom)
       this.scrollView?.scrollToEnd({ animated: true });
@@ -667,7 +672,10 @@ class Settings extends PureComponent {
           </Text>
         </Text>
 
-        <SeedPhraseVideo onClose={this.onBack} />
+        <SeedPhraseVideo
+          onClose={this.onBack}
+          showVideo={this.state.showVideo}
+        />
 
         <Text style={styles.desc}>
           {strings(


### PR DESCRIPTION

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR delays the rendering of `SeedPhraseVideo` after the navigation completes, fixing a navigation issue.

**Screenshots/Recordings**

~~_If applicable, add screenshots and/or recordings to visualize the before and after of your change_~~

**Issue**

Progresses #5478 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
