### PR TITLE
Fix/578 network not persisting

### DIFF
--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -89,7 +89,7 @@ class Engine {
 
       const networkControllerOpts = {
         infuraProjectId: process.env.MM_INFURA_PROJECT_ID || NON_EMPTY,
-        state: initialState.networkController,
+        state: initialState.NetworkController,
         messenger: this.controllerMessenger.getRestricted({
           name: 'NetworkController',
           allowedEvents: [],


### PR DESCRIPTION
**Development & PR Process**


**Description**
The network was not persisting when we kill the mobile app and re open it.

**Proposed Solution**
Small typo fix

**Test cases**
* Switch to other network than mainnet (example: goerli)
* Kill the app 
* Relaunch the app
* Expected behaviour, be on the network that you changed on beggining (in this case: goerli)

**Code impact**
Low

**Screenshots/Recordings**
https://recordit.co/oFAC7IcKuv

**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/578

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
