### PR TITLE
[FIX] Readd metametrics opt out alert 

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -478,6 +478,10 @@ class Settings extends PureComponent {
       await this.trackOptInEvent('Metrics Opt Out');
       MetaMetrics.disable();
       this.setState({ analyticsEnabled: false });
+      Alert.alert(
+        strings('app_settings.metametrics_opt_out'),
+        strings('app_settings.metametrics_restart_required'),
+      );
     }
   };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The metametrics opt out alert is missing on main. 
<img src=https://user-images.githubusercontent.com/12821081/222044303-113c30f6-e9f7-43be-89c1-d14ef7f787da.jpeg  width="200" height="480">

This readds the alert whenever metametrics is disabled. 


**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
