### PR TITLE
Bug/674 network search crash

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -72,6 +72,7 @@ import {
 import Button, {
   ButtonVariants,
   ButtonSize,
+  ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 
 const createStyles = (colors) =>
@@ -946,6 +947,7 @@ class NetworkSettings extends PureComponent {
               label={strings('app_settings.networks_default_cta')}
               size={ButtonSize.Lg}
               disabled={isActionDisabled}
+              width={ButtonWidthTypes.Full}
             />
           ) : (
             (addMode || editable) && (

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -18,7 +18,7 @@ import { strings } from '../../../../../locales/i18n';
 import Networks, {
   getAllNetworks,
   getNetworkImageSource,
-  isMainNet,
+  isDefaultMainnet,
 } from '../../../../util/networks';
 import StyledButton from '../../../UI/StyledButton';
 import Engine from '../../../../core/Engine';
@@ -208,7 +208,7 @@ class NetworksSettings extends PureComponent {
       <View key={`network-${network}`}>
         {
           // Do not change. This logic must check for 'mainnet' and is used for rendering the out of the box mainnet when searching.
-          isMainNet(network) ? (
+          isDefaultMainnet(network) ? (
             this.renderMainnet()
           ) : (
             <TouchableOpacity
@@ -322,8 +322,8 @@ class NetworksSettings extends PureComponent {
   handleSearchTextChange = (text) => {
     this.setState({ searchString: text });
     const defaultNetwork = getAllNetworks().map((network, i) => {
-      const { color, name } = Networks[network];
-      return { name, color, network, isCustomRPC: false };
+      const { color, name, chainId } = Networks[network];
+      return { name, color, network, isCustomRPC: false, chainId };
     });
     const customRPC = this.props.frequentRpcList.map((network, i) => {
       const { color, name, url, chainId } = {
@@ -351,7 +351,7 @@ class NetworksSettings extends PureComponent {
     if (this.state.filteredNetworks.length > 0) {
       return this.state.filteredNetworks.map((data, i) => {
         const { network, chainId, name, color, isCustomRPC } = data;
-        const image = getNetworkImageSource(chainId);
+        const image = getNetworkImageSource({ chainId });
         return this.networkElement(
           name,
           image || color,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR fixes 2 bugs in 6.1.0 regression
1. Fix network search crasher - [#674](https://github.com/MetaMask/mobile-planning/issues/674)

https://user-images.githubusercontent.com/10508597/221732951-3a3209db-ca89-4366-8338-c6172b4b7923.mov


2. Fix button width not stretching on custom url screen

https://user-images.githubusercontent.com/10508597/221732760-f0ffcca8-02a2-4ea1-b113-007243fdc2f1.mov

Issue reported by @cortisiko 
https://www.screencast.com/t/ijuHhv2C


**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
