### PR TITLE
Consolidate Bitrise setup

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,47 +12,22 @@ workflows:
       - nvm@1.3.0:
           inputs:
             - node_version: '14'
-  code_setup_cache:
-    before_run:
-      - setup
-    steps:
-      - cache-pull@2: {}
-      - yarn@0:
-          inputs:
-            - cache_local_deps: 'yes'
-            - command: setup
-          title: Yarn Setup
-      - yarn@0:
-          title: Lint
-          inputs:
-            - cache_local_deps: 'yes'
-            - command: lint
-      - yarn@0:
-          inputs:
-            - cache_local_deps: 'yes'
-            - command: audit:ci
-          title: Audit Dependencies
-      - cache-push@2: {}
   code_setup:
     before_run:
       - setup
     steps:
       - yarn@0:
           inputs:
-            - cache_local_deps: 'yes'
             - command: setup
           title: Yarn Setup
       - yarn@0:
-          inputs:
-            - cache_local_deps: 'yes'
-            - command: audit:ci
-          title: Audit Dependencies
-      - yarn@0:
           title: Lint
           inputs:
-            - cache_local_deps: 'yes'
             - command: lint
-          is_always_run: true
+      - yarn@0:
+          inputs:
+            - command: audit:ci
+          title: Audit Dependencies
 
   # Notifications utility workflows
   # Provides values for commit or branch message and path depending on commit env setup initialised or not
@@ -141,7 +116,7 @@ workflows:
   # CI Steps
   ci_test:
     before_run:
-      - code_setup_cache
+      - code_setup
     steps:
       - yarn@0:
           inputs:
@@ -236,7 +211,7 @@ workflows:
   # Parallel Build & Deploy Steps
   create_release_builds:
     before_run:
-      - code_setup_cache
+      - code_setup
     steps:
       - build-router-start@0:
           inputs:
@@ -253,7 +228,7 @@ workflows:
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
   release_to_stores:
     before_run:
-      - code_setup_cache
+      - code_setup
     steps:
       - build-router-start@0:
           inputs:
@@ -281,7 +256,7 @@ workflows:
           is_always_run: false
   create_qa_builds:
     before_run:
-      - code_setup_cache
+      - code_setup
     steps:
       - build-router-start@0:
           inputs:
@@ -355,7 +330,7 @@ workflows:
           title: Bitrise Deploy Sourcemaps
   build_android_qa:
     before_run:
-      - code_setup_cache
+      - code_setup
     after_run:
       - _upload_apk_to_browserstack
       - _build_failure_notify_on_slack
@@ -449,7 +424,7 @@ workflows:
                 BROWSERSTACK_TAG_EXPRESSION
   wdio_android_e2e_test:
     before_run:
-      - code_setup_cache
+      - code_setup
     after_run:
       - _e2e_notify_on_slack
     steps:
@@ -495,7 +470,7 @@ workflows:
             - ipa_path: ios/build/output/MetaMask.ipa
   build_ios_release:
     before_run:
-      - code_setup_cache
+      - code_setup
     after_run:
       - _build_failure_notify_on_slack
     steps:
@@ -534,7 +509,7 @@ workflows:
           title: Deploy Source Map
   build_ios_qa:
     before_run:
-      - code_setup_cache
+      - code_setup
     after_run:
       - _build_failure_notify_on_slack
     steps:


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The Bitrise config previously had two "code setup" steps, where Yarn dependencies were installed. They were identical except that one had caching and the other didn't (though the caching was broken, so they were in effect identical).

They have been consolidated into a single step, and the caching has been removed for now.

**Issue**

This was done to make it easier to add [preview build](https://github.com/MetaMask/core/blob/main/docs/contributing.md#using-packages-in-other-projects-during-developmenttesting) support to Bitrise, allowing us to generate QA builds and run e2e tests using preview builds. I don't think there is an issue for this yet, and I'm not sure which work it most directly relates to.

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
