### PR TITLE
Update order of browser page load events

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -972,8 +972,6 @@ export const BrowserTab = (props) => {
    * Website started to load
    */
   const onLoadStart = async ({ nativeEvent }) => {
-    const { hostname } = new URL(nativeEvent.url);
-
     if (
       nativeEvent.url !== url.current &&
       nativeEvent.loading &&

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -972,6 +972,8 @@ export const BrowserTab = (props) => {
    * Website started to load
    */
   const onLoadStart = async ({ nativeEvent }) => {
+    const { hostname } = new URL(nativeEvent.url);
+
     if (
       nativeEvent.url !== url.current &&
       nativeEvent.loading &&
@@ -993,6 +995,13 @@ export const BrowserTab = (props) => {
     // Reset the previous bridges
     backgroundBridges.current.length &&
       backgroundBridges.current.forEach((bridge) => bridge.onDisconnect());
+
+    // Cancel loading the page if we detect its a phishing page
+    if (!isAllowedUrl(hostname)) {
+      handleNotAllowedUrl(url);
+      return false;
+    }
+
     backgroundBridges.current = [];
     const origin = new URL(nativeEvent.url).origin;
     initializeBackgroundBridge(origin, true);

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -777,9 +777,17 @@ export const BrowserTab = (props) => {
    *  Return `true` to continue loading the request and `false` to stop loading.
    */
   const onShouldStartLoadWithRequest = ({ url }) => {
+    const { hostname } = new URL(url);
+
     // Stops normal loading when it's ens, instead call go to be properly set up
     if (isENSUrl(url)) {
       go(url.replace(/^http:\/\//, 'https://'));
+      return false;
+    }
+
+    // Cancel loading the page if we detect its a phishing page
+    if (!isAllowedUrl(hostname)) {
+      handleNotAllowedUrl(url);
       return false;
     }
 
@@ -972,10 +980,6 @@ export const BrowserTab = (props) => {
       nativeEvent.navigationType === 'backforward'
     ) {
       changeAddressBar({ ...nativeEvent });
-    }
-
-    if (!isAllowedUrl(hostname)) {
-      return handleNotAllowedUrl(nativeEvent.url);
     }
 
     setError(false);


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Addresses https://github.com/MetaMask/mobile-planning/issues/976 by improving the way we load events on the pages. This should allow for us to reduce redundant loads of phishing page unless the user explicitly decides they would like to proceed to that page.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

https://github.com/MetaMask/mobile-planning/issues/976

**Checklist**

* [X] There is a related GitHub issue
* [x] Tests are included if applicable
    * See issue [comment](https://github.com/MetaMask/mobile-planning/issues/976#issuecomment-1547977431) regarding testing
* [X] Any added code is fully documented
