### PR TITLE
[FIX] TabBar: pass itemText with translated label

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -24,6 +24,9 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
       const { options } = descriptors[route.key];
       const label = options.tabBarLabel as TabBarLabel;
       //TODO: use another option on add it to the prop interface
+      // Since we can't use label to translate text because it is being used to index tab icon
+      const itemText = options.itemText as string;
+      //TODO: use another option on add it to the prop interface
       const callback = options.callback;
       const key = `tab-bar-item-${label}`;
       const isSelected = state.index === index;
@@ -39,7 +42,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
         <TabBarItem
           key={key}
           isSelected={isSelected}
-          label={label}
+          label={itemText}
           icon={icon}
           onPress={onPress}
           {...generateTestId(Platform, key)}

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -67,6 +67,7 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import { getActiveTabUrl } from '../../../util/transactions';
 import { getPermittedAccountsByHostname } from '../../../core/Permissions';
 import { isEqual } from 'lodash';
+import { strings } from '../../../../locales/i18n';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -236,6 +237,7 @@ const HomeTabs = () => {
   const options = {
     home: {
       tabBarLabel: 'Wallet',
+      itemText: strings('bottom_tab_bar.wallet'),
       callback: () => {
         AnalyticsV2.trackEvent(MetaMetricsEvents.WALLET_OPENED, {
           number_of_accounts: accountsLength,
@@ -245,6 +247,7 @@ const HomeTabs = () => {
     },
     browser: {
       tabBarLabel: 'Browser',
+      itemText: strings('drawer.browser'),
       callback: () => {
         AnalyticsV2.trackEvent(MetaMetricsEvents.BROWSER_OPENED, {
           number_of_accounts: accountsLength,


### PR DESCRIPTION
**Description**

Add new property `itemText` to TabBar options object. We can't translate `label` value because it is used to index the tab icon

this fixes https://github.com/MetaMask/mobile-planning/issues/641
