### PR TITLE
Refactor `eth_sendTransaction` handler

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -26,7 +26,6 @@ import { PreferencesController } from '@metamask/preferences-controller';
 import {
   Transaction,
   TransactionController,
-  WalletDevice,
 } from '@metamask/transaction-controller';
 import { GasFeeController } from '@metamask/gas-fee-controller';
 import { ApprovalController } from '@metamask/approval-controller';
@@ -113,27 +112,6 @@ class Engine {
 
       const networkController = new NetworkController(networkControllerOpts);
       networkController.providerConfig = {
-        static: {
-          eth_sendTransaction: async (
-            payload: { params: any[]; origin: any },
-            _next: any,
-            end: (arg0: undefined, arg1: undefined) => void,
-          ) => {
-            const { TransactionController } = this.context;
-            try {
-              const hash = await (
-                await TransactionController.addTransaction(
-                  payload.params[0],
-                  payload.origin,
-                  WalletDevice.MM_MOBILE,
-                )
-              ).result;
-              end(undefined, hash);
-            } catch (error) {
-              end(error);
-            }
-          },
-        },
         getAccounts: (
           end: (arg0: null, arg1: any[]) => void,
           payload: { hostname: string | number },

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -1,0 +1,577 @@
+import {
+  JsonRpcEngine,
+  JsonRpcMiddleware,
+  JsonRpcRequest,
+  JsonRpcSuccess,
+} from 'json-rpc-engine';
+import { assertIsJsonRpcSuccess, JsonRpcFailure } from '@metamask/utils';
+import type { Transaction } from '@metamask/transaction-controller';
+import { ethErrors } from 'eth-json-rpc-errors';
+import Engine from '../Engine';
+import { store } from '../../store';
+import { getPermittedAccounts } from '../Permissions';
+import { RPC } from '../../constants/network';
+import { getRpcMethodMiddleware } from './RPCMethodMiddleware';
+
+jest.mock('../Engine', () => ({
+  context: {
+    NetworkController: {
+      state: {},
+    },
+    PreferencesController: {
+      state: {},
+    },
+    TransactionController: {
+      addTransaction: jest.fn(),
+    },
+  },
+}));
+const MockEngine = Engine as Omit<typeof Engine, 'context'> & {
+  context: {
+    NetworkController: Record<string, any>;
+    PreferencesController: Record<string, any>;
+    TransactionController: Record<string, any>;
+  };
+};
+
+jest.mock('../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
+}));
+const mockStore = store as { getState: jest.Mock };
+
+jest.mock('../Permissions', () => ({
+  getPermittedAccounts: jest.fn(),
+}));
+const mockGetPermittedAccounts = getPermittedAccounts as jest.Mock;
+
+/**
+ * This is used to build JSON-RPC requests. It is defined here for convenience, so that we don't
+ * need to use "as const" each time.
+ */
+const jsonrpc = '2.0' as const;
+
+/**
+ * Return a minimal set of options for `getRpcMethodMiddleware`. These options
+ * are complete enough to test at least some method handlers, and they are type-
+ * compatible. They don't represent a realistic scenario.
+ *
+ * @returns A minimal set of options for `getRpcMethodMiddleware`
+ */
+function getMinimalOptions() {
+  return {
+    hostname: '',
+    getProviderState: jest.fn(),
+    navigation: jest.fn(),
+    url: { current: '' },
+    title: { current: '' },
+    icon: { current: undefined },
+    // Bookmarks
+    isHomepage: jest.fn(),
+    // Show autocomplete
+    fromHomepage: { current: false },
+    toggleUrlModal: jest.fn(),
+    // Wizard
+    wizardScrollAdjusted: { current: false },
+    // For the browser
+    tabId: '' as const,
+    // For WalletConnect
+    isWalletConnect: false,
+    // For MM SDK
+    isMMSDK: false,
+    getApprovedHosts: jest.fn(),
+    setApprovedHosts: jest.fn(),
+    approveHost: jest.fn(),
+    injectHomePageScripts: jest.fn(),
+    analytics: {},
+  };
+}
+
+/**
+ * Return a minimal set of options for `getRpcMethodMiddleware` when used in a
+ * browser context.
+ *
+ * See {@link getMinimalOptions} for more details.
+ *
+ * @returns A minimal set of options for `getRpcMethodMiddleware`
+ */
+function getMinimalBrowserOptions() {
+  return {
+    ...getMinimalOptions(),
+    tabId: 1,
+  };
+}
+
+/**
+ * Return a minimal set of options for `getRpcMethodMiddleware` when used in a
+ * WalletConnect context.
+ *
+ * See {@link getMinimalOptions} for more details.
+ *
+ * @returns A minimal set of options for `getRpcMethodMiddleware`
+ */
+function getMinimalWalletConnectOptions() {
+  return {
+    ...getMinimalOptions(),
+    isWalletConnect: true,
+  };
+}
+
+/**
+ * Return a minimal set of options for `getRpcMethodMiddleware` when used in a
+ * MetaMask SDK context.
+ *
+ * See {@link getMinimalOptions} for more details.
+ *
+ * @returns A minimal set of options for `getRpcMethodMiddleware`
+ */
+function getMinimalSDKOptions() {
+  return {
+    ...getMinimalOptions(),
+    isMMSDK: true,
+  };
+}
+
+/**
+ * Process the given request with the provided middleware.
+ *
+ * @param arguments - Named arguments.
+ * @param arguments.middleware - The middleware to call.
+ * @param arguments.request - The request to process.
+ * @returns The JSON-RPC response.
+ */
+async function callMiddleware({
+  middleware,
+  request,
+}: {
+  middleware: JsonRpcMiddleware<unknown, unknown>;
+  request: JsonRpcRequest<unknown>;
+}) {
+  const engine = new JsonRpcEngine();
+  engine.push(middleware);
+
+  return await engine.handle(request);
+}
+
+describe('getRpcMethodMiddleware', () => {
+  it('allows unrecognized methods to pass through', async () => {
+    const engine = new JsonRpcEngine();
+    const middleware = getRpcMethodMiddleware(getMinimalOptions());
+    engine.push(middleware);
+    const nextMiddleware = jest
+      .fn()
+      .mockImplementation((_req, res, _next, end) => {
+        res.result = 'success';
+        end();
+      });
+    engine.push(nextMiddleware);
+
+    const response = await engine.handle({
+      jsonrpc,
+      id: 1,
+      method: 'this-is-a-fake-method',
+    });
+
+    assertIsJsonRpcSuccess(response);
+    expect(response.result).toBe('success');
+  });
+
+  describe('eth_sendTransaction', () => {
+    describe('browser', () => {
+      it('sends the transaction and returns the resulting hash', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address is permitted for the hostname used by this request
+        mockGetPermittedAccounts.mockImplementation((hostname) =>
+          hostname === 'example.metamask.io' ? [mockAddress] : [],
+        );
+        // Ensure tab used by middleware matches current tab
+        const mockTabId = 10;
+        mockStore.getState.mockImplementation(() => ({
+          browser: {
+            activeTab: mockTabId,
+          },
+        }));
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalBrowserOptions(),
+          hostname: 'example.metamask.io',
+          tabId: mockTabId,
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toBeUndefined();
+        expect((response as JsonRpcSuccess<string>).result).toBe('fake-hash');
+      });
+
+      it('returns a JSON-RPC error if the transaction is requested by a non-active tab', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address is permitted for the hostname used by this request
+        mockGetPermittedAccounts.mockImplementation((hostname) =>
+          hostname === 'example.metamask.io' ? [mockAddress] : [],
+        );
+        // Tab used by middleware DOES NOT match current tab
+        const mockTabId = 10;
+        mockStore.getState.mockImplementation(() => ({
+          browser: {
+            activeTab: 20,
+          },
+        }));
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalBrowserOptions(),
+          hostname: 'example.metamask.io',
+          tabId: mockTabId,
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+        const expectedError = ethErrors.provider.userRejectedRequest();
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toStrictEqual({
+          code: expectedError.code,
+          message: expectedError.message,
+        });
+      });
+
+      it('returns a JSON-RPC error if the site does not have permission to use the referenced account', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // No accounts permitted for this test
+        mockGetPermittedAccounts.mockImplementation(() => []);
+        // Ensure tab used by middleware matches current tab
+        const mockTabId = 10;
+        mockStore.getState.mockImplementation(() => ({
+          browser: {
+            activeTab: mockTabId,
+          },
+        }));
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalBrowserOptions(),
+          hostname: 'example.metamask.io',
+          tabId: mockTabId,
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+        const expectedError = ethErrors.rpc.invalidParams({
+          message: `Invalid parameters: must provide an Ethereum address.`,
+        });
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toStrictEqual({
+          code: expectedError.code,
+          message: expectedError.message,
+        });
+      });
+    });
+
+    describe('WalletConnect', () => {
+      it('sends the transaction and returns the resulting hash', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address matches the selected account
+        MockEngine.context.PreferencesController.state.selectedAddress =
+          mockAddress;
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalWalletConnectOptions(),
+          hostname: 'example.metamask.io',
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toBeUndefined();
+        expect((response as JsonRpcSuccess<string>).result).toBe('fake-hash');
+      });
+
+      it('returns a JSON-RPC error if the referenced account is not currently selected', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const differentMockAddress =
+          '0x0000000000000000000000000000000000000002';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address DOES NOT match the selected account
+        MockEngine.context.PreferencesController.state.selectedAddress =
+          differentMockAddress;
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalWalletConnectOptions(),
+          hostname: 'example.metamask.io',
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+        const expectedError = ethErrors.rpc.invalidParams({
+          message: `Invalid parameters: must provide an Ethereum address.`,
+        });
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toStrictEqual({
+          code: expectedError.code,
+          message: expectedError.message,
+        });
+      });
+    });
+
+    describe('SDK', () => {
+      it('sends the transaction and returns the resulting hash', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address matches the selected account
+        MockEngine.context.PreferencesController.state.selectedAddress =
+          mockAddress;
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalSDKOptions(),
+          hostname: 'example.metamask.io',
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toBeUndefined();
+        expect((response as JsonRpcSuccess<string>).result).toBe('fake-hash');
+      });
+
+      it('returns a JSON-RPC error if the referenced account is not currently selected', async () => {
+        const mockAddress = '0x0000000000000000000000000000000000000001';
+        const differentMockAddress =
+          '0x0000000000000000000000000000000000000002';
+        const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+        // Transaction will succeed when added
+        MockEngine.context.TransactionController.addTransaction.mockImplementation(
+          async () => ({ result: Promise.resolve('fake-hash') }),
+        );
+        // Set minimal network controller state to support validation
+        MockEngine.context.NetworkController.state.providerConfig = {
+          chainId: '1',
+          type: RPC,
+        };
+        // Ensure mock address DOES NOT match the selected account
+        MockEngine.context.PreferencesController.state.selectedAddress =
+          differentMockAddress;
+        const middleware = getRpcMethodMiddleware({
+          ...getMinimalSDKOptions(),
+          hostname: 'example.metamask.io',
+        });
+        const request = {
+          jsonrpc,
+          id: 1,
+          method: 'eth_sendTransaction',
+          params: [mockTransactionParameters],
+        };
+        const expectedError = ethErrors.rpc.invalidParams({
+          message: `Invalid parameters: must provide an Ethereum address.`,
+        });
+
+        const response = await callMiddleware({ middleware, request });
+
+        expect((response as JsonRpcFailure).error).toStrictEqual({
+          code: expectedError.code,
+          message: expectedError.message,
+        });
+      });
+    });
+
+    it('skips account validation if the account is missing from the transaction parameters', async () => {
+      // Downcast needed here because `from` is required by this type
+      const mockTransactionParameters = { chainId: 1 } as Transaction;
+      // Transaction will succeed when added
+      MockEngine.context.TransactionController.addTransaction.mockImplementation(
+        async () => ({ result: Promise.resolve('fake-hash') }),
+      );
+      // Set minimal network controller state to support validation
+      MockEngine.context.NetworkController.state.providerConfig = {
+        chainId: '1',
+        type: RPC,
+      };
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [mockTransactionParameters],
+      };
+
+      const response = await callMiddleware({ middleware, request });
+
+      expect((response as JsonRpcFailure).error).toBeUndefined();
+      expect((response as JsonRpcSuccess<string>).result).toBe('fake-hash');
+    });
+
+    it('skips chain ID validation if the chain ID is missing from the transaction parameters', async () => {
+      const mockAddress = '0x0000000000000000000000000000000000000001';
+      const mockTransactionParameters = { from: mockAddress };
+      // Transaction will succeed when added
+      MockEngine.context.TransactionController.addTransaction.mockImplementation(
+        async () => ({ result: Promise.resolve('fake-hash') }),
+      );
+      // Ensure mock address is permitted for the hostname used by this request
+      mockGetPermittedAccounts.mockImplementation((hostname) =>
+        hostname === 'example.metamask.io' ? [mockAddress] : [],
+      );
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [mockTransactionParameters],
+      };
+
+      const response = await callMiddleware({ middleware, request });
+
+      expect((response as JsonRpcFailure).error).toBeUndefined();
+      expect((response as JsonRpcSuccess<string>).result).toBe('fake-hash');
+    });
+
+    it('returns a JSON-RPC error if an error is thrown when adding this transaction', async () => {
+      // Omit `from` and `chainId` here to skip validation for simplicity
+      // Downcast needed here because `from` is required by this type
+      const mockTransactionParameters = {} as Transaction;
+      // Transaction fails before returning a result
+      MockEngine.context.TransactionController.addTransaction.mockImplementation(
+        async () => {
+          throw new Error('Failed to add transaction');
+        },
+      );
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [mockTransactionParameters],
+      };
+      const expectedError = ethErrors.rpc.internal('Failed to add transaction');
+
+      const response = await callMiddleware({ middleware, request });
+
+      expect((response as JsonRpcFailure).error.code).toBe(expectedError.code);
+      expect((response as JsonRpcFailure).error.message).toBe(
+        expectedError.message,
+      );
+    });
+
+    it('returns a JSON-RPC error if an error is thrown after approval', async () => {
+      // Omit `from` and `chainId` here to skip validation for simplicity
+      // Downcast needed here because `from` is required by this type
+      const mockTransactionParameters = {} as Transaction;
+      // Transaction returns an error as the result
+      MockEngine.context.TransactionController.addTransaction.mockImplementation(
+        async () => ({
+          result: Promise.reject(new Error('Failed to process transaction')),
+        }),
+      );
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [mockTransactionParameters],
+      };
+      const expectedError = ethErrors.rpc.internal(
+        'Failed to process transaction',
+      );
+
+      const response = await callMiddleware({ middleware, request });
+
+      expect((response as JsonRpcFailure).error.code).toBe(expectedError.code);
+      expect((response as JsonRpcFailure).error.message).toBe(
+        expectedError.message,
+      );
+    });
+  });
+});

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -1,10 +1,11 @@
 import {
   JsonRpcEngine,
+  JsonRpcFailure,
   JsonRpcMiddleware,
   JsonRpcRequest,
+  JsonRpcResponse,
   JsonRpcSuccess,
 } from 'json-rpc-engine';
