### PR TITLE
Sentry: remove DSN value from codebase

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -19,3 +19,4 @@ export MM_FOX_CODE="EXAMPLE_FOX_CODE"
 
 export MM_INFURA_PROJECT_ID="null"
 export IGNORE_BOXLOGS_DEVELOPMENT="false"
+export MM_SENTRY_DSN=""

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ cd metamask-mobile
   cp .js.env.example .js.env
 ```
 -   _Non-MetaMask Only:_ Create an account and generate your own API key at [Infura](https://infura.io) in order to connect to main and test nets. Fill `MM_INFURA_PROJECT_ID` in `.js.env`. (App will run without it, but will not be able to connect to actual network.)
+- _Non-MetaMask Only:_ Fill `MM_SENTRY_DSN` in `.js.env` if you want the app to emit logs to your own Sentry project.
 
 -   Install the app:
 ```

--- a/app/util/sentryUtils.js
+++ b/app/util/sentryUtils.js
@@ -6,10 +6,6 @@ import DefaultPreference from 'react-native-default-preference';
 import { AGREED, METRICS_OPT_IN } from '../constants/storage';
 
 const METAMASK_ENVIRONMENT = process.env['METAMASK_ENVIRONMENT'] || 'local'; // eslint-disable-line dot-notation
-const SENTRY_DSN_PROD =
-  'https://ae39e4b08d464bba9fbf121c85ccfca0@sentry.io/2299799'; // metamask-mobile
-const SENTRY_DSN_DEV =
-  'https://332890de43e44fe2bc070bb18d0934ea@sentry.io/2651591'; // test-metamask-mobile
 
 const ERROR_URL_ALLOWLIST = [
   'cryptocompare.com',
@@ -156,9 +152,10 @@ function sanitizeAddressesFromErrorMessages(report) {
 // Setup sentry remote error reporting
 export function setupSentry() {
   const init = async () => {
+    const dsn = process.env.MM_SENTRY_DSN;
+
     const environment =
       __DEV__ || !METAMASK_ENVIRONMENT ? 'development' : METAMASK_ENVIRONMENT;
-    const dsn = environment === 'production' ? SENTRY_DSN_PROD : SENTRY_DSN_DEV;
 
     const metricsOptIn = await DefaultPreference.get(METRICS_OPT_IN);
 


### PR DESCRIPTION
**Description**

Remove Sentry DSN from the codebase & load it from environment variables.

Sentry SDK won't send any events when DSN is not defined

For non Metamask developers there's a reference in the README markdown on what to do if they want to log app events on their own Sentry project.

**Issue**

Progresses https://github.com/metamask/mobile-planning/issues/580

