### PR TITLE
Modal confirmation refactoring

### DIFF
--- a/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.tsx
+++ b/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.tsx
@@ -40,6 +40,9 @@ const ModalConfirmation = ({ route }: ModalConfirmationProps) => {
     modalRef.current?.dismissModal(onConfirm);
   };
 
+  const handleModalDismiss = (hasPendingAction: boolean) =>
+    !hasPendingAction && onCancel?.();
+
   const renderHeader = () => (
     <Text style={styles.headerLabel} variant={TextVariants.sHeadingMD}>
       {title}
@@ -74,7 +77,11 @@ const ModalConfirmation = ({ route }: ModalConfirmationProps) => {
   );
 
   return (
-    <ReusableModal ref={modalRef} style={styles.screen} onDismiss={onCancel}>
+    <ReusableModal
+      ref={modalRef}
+      style={styles.screen}
+      onDismiss={handleModalDismiss}
+    >
       <View style={styles.modal}>
         <View style={styles.bodyContainer}>
           {renderHeader()}

--- a/app/component-library/components/Modals/ModalConfirmation/__snapshots__/ModalConfirmation.test.tsx.snap
+++ b/app/component-library/components/Modals/ModalConfirmation/__snapshots__/ModalConfirmation.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ModalConfirmation should render correctly 1`] = `
 <ForwardRef
+  onDismiss={[Function]}
   style={
     Object {
       "justifyContent": "center",


### PR DESCRIPTION
Description

We now utilize the boolean that ReusableModal onDismiss prop provides to decide what to do with the pending promise

Issue

This fixes https://github.com/MetaMask/mobile-planning/issues/612

PR into main from release/5.14.0 https://github.com/MetaMask/metamask-mobile/pull/5631