### PR TITLE
[ENHANCEMENT] add e2e tests announcement on Slack

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -151,6 +151,11 @@ workflows:
                 #!/usr/bin/env bash echo 'weew - everything passed!'
           title: All Tests Passed
           is_always_run: false
+      - yarn@0:
+          inputs:
+            - command: e2e:announce
+          title: Announcing e2e tests result
+          is_always_run: true
   # Parallel Build & Deploy Steps
   create_release_builds:
     before_run:
@@ -193,7 +198,7 @@ workflows:
       - yarn@0:
           inputs:
             - command: build:announce
-          title: Accouncing pre-release
+          title: Announcing pre-release
           is_always_run: false
   create_qa_builds:
     before_run:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start:android:e2e": "./scripts/build.sh android debugE2E",
     "build:static-logos": "node ./scripts/metamask-bot-build-generate-static-assets",
     "build:announce": "node ./scripts/metamask-bot-build-announce-bitrise.js",
+    "e2e:announce": "node ./scripts/metamask-bot-e2e-announce-bitrise.js",
     "build:android:release": "./scripts/build.sh android release",
     "build:android:release:e2e": "./scripts/build.sh android releaseE2E",
     "build:android:qa:e2e": "./scripts/build.sh android QAE2E",

--- a/scripts/metamask-bot-e2e-announce-bitrise.js
+++ b/scripts/metamask-bot-e2e-announce-bitrise.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// eslint-disable-next-line import/no-commonjs
+const axios = require('axios');
+
+const SLACK_TOKEN = process.env.MM_SLACK_TOKEN;
+const SLACK_SECRET = process.env.MM_SLACK_SECRET;
+const SLACK_ROOM = process.env.MM_SLACK_ROOM;
+const BITRISE_GIT_COMMIT = process.env.BITRISE_GIT_COMMIT;
+const BITRISE_GIT_COMMIT_MESSAGE = process.env.BITRISE_GIT_MESSAGE;
+const E2E_SUCCESS = process.env.BITRISE_BUILD_STATUS || false;
+const BITRISE_BUILD_URL = process.env.BITRISE_BUILD_URL;
+const BITRISE_BUILD_NUMBER = process.env.BITRISE_BUILD_NUMBER;
+const GIT_REPOSITORY_URL = 'https://github.com/MetaMask/metamask-mobile';
+const BITRISE_APP_TITLE = process.env.BITRISE_APP_TITLE;
+
+start().catch(console.error);
+
+async function start() {
+  const content = {
+    text: `*${
+      E2E_SUCCESS === '0'
+        ? ':large_green_circle: SUCCESSFUL'
+        : ':red_circle: FAILED'
+    } E2E tests* for ${BITRISE_APP_TITLE} <${BITRISE_BUILD_URL}|build #${BITRISE_BUILD_NUMBER}>`,
+    attachments: [
+      {
+        title_link: `${GIT_REPOSITORY_URL}/commit/${BITRISE_GIT_COMMIT}`,
+        title: `commit #${BITRISE_GIT_COMMIT}`,
+        text: BITRISE_GIT_COMMIT_MESSAGE,
+      },
+    ],
+  };
+
+  const JSON_PAYLOAD = JSON.stringify(content);
+  const SLACK_API_URI = `https://hooks.slack.com/services/${SLACK_TOKEN}/${SLACK_SECRET}/${SLACK_ROOM}`;
+
+  const headers = {
+    'Content-type': 'application/json',
+  };
+  await axios.post(SLACK_API_URI, JSON_PAYLOAD, { headers });
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
metamask/mobile-planning#446 requires to have notifications on e2e test result
_2. What is the improvement/solution?_
- add notification for e2e tests results (success or failure) in the Bitrise workflow
  - add JS script to send message on the Slack legacy webhook
  - add package.json script for running this task
  - add step in e2e test workflow in bitrise.yml
  - test all this locally and on Bitrise on a separate test account (see screenshots)
- non related typo fix on announcement steps 'Accouncing pre-release' in bitrise.yml 

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

Tested on my own Bitrise account with test repo:

**Test `bitrise.yml` workflow**

```yaml
---
format_version: '8'
project_type: other
default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
workflows:
  slack-annouce-test:fi
    steps:
      - activate-ssh-key@4:
          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
      - git-clone@6: {}
      - yarn@0:
          inputs:
            - command: install
          title: Intalling deps
      - script@1:
          inputs:
            - content: |
                #!/bin/bash
                echo 'weew - everything passed!'
          title: All Tests Passed
          is_always_run: false
      - yarn@0:
          inputs:
            - command: e2e:announce
          title: Announcing e2e tests result
          is_always_run: true
      - script@1:
          inputs:
            - content: |
                #!/bin/bash
                echo 'fail!'
                exit 1
          title: All Tests Failed
          is_always_run: false
      - yarn@0:
          inputs:
            - command: e2e:announce
          title: Announcing e2e tests result
          is_always_run: true


trigger_map:
- push_branch: main
  workflow: slack-annouce-test
```

Resulting in:

![image](https://user-images.githubusercontent.com/4677568/217361326-575e2d79-222a-4f8a-b471-2bbe5ef0df30.png)

The messages in Slack looks like this

<img width="731" alt="image" src="https://user-images.githubusercontent.com/4677568/217362352-40a81a73-4152-4809-9d7d-a58b173f892f.png">


**Issue**

fixes metamask/mobile-planning#446

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
