### PR TITLE
Refactor RPC `getAccounts` usage

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -111,23 +111,8 @@ class Engine {
       };
 
       const networkController = new NetworkController(networkControllerOpts);
-      networkController.providerConfig = {
-        getAccounts: (
-          end: (arg0: null, arg1: any[]) => void,
-          payload: { hostname: string | number },
-        ) => {
-          const { approvedHosts } = store.getState();
-          const isEnabled = approvedHosts[payload.hostname];
-          const { KeyringController } = this.context;
-          const isUnlocked = KeyringController.isUnlocked();
-          const selectedAddress =
-            this.context.PreferencesController.state.selectedAddress;
-          end(
-            null,
-            isUnlocked && isEnabled && selectedAddress ? [selectedAddress] : [],
-          );
-        },
-      };
+      // This still needs to be set because it has the side-effect of initializing the provider
+      networkController.providerConfig = {};
       const assetsContractController = new AssetsContractController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -324,6 +324,7 @@ export const getRpcMethodMiddleware = ({
       },
       eth_accounts: getEthAccounts,
       eth_coinbase: getEthAccounts,
+      parity_defaultAccount: getEthAccounts,
       eth_sendTransaction: async () => {
         checkTabActive();
         const { TransactionController } = Engine.context;


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `getAccounts` function is defined and used in two different places in the RPC pipeline: `RPCMethodMiddleware.ts` and
`web3-provider-engine`. The second one has been removed, so now all usage is in `RPCMethodMiddleware.ts`.

`getAccounts` is passed into `web3-provider-engine` and used in the `HookedWalletSubprovider`: https://github.com/MetaMask/web3-provider-engine/blob/cf612f898002833c36730d23972fe4c4dd483c76/subproviders/hooked-wallet.js

It is used in these methods:
* `eth_coinbase`
* `eth_accounts`
* `parity_defaultAccount`

It's also called to validate the sender, for the following methods:
* `eth_signTypedData`
* `eth_signTypedData_v3`
* `eth_signTypedData_v4`
* `encryption_public_key`
* `eth_decryptMessage`
* `personal_sign`
* `eth_sign`
* `eth_signTransaction`
* `eth_sendTransaction`

Of these methods, most of them are intercepted in
`RPCMethodMiddleware.ts`, so the requests never make it to `web3-provider-engine`.

These three methods will make their way there: `parity_defaultAccount`, `encryption_public_key`, and `eth_decryptMessage`. The decryption- related messages rely on constructor parameters that mobile does not pass in, so those always throw an error. The only method this hook is used for in practice is `parity_defaultAccount`.

The `parity_defaultAccount` method was added to
`RPCMethodMiddleware.ts`, so now that method won't make it to `web3-provider-engine` either. Functionally it is the same as `eth_coinbase`, so the same implementation has been used.

This should have no functional changes.

**Issue**

This relates to https://github.com/MetaMask/metamask-mobile/issues/5513

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
