### PR TITLE
On-ramp: add fiatOrders reducer tests

### DIFF
--- a/app/reducers/fiatOrders/index.test.ts
+++ b/app/reducers/fiatOrders/index.test.ts
@@ -1,10 +1,12 @@
 import fiatOrderReducer, {
   addFiatCustomIdData,
+  getProviderName,
   initialState,
   removeFiatCustomIdData,
   updateFiatCustomIdData,
 } from '.';
-import { CustomIdData, Action } from './types';
+import { FIAT_ORDER_PROVIDERS } from '../../constants/on-ramp';
+import { CustomIdData, Action, FiatOrder } from './types';
 
 const dummyCustomOrderIdData1: CustomIdData = {
   id: '123',
@@ -144,5 +146,40 @@ describe('fiatOrderReducer', () => {
       dummyCustomOrderIdData1,
       dummyCustomOrderIdData3,
     ]);
+  });
+});
+
+describe('getProviderName', () => {
+  it.each`
+    provider                               | providerName
+    ${FIAT_ORDER_PROVIDERS.WYRE}           | ${'Wyre'}
+    ${FIAT_ORDER_PROVIDERS.WYRE_APPLE_PAY} | ${'Wyre'}
+    ${FIAT_ORDER_PROVIDERS.TRANSAK}        | ${'Transak'}
+    ${FIAT_ORDER_PROVIDERS.MOONPAY}        | ${'MoonPay'}
+    ${FIAT_ORDER_PROVIDERS.AGGREGATOR}     | ${'Test Provider'}
+  `('should return the correct provider name', ({ provider, providerName }) => {
+    const dummyData = {
+      provider: {
+        name: 'Test Provider',
+      },
+    } as Partial<FiatOrder['data']>;
+    expect(getProviderName(provider, dummyData as FiatOrder['data'])).toEqual(
+      providerName,
+    );
+  });
+
+  it('should return the correct provider name for unknown provider', () => {
+    expect(
+      getProviderName(
+        'unknown provider' as FIAT_ORDER_PROVIDERS,
+        {} as FiatOrder['data'],
+      ),
+    ).toEqual('unknown provider');
+  });
+
+  it('should return ... for missing aggregator provider', () => {
+    expect(
+      getProviderName(FIAT_ORDER_PROVIDERS.AGGREGATOR, {} as FiatOrder['data']),
+    ).toEqual('...');
   });
 });

--- a/app/reducers/fiatOrders/index.test.ts
+++ b/app/reducers/fiatOrders/index.test.ts
@@ -1,12 +1,74 @@
+import { Order } from '@consensys/on-ramp-sdk';
 import fiatOrderReducer, {
+  addActivationKey,
+  addAuthenticationUrl,
   addFiatCustomIdData,
+  addFiatOrder,
   getProviderName,
   initialState,
+  removeActivationKey,
+  removeAuthenticationUrl,
   removeFiatCustomIdData,
+  removeFiatOrder,
+  resetFiatOrders,
+  setFiatOrdersGetStartedAGG,
+  setFiatOrdersPaymentMethodAGG,
+  setFiatOrdersRegionAGG,
+  updateActivationKey,
   updateFiatCustomIdData,
+  updateFiatOrder,
 } from '.';
 import { FIAT_ORDER_PROVIDERS } from '../../constants/on-ramp';
