### PR TITLE
[FIX]  Keystone transaction with account balance empty

### DIFF
--- a/app/components/UI/QRHardware/QRSigningModal/index.tsx
+++ b/app/components/UI/QRHardware/QRSigningModal/index.tsx
@@ -41,7 +41,10 @@ const QRSigningModal = ({
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const [isModalCompleteShow, setModalCompleteShow] = useState(false);
-  const { from } = useSelector(getNormalizedTxState);
+  const selectedAddress = useSelector(
+    (state: any) =>
+      state.engine.backgroundState.PreferencesController.selectedAddress,
+  );
 
   return (
     <Modal
@@ -73,7 +76,7 @@ const QRSigningModal = ({
           cancelCallback={onCancel}
           failureCallback={onFailure}
           bypassAndroidCameraAccessCheck={false}
-          fromAddress={from}
+          fromAddress={selectedAddress}
         />
       </View>
     </Modal>


### PR DESCRIPTION
**Description**
The top of the approval modal for a keystone transaction has artifacts related to the account balance

**Screenshots/Recordings**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/218191308-9266d926-f566-49b3-b66c-e50b8b0563a6.png">

Test cases: 
* Bind your keystone device
* Attempt to perform a swap with tokens you never swapped before. (This step is important)
* On the swaps confirmation view, edit your spend limit. Set it to a custom amount like 5 or something.
* Go ahead with the swap.
* Notice the approval modal appears. The balance it's correct

**Issue**

Progresses #


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
