### PR TITLE
On-ramp: Add NavBar tests to GetStarted and Regions Views

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.constants.ts
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.constants.ts
@@ -1,2 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-export const TEST_ID_GET_STARTED_BUTTON = 'get-started-button';

--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
@@ -44,25 +44,22 @@ const mockReset = jest.fn();
 const mockPop = jest.fn();
 const mockTrackEvent = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => {
-    const actualUseNavigation = jest.requireActual(
-      '@react-navigation/native',
-    ).useNavigation;
-
-    return {
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
       navigate: mockNavigate,
       setOptions: mockSetOptions.mockImplementation(
-        actualUseNavigation().setOptions,
+        actualReactNavigation.useNavigation().setOptions,
       ),
       reset: mockReset,
       dangerouslyGetParent: () => ({
         pop: mockPop,
       }),
-    };
-  },
-}));
+    }),
+  };
+});
 
 jest.mock('../../sdk', () => ({
   ...jest.requireActual('../../sdk'),

--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
@@ -3,16 +3,27 @@ import { fireEvent } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 
 import GetStarted from './GetStarted';
-import { TEST_ID_GET_STARTED_BUTTON } from './GetStarted.constants';
 import { Region } from '../../types';
 import { OnRampSDK } from '../../sdk';
 import Routes from '../../../../../constants/navigation/Routes';
 import { createRegionsNavDetails } from '../Regions/Regions';
 
 function render(Component: React.ComponentType) {
-  return renderScreen(Component, {
-    name: Routes.FIAT_ON_RAMP_AGGREGATOR.GET_STARTED,
-  });
+  return renderScreen(
+    Component,
+    {
+      name: Routes.FIAT_ON_RAMP_AGGREGATOR.GET_STARTED,
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: { provider: { type: 'mainnet', chainId: 1 } },
+          },
+        },
+      },
+    },
+  );
 }
 
 const mockuseFiatOnRampSDKInitialValues: Partial<OnRampSDK> = {
@@ -30,14 +41,27 @@ let mockUseFiatOnRampSDKValues: Partial<OnRampSDK> = {
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
+const mockPop = jest.fn();
+const mockTrackEvent = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    navigate: mockNavigate,
-    setOptions: mockSetOptions,
-    reset: mockReset,
-  }),
+  useNavigation: () => {
+    const actualUseNavigation = jest.requireActual(
+      '@react-navigation/native',
+    ).useNavigation;
+
+    return {
+      navigate: mockNavigate,
+      setOptions: mockSetOptions.mockImplementation(
+        actualUseNavigation().setOptions,
+      ),
+      reset: mockReset,
+      dangerouslyGetParent: () => ({
+        pop: mockPop,
+      }),
+    };
+  },
 }));
 
 jest.mock('../../sdk', () => ({
@@ -45,11 +69,15 @@ jest.mock('../../sdk', () => ({
   useFiatOnRampSDK: () => mockUseFiatOnRampSDKValues,
 }));
 
+jest.mock('../../hooks/useAnalytics', () => () => mockTrackEvent);
+
 describe('GetStarted', () => {
   afterEach(() => {
     mockNavigate.mockClear();
     mockSetOptions.mockClear();
     mockReset.mockClear();
+    mockPop.mockClear();
+    mockTrackEvent.mockClear();
     (mockuseFiatOnRampSDKInitialValues.setGetStarted as jest.Mock).mockClear();
   });
 
@@ -84,14 +112,27 @@ describe('GetStarted', () => {
     expect(mockSetOptions).toBeCalledTimes(1);
   });
 
-  it('navigates on button press', async () => {
+  it('navigates on get started button press', async () => {
     mockUseFiatOnRampSDKValues = {
       ...mockuseFiatOnRampSDKInitialValues,
     };
     const rendered = render(GetStarted);
-    fireEvent.press(rendered.getByTestId(TEST_ID_GET_STARTED_BUTTON));
+    fireEvent.press(rendered.getByRole('button', { name: 'Get started' }));
     expect(mockNavigate).toHaveBeenCalledWith(...createRegionsNavDetails());
     expect(mockUseFiatOnRampSDKValues.setGetStarted).toHaveBeenCalledWith(true);
+  });
+
+  it('navigates and tracks event on cancel button press', async () => {
+    mockUseFiatOnRampSDKValues = {
+      ...mockuseFiatOnRampSDKInitialValues,
+    };
+    const rendered = render(GetStarted);
+    fireEvent.press(rendered.getByRole('button', { name: 'Cancel' }));
+    expect(mockPop).toHaveBeenCalled();
+    expect(mockTrackEvent).toBeCalledWith('ONRAMP_CANCELED', {
+      chain_id_destination: '1',
+      location: 'Get Started Screen',
+    });
   });
 
   it('navigates to select region screen when getStarted is true and selectedRegion is null', async () => {

--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.tsx
@@ -12,7 +12,6 @@ import ErrorViewWithReporting from '../../components/ErrorViewWithReporting';
 import Routes from '../../../../../constants/navigation/Routes';
 import useAnalytics from '../../hooks/useAnalytics';
 import styles from './GetStarted.styles';
-import { TEST_ID_GET_STARTED_BUTTON } from './GetStarted.constants';
 import { createRegionsNavDetails } from '../Regions/Regions';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
@@ -120,11 +119,7 @@ const GetStarted: React.FC = () => {
 
       <ScreenLayout.Footer>
         <ScreenLayout.Content>
-          <StyledButton
-            type={'confirm'}
-            onPress={handleOnPress}
-            testID={TEST_ID_GET_STARTED_BUTTON}
-          >
+          <StyledButton type={'confirm'} onPress={handleOnPress}>
             {strings('fiat_on_ramp_aggregator.onboarding.get_started')}
           </StyledButton>
         </ScreenLayout.Content>

--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
@@ -51,10 +51,11 @@ exports[`GetStarted renders correctly 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -97,31 +98,135 @@ exports[`GetStarted renders correctly 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  What to Expect
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                GetStarted
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -211,8 +316,6 @@ exports[`GetStarted renders correctly 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -504,7 +607,6 @@ exports[`GetStarted renders correctly 1`] = `
                                   null,
                                 ]
                               }
-                              testID="get-started-button"
                             >
                               <Text
                                 style={
@@ -602,10 +704,11 @@ exports[`GetStarted renders correctly when getStarted is true 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -648,31 +751,135 @@ exports[`GetStarted renders correctly when getStarted is true 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  What to Expect
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                GetStarted
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -762,8 +969,6 @@ exports[`GetStarted renders correctly when getStarted is true 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -925,10 +1130,11 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -971,31 +1177,135 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  What to Expect
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                GetStarted
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -1085,8 +1395,6 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={

--- a/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
@@ -11,9 +11,21 @@ import { createPaymentMethodsNavDetails } from '../PaymentMethods';
 import Routes from '../../../../../constants/navigation/Routes';
 
 function render(Component: React.ComponentType) {
-  return renderScreen(Component, {
-    name: Routes.FIAT_ON_RAMP_AGGREGATOR.REGION,
-  });
+  return renderScreen(
+    Component,
+    {
+      name: Routes.FIAT_ON_RAMP_AGGREGATOR.REGION,
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: { provider: { type: 'mainnet', chainId: 1 } },
+          },
+        },
+      },
+    },
+  );
 }
 
 const mockSetSelectedRegion = jest.fn();
@@ -74,22 +86,35 @@ jest.mock('../../hooks/useRegions', () => jest.fn(() => mockUseRegionsValues));
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
 const mockPop = jest.fn();
+const mockTrackEvent = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    navigate: mockNavigate,
-    setOptions: mockSetOptions,
-    dangerouslyGetParent: () => ({
-      pop: mockPop,
-    }),
-  }),
+  useNavigation: () => {
+    const actualUseNavigation = jest.requireActual(
+      '@react-navigation/native',
+    ).useNavigation;
+
+    return {
+      navigate: mockNavigate,
+      setOptions: mockSetOptions.mockImplementation(
+        actualUseNavigation().setOptions,
+      ),
+      dangerouslyGetParent: () => ({
+        pop: mockPop,
+      }),
+    };
+  },
 }));
+
+jest.mock('../../hooks/useAnalytics', () => () => mockTrackEvent);
 
 describe('Regions View', () => {
   afterEach(() => {
     mockNavigate.mockClear();
     mockSetOptions.mockClear();
+    mockPop.mockClear();
+    mockTrackEvent.mockClear();
     (
       mockuseFiatOnRampSDKInitialValues.setSelectedRegion as jest.Mock
     ).mockClear();
@@ -177,6 +202,19 @@ describe('Regions View', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       ...createPaymentMethodsNavDetails(),
     );
+  });
+
+  it('navigates and tracks event on cancel button press', async () => {
+    mockUseFiatOnRampSDKValues = {
+      ...mockuseFiatOnRampSDKInitialValues,
+    };
+    const rendered = render(Regions);
+    fireEvent.press(rendered.getByRole('button', { name: 'Cancel' }));
+    expect(mockPop).toHaveBeenCalled();
+    expect(mockTrackEvent).toBeCalledWith('ONRAMP_CANCELED', {
+      chain_id_destination: '1',
+      location: 'Region Screen',
+    });
   });
 
   it('has continue button disabled', async () => {

--- a/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
@@ -88,24 +88,21 @@ const mockNavigate = jest.fn();
 const mockPop = jest.fn();
 const mockTrackEvent = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => {
-    const actualUseNavigation = jest.requireActual(
-      '@react-navigation/native',
-    ).useNavigation;
-
-    return {
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
       navigate: mockNavigate,
       setOptions: mockSetOptions.mockImplementation(
-        actualUseNavigation().setOptions,
+        actualReactNavigation.useNavigation().setOptions,
       ),
       dangerouslyGetParent: () => ({
         pop: mockPop,
       }),
-    };
-  },
-}));
+    }),
+  };
+});
 
 jest.mock('../../hooks/useAnalytics', () => () => mockTrackEvent);
 

--- a/app/components/UI/FiatOnRampAggregator/Views/Regions/__snapshots__/Regions.test.tsx.snap
+++ b/app/components/UI/FiatOnRampAggregator/Views/Regions/__snapshots__/Regions.test.tsx.snap
@@ -51,10 +51,11 @@ exports[`Regions View renders correctly 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -97,31 +98,135 @@ exports[`Regions View renders correctly 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -211,8 +316,6 @@ exports[`Regions View renders correctly 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -2280,10 +2383,11 @@ exports[`Regions View renders correctly while loading 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -2326,31 +2430,135 @@ exports[`Regions View renders correctly while loading 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -2440,8 +2648,6 @@ exports[`Regions View renders correctly while loading 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -2769,10 +2975,11 @@ exports[`Regions View renders correctly with error 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -2815,31 +3022,135 @@ exports[`Regions View renders correctly with error 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -2929,8 +3240,6 @@ exports[`Regions View renders correctly with error 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -3332,10 +3641,11 @@ exports[`Regions View renders correctly with no data 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -3378,31 +3688,135 @@ exports[`Regions View renders correctly with no data 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -3492,8 +3906,6 @@ exports[`Regions View renders correctly with no data 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -3821,10 +4233,11 @@ exports[`Regions View renders correctly with sdkError 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -3867,31 +4280,135 @@ exports[`Regions View renders correctly with sdkError 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -3981,8 +4498,6 @@ exports[`Regions View renders correctly with sdkError 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -4384,10 +4899,11 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -4430,31 +4946,135 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -4544,8 +5164,6 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -6611,10 +7229,11 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -6657,31 +7276,135 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
             }
           >
             <View
+              collapsable={false}
+              nativeID="animatedComponent"
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              nativeID="animatedComponent"
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -6771,8 +7494,6 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={
@@ -8836,10 +9557,11 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
           <View
             style={
               Object {
-                "backgroundColor": "rgb(255, 255, 255)",
+                "backgroundColor": "#FFFFFF",
                 "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
                 "flex": 1,
-                "shadowColor": "rgb(216, 216, 216)",
+                "shadowColor": "transparent",
                 "shadowOffset": Object {
                   "height": 0.5,
                   "width": 0,
@@ -8885,28 +9607,128 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
               pointerEvents="box-none"
               style={
                 Object {
-                  "marginHorizontal": 16,
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "marginHorizontal": 72,
                   "opacity": 1,
                 }
               }
             >
-              <Text
-                accessibilityRole="header"
-                aria-level="1"
-                collapsable={false}
-                nativeID="animatedComponent"
-                numberOfLines={1}
-                onLayout={[Function]}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
                 style={
                   Object {
-                    "color": "rgb(28, 28, 30)",
-                    "fontSize": 17,
-                    "fontWeight": "600",
+                    "alignItems": "center",
+                    "flex": 1,
+                  }
+                }
+                testID="open-networks-button"
+              >
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Object {
+                      "color": "#24272A",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 18,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Buy Crypto Tokens
+                </Text>
+                <View
+                  style={
+                    Object {
+                      "flexDirection": "row",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "borderRadius": 100,
+                          "height": 5,
+                          "marginRight": 5,
+                          "marginTop": 4,
+                          "width": 5,
+                        },
+                        Object {
+                          "backgroundColor": "#3cc29e",
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "color": "#535A61",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 11,
+                        "fontWeight": "400",
+                      }
+                    }
+                    testID="navbar-title-networks"
+                  >
+                    Ethereum Main Network
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <TouchableOpacity
+                accessibilityRole="button"
+                onPress={[Function]}
+                style={
+                  Object {
+                    "paddingHorizontal": 18,
+                    "paddingVertical": 8,
                   }
                 }
               >
-                Region
-              </Text>
+                <Text
+                  style={
+                    Object {
+                      "color": "#037DD6",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                    }
+                  }
+                >
+                  Cancel
+                </Text>
+              </TouchableOpacity>
             </View>
           </View>
         </View>
@@ -8996,8 +9818,6 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
           }
         >
           <View
-            collapsable={false}
-            nativeID="animatedComponent"
             needsOffscreenAlphaCompositing={false}
             pointerEvents="box-none"
             style={

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1497,7 +1497,11 @@ export function getFiatOnRampAggNavbar(
       if (!showBack) return <View />;
 
       return Device.isAndroid() ? (
-        <TouchableOpacity onPress={leftAction} style={styles.backButton}>
+        <TouchableOpacity
+          onPress={leftAction}
+          style={styles.backButton}
+          accessibilityRole="button"
+        >
           <IonicIcon
             name={'md-arrow-back'}
             size={24}
@@ -1505,7 +1509,11 @@ export function getFiatOnRampAggNavbar(
           />
         </TouchableOpacity>
       ) : (
-        <TouchableOpacity onPress={leftAction} style={styles.closeButton}>
+        <TouchableOpacity
+          onPress={leftAction}
+          style={styles.closeButton}
+          accessibilityRole="button"
+        >
           <Text style={innerStyles.headerButtonText}>{leftActionText}</Text>
         </TouchableOpacity>
       );
@@ -1517,6 +1525,7 @@ export function getFiatOnRampAggNavbar(
           onCancel?.();
         }}
         style={styles.closeButton}
+        accessibilityRole="button"
       >
         <Text style={innerStyles.headerButtonText}>
           {strings('navigation.cancel')}


### PR DESCRIPTION


**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
This PR adds to GetStarted and Regions Views:
- Missing rendering of the Navigation Bar
- Tests of the navigation and analytics events

Bringing coverage to 100%:

![_getstartedcoverage](https://user-images.githubusercontent.com/1024246/212405194-c8662414-d02f-4d91-9faf-99428f56bc34.png)
![_regionscoverage](https://user-images.githubusercontent.com/1024246/212405200-77ef1a02-af50-4757-b2ed-fc184b096ba8.png)


**Screenshots/Recordings**

~~_If applicable, add screenshots and/or recordings to visualize the before and after of your change_~~

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
