### PR TITLE
Refactor SeedPhraseVideo to mount player after transition

### DIFF
--- a/app/components/UI/SeedPhraseVideo/index.js
+++ b/app/components/UI/SeedPhraseVideo/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, View } from 'react-native';
+import { InteractionManager, StyleSheet, View } from 'react-native';
 import MediaPlayer from '../../Views/MediaPlayer';
 import scaling from '../../../util/scaling';
 import { video_source_uri, getSubtitleUri } from '../../../util/video';
@@ -19,7 +19,8 @@ const styles = StyleSheet.create({
   },
 });
 
-const SeedPhraseVideo = ({ style, onClose, showVideo }) => {
+const SeedPhraseVideo = ({ style, onClose }) => {
+  const [showVideo, setShowVideo] = useState(false);
   const language = I18n.locale.substr(0, 2);
   const subtitle_source_tracks = [
     {
@@ -30,6 +31,12 @@ const SeedPhraseVideo = ({ style, onClose, showVideo }) => {
       uri: getSubtitleUri(language),
     },
   ];
+
+  useEffect(() => {
+    InteractionManager.runAfterInteractions(() => {
+      setShowVideo(true);
+    });
+  }, []);
 
   return (
     <View style={styles.videoContainer}>
@@ -49,7 +56,6 @@ const SeedPhraseVideo = ({ style, onClose, showVideo }) => {
 SeedPhraseVideo.propTypes = {
   style: PropTypes.object,
   onClose: PropTypes.func,
-  showVideo: PropTypes.bool,
 };
 
 export default SeedPhraseVideo;

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -310,7 +310,6 @@ class Settings extends PureComponent {
     passcodeChoice: false,
     showHint: false,
     hintText: '',
-    showVideo: false,
   };
 
   autolockOptions = [
@@ -406,10 +405,6 @@ class Settings extends PureComponent {
         hintText: manualBackup,
       });
     }
-
-    InteractionManager.runAfterInteractions(() => {
-      this.setState({ showVideo: true });
-    });
 
     if (this.props.route?.params?.scrollToBottom)
       this.scrollView?.scrollToEnd({ animated: true });
@@ -672,10 +667,7 @@ class Settings extends PureComponent {
           </Text>
         </Text>
 
-        <SeedPhraseVideo
-          onClose={this.onBack}
-          showVideo={this.state.showVideo}
-        />
+        <SeedPhraseVideo onClose={this.onBack} />
 
         <Text style={styles.desc}>
           {strings(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR delays the mounting of the media player in `SeedPhraseVideo` after any navigation transition has finished

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
