### PR TITLE
Add Bitrise caching

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,7 +32,7 @@ workflows:
           inputs:
             # The Yarn cache is easier and safer to cache than `node_modules`, which could include
             # postinstall script modifications and could affect hoisting on subsequent installs.
-            - cache_paths: "$YARN_CACHE_DIR"
+            - cache_paths: "$YARN_CACHE_DIR -> ./yarn.lock"
       - yarn@0:
           title: Lint
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -27,12 +27,6 @@ workflows:
           inputs:
             - command: setup
           title: Yarn Setup
-      - cache-push@2:
-          # Manual cache path needed here because the `yarn` step only caches for the `install` command
-          inputs:
-            # The Yarn cache is easier and safer to cache than `node_modules`, which could include
-            # postinstall script modifications and could affect hoisting on subsequent installs.
-            - cache_paths: "$YARN_CACHE_DIR -> ./yarn.lock"
       - yarn@0:
           title: Lint
           inputs:
@@ -41,6 +35,12 @@ workflows:
           inputs:
             - command: audit:ci
           title: Audit Dependencies
+      - cache-push@2:
+          # Manual cache path needed here because the `yarn` step only caches for the `install` command
+          inputs:
+            # The Yarn cache is easier and safer to cache than `node_modules`, which could include
+            # postinstall script modifications and could affect hoisting on subsequent installs.
+            - cache_paths: "$YARN_CACHE_DIR -> ./yarn.lock"
   code_setup_dev:
     before_run:
       - setup

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,10 +16,23 @@ workflows:
     before_run:
       - setup
     steps:
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                envman add --key YARN_CACHE_DIR --value "$(yarn cache dir)"
+          title: Get Yarn cache directory
+      - cache-pull@2: {}
       - yarn@0:
           inputs:
             - command: setup
           title: Yarn Setup
+      - cache-push@2:
+          # Manual cache path needed here because the `yarn` step only caches for the `install` command
+          inputs:
+            # The Yarn cache is easier and safer to cache than `node_modules`, which could include
+            # postinstall script modifications and could affect hoisting on subsequent installs.
+            - cache_paths: "$YARN_CACHE_DIR"
       - yarn@0:
           title: Lint
           inputs:


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Caching has been added to our Bitrise CI config. It uses the [legacy branch caching API](https://devcenter.bitrise.io/en/builds/caching/branch-based-caching.html) because our current plan does not support the newer [key-based caching API](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html).

Typically the way caching works on Bitrise is that each step will have internal steps to "stage" data for caching, and the explicit cache step saves all of this data in the end. However the `yarn` step doesn't stage things correctly for us for two reasons:
* It only supports caching the `install` command, but we use `setup`
* It caches the `node_modules` directory, but we want to cache the Yarn cache directory.

Caching `node_modules` could result in a difficult-to-reproduce build because it could lead to a different directory structure when the build runs, and it could cache the output of `postinstall` steps that aren't intended to be run multiple times. However it should be save to cache the Yarn cache because it doesn't affect hoisting, and doesn't include any content that gets modified during the install process.

**Issue**

Fixes #5810

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