-import { CustomIdData, Action, FiatOrder } from './types';
+import { CustomIdData, Action, FiatOrder, Region } from './types';
+
+const mockOrder1 = {
+  id: 'test-id-1',
+  provider: 'AGGREGATOR' as FiatOrder['provider'],
+  createdAt: 1673886669608,
+  amount: 123,
+  fee: 9,
+  cryptoAmount: 0.012361263,
+  cryptoFee: 9,
+  currency: 'USD',
+  currencySymbol: '$',
+  cryptocurrency: 'BTC',
+  state: 'COMPLETED' as FiatOrder['state'],
+  account: '0x1234',
+  network: '1',
+  txHash: '0x987654321',
+  excludeFromPurchases: false,
+  orderType: 'BUY',
+  data: {
+    id: 'test-id',
+    isOnlyLink: false,
+    provider: {
+      id: 'test-provider',
+      name: 'Test Provider',
+    },
+    createdAt: 1673886669608,
+    fiatAmount: 123,
+    totalFeesFiat: 9,
+    cryptoAmount: 0.012361263,
+    cryptoCurrency: {
+      symbol: 'BTC',
+    },
+    fiatCurrency: {
+      symbol: 'USD',
+      denomSymbol: '$',
+    },
+    network: '1',
+    status: 'COMPLETED',
+    orderType: 'BUY',
+    walletAddress: '0x1234',
+    txHash: '0x987654321',
+    excludeFromPurchases: false,
+  } as Order,
+};
+
+const mockOrder2 = {
+  ...mockOrder1,
+  id: 'test-id-2',
+};
 
 const dummyCustomOrderIdData1: CustomIdData = {
   id: '123',
@@ -37,6 +99,136 @@ const dummyCustomOrderIdData3: CustomIdData = {
 describe('fiatOrderReducer', () => {
   it('should return the initial state', () => {
     expect(fiatOrderReducer(undefined, {} as Action)).toEqual(initialState);
+  });
+
+  it('should return the current state if action missing', () => {
+    expect(
+      fiatOrderReducer(initialState, undefined as unknown as Action),
+    ).toEqual(initialState);
+  });
+
+  it('should add a fiat order', () => {
+    const stateWithOrder1 = fiatOrderReducer(
+      initialState,
+      addFiatOrder(mockOrder1),
+    );
+
+    const stateWithOrder1Again = fiatOrderReducer(
+      stateWithOrder1,
+      addFiatOrder(mockOrder1),
+    );
+
+    expect(stateWithOrder1.orders).toEqual([mockOrder1]);
+    expect(stateWithOrder1Again.orders).toEqual([mockOrder1]);
+  });
+
+  it('should update a fiat order', () => {
+    const updatedOrder = {
+      ...mockOrder1,
+      createdAt: 456,
+    };
+
+    const updatedNonExistentOrder = {
+      ...mockOrder2,
+      createdAt: 456,
+    };
+
+    const stateWithOrder1Updated = fiatOrderReducer(
+      {
+        ...initialState,
+        orders: [mockOrder1],
+      },
+      updateFiatOrder(updatedOrder),
+    );
+
+    const stateWithNonExistentOrder = fiatOrderReducer(
+      initialState,
+      updateFiatOrder(updatedNonExistentOrder),
+    );
+
+    expect(stateWithOrder1Updated.orders).toEqual([updatedOrder]);
+    expect(stateWithNonExistentOrder.orders).toEqual([]);
+  });
+
+  it('should remove a fiat order', () => {
+    const stateWithOrder1Removed = fiatOrderReducer(
+      {
+        ...initialState,
+        orders: [mockOrder1],
+      },
+      removeFiatOrder(mockOrder1),
+    );
+
+    const stateWithNonExistentOrderRemoved = fiatOrderReducer(
+      {
+        ...initialState,
+        orders: [mockOrder1],
+      },
+      removeFiatOrder(mockOrder2),
+    );
+
+    expect(stateWithOrder1Removed.orders).toEqual([]);
+    expect(stateWithNonExistentOrderRemoved.orders).toEqual([mockOrder1]);
+  });
+
+  it('should reset the state', () => {
+    const resetState = fiatOrderReducer(
+      {
+        ...initialState,
+        getStartedAgg: true,
+        orders: [mockOrder1],
+      },
+      resetFiatOrders(),
+    );
+    expect(resetState).toEqual(initialState);
+  });
+
+  it('should set get started', () => {
+    const stateWithStartedTrue = fiatOrderReducer(
+      initialState,
+      setFiatOrdersGetStartedAGG(true),
+    );
+    const stateWithStartedFalse = fiatOrderReducer(
+      stateWithStartedTrue,
+      setFiatOrdersGetStartedAGG(false),
+    );
+    expect(stateWithStartedTrue.getStartedAgg).toEqual(true);
+    expect(stateWithStartedFalse.getStartedAgg).toEqual(false);
+  });
+
+  it('should set the selected region', () => {
+    const testRegion = {
+      id: 'test-region',
+      name: 'Test Region',
+    } as Region;
+    const stateWithSelectedRegion = fiatOrderReducer(
+      initialState,
+      setFiatOrdersRegionAGG(testRegion),
+    );
+    const stateWithoutSelectedRegion = fiatOrderReducer(
+      stateWithSelectedRegion,
+      setFiatOrdersRegionAGG(null),
+    );
+
+    expect(stateWithSelectedRegion.selectedRegionAgg).toEqual(testRegion);
+    expect(stateWithoutSelectedRegion.selectedRegionAgg).toEqual(null);
+  });
+
+  it('should set the selected payment method', () => {
+    const stateWithSelectedPaymentMethod = fiatOrderReducer(
+      initialState,
+      setFiatOrdersPaymentMethodAGG('test-payment-method'),
+    );
+    const stateWithoutSelectedPaymentMethod = fiatOrderReducer(
+      stateWithSelectedPaymentMethod,
+      setFiatOrdersPaymentMethodAGG(null),
+    );
+    expect(stateWithSelectedPaymentMethod.selectedPaymentMethodAgg).toEqual(
+      'test-payment-method',
+    );
+    expect(stateWithoutSelectedPaymentMethod.selectedPaymentMethodAgg).toEqual(
+      null,
+    );
   });
 
   it('should add a custom order id object', () => {
@@ -146,6 +338,115 @@ describe('fiatOrderReducer', () => {
       dummyCustomOrderIdData1,
       dummyCustomOrderIdData3,
     ]);
+  });
+
+  it('should add an authentication url', () => {
+    const stateWithAuthenticationUrl = fiatOrderReducer(
+      initialState,
+      addAuthenticationUrl('test-authentication-url'),
+    );
+    const stateWithAuthenticationUrlAgain = fiatOrderReducer(
+      stateWithAuthenticationUrl,
+      addAuthenticationUrl('test-authentication-url'),
+    );
+
+    expect(stateWithAuthenticationUrl.authenticationUrls).toEqual([
+      'test-authentication-url',
+    ]);
+    expect(stateWithAuthenticationUrlAgain.authenticationUrls).toEqual([
+      'test-authentication-url',
+    ]);
+  });
+
+  it('should remove an authentication url', () => {
+    const stateWithAuthenticationUrl = fiatOrderReducer(
+      {
+        ...initialState,
+        authenticationUrls: ['test-authentication-url'],
+      },
+      removeAuthenticationUrl('test-authentication-url'),
+    );
+    const stateWithNonExistentAuthenticationUrlRemoved = fiatOrderReducer(
+      stateWithAuthenticationUrl,
+      removeAuthenticationUrl('non-existent-authentication-url'),
+    );
+
+    expect(stateWithAuthenticationUrl.authenticationUrls).toEqual([]);
+    expect(
+      stateWithNonExistentAuthenticationUrlRemoved.authenticationUrls,
+    ).toEqual([]);
+  });
+
+  it('should add an activation key', () => {
+    const stateWithActivationKey = fiatOrderReducer(
+      initialState,
+      addActivationKey('test-activation-key'),
+    );
+    const stateWithActivationKeyAgain = fiatOrderReducer(
+      stateWithActivationKey,
+      addActivationKey('test-activation-key'),
+    );
+
+    expect(stateWithActivationKey.activationKeys).toEqual([
+      { key: 'test-activation-key', active: true },
+    ]);
+    expect(stateWithActivationKeyAgain.activationKeys).toEqual([
+      { key: 'test-activation-key', active: true },
+    ]);
+  });
+
+  it('should remove an activation key', () => {
+    const stateWithActivationKey = fiatOrderReducer(
+      {
+        ...initialState,
+        activationKeys: [{ key: 'test-activation-key', active: true }],
+      },
+      removeActivationKey('test-activation-key'),
+    );
+    const stateWithNonExistentActivationKeyRemoved = fiatOrderReducer(
+      {
+        ...initialState,
+        activationKeys: [{ key: 'test-activation-key', active: true }],
+      },
+      removeActivationKey('non-existent-activation-key'),
+    );
+
+    expect(stateWithActivationKey.activationKeys).toEqual([]);
+    expect(stateWithNonExistentActivationKeyRemoved.activationKeys).toEqual([
+      {
+        key: 'test-activation-key',
+        active: true,
+      },
+    ]);
+  });
+
+  it('should update an activation key', () => {
+    const stateWithActivationKey = fiatOrderReducer(
+      {
+        ...initialState,
+        activationKeys: [{ key: 'test-activation-key', active: true }],
+      },
+      updateActivationKey('test-activation-key', false),
+    );
+    const stateWithNonExistentActivationKeySetInactive = fiatOrderReducer(
+      {
+        ...initialState,
+        activationKeys: [{ key: 'test-activation-key', active: true }],
+      },
+      updateActivationKey('non-existent-activation-key', false),
+    );
+
+    expect(stateWithActivationKey.activationKeys).toEqual([
+      { key: 'test-activation-key', active: false },
+    ]);
+    expect(stateWithNonExistentActivationKeySetInactive.activationKeys).toEqual(
+      [
+        {
+          key: 'test-activation-key',
+          active: true,
+        },
+      ],
+    );
   });
 });
 

--- a/app/reducers/fiatOrders/index.ts
+++ b/app/reducers/fiatOrders/index.ts
@@ -36,7 +36,9 @@ export const setFiatOrdersRegionAGG = (region: Region | null) => ({
   type: ACTIONS.FIAT_SET_REGION_AGG,
   payload: region,
 });
-export const setFiatOrdersPaymentMethodAGG = (paymentMethodId: string) => ({
+export const setFiatOrdersPaymentMethodAGG = (
+  paymentMethodId: string | null,
+) => ({
   type: ACTIONS.FIAT_SET_PAYMENT_METHOD_AGG,
   payload: paymentMethodId,
 });
@@ -260,6 +262,10 @@ const fiatOrderReducer: (
       const orders = state.orders;
       const order = action.payload;
       const index = findOrderIndex(order.provider, order.id, state.orders);
+      if (index === -1) {
+        return state;
+      }
+
       return {
         ...state,
         orders: [...orders.slice(0, index), ...orders.slice(index + 1)],

--- a/app/reducers/fiatOrders/index.ts
+++ b/app/reducers/fiatOrders/index.ts
@@ -32,10 +32,6 @@ export const updateFiatOrder = (order: FiatOrder) => ({
   type: ACTIONS.FIAT_UPDATE_ORDER,
   payload: order,
 });
-export const setFiatOrdersCountry = (countryCode: string) => ({
-  type: ACTIONS.FIAT_SET_COUNTRY,
-  payload: countryCode,
-});
 export const setFiatOrdersRegionAGG = (region: Region | null) => ({
   type: ACTIONS.FIAT_SET_REGION_AGG,
   payload: region,
@@ -117,10 +113,6 @@ export const getProviderName = (
   }
 };
 
-const INITIAL_SELECTED_REGION = null;
-const INITIAL_GET_STARTED = false;
-const INITIAL_PAYMENT_METHOD = '/payments/debit-credit-card';
-
 const ordersSelector = (state: RootState) =>
   (state.fiatOrders.orders as FiatOrdersState['orders']) || [];
 export const chainIdSelector: (state: RootState) => string = (
@@ -130,10 +122,6 @@ export const chainIdSelector: (state: RootState) => string = (
 export const selectedAddressSelector: (state: RootState) => string = (
   state: RootState,
 ) => state.engine.backgroundState.PreferencesController.selectedAddress;
-export const fiatOrdersCountrySelector: (
-  state: RootState,
-) => FiatOrdersState['selectedCountry'] = (state: RootState) =>
-  state.fiatOrders.selectedCountry;
 export const fiatOrdersRegionSelectorAgg: (
   state: RootState,
 ) => FiatOrdersState['selectedRegionAgg'] = (state: RootState) =>
@@ -213,11 +201,9 @@ export const getHasOrders = createSelector(
 export const initialState: FiatOrdersState = {
   orders: [],
   customOrderIds: [],
-  selectedCountry: 'US',
-  // initial state for fiat on-ramp aggregator
-  selectedRegionAgg: INITIAL_SELECTED_REGION,
-  selectedPaymentMethodAgg: INITIAL_PAYMENT_METHOD,
-  getStartedAgg: INITIAL_GET_STARTED,
+  selectedRegionAgg: null,
+  selectedPaymentMethodAgg: null,
+  getStartedAgg: false,
   authenticationUrls: [],
   activationKeys: [],
 };
@@ -286,12 +272,6 @@ const fiatOrderReducer: (
       return {
         ...state,
         getStartedAgg: action.payload,
-      };
-    }
-    case ACTIONS.FIAT_SET_COUNTRY: {
-      return {
-        ...state,
-        selectedCountry: action.payload,
       };
     }
     case ACTIONS.FIAT_SET_REGION_AGG: {

--- a/app/reducers/fiatOrders/types.ts
+++ b/app/reducers/fiatOrders/types.ts
@@ -9,7 +9,6 @@ import {
   removeFiatOrder,
   removeActivationKey,
   resetFiatOrders,
-  setFiatOrdersCountry,
   setFiatOrdersGetStartedAGG,
   setFiatOrdersPaymentMethodAGG,
   setFiatOrdersRegionAGG,
@@ -71,9 +70,8 @@ export interface ActivationKey {
 export interface FiatOrdersState {
   orders: FiatOrder[];
   customOrderIds: CustomIdData[];
-  selectedCountry: string;
   selectedRegionAgg: Country | null;
-  selectedPaymentMethodAgg: string;
+  selectedPaymentMethodAgg: string | null;
   getStartedAgg: boolean;
   authenticationUrls: string[];
   activationKeys: ActivationKey[];
@@ -104,7 +102,6 @@ export type Action =
   | ReturnType<typeof addFiatOrder>
   | ReturnType<typeof removeFiatOrder>
   | ReturnType<typeof updateFiatOrder>
-  | ReturnType<typeof setFiatOrdersCountry>
   | ReturnType<typeof setFiatOrdersRegionAGG>
   | ReturnType<typeof setFiatOrdersPaymentMethodAGG>
   | ReturnType<typeof setFiatOrdersGetStartedAGG>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR adds tests for the fiatOrder reducers 

<img src="https://user-images.githubusercontent.com/1024246/212768277-73176a3c-65eb-49f7-b7cb-2db8c1819522.jpg" />


**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented
