### PR TITLE
[IMPROVEMENT] Delete update PhishingController on app start

### DIFF
--- a/app/core/Engine.js
+++ b/app/core/Engine.js
@@ -253,7 +253,6 @@ class Engine {
       });
 
       const phishingController = new PhishingController();
-      phishingController.updatePhishingLists();
 
       const additionalKeyrings = [QRHardwareKeyring];
 


### PR DESCRIPTION
**Description**
To improve the app start time this PR it was deleted the update of phishingListController from the Engine because it was already being done on the BrowserTab component

The difference between 6.0.0 and this one it's small under good network conditions, but definitely will improve with worst network conditions since it's less one endpoint that we call during our app start that loads a good amount of data.

**Screenshots/Recordings**
Phishing controller reproduction:
https://recordit.co/DGSeZnZe0T

App start time with qa build without importing account:
https://recordit.co/81dk9Nvwjf

App start time with qa build with 5 accounts imported:
https://recordit.co/LU8aMJmmeg

Test cases:
* Go to browser
* browse for metamasl.net
* Check the phishing screen

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/627

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
