### PR TITLE
On-ramp: Use themeAppearance

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/components/CustomActionButton.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/CustomActionButton.tsx
@@ -4,7 +4,7 @@ import {
   PaymentCustomActionButton,
   TextOrImage,
 } from '@consensys/on-ramp-sdk/dist/API';
-import { useAssetFromTheme } from '../../../../util/theme';
+import { useTheme } from '../../../../util/theme';
 import StyledButton from '../../StyledButton';
 import RemoteImage from '../../../Base/RemoteImage';
 import Text from '../../../Base/Text';
@@ -49,8 +49,9 @@ const renderButtonValue = (value: TextOrImage, textColor: string) => {
 const CustomActionButton: React.FC<
   Props & React.ComponentProps<StyledButton>
 > = ({ customActionButton, isLoading, ...props }: Props) => {
-  const themeKey: 'light' | 'dark' = useAssetFromTheme('light', 'dark');
-  const { backgroundColor, textColor, value } = customActionButton[themeKey];
+  const { themeAppearance } = useTheme();
+  const { backgroundColor, textColor, value } =
+    customActionButton[themeAppearance];
   return (
     <StyledButton
       type="confirm"

--- a/app/components/UI/FiatOnRampAggregator/components/InfoAlert.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/InfoAlert.tsx
@@ -8,7 +8,7 @@ import Box from '../components/Box';
 import Text from '../../../Base/Text';
 import Title from '../../../Base/Title';
 import RemoteImage from '../../../Base/RemoteImage';
-import { useAssetFromTheme, useTheme } from '../../../../util/theme';
+import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import { Colors } from '../../../../util/theme/models';
 import useAnalytics from '../hooks/useAnalytics';
@@ -66,11 +66,10 @@ const InfoAlert: React.FC<Props> = ({
   providerPrivacyPolicy,
   providerSupport,
 }: Props) => {
-  const { colors } = useTheme();
+  const { colors, themeAppearance } = useTheme();
+
   const styles = createStyles(colors);
   const trackEvent = useAnalytics();
-
-  const logoKey: 'light' | 'dark' = useAssetFromTheme('light', 'dark');
 
   const handleProviderHomepageLinkPress = useCallback(
     (url: string) => {
@@ -128,13 +127,13 @@ const InfoAlert: React.FC<Props> = ({
           <IonicIcon name="ios-close" size={30} color={colors.icon.default} />
         </TouchableOpacity>
         <View style={styles.title}>
-          {logos?.[logoKey] ? (
+          {logos?.[themeAppearance] ? (
             <RemoteImage
               style={{
                 width: logos.width * LOGO_SIZE,
                 height: logos.height * LOGO_SIZE,
               }}
-              source={{ uri: logos[logoKey] }}
+              source={{ uri: logos[themeAppearance] }}
             />
           ) : (
             <Title centered>{providerName}</Title>

--- a/app/components/UI/FiatOnRampAggregator/components/PaymentMethodBadges.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/PaymentMethodBadges.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ImageStyle, StyleProp } from 'react-native';
 import { Payment } from '@consensys/on-ramp-sdk';
-import { useAssetFromTheme } from '../../../../util/theme';
+import { useTheme } from '../../../../util/theme';
 import RemoteImage from '../../../Base/RemoteImage';
 interface Props {
   style?: StyleProp<ImageStyle>;
@@ -12,9 +12,9 @@ const PaymentMethodBadges: React.FC<Props> = ({
   logosByTheme,
   style,
 }: Props) => {
-  const theme: 'light' | 'dark' = useAssetFromTheme('light', 'dark');
+  const { themeAppearance } = useTheme();
 
-  const logos = logosByTheme[theme];
+  const logos = logosByTheme[themeAppearance];
 
   return (
     <>

--- a/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/Quote.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../../../util/number';
 import { strings } from '../../../../../locales/i18n';
 import ApplePayButton from '../containers/ApplePayButton';
-import { useAssetFromTheme, useTheme } from '../../../../util/theme';
+import { useTheme } from '../../../../util/theme';
 import RemoteImage from '../../../Base/RemoteImage';
 
 import { Colors } from '../../../../util/theme/models';
@@ -80,9 +80,8 @@ const Quote: React.FC<Props> = ({
   isLoading,
   highlighted,
 }: Props) => {
-  const { colors } = useTheme();
+  const { colors, themeAppearance } = useTheme();
   const styles = createStyles(colors);
-  const logoKey: 'light' | 'dark' = useAssetFromTheme('light', 'dark');
   const {
     networkFee = 0,
     providerFee = 0,
@@ -139,13 +138,13 @@ const Quote: React.FC<Props> = ({
               accessibilityLabel={quote.provider?.name}
             >
               <View style={styles.title}>
-                {quote.provider?.logos?.[logoKey] ? (
+                {quote.provider?.logos?.[themeAppearance] ? (
                   <RemoteImage
                     style={{
                       width: quote.provider.logos.width,
                       height: quote.provider.logos.height,
                     }}
-                    source={{ uri: quote.provider?.logos?.[logoKey] }}
+                    source={{ uri: quote.provider?.logos?.[themeAppearance] }}
                   />
                 ) : (
                   <Title>{quote?.provider?.name}</Title>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Use `themeAppearance` in on-ramp folder instead of wrongly used `useAssetFromTheme` 

**Screenshots/Recordings**

~~_If applicable, add screenshots and/or recordings to visualize the before and after of your change_~~

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
