### PR TITLE
[FIX] Importing private key via QR code redirects to browser

### DIFF
--- a/app/components/Views/ImportPrivateKeySuccess/index.js
+++ b/app/components/Views/ImportPrivateKeySuccess/index.js
@@ -109,7 +109,7 @@ class ImportPrivateKeySuccess extends PureComponent {
 
   dismiss = () => {
     this.props.navigation.popToTop();
-    this.props.navigation.goBack(null);
+    this.props.navigation.canGoBack() && this.props.navigation.goBack(null);
   };
 
   render() {

--- a/app/components/Views/ImportPrivateKeySuccess/index.js
+++ b/app/components/Views/ImportPrivateKeySuccess/index.js
@@ -108,8 +108,9 @@ class ImportPrivateKeySuccess extends PureComponent {
   };
 
   dismiss = () => {
-    this.props.navigation.popToTop();
-    this.props.navigation.canGoBack() && this.props.navigation.goBack(null);
+    const { popToTop, canGoBack, goBack } = this.props.navigation;
+    popToTop();
+    canGoBack() && goBack(null);
   };
 
   render() {


### PR DESCRIPTION
**Description**
*Only tested on android*
When it was imported an account (private key) via QR code, closing the "successful screen" is redirecting to the browser tab.

**Proposed solution**
On dev mode was an error being prompted `The action GO_BACK was not handled by any navigator` and it's fixed, the browser never appeared again on android after importing an account with private key qr code

**Screenshots/Recordings**
No recording because of privacy content

**Test Cases**
(Only tested on Android)
* Open qr code scanner on wallet view (up right corner)
* import wallet with their private key
* Close successful import screen
* Expect to land on wallet view

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses # https://github.com/MetaMask/mobile-planning/issues/633

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
