### PR TITLE
Trigger e2e on release push

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -227,6 +227,7 @@ workflows:
           inputs:
             - workflows: |-
                 ios_e2e_test
+                wdio_android_e2e_test
             - wait_for_builds: 'true'
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
       - build-router-wait@0:
@@ -618,3 +619,7 @@ app:
 meta:
   bitrise.io:
     stack: osx-xcode-13.4.x
+
+trigger_map:
+  - push_branch: release/*
+    workflow: start_e2e_tests


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
As indicated in Metamask/mobile-planning#573 QA would like tot have e2e tests triggered when a new content is pushed to any release branch.
_2. What is the improvement/solution?_
- add android `wdio_android_e2e_test` to `start_e2e_tests` workflow start so that it starts both Android and iOS e2e (`start_e2e_tests` already starts `ios_e2e_test`) 
- add trigger in trigger map for all release branches of the form `release/*` to start `start_e2e_tests` workflow

## Testing the change

For the trigger to work, it requires that Bitrise push webhook is setup on the github repos: this has been confirmed to be ok. 

The trigger only takes effect once merged and when a release branch is created.
So for testing I created the same process on my test Bitrise project with a private Github repo.
The trigger successfully ran the workflow.

Creating the trigger in config and checking ot appears on workflow dashboard
![image](https://user-images.githubusercontent.com/4677568/221960498-6a9ba5a9-52fd-45f8-aac9-69e7f6fcdeef.png)

Create the release branch
![image](https://user-images.githubusercontent.com/4677568/221960693-a8c50667-dffe-496b-9a4b-6e6c52bc49dd.png)

Check the workflow is triggered
![image](https://user-images.githubusercontent.com/4677568/221960754-a10deaa3-5b10-4934-bc31-1f630bfb6d4e.png)

**Issue**

fixes Metamask/mobile-planning#573

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
