### PR TITLE
[IMPLEMENT] Deep link case when start by "metamask://"

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -326,6 +326,15 @@ class DeeplinkManager {
             params?.autosign,
             origin,
           );
+        } else if (
+          urlObj.href.startsWith(`${PREFIXES.METAMASK}${ACTIONS.DAPP}`)
+        ) {
+          const newUrl = urlObj.href.replace(
+            `${PREFIXES.METAMASK}${ACTIONS.DAPP}/`,
+            PREFIXES[ACTIONS.DAPP],
+          );
+
+          this.parse(newUrl, { browserCallBack });
         }
 
         break;


### PR DESCRIPTION
**Description**
Deep links on simulator were not working

**Propose Solution**
Added use case for when the deep link started by `metamask://`

**Test Cases**
Tested deep links and universal links on https://cortisiko.github.io/
* Deep links are working (exception of Plants vs Undead, giving me timeout as well on chrome browser https://plantvsundead.com/) 
* Same result on Universal link when trying Plants vs Undead
* On universal link warning alert isn't happening
* When trying to go to uniswap via universal link isn't working (it's happening in prod as well version 5.12.1 tested on Android device)
* Send BSC, Polygon, Goerli and ETH with universal link are working (didn't press confirm to complete any transaction here because unknown recipient, in case of Goerli the balance was insufficient to perform the tx)
* Mainnet contract approval giving error and not appearing
* Grant access for MATIC is working (didn't switch the network, I was on goerli I stayed on goerli)



**Screenshots/Recordings**
https://recordit.co/BBIm8Kdu1X

**Issue**

Progresses #5536

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
