### PR TITLE
[FIX] Settings networks icons were missing

### DIFF
--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -15,6 +15,7 @@ import { fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import Networks, {
   getAllNetworks,
+  getNetworkImageSource,
   isSafeChainId,
 } from '../../../util/networks';
 import { connect } from 'react-redux';
@@ -27,19 +28,19 @@ import { ThemeContext, mockTheme } from '../../../util/theme';
 import { MAINNET, RPC, PRIVATENETWORK } from '../../../constants/network';
 import { ETH } from '../../../util/custom-gas';
 import sanitizeUrl from '../../../util/sanitizeUrl';
-import getImage from '../../../util/getImage';
 import {
   NETWORK_LIST_CLOSE_ICON,
   NETWORK_LIST_MODAL_CONTAINER_ID,
   NETWORK_SCROLL_ID,
 } from '../../../../wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds';
 import ImageIcon from '../ImageIcon';
-import Avatar, {
+import {
   AvatarVariants,
   AvatarSize,
 } from '../../../component-library/components/Avatars/Avatar';
 import { ADD_NETWORK_BUTTON } from '../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
 import generateTestId from '../../../../wdio/utils/generateTestId';
+import AvatarNetwork from '../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -286,17 +287,15 @@ export class NetworkList extends PureComponent {
         >
           {selected}
         </View>
-        {isCustomRpc &&
-          // TODO - Refactor to use only AvatarNetwork with getNetworkImageSource
-          (image ? (
-            <Avatar
-              variant={AvatarVariants.Network}
-              name={name}
-              imageSource={image}
-              style={styles.networkIcon}
-              size={AvatarSize.Xs}
-            />
-          ) : null)}
+        {isCustomRpc && (
+          <AvatarNetwork
+            variant={AvatarVariants.Network}
+            name={name}
+            imageSource={image}
+            style={styles.networkIcon}
+            size={AvatarSize.Xs}
+          />
+        )}
         {!isCustomRpc &&
           (image ? (
             <ImageIcon
@@ -347,7 +346,7 @@ export class NetworkList extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     return frequentRpcList.map(({ nickname, rpcUrl, chainId }, i) => {
       const { name } = { name: nickname || rpcUrl, chainId, color: null };
-      const image = getImage(chainId);
+      const image = getNetworkImageSource({ chainId });
       const isCustomRpc = true;
       const rpcTargetHref =
         provider.rpcTarget && new URL(provider.rpcTarget)?.href;

--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -287,7 +287,7 @@ export class NetworkList extends PureComponent {
         >
           {selected}
         </View>
-        {isCustomRpc && (
+        {isCustomRpc ? (
           <AvatarNetwork
             variant={AvatarVariants.Network}
             name={name}
@@ -295,7 +295,7 @@ export class NetworkList extends PureComponent {
             style={styles.networkIcon}
             size={AvatarSize.Xs}
           />
-        )}
+        ) : null}
         {!isCustomRpc &&
           (image ? (
             <ImageIcon

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -15,20 +15,24 @@ import { fontStyles } from '../../../../styles/common';
 import CustomText from '../../../../components/Base/Text';
 import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import { strings } from '../../../../../locales/i18n';
-import Networks, { getAllNetworks, isMainNet } from '../../../../util/networks';
+import Networks, {
+  getAllNetworks,
+  getNetworkImageSource,
+  isMainNet,
+} from '../../../../util/networks';
 import StyledButton from '../../../UI/StyledButton';
 import Engine from '../../../../core/Engine';
-import getImage from '../../../../util/getImage';
 import { MAINNET, RPC } from '../../../../constants/network';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import ImageIcons from '../../../UI/ImageIcon';
 import { ADD_NETWORK_BUTTON } from '../../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
 import { compareSanitizedUrl } from '../../../../util/sanitizeUrl';
-import Avatar, {
+import {
   AvatarSize,
   AvatarVariants,
 } from '../../../../component-library/components/Avatars/Avatar';
+import AvatarNetwork from '../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -214,18 +218,15 @@ class NetworksSettings extends PureComponent {
               testID={'select-network'}
             >
               <View style={styles.network}>
-                {isCustomRPC &&
-                  // TODO - Refactor to use only AvatarNetwork with getNetworkImageSource
-                  (image ? (
-                    <ImageIcons image={image} style={styles.networkIcon} />
-                  ) : (
-                    <Avatar
-                      variant={AvatarVariants.Network}
-                      name={name}
-                      style={styles.networkIcon}
-                      size={AvatarSize.Xs}
-                    />
-                  ))}
+                {isCustomRPC && (
+                  <AvatarNetwork
+                    variant={AvatarVariants.Network}
+                    name={name}
+                    imageSource={image}
+                    style={styles.networkIcon}
+                    size={AvatarSize.Xs}
+                  />
+                )}
                 {!isCustomRPC &&
                   (image ? (
                     <ImageIcons
@@ -267,7 +268,7 @@ class NetworksSettings extends PureComponent {
     const { frequentRpcList } = this.props;
     return frequentRpcList.map(({ rpcUrl, nickname, chainId }, i) => {
       const { name } = { name: nickname || rpcUrl };
-      const image = getImage(chainId);
+      const image = getNetworkImageSource({ chainId });
       return this.networkElement(name, image, i, rpcUrl, true);
     });
   };
@@ -350,7 +351,7 @@ class NetworksSettings extends PureComponent {
     if (this.state.filteredNetworks.length > 0) {
       return this.state.filteredNetworks.map((data, i) => {
         const { network, chainId, name, color, isCustomRPC } = data;
-        const image = getImage(chainId);
+        const image = getNetworkImageSource(chainId);
         return this.networkElement(
           name,
           image || color,

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -218,7 +218,7 @@ class NetworksSettings extends PureComponent {
               testID={'select-network'}
             >
               <View style={styles.network}>
-                {isCustomRPC && (
+                {isCustomRPC ? (
                   <AvatarNetwork
                     variant={AvatarVariants.Network}
                     name={name}
@@ -226,7 +226,7 @@ class NetworksSettings extends PureComponent {
                     style={styles.networkIcon}
                     size={AvatarSize.Xs}
                   />
-                )}
+                ) : null}
                 {!isCustomRPC &&
                   (image ? (
                     <ImageIcons


### PR DESCRIPTION
**Description**
Networks icons were missing on the Networks list on the settings list.

**Proposed Solution**
Now the icons appear on the network settings

**Technical**
Refactor done to use the `AvatarNetwork` component and `getNetworkImageSource`  method

**Test Cases**
 * Added avalanche network
 * Opened network list (icons expected to be there)
 * Open settings -> Networks
 * Expected to the icon of the avalanche network be there
 * [Added gnosis chain network](https://docs.gnosischain.com/tools/wallets/metamask/)
 * Check if the network icon are on Network popular list and on Settings -> Networks

**Screenshots/Recordings**
https://recordit.co/AwXJ8Xe1eo


**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/634

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
