### PR TITLE
chore: remove mixpanel submodule from project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "ios/branch-ios-sdk"]
 	path = ios/branch-ios-sdk
 	url = https://github.com/BranchMetrics/ios-branch-deep-linking-attribution
-
-[submodule "ios/mixpanel-iphone"]
-	path = ios/mixpanel-iphone
-	url = https://github.com/mixpanel/mixpanel-iphone


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

With the Segment integration (https://github.com/MetaMask/metamask-mobile/pull/5139) We no longer need mixpanel submodule.

This PR removes the submodule from ios project folder & submodule registry

**Acceptance Criteria**

**Run** `git submodule update --init`. It should update branch-io submodule successfully.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
