### PR TITLE
[FIX] Back navigation CTAs in RevealPrivateCredential view

### DIFF
--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -175,7 +175,7 @@ const RevealPrivateCredential = ({
   }, []);
 
   const navigateBack = () => {
-    hasNavigation && navigation.pop();
+    if (hasNavigation || route.params?.hasNavigation) navigation.pop();
   };
 
   const cancelReveal = () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off
-->

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_

The CTAs `Done` and `Cancel` have a bug where the navigation is disabled. This PR updates the condition and enable the navigation back.

**Screenshots/Recordings**

https://user-images.githubusercontent.com/17601467/217998526-08bf5362-e9b2-4bb7-a6f0-b76cf4d91fc7.mov

**Issue**

Progresses https://github.com/MetaMask/metamask-mobile/issues/5745

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
