### PR TITLE
Isolate e2e-Appium Feature test scenario runs by default

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -275,8 +275,11 @@ export const config = {
    * @param {ITestCaseHookParameter} world    world object containing information on pickle and test step
    * @param {Object}                 context  Cucumber World object
    */
-  // beforeScenario: function (world, context) {
-  // },
+  beforeScenario: async function (world, context) {
+    if(!JSON.stringify(world.pickle.tags).includes("@ChainScenarios")){
+      await driver.launchApp();
+    }
+  },
   /**
    *
    * Runs before a Cucumber Step.
@@ -309,8 +312,11 @@ export const config = {
    * @param {number}                 result.duration  duration of scenario in milliseconds
    * @param {Object}                 context          Cucumber World object
    */
-  // afterScenario: function (world, result, context) {
-  // },
+  afterScenario: async function (world, result, context) {
+    if(!JSON.stringify(world.pickle.tags).includes("@ChainScenarios")){
+      await driver.closeApp();
+    }
+  },
   /**
    *
    * Runs after a Cucumber Feature.

--- a/wdio/features/AddressFlow.feature
+++ b/wdio/features/AddressFlow.feature
@@ -1,4 +1,4 @@
-@androidApp
+@androidApp @ChainScenarios
 Feature: Address
   You can saved an ENS name to your address book
   The contacts you saved on network A does not carry over to network B

--- a/wdio/features/CreateNewWallet.feature
+++ b/wdio/features/CreateNewWallet.feature
@@ -1,4 +1,4 @@
-@iosApp @androidApp
+@androidApp @ChainScenarios
 Feature: New wallet flow
 
    Scenario: Onboarding New walllet

--- a/wdio/features/CreatingWalletAccount.feature
+++ b/wdio/features/CreatingWalletAccount.feature
@@ -1,5 +1,5 @@
 Feature: Creating account in wallet
-
+    @ChainScenarios
     Scenario: Import account
         Given I have imported my wallet
         # Given I have created my wallet

--- a/wdio/features/ImportCustomToken.feature
+++ b/wdio/features/ImportCustomToken.feature
@@ -1,4 +1,4 @@
-@androidApp
+@androidApp @ChainScenarios
 Feature: Adding a custom token to your wallet
 
     Scenario: Import account

--- a/wdio/features/ImportWalletRegression.feature
+++ b/wdio/features/ImportWalletRegression.feature
@@ -1,4 +1,4 @@
-@iosApp @androidApp
+@iosApp @androidApp @ChainScenarios
 Feature: Import Wallet Regression
     Users can use the app to import an existing wallet or create a new one.
 

--- a/wdio/features/ImportingAccount.feature
+++ b/wdio/features/ImportingAccount.feature
@@ -1,4 +1,4 @@
-@androidApp
+@androidApp @ChainScenarios
 Feature: Importing account in wallet
 
     Scenario: Import account

--- a/wdio/features/LockResetWallet.feature
+++ b/wdio/features/LockResetWallet.feature
@@ -1,4 +1,4 @@
-@iosApp @androidApp
+@iosApp @androidApp @ChainScenarios
 Feature: Lock and Reset Wallet
 
     Scenario: Import wallet

--- a/wdio/features/NetworkFlow.feature
+++ b/wdio/features/NetworkFlow.feature
@@ -1,4 +1,4 @@
-@androidApp
+@androidApp @ChainScenarios
 Feature: Blockchain Networks
   A user should be able to add a custom network via the popular network flow
   A user should also have the ability to a add custom network via the custom network flow.

--- a/wdio/features/step-definitions/network-flow.js
+++ b/wdio/features/step-definitions/network-flow.js
@@ -214,7 +214,7 @@ Then(/^I tap on network "([^"]*)?" on networks screen/, async (network) => {
   await NetworksScreen.tapOnNetwork(network);
 });
 
-Then(/^I switch to "([^"]*)?" in the network list modal /, async () => {
+Then(/^I switch to "([^"]*)?" in the network list modal /, async (text) => {
     const setTimeout = 1500;
     await driver.pause(setTimeout);
     await NetworkListModal.changeNetwork(text);


### PR DESCRIPTION

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
- Small implementation enabling e2e appium/cucumber tests to run in isolation by default, with the option of chaining scenario test runs using tag '@ChainScenarios'.

- Some test scenarios required a reset of the application after each scenario test run.

**Issue**

Progresses #???

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented
