### PR TITLE
Fix app won't react to WalletConnect requests after been locked

### DIFF
--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -277,12 +277,22 @@ class DeeplinkManager {
         wcCleanUrl = url.replace('wc://wc?uri=', '');
         if (!WalletConnect.isValidUri(wcCleanUrl)) return;
 
-        WalletConnect.newSession(
-          wcCleanUrl,
-          params?.redirect,
-          params?.autosign,
-          origin,
-        );
+        const { KeyringController } = Engine.context;
+        const createSession = () => {
+          WalletConnect.newSession(
+            wcCleanUrl,
+            params?.redirect,
+            params?.autosign,
+            origin,
+          );
+        }
+
+        if (KeyringController.isUnlocked()) {
+          createSession();
+        } else {
+          KeyringController.once('unlock', createSession);
+        }
+
         break;
 
       case PROTOCOLS.ETHEREUM:

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -290,6 +290,7 @@ class DeeplinkManager {
         if (KeyringController.isUnlocked()) {
           createSession();
         } else {
+          // Wait until app unlocked
           KeyringController.once('unlock', createSession);
         }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Wallet currently won't respond to any WalletConnect requests (connect, sign message, etc.) after been locked in background (by auto-lock feature).
To reproduce, simply go to security settings and set auto-lock to `immediately`. Then dapps can no longer interact with Wallet anymore.
This PR simply add an lock-state check, and if app is locked when receiving wallet connect deep-link, it add an one time callback to delay the action to unlock state.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Close #2010
Related to #2045

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
