### PR TITLE
[FIX] NetworkInfo network name casing

### DIFF
--- a/app/components/UI/NetworkInfo/index.tsx
+++ b/app/components/UI/NetworkInfo/index.tsx
@@ -162,6 +162,11 @@ const NetworkInfo = (props: NetworkInfoProps) => {
     [networkProvider],
   );
 
+  const getCapitalizeNetworkName = (networkName: string) => {
+    const firstLetterUppercase = networkName.charAt(0).toUpperCase();
+    return `${firstLetterUppercase}${networkName.slice(1)}`;
+  };
+
   const getNetworkName = useCallback(() => {
     let networkName = '';
     if (ticker === undefined) {
@@ -177,7 +182,7 @@ const NetworkInfo = (props: NetworkInfoProps) => {
               type,
             })}`;
     }
-    return type === RPC ? networkName : networkName.toUpperCase();
+    return type === RPC ? networkName : getCapitalizeNetworkName(networkName);
   }, [ticker, type, isMainnet, nickname]);
 
   const networkName = getNetworkName();
@@ -199,7 +204,7 @@ const NetworkInfo = (props: NetworkInfoProps) => {
               imageSource={networkImageSource}
             />
             <Text
-              style={[styles.tokenText, styles.capitalizeText]}
+              style={styles.tokenText}
               testID={NETWORK_EDUCATION_MODAL_NETWORK_NAME_ID}
             >
               {networkName}

--- a/app/components/UI/NetworkInfo/index.tsx
+++ b/app/components/UI/NetworkInfo/index.tsx
@@ -21,6 +21,7 @@ import {
 import Avatar, {
   AvatarVariants,
 } from '../../../component-library/components/Avatars/Avatar';
+import { getCapitalizedString } from '../../../util/strings';
 
 const createStyles = (colors: {
   background: { default: string };
@@ -162,11 +163,6 @@ const NetworkInfo = (props: NetworkInfoProps) => {
     [networkProvider],
   );
 
-  const getCapitalizeNetworkName = (networkName: string) => {
-    const firstLetterUppercase = networkName.charAt(0).toUpperCase();
-    return `${firstLetterUppercase}${networkName.slice(1)}`;
-  };
-
   const getNetworkName = useCallback(() => {
     let networkName = '';
     if (ticker === undefined) {
@@ -182,7 +178,7 @@ const NetworkInfo = (props: NetworkInfoProps) => {
               type,
             })}`;
     }
-    return type === RPC ? networkName : getCapitalizeNetworkName(networkName);
+    return type === RPC ? networkName : getCapitalizedString(networkName);
   }, [ticker, type, isMainnet, nickname]);
 
   const networkName = getNetworkName();

--- a/app/util/strings.test.ts
+++ b/app/util/strings.test.ts
@@ -1,0 +1,23 @@
+import { getCapitalizedString } from './strings';
+
+describe('getCapitalizedString', () => {
+  const lowercaseString = 'thisisateststring';
+  const lowercaseStringWithSpaces = 'this is a test string';
+  const uppercaseString = 'THISISATESTSTRING';
+  const uppercaseStringWithSpaces = 'THIS IS A TEST STRING';
+
+  const capitalizedString = 'Thisisateststring';
+  const capitalizedStringWithSpaces = 'This is a test string';
+  it('should capitalize a lowercase string without spaces', () =>
+    expect(getCapitalizedString(lowercaseString)).toBe(capitalizedString));
+  it('should capitalize a lowercase string with spaces', () =>
+    expect(getCapitalizedString(lowercaseStringWithSpaces)).toBe(
+      capitalizedStringWithSpaces,
+    ));
+  it('should capitalize a UPPERCASE string without spaces', () =>
+    expect(getCapitalizedString(uppercaseString)).toBe(capitalizedString));
+  it('should capitalize a UPPERCASE string with spaces', () =>
+    expect(getCapitalizedString(uppercaseStringWithSpaces)).toBe(
+      capitalizedStringWithSpaces,
+    ));
+});

--- a/app/util/strings.ts
+++ b/app/util/strings.ts
@@ -1,0 +1,13 @@
+/**
+ * Takes a string as input and transforms it into a capitalized string
+ *
+ * @param inputString string to be transformed
+ * @returns capitalized
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const getCapitalizedString = (inputString: string) => {
+  const lowCaseString = inputString.toLowerCase();
+  const upperCaseFirstLetter = lowCaseString.charAt(0).toUpperCase();
+
+  return `${upperCaseFirstLetter}${lowCaseString.slice(1)}`;
+};

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "**/json-schema": "^0.4.0",
     "@sentry/react-native/**/xmldom": "^0.6.0",
     "@sentry/**/simple-plist": "^1.3.1",
+    "@sideway/formula": "3.0.1",
     "react-native/**/simple-plist": "^1.3.1",
     "react-native-svg/**/nth-check": "^2.0.1",
     "**/set-value": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4844,10 +4844,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@sideway/formula@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
-  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+"@sideway/formula@3.0.1", "@sideway/formula@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
 
 "@sideway/pinpoint@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
**Description**

Change how a network name case is manipulated. Now it will only capitalize network names that are not `type === RPC`

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/639
