### PR TITLE
[FIX] Wallet connect session modal not breaking

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -471,6 +471,7 @@ const RootRPCMethodsUI = (props) => {
 
   const renderWalletConnectSessionRequestModal = () => {
     const meta = walletConnectRequestInfo.peerMeta || null;
+    if (!meta) return null;
     return (
       <Modal
         isVisible={walletConnectRequest}


### PR DESCRIPTION
**Description**
The wallet connects session modal was rendered before the state get updated with the information of the wallet connect dapp.

**Proposed Solution**
Rendering the modal when the information about the dapp is defined.

Test Case
* Go to sushi swap
* connect wallet


**Screenshots/Recordings**
https://recordit.co/GFNbnwZyyQ


**Issue**

Progresses #

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
