### PR TITLE
[FIX] analytics: add missing property to connect completed event

### DIFF
--- a/app/components/UI/AccountApproval/index.js
+++ b/app/components/UI/AccountApproval/index.js
@@ -129,6 +129,7 @@ class AccountApproval extends PureComponent {
         dapp_url: currentPageInformation?.url,
         chain_id: chainId,
         number_of_accounts: accountsLength,
+        number_of_accounts_connected: 1,
         source: 'SDK / WalletConnect',
         ...currentPageInformation?.analytics,
       };


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

### **Description**

Connect Request Completed analytics event is missing `number_of_accounts_connected` property for when the user connects through SDK or walletconnect.
It is only possible to connect one account this way.

### **Acceptance Criteria**

Mixpanel Connect Request Completed event should not have the property `number_of_accounts_connected` as undefined when the user connects through SDK or walletconnect. It should show the number `1`

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/665

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
