### PR TITLE
[IMPROVEMENT] Use Set when filtering blocklist

### DIFF
--- a/patches/@metamask+phishing-controller+1.1.0.patch
+++ b/patches/@metamask+phishing-controller+1.1.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@metamask/phishing-controller/dist/PhishingController.js b/node_modules/@metamask/phishing-controller/dist/PhishingController.js
+index be85782..3756186 100644
+--- a/node_modules/@metamask/phishing-controller/dist/PhishingController.js
++++ b/node_modules/@metamask/phishing-controller/dist/PhishingController.js
+@@ -202,10 +202,14 @@ _PhishingController_inProgressUpdate = new WeakMap(), _PhishingController_instan
+         if (metamaskConfigLegacy) {
+             configs.push(metamaskConfig);
+         }
++
++        // Create a Set for more efficient checking when filtering phishfortHotlist.
++        const blocklistSet = new Set(metamaskConfig.blocklist);
++
+         // Correctly shaping PhishFort config.
+         const phishfortConfig = {
+             allowlist: [],
+-            blocklist: (phishfortHotlist || []).filter((i) => !metamaskConfig.blocklist.includes(i)),
++            blocklist: (phishfortHotlist || []).filter(i => !blocklistSet.has(i)),
+             fuzzylist: [],
+             tolerance: 0,
+             name: `PhishFort`,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR patches the `PhishingController` to use `Set` when filtering on the blocklist. The improvement here (at least testing locally on iOS) is that look up in `Set` vs using `includes` while filtering reduces same business logic processing time by 4x. This translates to a user experiencing 4x faster cold start times than before.

**Issue**

Progresses #5382

**Test**

We should expect cold start times on iOS to be ~4seconds, while Android (depending on device) shouldn't take more than 10 seconds. (Both times reported by Curtis). Relative to the previous app version, the cold start up times should be noticeably lower.
