### PR TITLE
[ENHANCEMENT] adding Bitrise workflow for build failure Slack notification [skip ci]

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,13 +6,6 @@ workflows:
   # Code Setups
   setup:
     steps:
-      - script@1: # TODO remove this DEBUG script before final commit
-          is_always_run: true
-          inputs:
-            - content: |
-                #!/bin/bash
-                exit ${DEBUG_EXIT_CODE:-0}
-          title: DEBUG STEP TO MAKE WORKFLOW FAIL, REMOVE AFTER 441 is tested!
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@6: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ workflows:
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-      - git-clone@6: {}
+      - git-clone@6: { }
       - nvm@1.3.0:
           inputs:
             - node_version: '14'
@@ -16,7 +16,7 @@ workflows:
     before_run:
       - setup
     steps:
-      - cache-pull@2: {}
+      - cache-pull@2: { }
       - yarn@0:
           inputs:
             - cache_local_deps: 'yes'
@@ -33,7 +33,7 @@ workflows:
             - cache_local_deps: 'yes'
             - command: lint
           is_always_run: true
-      - cache-push@2: {}
+      - cache-push@2: { }
   code_setup:
     before_run:
       - setup
@@ -54,6 +54,63 @@ workflows:
             - cache_local_deps: 'yes'
             - command: lint
           is_always_run: true
+
+  # Notifications utility workflows
+  # Provides values for commit or branch message and path depending on commit env setup initialised or not
+  _get_workflow_info:
+    steps:
+      - activate-ssh-key@4:
+          is_always_run: true
+          run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+      - git-clone@6:
+          is_always_run: true
+      - script@1:
+          is_always_run: true
+          inputs:
+            - content: |
+                #!/bin/bash
+                # generate reference to commit from env or using git
+                COMMIT_SHORT_HASH="${BITRISE_GIT_COMMIT:0:7}"
+                BRANCH_HEIGHT=''
+                WORKFLOW_TRIGGER='Push'
+                if [ ! -n "$BITRISE_GIT_COMMIT" ]; then
+                    COMMIT_SHORT_HASH=`git rev-parse --short HEAD`
+                    BRANCH_HEIGHT='HEAD'
+                    WORKFLOW_TRIGGER='Manual'
+                fi
+                envman add --key COMMIT_SHORT_HASH --value "$COMMIT_SHORT_HASH"
+                envman add --key BRANCH_HEIGHT --value "$BRANCH_HEIGHT"
+                envman add --key WORKFLOW_TRIGGER --value "$WORKFLOW_TRIGGER"
+          title: Get commit or branch name and path variables
+
+  # Send a Slack message when build workflow fails
+  _build_failure_notify_on_slack:
+    before_run:
+      - _get_workflow_info
+    steps:
+      - slack@3:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - pretext_on_error: ":red_circle: *${BITRISE_APP_TITLE} build failed!*"
+            - title: "Commit #$COMMIT_SHORT_HASH $BRANCH_HEIGHT"
+            - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
+            - message: ${BITRISE_GIT_MESSAGE}
+            - fields: |
+                Branch|${BITRISE_GIT_BRANCH}
+                Workflow|${BITRISE_TRIGGERED_WORKFLOW_TITLE}
+                Trigger|${WORKFLOW_TRIGGER}
+                Build|${BITRISE_BUILD_NUMBER}
+            - buttons: |
+                View app|${BITRISE_APP_URL}
+                View build|${BITRISE_BUILD_URL}
+                View commit|https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
+            - footer: "Notification sent by Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow"
+            - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
+
+  ############################
+  ### Triggerable workflows ##
+  ############################
   # CI Steps
   ci_test:
     before_run:
@@ -94,7 +151,7 @@ workflows:
             - api_level: '29'
             - create_command_flags: '--sdcard 4096M'
             - profile: pixel
-      - wait-for-android-emulator@1: {}
+      - wait-for-android-emulator@1: { }
       - file-downloader@1:
           inputs:
             - source: $BITRISEIO_ANDROID_KEYSTORE_URL
@@ -110,7 +167,7 @@ workflows:
       - code_setup
       - e2e_setup
     steps:
-      - certificate-and-profile-installer@1: {}
+      - certificate-and-profile-installer@1: { }
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
@@ -234,6 +291,8 @@ workflows:
   build_android_release:
     before_run:
       - code_setup
