### PR TITLE
[HOTFIX] Browser: handle unsupported URLs

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -69,6 +69,7 @@ import { getPermittedAccountsByHostname } from '../../../core/Permissions';
 import { TabBarIconKey } from '../../../component-library/components/Navigation/TabBar/TabBar.types';
 import { isEqual } from 'lodash';
 import { strings } from '../../../../locales/i18n';
+import isUrl from 'is-url';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -226,7 +227,7 @@ const HomeTabs = () => {
   /* activeTab: state.browser.activeTab, */
   const activeConnectedDapp = useSelector((state) => {
     const activeTabUrl = getActiveTabUrl(state);
-    if (!activeTabUrl) return [];
+    if (!isUrl(activeTabUrl)) return [];
 
     const permissionsControllerState =
       state.engine.backgroundState.PermissionController;

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
@@ -5,7 +5,6 @@ import { useStyles } from '../../../component-library/hooks';
 import { getURLProtocol } from '../../../util/general';
 import { PROTOCOLS } from '../../../constants/deeplinks';
 import { isGatewayUrl } from '../../../lib/ens-ipfs/resolver';
-import URL from 'url-parse';
 import AppConstants from '../../../core/AppConstants';
 import Icon, {
   IconName,
@@ -17,12 +16,13 @@ import { BrowserUrlBarProps } from './BrowserUrlBar.types';
 import stylesheet from './BrowserUrlBar.styles';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { NAVBAR_TITLE_NETWORK } from '../../../../wdio/screen-objects/testIDs/BrowserScreen/BrowserScreen.testIds';
+import Url from 'url-parse';
 
 const BrowserUrlBar = ({ url, route, onPress }: BrowserUrlBarProps) => {
   const getDappMainUrl = () => {
     if (!url) return;
 
-    const urlObj = new URL(url);
+    const urlObj = new Url(url);
     const ensUrl = route.params?.currentEnsName ?? '';
 
     if (

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
@@ -5,6 +5,7 @@ import { useStyles } from '../../../component-library/hooks';
 import { getURLProtocol } from '../../../util/general';
 import { PROTOCOLS } from '../../../constants/deeplinks';
 import { isGatewayUrl } from '../../../lib/ens-ipfs/resolver';
+import URL from 'url-parse';
 import AppConstants from '../../../core/AppConstants';
 import Icon, {
   IconName,

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -32,7 +32,7 @@ import {
 } from '../../../component-library/components/Toast';
 import { strings } from '../../../../locales/i18n';
 import { AvatarAccountType } from '../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
-
+import URL from 'url-parse';
 import { isEqual } from 'lodash';
 const margin = 16;
 const THUMB_WIDTH = Dimensions.get('window').width / 2 - margin * 2;


### PR DESCRIPTION
**Description**

In-App browser do not handle special URLs (deeplinks like market://details?...)

Change from native URL API to `url-parse` package. 
This allows the app to handle unsupported URLs instead of throwing an error.

**Screenshots/Recordings**

Screen that will appear when the user tries to use a special URL / deeplink inside In-App browser
<img width="387" alt="image" src="https://user-images.githubusercontent.com/1649425/220201130-537e458f-e3d0-4ef2-9751-dc1fa3112713.png">

**Issue**

Progresses #5794 
