### PR TITLE
Clear Hex data when Token Transfer reverts ETH

### DIFF
--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -89,6 +89,7 @@ import {
   selectProviderType,
   selectTicker,
 } from '../../../../selectors/networkController';
+import { PREFIX_HEX_STRING } from '../../../../constants/transaction';
 
 const KEYBOARD_OFFSET = Device.isSmallDevice() ? 80 : 120;
 
@@ -704,7 +705,7 @@ class Amount extends PureComponent {
     }
 
     if (selectedAsset.isETH) {
-      transactionObject.data = '0x';
+      transactionObject.data = PREFIX_HEX_STRING;
       transactionObject.to = transactionTo;
     }
 

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -703,7 +703,10 @@ class Amount extends PureComponent {
       transactionObject.readableValue = value;
     }
 
-    if (selectedAsset.isETH) transactionObject.to = transactionTo;
+    if (selectedAsset.isETH) {
+      transactionObject.data = undefined;
+      transactionObject.to = transactionTo;
+    }
 
     setTransactionObject(transactionObject);
   };

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -704,7 +704,7 @@ class Amount extends PureComponent {
     }
 
     if (selectedAsset.isETH) {
-      transactionObject.data = undefined;
+      transactionObject.data = '0x';
       transactionObject.to = transactionTo;
     }
 

--- a/app/constants/transaction.ts
+++ b/app/constants/transaction.ts
@@ -18,3 +18,4 @@ export const UINT256_HEX_MAX_VALUE =
 
 // https://github.com/ethjs/ethjs-ens/blob/8ea29591ae545a5da243b0f071b5676ff95aa647/index.js#L13
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const PREFIX_HEX_STRING = '0x';

--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -107,6 +107,7 @@ const transactionReducer = (state = initialState, action) => {
         transaction: {
           ...state.transaction,
           ...getTxData(action.transaction),
+          data: action.transaction.data,
         },
         ...txMeta,
       };

--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -107,7 +107,6 @@ const transactionReducer = (state = initialState, action) => {
         transaction: {
           ...state.transaction,
           ...getTxData(action.transaction),
-          data: action.transaction.data,
         },
         ...txMeta,
       };


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
When you send ETH the hex data should be empty by default (0x). For token transfers, we are interacting with contacts, so the Hex Data is then filled with the long values (representing the method, and the arguments passed). If we switch back to ETH, it should clear the hex data to default (0x)

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
_2. What is the improvement/solution?_

**Screenshots/Recordings**
http://recordit.co/Alt9uBAOz0

**Issue**

Progresses #5759 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