+    after_run:
+      - _build_failure_notify_on_slack
     steps:
       - change-android-versioncode-and-versionname@1:
           inputs:
@@ -280,6 +339,7 @@ workflows:
     before_run:
       - code_setup_cache
     after_run:
+      - _build_failure_notify_on_slack
       - _upload_apk_to_browserstack
     steps:
       - change-android-versioncode-and-versionname@1:
@@ -376,7 +436,7 @@ workflows:
                 cp -r $BITRISE_SOURCE_DIR/wdio/reports/junit-results/ $BITRISE_TEST_RESULT_DIR/
       - deploy-to-bitrise-io@1:
           inputs:
-              - deploy_path: $BITRISE_TEST_RESULT_DIR
+            - deploy_path: $BITRISE_TEST_RESULT_DIR
           title: Deploy test report files
   deploy_android_to_store:
     before_run:
@@ -402,14 +462,16 @@ workflows:
   build_ios_release:
     before_run:
       - code_setup_cache
+    after_run:
+      - _build_failure_notify_on_slack
     steps:
-      - certificate-and-profile-installer@1: {}
+      - certificate-and-profile-installer@1: { }
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
             - build_version: $VERSION_NUMBER
             - plist_path: $PROJECT_LOCATION_IOS/MetaMask/Info.plist
-      - cocoapods-install@2: {}
+      - cocoapods-install@2: { }
       - script@1:
           inputs:
             - content: |-
@@ -433,14 +495,16 @@ workflows:
   build_ios_qa:
     before_run:
       - code_setup_cache
+    after_run:
+      - _build_failure_notify_on_slack
     steps:
-      - certificate-and-profile-installer@1: {}
+      - certificate-and-profile-installer@1: { }
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
             - build_version: $VERSION_NUMBER
             - plist_path: $PROJECT_LOCATION_IOS/MetaMask/MetaMask-QA-Info.plist
-      - cocoapods-install@2: {}
+      - cocoapods-install@2: { }
       - script@1:
           inputs:
             - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -73,11 +73,13 @@ workflows:
                 COMMIT_SHORT_HASH="${BITRISE_GIT_COMMIT:0:7}"
                 BRANCH_HEIGHT=''
                 WORKFLOW_TRIGGER='Push'
-                if [ ! -n "$BITRISE_GIT_COMMIT" ]; then
-                    COMMIT_SHORT_HASH=`git rev-parse --short HEAD`
-                    BRANCH_HEIGHT='HEAD'
-                    WORKFLOW_TRIGGER='Manual'
+
+                if [[ -z "$BITRISE_GIT_COMMIT" ]]; then
+                COMMIT_SHORT_HASH="$(git rev-parse --short HEAD)"
+                BRANCH_HEIGHT='HEAD'
+                WORKFLOW_TRIGGER='Manual'
                 fi
+
                 envman add --key COMMIT_SHORT_HASH --value "$COMMIT_SHORT_HASH"
                 envman add --key BRANCH_HEIGHT --value "$BRANCH_HEIGHT"
                 envman add --key WORKFLOW_TRIGGER --value "$WORKFLOW_TRIGGER"
@@ -92,6 +94,7 @@ workflows:
           is_always_run: true
           run_if: .IsBuildFailed
           inputs:
+            - text: "${BITRISE_APP_TITLE} workflow notification"
             - pretext_on_error: ":red_circle: *${BITRISE_APP_TITLE} build failed!*"
             - title: "Commit #$COMMIT_SHORT_HASH $BRANCH_HEIGHT"
             - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
@@ -108,9 +111,35 @@ workflows:
             - footer: "Notification sent by Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow"
             - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
 
