### PR TITLE
Fix currency display for main

### DIFF
--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -337,20 +337,25 @@ class Engine {
           },
           { interval: 10000 },
         ),
-        new TokenRatesController({
-          onTokensStateChange: (listener) =>
-            tokensController.subscribe(listener),
-          onCurrencyRateStateChange: (listener) =>
-            this.controllerMessenger.subscribe(
-              `${currencyRateController.name}:stateChange`,
-              listener,
-            ),
-          onNetworkStateChange: (listener) =>
-            this.controllerMessenger.subscribe(
-              AppConstants.NETWORK_STATE_CHANGE_EVENT,
-              listener,
-            ),
-        }),
+        new TokenRatesController(
+          {
+            onTokensStateChange: (listener) =>
+              tokensController.subscribe(listener),
+            onCurrencyRateStateChange: (listener) =>
+              this.controllerMessenger.subscribe(
+                `${currencyRateController.name}:stateChange`,
+                listener,
+              ),
+            onNetworkStateChange: (listener) =>
+              this.controllerMessenger.subscribe(
+                AppConstants.NETWORK_STATE_CHANGE_EVENT,
+                listener,
+              ),
+          },
+          {
+            chainId: networkController.state.provider.chainId,
+          },
+        ),
         new TransactionController({
           getNetworkState: () => networkController.state,
           onNetworkStateChange: (listener) =>


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This is a fix for displaying token fiat currencies listed in this ticket
https://github.com/MetaMask/mobile-planning/issues/609

The issue was that the `TokenRatesController` was missing a `chainId` during initialization and as a result, failed to pull the rates required to calculate the fiat amounts.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**
https://github.com/MetaMask/mobile-planning/issues/609

Progresses #???

**Tests**

Prior to this fix, the fiat balances would not show at all.
After this fix, you should see fiat balances appear under each token shortly after you import an account via SRP, seed, or hardware.
