### PR TITLE
[FIX] Style of Secret recovery phrase screen

### DIFF
--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -21,12 +21,12 @@ export const createStyles = (colors: any) =>
       fontSize: 20,
       textAlign: 'center',
       color: colors.text.default,
-      ...fontStyles.normal,
-    },
-    seedPhraseView: {
       borderRadius: 10,
       borderWidth: 1,
       borderColor: colors.border.default,
+      ...fontStyles.normal,
+    },
+    seedPhraseView: {
       marginTop: 10,
       alignItems: 'center',
     },


### PR DESCRIPTION

**Description**
Small fix on styles on SRP page

**Code impact**
Low

**Screenshots/Recordings**
Iphone 14 pro and Nexus S
<img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/212220686-600811a7-824b-4b7a-b574-c24f63736082.png">


**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/579

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
