### PR TITLE
middleware - include the request in the error params

### DIFF
--- a/app/util/middlewares.js
+++ b/app/util/middlewares.js
@@ -97,6 +97,7 @@ export function createLoggerMiddleware(opts) {
               message: 'Error in RPC response',
               orginalError: error,
               res: resWithoutError,
+              req,
             };
 
             if (error.message) {


### PR DESCRIPTION
add request params into the error obj for json rpc errors