-  ############################
-  ### Triggerable workflows ##
-  ############################
+  # Send a Slack message when e2e workflow fails or succeeds
+  _e2e_notify_on_slack:
+    before_run:
+      - _get_workflow_info
+    steps:
+      - slack@3:
+          is_always_run: true
+          inputs:
+            - text: "${BITRISE_APP_TITLE} workflow notification"
+            - pretext: ":large_green_circle: *E2E tests succeeded!*"
+            - pretext_on_error: ":red_circle: *E2E tests failed!*"
+            - title: "Commit #$COMMIT_SHORT_HASH $BRANCH_HEIGHT"
+            - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
+            - message: ${BITRISE_GIT_MESSAGE}
+            - fields: |
+                Branch|${BITRISE_GIT_BRANCH}
+                Workflow|${BITRISE_TRIGGERED_WORKFLOW_TITLE}
+                Trigger|${WORKFLOW_TRIGGER}
+                Build|${BITRISE_BUILD_NUMBER}
+            - buttons: |
+                View app|${BITRISE_APP_URL}
+                View build|${BITRISE_BUILD_URL}
+                View commit|https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
+            - footer: "Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow notification"
+            - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
+
+  #########################
+  # Triggerable workflows #
+  #########################
   # CI Steps
   ci_test:
     before_run:
@@ -141,6 +170,8 @@ workflows:
     before_run:
       - code_setup
       - e2e_setup
+    after_run:
+      - _e2e_notify_on_slack
     steps:
       - install-missing-android-tools@2:
           inputs:
@@ -166,6 +197,8 @@ workflows:
     before_run:
       - code_setup
       - e2e_setup
+    after_run:
+      - _e2e_notify_on_slack
     steps:
       - certificate-and-profile-installer@1: { }
       - set-xcode-build-number@1:
@@ -202,31 +235,6 @@ workflows:
           inputs:
             - abort_on_fail: 'yes'
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
-      - script@1:
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash echo 'weew - everything passed!'
-          title: All Tests Passed
-          is_always_run: false
-      - slack@3:
-          inputs:
-            - text: "${BITRISE_APP_TITLE} workflow notification"
-            - pretext: ":large_green_circle: *E2E tests succeeded!*"
-            - pretext_on_error: ":red_circle: *E2E tests failed!*"
-            - title: "Commit #${BITRISE_GIT_COMMIT}"
-            - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${BITRISE_GIT_COMMIT}
-            - message: ${BITRISE_GIT_MESSAGE}
-            - fields: |
-                App|${BITRISE_APP_TITLE}
-                Branch|${BITRISE_GIT_BRANCH}
-                Workflow|${BITRISE_TRIGGERED_WORKFLOW_TITLE}
-                Build|${BITRISE_BUILD_NUMBER}
-            - buttons: |
-                View app|${BITRISE_APP_URL}
-                View build|${BITRISE_BUILD_URL}
-                View commit|https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${BITRISE_GIT_COMMIT}
-            - footer: "Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow notification"
-            - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
   # Parallel Build & Deploy Steps
   create_release_builds:
     before_run:
@@ -420,6 +428,8 @@ workflows:
   wdio_android_e2e_test:
     before_run:
       - code_setup_cache
+    after_run:
+      - _e2e_notify_on_slack
     steps:
       - script@1:
           title: Run Android E2E tests on Browserstack

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,7 +8,7 @@ workflows:
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-      - git-clone@6: { }
+      - git-clone@6: {}
       - nvm@1.3.0:
           inputs:
             - node_version: '14'
@@ -16,7 +16,7 @@ workflows:
     before_run:
       - setup
     steps:
-      - cache-pull@2: { }
+      - cache-pull@2: {}
       - yarn@0:
           inputs:
             - cache_local_deps: 'yes'
@@ -33,7 +33,7 @@ workflows:
             - cache_local_deps: 'yes'
             - command: lint
           is_always_run: true
-      - cache-push@2: { }
+      - cache-push@2: {}
   code_setup:
     before_run:
       - setup
@@ -77,9 +77,9 @@ workflows:
                 WORKFLOW_TRIGGER='Push'
 
                 if [[ -z "$BITRISE_GIT_COMMIT" ]]; then
-                COMMIT_SHORT_HASH="$(git rev-parse --short HEAD)"
-                BRANCH_HEIGHT='HEAD'
-                WORKFLOW_TRIGGER='Manual'
+                  COMMIT_SHORT_HASH="$(git rev-parse --short HEAD)"
+                  BRANCH_HEIGHT='HEAD'
+                  WORKFLOW_TRIGGER='Manual'
                 fi
 
                 envman add --key COMMIT_SHORT_HASH --value "$COMMIT_SHORT_HASH"
@@ -139,9 +139,6 @@ workflows:
             - footer: "Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow notification"
             - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
 
-  #########################
-  # Triggerable workflows #
-  #########################
   # CI Steps
   ci_test:
     before_run:
