### PR TITLE
[#4431] fire cancel event when rejecting approval

### DIFF
--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -467,6 +467,15 @@ class Approve extends PureComponent {
       title: strings('notifications.approved_tx_rejected_title'),
       description: strings('notifications.wc_description'),
     });
+
+    try {
+      const { TransactionController } = Engine.context;
+      TransactionController.cancelTransaction(this.props.transaction.id);
+    } catch {
+      this.setState({ transactionHandled: false });
+    } finally {
+      this.props.toggleApproveModal(false);
+    }
   };
 
   review = () => {


### PR DESCRIPTION
credit to [HughLaw](https://github.com/hughlaw)
https://github.com/MetaMask/metamask-mobile/pull/4867

Description

What is the reason for the change?
When a user rejects an approve transaction, metamask should throw a 4001 error to inform dApps that this event has happened. This works without issue using the metamask browser extension, but does not seem to be fired from the mobile app.

What is the improvement/solution?
Updates the "Approve" view to create and cancel a transaction when the user taps the reject button. This causes the event to be fired the same as other transaction events

Screenshots/Recordings

Before
https://user-images.githubusercontent.com/3457716/184844374-d943a659-e5a9-42a4-a0d5-b935005db616.mp4

After
https://user-images.githubusercontent.com/3457716/184844648-9cd88206-2a12-49b0-9fa9-f2734a0b7a32.mp4

Progresses #
There are various bugs logged in the project which I feel this might address or is related to:
https://github.com/MetaMask/metamask-mobile/issues/4431
https://github.com/MetaMask/metamask-mobile/issues/4706
https://github.com/MetaMask/metamask-mobile/issues/4482
https://github.com/MetaMask/metamask-mobile/issues/1880

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
