### PR TITLE
Swaps disabled on fresh install on some networks

### DIFF
--- a/app/components/UI/Swaps/SwapsLiveness.js
+++ b/app/components/UI/Swaps/SwapsLiveness.js
@@ -41,7 +41,7 @@ function SwapLiveness({ isLive, chainId, setLiveness }) {
 
   // Check on mount
   useEffect(() => {
-    if (isSwapsAllowed(chainId) && !isLive && !hasMountChecked) {
+    if (isSwapsAllowed(chainId) && !isLive) {
       setHasMountChecked(true);
       checkLiveness();
     }

--- a/app/components/UI/Swaps/SwapsLiveness.ts
+++ b/app/components/UI/Swaps/SwapsLiveness.ts
@@ -1,7 +1,7 @@
 import { swapsUtils } from '@metamask/swaps-controller';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { AppState } from 'react-native';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import AppConstants from '../../../core/AppConstants';
 import {
   setSwapsLiveness,
@@ -11,12 +11,20 @@ import Device from '../../../util/device';
 import Logger from '../../../util/Logger';
 import useInterval from '../../hooks/useInterval';
 import { isSwapsAllowed } from './utils';
-
 const POLLING_FREQUENCY = AppConstants.SWAPS.LIVENESS_POLLING_FREQUENCY;
-
-function SwapLiveness({ isLive, chainId, setLiveness }) {
-  const [hasMountChecked, setHasMountChecked] = useState(false);
-
+function SwapLiveness() {
+  const isLive = useSelector(swapsLivenessSelector);
+  const chainId = useSelector(
+    (state: any) =>
+      state.engine.backgroundState.NetworkController.provider.chainId,
+  );
+  const dispatch = useDispatch();
+  const setLiveness = useCallback(
+    (liveness, currentChainId) => {
+      dispatch(setSwapsLiveness(liveness, currentChainId));
+    },
+    [dispatch],
+  );
   const checkLiveness = useCallback(async () => {
     try {
       const data = await swapsUtils.fetchSwapsFeatureLiveness(
@@ -31,32 +39,29 @@ function SwapLiveness({ isLive, chainId, setLiveness }) {
         ? 'mobileActiveAndroid'
         : 'mobileActive';
       const liveness =
+        // @ts-expect-error interface mismatch
         typeof data === 'boolean' ? data : data?.[featureFlagKey] ?? false;
       setLiveness(liveness, chainId);
     } catch (error) {
-      Logger.error(error, 'Swaps: error while fetching swaps liveness');
+      Logger.error(error as any, 'Swaps: error while fetching swaps liveness');
       setLiveness(false, chainId);
     }
   }, [setLiveness, chainId]);
 
-  // Check on mount
   useEffect(() => {
     if (isSwapsAllowed(chainId) && !isLive) {
-      setHasMountChecked(true);
       checkLiveness();
     }
-  }, [chainId, checkLiveness, hasMountChecked, isLive]);
-
-  // Check con appstate change
+  }, [chainId, checkLiveness, isLive]);
+  // Check on AppState change
   const appStateHandler = useCallback(
     (newState) => {
-      if (hasMountChecked && !isLive && newState === 'active') {
+      if (!isLive && newState === 'active') {
         checkLiveness();
       }
     },
-    [checkLiveness, hasMountChecked, isLive],
+    [checkLiveness, isLive],
   );
-
   useEffect(() => {
     if (isSwapsAllowed(chainId)) {
       AppState.addEventListener('change', appStateHandler);
@@ -65,7 +70,6 @@ function SwapLiveness({ isLive, chainId, setLiveness }) {
       };
     }
   }, [appStateHandler, chainId]);
-
   // Check on interval
   useInterval(
     async () => {
@@ -73,18 +77,6 @@ function SwapLiveness({ isLive, chainId, setLiveness }) {
     },
     isSwapsAllowed(chainId) && !isLive ? POLLING_FREQUENCY : null,
   );
-
   return null;
 }
-
-const mapStateToProps = (state) => ({
-  isLive: swapsLivenessSelector(state),
-  chainId: state.engine.backgroundState.NetworkController.provider.chainId,
-});
-
-const mapDispatchToProps = (dispatch) => ({
-  setLiveness: (liveness, chainId) =>
-    dispatch(setSwapsLiveness(liveness, chainId)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(SwapLiveness);
+export default SwapLiveness;


### PR DESCRIPTION
**Description**
Swaps were disabled on networks after a fresh install.
This is an old bug since I went back until 5.6.0 and it was happening https://recordit.co/EZ2P5eyFeT

**Proposed Solution**
Swaps are enabled on fresh installation for all networks

**Technical Solution**
When the network changed, the SwapsLiveness component was not mounted again, which makes the `hasMountChecked` state true and not false like it supposes to be. Since there isn't any reason on my sight for not running the `checkLiveness` function if the `hasMountChecked` is true, I removed the condition.

**Test Cases**
* Fresh install
* Changed to avalanche network (swaps enabled)
* Changed to Binance Smart Chain (swaps enabled)
* Performed one swap


**Screenshots/Recordings**
https://recordit.co/UR0XppwkNQ

**Code Impact**
Small

**Issue**

Progresses #[589](https://github.com/MetaMask/mobile-planning/issues/589)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