@@ -184,7 +181,7 @@ workflows:
             - api_level: '29'
             - create_command_flags: '--sdcard 4096M'
             - profile: pixel
-      - wait-for-android-emulator@1: { }
+      - wait-for-android-emulator@1: {}
       - file-downloader@1:
           inputs:
             - source: $BITRISEIO_ANDROID_KEYSTORE_URL
@@ -202,7 +199,7 @@ workflows:
     after_run:
       - _e2e_notify_on_slack
     steps:
-      - certificate-and-profile-installer@1: { }
+      - certificate-and-profile-installer@1: {}
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
@@ -448,7 +445,7 @@ workflows:
                 cp -r $BITRISE_SOURCE_DIR/wdio/reports/junit-results/ $BITRISE_TEST_RESULT_DIR/
       - deploy-to-bitrise-io@1:
           inputs:
-            - deploy_path: $BITRISE_TEST_RESULT_DIR
+              - deploy_path: $BITRISE_TEST_RESULT_DIR
           title: Deploy test report files
   deploy_android_to_store:
     before_run:
@@ -477,13 +474,13 @@ workflows:
     after_run:
       - _build_failure_notify_on_slack
     steps:
-      - certificate-and-profile-installer@1: { }
+      - certificate-and-profile-installer@1: {}
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
             - build_version: $VERSION_NUMBER
             - plist_path: $PROJECT_LOCATION_IOS/MetaMask/Info.plist
-      - cocoapods-install@2: { }
+      - cocoapods-install@2: {}
       - script@1:
           inputs:
             - content: |-
@@ -510,13 +507,13 @@ workflows:
     after_run:
       - _build_failure_notify_on_slack
     steps:
-      - certificate-and-profile-installer@1: { }
+      - certificate-and-profile-installer@1: {}
       - set-xcode-build-number@1:
           inputs:
             - build_short_version_string: $VERSION_NAME
             - build_version: $VERSION_NUMBER
             - plist_path: $PROJECT_LOCATION_IOS/MetaMask/MetaMask-QA-Info.plist
-      - cocoapods-install@2: { }
+      - cocoapods-install@2: {}
       - script@1:
           inputs:
             - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -63,6 +63,8 @@ workflows:
           is_always_run: true
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@6:
+          inputs:
+            - update_submodules: no
           is_always_run: true
       - script@1:
           is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,6 +6,13 @@ workflows:
   # Code Setups
   setup:
     steps:
+      - script@1:
+          is_always_run: true
+          inputs:
+            - content: |
+                #!/bin/bash
+                exit ${DEBUG_EXIT_CODE:-0}
+          title: DEBUG STEP TO MAKE WORKFLOW FAIL, REMOVE AFTER 441 is tested!
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@6: {}
@@ -270,9 +277,9 @@ workflows:
             - build_artifacts_save_path: $BITRISE_DEPLOY_DIR
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $BITRISE_DEPLOY_DIR/app-prod-release.apk
           title: Bitrise Deploy APK
       - yarn@0:
@@ -325,41 +332,41 @@ workflows:
           title: Build Android Pre-Release Bundle
           is_always_run: false
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/prod/release/app-prod-release.apk
           title: Bitrise Deploy APK
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/prod/release/sha512sums.txt
           title: Bitrise Deploy Checksum
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/mapping/prodRelease/mapping.txt
           title: Bitrise ProGuard Map Files
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/bundle/prodRelease/app-prod-release.aab
           title: Bitrise Deploy AAB
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: sourcemaps/android/index.js.map
           title: Bitrise Deploy Sourcemaps
   build_android_qa:
     before_run:
       - code_setup_cache
     after_run:
-      - _build_failure_notify_on_slack
       - _upload_apk_to_browserstack
+      - _build_failure_notify_on_slack
     steps:
       - change-android-versioncode-and-versionname@1:
           inputs:
@@ -383,33 +390,33 @@ workflows:
           title: Build Android Pre-Release Bundle
           is_always_run: false
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/qa/release/app-qa-release.apk
           title: Bitrise Deploy APK
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/qa/release/sha512sums.txt
           title: Bitrise Deploy Checksum
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/mapping/qaRelease/mapping.txt
           title: Bitrise ProGuard Map Files
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/bundle/qaRelease/app-qa-release.aab
           title: Bitrise Deploy AAB
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: sourcemaps/android/index.js.map
           title: Bitrise Deploy Sourcemaps
   _upload_apk_to_browserstack:
