### PR TITLE
[FIX] Minor UI bugs in credential views

### DIFF
--- a/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
+++ b/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
@@ -69,7 +69,8 @@ const SRPQuiz = () => {
     AnalyticsV2.trackEvent(MetaMetricsEvents.REVEAL_SRP_INITIATED, {});
     AnalyticsV2.trackEvent(MetaMetricsEvents.REVEAL_SRP_CTA, {});
     navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-      privateCredentialName: 'seed_phrase',
+      credentialName: 'seed_phrase',
+      hasNavigation: true,
     });
   }, [navigation]);
 

--- a/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
+++ b/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
@@ -291,7 +291,7 @@ const SRPQuiz = () => {
           {
             label: strings('srp_security_quiz.try_again'),
             onPress: () => setStage(QuizStage.questionTwo),
-            variant: ButtonVariants.Link,
+            variant: ButtonVariants.Primary,
           },
           {
             label: strings('srp_security_quiz.learn_more'),

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -103,7 +103,7 @@ const RevealPrivateCredential = ({
   };
 
   const isPrivateKey = () => {
-    const credential = credentialName || route.params.privateCredentialName;
+    const credential = credentialName || route.params.credentialName;
     return credential === PRIVATE_KEY;
   };
 

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -83,19 +83,16 @@ const RevealPrivateCredential = ({
   const { colors, themeAppearance } = useTheme();
   const styles = createStyles(colors);
 
-  const privateCredentialName =
-    credentialName || route.params.privateCredentialName;
+  const privateCredentialName = credentialName || route.params.credentialName;
 
   const updateNavBar = () => {
-    if (!hasNavigation) {
+    if (!hasNavigation && !route.params?.hasNavigation) {
       return;
     }
     navigation.setOptions(
       getNavigationOptionsTitle(
         strings(
-          `reveal_credential.${
-            route.params?.privateCredentialName ?? ''
-          }_title`,
+          `reveal_credential.${route.params?.credentialName ?? ''}_title`,
         ),
         navigation,
         false,

--- a/app/components/Views/Settings/SecuritySettings/Sections/ProtectYourWallet/styles.ts
+++ b/app/components/Views/Settings/SecuritySettings/Sections/ProtectYourWallet/styles.ts
@@ -55,5 +55,6 @@ export const createStyles = (colors: any) =>
     },
     confirm: {
       marginTop: 18,
+      width: '100%',
     },
   });

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -517,7 +517,8 @@ class Settings extends PureComponent {
   goToExportPrivateKey = () => {
     AnalyticsV2.trackEvent(MetaMetricsEvents.REVEAL_PRIVATE_KEY_INITIATED);
     this.props.navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-      privateCredentialName: 'private_key',
+      credentialName: 'private_key',
+      hasNavigation: true,
     });
   };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off
-->

**Description**

The credential views (SRP & Private key) have several UI bugs. This PR solves three of them,

- Button "Reveal Secret Recovery Phrase" wrong width

<img src="https://user-images.githubusercontent.com/17601467/217419029-3d40bab5-ba98-4541-84ef-f8d936cbbc03.png" width="300" /> <img src="https://user-images.githubusercontent.com/17601467/217420449-b2d4b983-e5e2-4d7d-9b64-209adb757cb2.png" width="300" />

- SRP Quiz wrong button variant

<img src="https://user-images.githubusercontent.com/17601467/217552865-3f2b96c9-afc2-4996-87f9-b24177c81909.png" width="300" /> <img src="https://user-images.githubusercontent.com/17601467/217553528-0c755e9d-24d8-4119-ae21-8c323a4782e7.png" width="300" />


- Views title

<img src="https://user-images.githubusercontent.com/17601467/217422254-985d8bde-f166-438c-9b8d-857bc9282f78.png" width="300" /> <img src="https://user-images.githubusercontent.com/17601467/217553626-200eaa7f-57f9-4ded-9211-8bed101d725f.png" width="300" />

**Screenshots/Recordings**

Images above

**Issue**

Progresses #X

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
