### PR TITLE
[FIX] fix Slack e2e announcement

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -134,6 +134,8 @@ workflows:
           title: Detox Build & Test
           is_always_run: false
   start_e2e_tests:
+    before_run:
+      - code_setup_cache
     steps:
       - build-router-start@0:
           inputs:


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
Hard to test before running in prod, the `start_e2e_tests` workflow announcement step fails because of workflow not cloning the repo.
_2. What is the improvement/solution?_
Add `code_setup_cache` workflow in the `before_run` of `start_e2e_tests` workflow

**Issue**

fixes MetaMask/mobile-planning#643

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
