### PR TITLE
[FIX]  Keystone transaction with account balance empty

### DIFF
--- a/app/components/UI/QRHardware/QRSigningModal/index.tsx
+++ b/app/components/UI/QRHardware/QRSigningModal/index.tsx
@@ -4,8 +4,9 @@ import { IQRState } from '../types';
 import { StyleSheet, View } from 'react-native';
 import QRSigningDetails from '../QRSigningDetails';
 import { useTheme } from '../../../../util/theme';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getNormalizedTxState } from '../../../../util/transactions';
+import { resetTransaction } from '../../../../actions/transaction';
 
 interface IQRSigningModalProps {
   isVisible: boolean;
@@ -39,9 +40,24 @@ const QRSigningModal = ({
   onFailure,
 }: IQRSigningModalProps) => {
   const { colors } = useTheme();
+  const dispatch = useDispatch();
   const styles = createStyles(colors);
   const [isModalCompleteShow, setModalCompleteShow] = useState(false);
   const { from } = useSelector(getNormalizedTxState);
+
+  const handleCancel = () => {
+    onCancel?.();
+    dispatch(resetTransaction());
+  };
+  const handleSuccess = () => {
+    onSuccess?.();
+    dispatch(resetTransaction());
+  };
+
+  const handleFailure = () => {
+    onFailure?.();
+    dispatch(resetTransaction());
+  };
 
   return (
     <Modal
@@ -69,9 +85,9 @@ const QRSigningModal = ({
           tighten
           showHint
           shouldStartAnimated={isModalCompleteShow}
-          successCallback={onSuccess}
-          cancelCallback={onCancel}
-          failureCallback={onFailure}
+          successCallback={handleSuccess}
+          cancelCallback={handleCancel}
+          failureCallback={handleFailure}
           bypassAndroidCameraAccessCheck={false}
           fromAddress={from}
         />

--- a/app/components/UI/QRHardware/QRSigningModal/index.tsx
+++ b/app/components/UI/QRHardware/QRSigningModal/index.tsx
@@ -54,8 +54,8 @@ const QRSigningModal = ({
     dispatch(resetTransaction());
   };
 
-  const handleFailure = () => {
-    onFailure?.();
+  const handleFailure = (error: string) => {
+    onFailure?.(error);
     dispatch(resetTransaction());
   };
 

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -933,6 +933,9 @@ function SwapsQuotesView({
       selectedQuote,
       sourceToken,
       updateSwapsTransactions,
+      selectedAddress,
+      setRecipient,
+      resetTransaction,
     ],
   );
 

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -900,6 +900,7 @@ function SwapsQuotesView({
       }
 
       try {
+        resetTransaction();
         const { transactionMeta } = await TransactionController.addTransaction(
           {
             ...selectedQuote.trade,
@@ -917,7 +918,7 @@ function SwapsQuotesView({
           approvalTransactionMetaId,
           newSwapsTransactions,
         );
-
+        setRecipient(selectedAddress);
         await addTokenToAssetsController(destinationToken);
         await addTokenToAssetsController(sourceToken);
       } catch (e) {

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -78,6 +78,7 @@ import FadeAnimationView from '../FadeAnimationView';
 import Logger from '../../../util/Logger';
 import { useTheme } from '../../../util/theme';
 import { isQRHardwareAccount } from '../../../util/address';
+import { resetTransaction, setRecipient } from '../../../actions/transaction';
 
 const POLLING_INTERVAL = 30000;
 const SLIPPAGE_BUCKETS = {
@@ -364,6 +365,8 @@ function SwapsQuotesView({
   gasFeeEstimates,
   usedGasEstimate,
   usedCustomGas,
+  setRecipient,
+  resetTransaction,
 }) {
   const navigation = useNavigation();
   /* Get params from navigation */
@@ -914,6 +917,7 @@ function SwapsQuotesView({
           approvalTransactionMetaId,
           newSwapsTransactions,
         );
+
         await addTokenToAssetsController(destinationToken);
         await addTokenToAssetsController(sourceToken);
       } catch (e) {
@@ -939,6 +943,7 @@ function SwapsQuotesView({
       isHardwareAccount,
     ) => {
       try {
+        resetTransaction();
         const { transactionMeta } = await TransactionController.addTransaction(
           {
             ...approvalTransaction,
@@ -950,6 +955,9 @@ function SwapsQuotesView({
           process.env.MM_FOX_CODE,
           WalletDevice.MM_MOBILE,
         );
+
+        setRecipient(selectedAddress);
+
         approvalTransactionMetaId = transactionMeta.id;
         newSwapsTransactions[transactionMeta.id] = {
           action: 'approval',
@@ -989,6 +997,9 @@ function SwapsQuotesView({
       handleSwapTransaction,
       sourceToken.address,
       sourceToken.decimals,
+      selectedAddress,
+      setRecipient,
+      resetTransaction,
     ],
   );
 
@@ -2315,6 +2326,8 @@ SwapsQuotesView.propTypes = {
   gasFeeEstimates: PropTypes.object,
   usedGasEstimate: PropTypes.object,
   usedCustomGas: PropTypes.object,
+  setRecipient: PropTypes.func,
+  resetTransaction: PropTypes.func,
 };
 
 const mapStateToProps = (state) => ({
@@ -2354,4 +2367,9 @@ const mapStateToProps = (state) => ({
   swapsTokens: swapsTokensSelector(state),
 });
 
-export default connect(mapStateToProps)(SwapsQuotesView);
+const mapDispatchToProps = (dispatch) => ({
+  setRecipient: (from) => dispatch(setRecipient(from, '', '', '', '')),
+  resetTransaction: () => dispatch(resetTransaction()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SwapsQuotesView);


### PR DESCRIPTION
**Description**
The top of the approval modal for a keystone transaction has artifacts related to the account balance

**Screenshots/Recordings**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/218191308-9266d926-f566-49b3-b66c-e50b8b0563a6.png">

Test cases: 
* Bind your keystone device
* Attempt to perform a swap with tokens you never swapped before. (This step is important)
* On the swaps confirmation view, edit your spend limit. Set it to a custom amount like 5 or something.
* Go ahead with the swap.
* Notice the approval modal appears. The balance it's correct

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
