### PR TITLE
[IMPROVEMENT] Move PhishingController logic to browser tab

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -83,6 +83,7 @@ import {
   RELOAD_OPTION,
   SHARE_OPTION,
 } from '../../../../wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds';
+import { PhishingController } from '@metamask/phishing-controller';
 
 const { HOMEPAGE_URL, NOTIFICATION_NAMES } = AppConstants;
 const HOMEPAGE_HOST = new URL(HOMEPAGE_URL)?.hostname;
@@ -396,17 +397,16 @@ export const BrowserTab = (props) => {
    * Check if a hostname is allowed
    */
   const isAllowedUrl = useCallback((hostname) => {
-    const { PhishingController } = Engine.context;
-
+    const phishingController = new PhishingController();
     // Update phishing configuration if it is out-of-date
-    const phishingListsAreOutOfDate = PhishingController.isOutOfDate();
+    const phishingListsAreOutOfDate = phishingController.isOutOfDate();
     if (phishingListsAreOutOfDate) {
       // This is async but we are not `await`-ing it here intentionally, so that we don't slow
       // down network requests. The configuration is updated for the next request.
-      PhishingController.updatePhishingLists();
+      phishingController.updatePhishingLists();
     }
 
-    const phishingControllerTestResult = PhishingController.test(hostname);
+    const phishingControllerTestResult = phishingController.test(hostname);
 
     // Only assign the if the hostname is on the block list
     if (phishingControllerTestResult.result)

--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -20,7 +20,6 @@ import {
   TypedMessageManager,
 } from '@metamask/message-manager';
 import { NetworkController } from '@metamask/network-controller';
-import { PhishingController } from '@metamask/phishing-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import {
   Transaction,
@@ -252,9 +251,6 @@ class Engine {
         showApprovalRequest: () => null,
       });
 
-      const phishingController = new PhishingController();
-      phishingController.updatePhishingLists();
-
       const additionalKeyrings = [QRHardwareKeyring];
 
       const getIdentities = () => {
@@ -350,7 +346,6 @@ class Engine {
         new PersonalMessageManager(),
         new MessageManager(),
         networkController,
-        phishingController,
         preferencesController,
         new TokenBalancesController(
           {
@@ -865,7 +860,6 @@ export default {
       PersonalMessageManager,
       NetworkController,
       PreferencesController,
-      PhishingController,
       TokenBalancesController,
       TokenRatesController,
       TransactionController,
@@ -898,7 +892,6 @@ export default {
       KeyringController,
       PersonalMessageManager,
       NetworkController,
-      PhishingController,
       PreferencesController,
       TokenBalancesController,
       TokenRatesController,

--- a/app/core/Engine.test.js
+++ b/app/core/Engine.test.js
@@ -13,7 +13,6 @@ describe('Engine', () => {
     expect(engine.context).toHaveProperty('KeyringController');
     expect(engine.context).toHaveProperty('NetworkController');
     expect(engine.context).toHaveProperty('PersonalMessageManager');
-    expect(engine.context).toHaveProperty('PhishingController');
     expect(engine.context).toHaveProperty('PreferencesController');
     expect(engine.context).toHaveProperty('TokenBalancesController');
     expect(engine.context).toHaveProperty('TokenRatesController');

--- a/app/core/EngineService.ts
+++ b/app/core/EngineService.ts
@@ -30,7 +30,6 @@ class EngineService {
       { name: 'KeyringController' },
       { name: 'AccountTrackerController' },
       { name: 'NetworkController' },
-      { name: 'PhishingController' },
       { name: 'PreferencesController' },
       { name: 'TokenBalancesController' },
       { name: 'TokenRatesController' },

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -61,12 +61,8 @@ const MigratedStorage = {
  */
 const persistTransform = createTransform(
   (inboundState) => {
-    const {
-      TokenListController,
-      SwapsController,
-      PhishingController,
-      ...controllers
-    } = inboundState.backgroundState || {};
+    const { TokenListController, SwapsController, ...controllers } =
+      inboundState.backgroundState || {};
     const { tokenList, tokensChainCache, ...persistedTokenListController } =
       TokenListController;
     const {
@@ -79,8 +75,6 @@ const persistTransform = createTransform(
       topAssetsLastFetched,
       ...persistedSwapsController
     } = SwapsController;
-    const { phishing, whitelist, ...persistedPhishingController } =
-      PhishingController;
 
     // Reconstruct data to persist
     const newState = {
@@ -88,7 +82,6 @@ const persistTransform = createTransform(
         ...controllers,
         TokenListController: persistedTokenListController,
         SwapsController: persistedSwapsController,
-        PhishingController: persistedPhishingController,
       },
     };
     return newState;

--- a/app/store/migrations.js
+++ b/app/store/migrations.js
@@ -326,6 +326,10 @@ export const migrations = {
 
     return state;
   },
+  13: (state) => {
+    delete state.engine.backgroundState.PhishingController;
+    return state;
+  },
 };
 
 export const version = 12;

--- a/app/util/logs/index.test.ts
+++ b/app/util/logs/index.test.ts
@@ -20,7 +20,6 @@ describe('logs :: generateStateLogs', () => {
           AssetsContractController: {},
           TokenDetectionController: {},
           NftDetectionController: {},
-          PhishingController: {},
           KeyringController: {
             vault: 'vault mock',
           },
@@ -33,7 +32,6 @@ describe('logs :: generateStateLogs', () => {
     expect(logs.includes('AssetsContractController')).toBe(false);
     expect(logs.includes('TokenDetectionController')).toBe(false);
     expect(logs.includes('NftDetectionController')).toBe(false);
-    expect(logs.includes('PhishingController')).toBe(false);
     expect(logs.includes("vault: 'vault mock'")).toBe(false);
   });
 });

--- a/app/util/logs/index.ts
+++ b/app/util/logs/index.ts
@@ -8,7 +8,6 @@ export const generateStateLogs = (state: any): string => {
   delete fullState.engine.backgroundState.TokensController;
   delete fullState.engine.backgroundState.TokenDetectionController;
   delete fullState.engine.backgroundState.NftDetectionController;
-  delete fullState.engine.backgroundState.PhishingController;
   delete fullState.engine.backgroundState.AssetsContractController;
 
   // Remove encrypted vault from logs


### PR DESCRIPTION
**Description**
To improve the app start time this PR moves the PhishingController logic to the browser tab component.
Also removes the PhishingController from our redux state since it's only needed on the browser tab

**Screenshots/Recordings**
Phishing controller reproduction:
https://recordit.co/DGSeZnZe0T

App start time with qa build without importing account:
https://recordit.co/rPK4BGLM29

App start time with qa build with 3 accounts imported:
https://recordit.co/CuM2u634w7

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/627

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