@@ -428,9 +435,9 @@ workflows:
                 curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APK_PATH" -F 'data={"custom_id": "'$CUSTOM_ID'"}' | jq -j '.app_url' | envman add --key BROWSERSTACK_APP_URL
                 curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/recent_apps | jq > browserstack_uploaded_apps.json
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: browserstack_uploaded_apps.json
           title: Bitrise Deploy Browserstack Uploaded Apps
       - build-router-start@0:
@@ -468,9 +475,9 @@ workflows:
                 #!/usr/bin/env bash
                 cp -r $BITRISE_SOURCE_DIR/wdio/reports/junit-results/ $BITRISE_TEST_RESULT_DIR/
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-              - is_always_run: false
-              - is_skippable: true
               - deploy_path: $BITRISE_TEST_RESULT_DIR
           title: Deploy test report files
   deploy_android_to_store:
@@ -516,21 +523,21 @@ workflows:
           title: iOS Sourcemaps & Build
           is_always_run: false
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: ios/build/output/MetaMask.ipa
           title: Deploy iOS IPA
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: ios/build/MetaMask.xcarchive
           title: Deploy Symbols File
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: sourcemaps/ios/index.js.map
           title: Deploy Source Map
   build_ios_qa:
@@ -555,21 +562,21 @@ workflows:
           title: iOS Sourcemaps & Build
           is_always_run: false
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: ios/build/output/MetaMask-QA.ipa
           title: Deploy iOS IPA
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: ios/build/MetaMask-QA.xcarchive
           title: Deploy Symbols File
       - deploy-to-bitrise-io@1:
+          is_always_run: false
+          is_skippable: true
           inputs:
-            - is_always_run: false
-            - is_skippable: true
             - deploy_path: sourcemaps/ios/index.js.map
           title: Deploy Source Map
 app:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,16 +30,15 @@ workflows:
             - command: setup
           title: Yarn Setup
       - yarn@0:
-          inputs:
-            - cache_local_deps: 'yes'
-            - command: audit:ci
-          title: Audit Dependencies
-      - yarn@0:
           title: Lint
           inputs:
             - cache_local_deps: 'yes'
             - command: lint
-          is_always_run: true
+      - yarn@0:
+          inputs:
+            - cache_local_deps: 'yes'
+            - command: audit:ci
+          title: Audit Dependencies
       - cache-push@2: {}
   code_setup:
     before_run:
@@ -67,14 +66,14 @@ workflows:
   _get_workflow_info:
     steps:
       - activate-ssh-key@4:
-          is_always_run: true
+          is_always_run: true # always run to also feed failure notifications
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@6:
           inputs:
-            - update_submodules: no
-          is_always_run: true
+            - update_submodules: 'no'
+          is_always_run: true # always run to also feed failure notifications
       - script@1:
-          is_always_run: true
+          is_always_run: true # always run to also feed failure notifications
           inputs:
             - content: |
                 #!/bin/bash

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,7 +6,7 @@ workflows:
   # Code Setups
   setup:
     steps:
-      - script@1:
+      - script@1: # TODO remove this DEBUG script before final commit
           is_always_run: true
           inputs:
             - content: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -352,14 +352,6 @@ workflows:
       - _build_failure_notify_on_slack
       - _upload_apk_to_browserstack
     steps:
-      # TODO DEBUG TO MAKE WORKFLOW FAIL. REMOVE ONCE TESTED!
-      - script@1:
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                exit 1
-          title: DEBUG TO MAKE WORKFLOW FAIL. REMOVE ONCE TESTED!
-          is_always_run: true
       - change-android-versioncode-and-versionname@1:
           inputs:
             - new_version_name: $VERSION_NAME

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -271,6 +271,8 @@ workflows:
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $BITRISE_DEPLOY_DIR/app-prod-release.apk
           title: Bitrise Deploy APK
       - yarn@0:
@@ -324,22 +326,32 @@ workflows:
           is_always_run: false
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/prod/release/app-prod-release.apk
           title: Bitrise Deploy APK
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/prod/release/sha512sums.txt
           title: Bitrise Deploy Checksum
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/mapping/prodRelease/mapping.txt
           title: Bitrise ProGuard Map Files
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/bundle/prodRelease/app-prod-release.aab
           title: Bitrise Deploy AAB
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: sourcemaps/android/index.js.map
           title: Bitrise Deploy Sourcemaps
   build_android_qa:
