### PR TITLE
[FIX] Initial Analytics Opt Out

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData/DeleteMetaMetricsData.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData/DeleteMetaMetricsData.tsx
@@ -102,7 +102,7 @@ const DeleteMetaMetricsData = () => {
         sectionTitle={strings('app_settings.delete_metrics_title')}
         sectionButtonText={strings('app_settings.delete_metrics_button')}
         descriptionText={
-          hasCollectedData ? (
+          hasCollectedData || !deletionTaskDate ? (
             <>
               <Text>
                 {strings('app_settings.delete_metrics_description_part_one')}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off
-->

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_

_1. What is the reason for the change?_

There's a bug related to the scenario when a user is onboarding into the app and opts out of MetaMetrics. See first image for reference.

_2. What is the improvement/solution?_

Add a new conditional to check for the existence of  "Deletion Request Date".  This should render another content explaining the use of the "Delete Data" feature. See second image for reference.

The "Delete MetaMetrics data" CTA should be disabled.

**Screenshots/Recordings**

BUG

<img src='https://user-images.githubusercontent.com/17601467/222143733-c0ce80c3-bd84-404b-aaae-82526150c50b.png' width='300' />

FIX

<img src='https://user-images.githubusercontent.com/17601467/222143916-0aa3cd76-7105-40a8-a048-99b131cc4c49.png' width='300' />

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