-import { assertIsJsonRpcSuccess, JsonRpcFailure } from '@metamask/utils';
 import type { Transaction } from '@metamask/transaction-controller';
 import { ethErrors } from 'eth-json-rpc-errors';
 import Engine from '../Engine';
@@ -51,6 +52,24 @@ const mockGetPermittedAccounts = getPermittedAccounts as jest.Mock;
  * need to use "as const" each time.
  */
 const jsonrpc = '2.0' as const;
+
+/**
+ * Assert that the given response was successful.
+ *
+ * TODO: Replace this with `assertIsJsonRpcSuccess` from `@metamask/utils`
+ *
+ * @param value - The value to check.
+ * @throws If the given value is not a valid {@link JsonRpcSuccess} object.
+ */
+function assertIsJsonRpcSuccess(
+  response: JsonRpcResponse<unknown>,
+): asserts response is JsonRpcSuccess<unknown> {
+  if ('error' in response) {
+    throw new Error(`Response failed with error '${JSON.stringify('error')}'`);
+  } else if (!('result' in response)) {
+    throw new Error(`Response is missing 'result' property`);
+  }
+}
 
 /**
  * Return a minimal set of options for `getRpcMethodMiddleware`. These options

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -46,7 +46,7 @@ interface RPCMethodsMiddleParameters {
   // Wizard
   wizardScrollAdjusted: { current: boolean };
   // For the browser
-  tabId: string;
+  tabId: number | '' | false;
   // For WalletConnect
   isWalletConnect: boolean;
   // For MM SDK

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -326,10 +326,14 @@ export const getRpcMethodMiddleware = ({
       eth_coinbase: getEthAccounts,
       eth_sendTransaction: async () => {
         checkTabActive();
+        const { TransactionController } = Engine.context;
         return RPCMethods.eth_sendTransaction({
-          next,
+          hostname,
           req,
           res,
+          sendTransaction: TransactionController.addTransaction.bind(
+            TransactionController,
+          ),
           validateAccountAndChainId: async ({
             from,
             chainId,

--- a/app/core/RPCMethods/eth_sendTransaction.test.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.test.ts
@@ -1,6 +1,11 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { inspect } from 'util';
 import type { JsonRpcRequest, PendingJsonRpcResponse } from 'json-rpc-engine';
+import type {
+  Transaction,
+  TransactionController,
+  WalletDevice,
+} from '@metamask/transaction-controller';
 import eth_sendTransaction from './eth_sendTransaction';
 
 /**
@@ -32,19 +37,92 @@ function constructPendingJsonRpcResponse(): PendingJsonRpcResponse<unknown> {
   };
 }
 
+/**
+ * Get a mock implementation of `TransactionController.addTransaction`.
+ *
+ * A return value or some type of error must be provided.
+ *
+ * @param arguments - Named arguments for this function.
+ * @param arguments.addTransactionerror - An error to throw when adding the transaction.
+ * @param arguments.expectedOrigin - The origin this is mock is expected to be called with.
+ * @param arguments.expectedTransaction - The transaction parameters this is mock is expected to be
+ * called with.
+ * @param arguments.processTransactionError - An error to throw when the transaction is being
+ * processed, after it was successfully added.
+ * @param arguments.returnValue - The hash to return once the transaction has succeeded.
+ */
+function getMockAddTransaction({
+  addTransactionError,
+  expectedOrigin,
+  expectedTransaction,
+  processTransactionError,
+  returnValue,
+}: {
+  addTransactionError?: Error;
+  expectedOrigin?: Parameters<TransactionController['addTransaction']>[1];
+  expectedTransaction?: Parameters<TransactionController['addTransaction']>[0];
+  processTransactionError?: Error;
+  returnValue?: string;
+}) {
+  if (addTransactionError && processTransactionError) {
+    throw new Error('Only one type of error can be provided');
+  } else if ((addTransactionError || processTransactionError) && returnValue) {
+    throw new Error('Must provide either an error or a return value, not both');
+  } else if (!addTransactionError && !processTransactionError && !returnValue) {
+    throw new Error('No return value or error provided');
+  }
+
+  return jest
+    .fn()
+    .mockImplementation(
+      async (
+        transaction: Transaction,
+        origin: string,
+        deviceConfirmedOn: WalletDevice,
+      ) => {
+        expect(deviceConfirmedOn).toBe('metamask_mobile');
+        if (expectedOrigin) {
+          expect(origin).toBe(expectedOrigin);
+        }
+        if (expectedTransaction) {
+          expect(transaction).toBe(expectedTransaction);
+        }
+
+        if (addTransactionError) {
+          throw addTransactionError;
+        } else if (processTransactionError) {
+          return {
+            result: Promise.reject(processTransactionError),
+          };
+        } else {
+          return {
+            result: Promise.resolve('fake-hash'),
+          };
+        }
+      },
+    );
+}
+
 describe('eth_sendTransaction', () => {
-  it('invokes next middleware for a valid request', async () => {
-    const nextMock = jest.fn();
-    const minimalValidParams = [{}];
+  it('sends the transaction and returns the resulting hash', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const mockTransactionParameters = { from: mockAddress };
+    const expectedResult = 'fake-hash';
+    const pendingResult = constructPendingJsonRpcResponse();
 
     await eth_sendTransaction({
-      next: nextMock,
-      req: constructSendTransactionRequest(minimalValidParams),
-      res: constructPendingJsonRpcResponse(),
+      hostname: 'example.metamask.io',
+      req: constructSendTransactionRequest([mockTransactionParameters]),
+      res: pendingResult,
+      sendTransaction: getMockAddTransaction({
+        expectedTransaction: mockTransactionParameters,
+        expectedOrigin: 'example.metamask.io',
+        returnValue: expectedResult,
+      }),
       validateAccountAndChainId: jest.fn(),
     });
 
-    expect(nextMock).toHaveBeenCalledTimes(1);
+    expect(pendingResult.result).toBe(expectedResult);
   });
 
   const invalidParameters = [null, undefined, '', {}];
@@ -52,18 +130,18 @@ describe('eth_sendTransaction', () => {
     it(`throws a JSON-RPC invalid parameters error if given "${inspect(
       invalidParameter,
     )}"`, async () => {
-      const nextMock = jest.fn();
-
       await expect(
         async () =>
           await eth_sendTransaction({
-            next: nextMock,
+            hostname: 'example.metamask.io',
             req: constructSendTransactionRequest(invalidParameter),
             res: constructPendingJsonRpcResponse(),
+            sendTransaction: getMockAddTransaction({
+              returnValue: 'fake-hash',
+            }),
             validateAccountAndChainId: jest.fn(),
           }),
       ).rejects.toThrow('Invalid parameters: expected an array');
-      expect(nextMock).not.toHaveBeenCalled();
     });
   }
 
@@ -72,39 +150,82 @@ describe('eth_sendTransaction', () => {
     it(`throws a JSON-RPC invalid parameters error if given "${inspect(
       invalidTransactionParameter,
     )}" transaction parameters`, async () => {
-      const nextMock = jest.fn();
       const invalidParameter = [invalidTransactionParameter];
 
       await expect(
         async () =>
           await eth_sendTransaction({
-            next: nextMock,
+            hostname: 'example.metamask.io',
             req: constructSendTransactionRequest(invalidParameter),
             res: constructPendingJsonRpcResponse(),
+            sendTransaction: getMockAddTransaction({
+              returnValue: 'fake-hash',
+            }),
             validateAccountAndChainId: jest.fn(),
           }),
       ).rejects.toThrow(
         'Invalid parameters: expected the first parameter to be an object',
       );
-      expect(nextMock).not.toHaveBeenCalled();
     });
   }
 
   it('throws any validation errors', async () => {
-    const nextMock = jest.fn();
-    const minimalValidParams = [{}];
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const mockTransactionParameters = { from: mockAddress };
 
     await expect(
       async () =>
         await eth_sendTransaction({
-          next: nextMock,
-          req: constructSendTransactionRequest(minimalValidParams),
+          hostname: 'example.metamask.io',
+          req: constructSendTransactionRequest([mockTransactionParameters]),
           res: constructPendingJsonRpcResponse(),
+          sendTransaction: getMockAddTransaction({
+            returnValue: 'fake-hash',
+          }),
           validateAccountAndChainId: jest.fn().mockImplementation(async () => {
             throw new Error('test validation error');
           }),
         }),
     ).rejects.toThrow('test validation error');
-    expect(nextMock).not.toHaveBeenCalled();
+  });
+
+  it('throws if the sendTransaction function throws', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const mockTransactionParameters = { from: mockAddress };
+
+    await expect(
+      async () =>
+        await eth_sendTransaction({
+          hostname: 'example.metamask.io',
+          req: constructSendTransactionRequest([mockTransactionParameters]),
+          res: constructPendingJsonRpcResponse(),
+          sendTransaction: getMockAddTransaction({
+            expectedTransaction: mockTransactionParameters,
+            expectedOrigin: 'example.metamask.io',
+            addTransactionError: new Error('Failed to add transaction'),
+          }),
+          validateAccountAndChainId: jest.fn(),
+        }),
+    ).rejects.toThrow('Failed to add transaction');
+  });
+
+  it('throws if the transaction fails after approval', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const mockTransactionParameters = { from: mockAddress };
+
+    await expect(
+      async () =>
+        await eth_sendTransaction({
+          hostname: 'example.metamask.io',
+          req: constructSendTransactionRequest([mockTransactionParameters]),
+          res: constructPendingJsonRpcResponse(),
+          sendTransaction: getMockAddTransaction({
+            expectedTransaction: mockTransactionParameters,
+            expectedOrigin: 'example.metamask.io',
+            processTransactionError: new Error('User rejected the transaction'),
+          }),
+          validateAccountAndChainId: jest.fn(),
+        }),
+    ).rejects.toThrow('User rejected the transaction');
   });
 });


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The handler for `eth_sendTransaction` was previously spread between `RPCMethodMiddleware.ts` and the static middleware of `web3-provider-engine`. Instead it is all handled in `RPCMethodMiddleware.ts` now.

This should have no functional impact. It is difficult to trace through `web3-provider-engine`, but this case is one of the easier ones because the static middleware is run first, and in this case it will always end the request.

**Issue**

This relates to #5513

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