@@ -372,22 +384,32 @@ workflows:
           is_always_run: false
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/qa/release/app-qa-release.apk
           title: Bitrise Deploy APK
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/apk/qa/release/sha512sums.txt
           title: Bitrise Deploy Checksum
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/mapping/qaRelease/mapping.txt
           title: Bitrise ProGuard Map Files
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/bundle/qaRelease/app-qa-release.aab
           title: Bitrise Deploy AAB
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: sourcemaps/android/index.js.map
           title: Bitrise Deploy Sourcemaps
   _upload_apk_to_browserstack:
@@ -407,6 +429,8 @@ workflows:
                 curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/recent_apps | jq > browserstack_uploaded_apps.json
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: browserstack_uploaded_apps.json
           title: Bitrise Deploy Browserstack Uploaded Apps
       - build-router-start@0:
@@ -445,6 +469,8 @@ workflows:
                 cp -r $BITRISE_SOURCE_DIR/wdio/reports/junit-results/ $BITRISE_TEST_RESULT_DIR/
       - deploy-to-bitrise-io@1:
           inputs:
+              - is_always_run: false
+              - is_skippable: true
               - deploy_path: $BITRISE_TEST_RESULT_DIR
           title: Deploy test report files
   deploy_android_to_store:
@@ -491,14 +517,20 @@ workflows:
           is_always_run: false
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: ios/build/output/MetaMask.ipa
           title: Deploy iOS IPA
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: ios/build/MetaMask.xcarchive
           title: Deploy Symbols File
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: sourcemaps/ios/index.js.map
           title: Deploy Source Map
   build_ios_qa:
@@ -524,14 +556,20 @@ workflows:
           is_always_run: false
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: ios/build/output/MetaMask-QA.ipa
           title: Deploy iOS IPA
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: ios/build/MetaMask-QA.xcarchive
           title: Deploy Symbols File
       - deploy-to-bitrise-io@1:
           inputs:
+            - is_always_run: false
+            - is_skippable: true
             - deploy_path: sourcemaps/ios/index.js.map
           title: Deploy Source Map
 app:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -350,6 +350,14 @@ workflows:
       - _build_failure_notify_on_slack
       - _upload_apk_to_browserstack
     steps:
+      # TODO DEBUG TO MAKE WORKFLOW FAIL. REMOVE ONCE TESTED!
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                exit 1
+          title: DEBUG TO MAKE WORKFLOW FAIL. REMOVE ONCE TESTED!
+          is_always_run: true
       - change-android-versioncode-and-versionname@1:
           inputs:
             - new_version_name: $VERSION_NAME


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

## Description

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- Build have a success notification but nothing when it fails 

_2. What is the improvement/solution?_
- Add a new workflow for slack notification that runs after the build only in case of failure
- Make Slack notifications consistent (not par of the issue initially but otherwise not being consistent increases the complexity)
- Prevent `deploy-to-bitrise-io` steps to run even when everything failed before. Only notification should run after a failure.

This changes leverage the use of the Slack step and I included making the previously added notifications consistent.

It make the PR a bit large scoped but if we split into multiple PRs, I tend to think it will increase the complexity as the yml will be in a non consistent status until we consolidate.
Given it’s very clearly related and similar, I decided to have it all in this PR.
I leave the `release_to_stores` workflow announcement out of the scope for now here but it is a good candidate to move to the Slack step too, making everything even more consistent.

## NOTE

[skip ci] added to prevent auto trigger of the workflow on push and send notifications on actual Slack channel for no reason...
So testing with manual trigger and custom Slack creds env vars

## Screenshots

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

Failure notification will look like this:

<img width="509" alt="image" src="https://user-images.githubusercontent.com/4677568/220461123-790a316c-008b-481e-8c9e-516a03fc05cb.png">

(screenshot from the test slack sent from [failed on purpose build `#5918`](https://app.bitrise.io/build/3c05c77d-a366-4fc4-b261-27eb3b75a2ef))


## Issue

fixes MetaMask/mobile-planning#441

## Checklist

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
