### PR TITLE
Refactor remaining `web3-provider-engine` methods

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -2,6 +2,7 @@ import { Alert } from 'react-native';
 import { getVersion } from 'react-native-device-info';
 import { createAsyncMiddleware } from 'json-rpc-engine';
 import { ethErrors } from 'eth-json-rpc-errors';
+import { recoverPersonalSignature } from '@metamask/eth-sig-util';
 import RPCMethods from './index.js';
 import { RPC } from '../../constants/network';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
@@ -439,6 +440,21 @@ export const getRpcMethodMiddleware = ({
         });
 
         res.result = rawSig;
+      },
+
+      personal_ecRecover: () => {
+        const data = req.params[0];
+        const signature = req.params[1];
+        const address = recoverPersonalSignature({ data, signature });
+
+        res.result = address;
+      },
+
+      parity_checkRequest: () => {
+        // This method is retained for legacy reasons
+        // It doesn't serve it's intended purpose anymore of checking parity requests,
+        // because our API doesn't support parity requests.
+        res.result = null;
       },
 
       eth_signTypedData: async () => {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@metamask/controller-utils": "^1.0.0",
     "@metamask/design-tokens": "^1.11.1",
     "@metamask/etherscan-link": "^2.0.0",
+    "@metamask/eth-sig-util": "^4.0.1",
     "@metamask/gas-fee-controller": "^2.0.1",
     "@metamask/keyring-controller": "^1.0.1",
     "@metamask/message-manager": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4111,7 +4111,7 @@
     ethereumjs-util "^7.0.9"
     ethereumjs-wallet "^1.0.1"
 
-"@metamask/eth-sig-util@^4.0.0":
+"@metamask/eth-sig-util@^4.0.0", "@metamask/eth-sig-util@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
   integrity sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The remaining non-static methods from `web3-provider-engine` have been migrated to `RPCMethodMiddleware.ts` with the rest of the method handlers. The two methods left were `personal_ecRecover` and `parity_checkRequest`.

`personal_ecRecover` will recover the signing account from a signature. This operation requires no private keys. Commonly dapps will do this themselves. Persumably it was added to the dapp API at some point for convenience. It has been preserved just to avoid making breaking changes to the dapp API.

`parity_checkRequest` would return the result of a parity signature or transaction. It returned `null` if none were found. The parity signature and request methods have been throwing an error for some time now, so there is never any result to check. As a result, this method has been returning `null` for all requests in practice. It has been preserved just to avoid making breaking changes to the dapp API.

**Issue**

This relates to https://github.com/MetaMask/metamask-mobile/issues/5513

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
