### PR TITLE
fix tapReminder step

### DIFF
--- a/wdio/step-definitions/onboarding.steps.js
+++ b/wdio/step-definitions/onboarding.steps.js
@@ -162,7 +162,7 @@ When(/^Select "([^"]*)?" on remind secure modal/, async (button) => {
 });
 
 When(/^I select remind me later on secure wallet screen/, async () => {
-  await CreateNewWalletScreen.selectRemindMeLater();
+  await CreateNewWalletScreen.tapRemindMeLater();
 });
 
 When(/^secure wallet page is presented/, async () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Tapping remind me later was changed but not updated in step file.  Fixed now.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
