### PR TITLE
Set different CPU capacity in jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ const config = {
   coveragePathIgnorePatterns: ['/node_modules/', '__mocks__', '<rootDir>/e2e/'],
   coverageReporters: ['text-summary', 'lcov'],
   coverageDirectory: '<rootDir>/tests/coverage',
-  maxWorkers: process.env.NODE_ENV !== 'production' ? '25%' : '50%',
+  maxWorkers: process.env.NODE_ENV !== 'production' ? '25%' : '100%',
 };
 
 // eslint-disable-next-line import/no-commonjs

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ const config = {
   coveragePathIgnorePatterns: ['/node_modules/', '__mocks__', '<rootDir>/e2e/'],
   coverageReporters: ['text-summary', 'lcov'],
   coverageDirectory: '<rootDir>/tests/coverage',
+  maxWorkers: process.env.NODE_ENV !== 'production' ? '25%' : '50%',
 };
 
 // eslint-disable-next-line import/no-commonjs


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
_1. What is the reason for the change?_
Fix memory leaks when running tests on machines with high numbers of CPUs.

_2. What is the improvement/solution?_
Reduce to 25% of the available CPUs in development, this changes the jest default of 100%, for example, an Apple M1 Pro (10 cores) to spin that number of cores minus one (main thread) in test instances increasing memory usage exponentially. This doesn’t happen on CI because those servers are usually like 1-2 vCPUs, using way less memory.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/477

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
