### PR TITLE
[FIX] Updated ButtonBase to use flex-start instead of baseline

### DIFF
--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
@@ -19,7 +19,7 @@ const styleSheet = (params: { theme: Theme; vars: any }) => {
   let widthObject;
   switch (width) {
     case ButtonWidthTypes.Auto:
-      widthObject = { alignSelf: 'baseline' };
+      widthObject = { alignSelf: 'flex-start' };
       break;
     case ButtonWidthTypes.Full:
       widthObject = { alignSelf: 'stretch' };

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ButtonBase should render correctly 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "alignSelf": "baseline",
+      "alignSelf": "flex-start",
       "backgroundColor": "#F2F4F6",
       "borderRadius": 20,
       "flexDirection": "row",


### PR DESCRIPTION
**Description**

Updated ButtonBase to not use 'baseline' due to ReactNative's yoga's 'baseline' function still being unstable. Updated to use 'flex-start' instead.
