### PR TITLE
[FIX] Set @metamask/contract-metadata to fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@metamask/assets-controllers": "^3.0.1",
     "@metamask/base-controller": "^1.1.1",
     "@metamask/composable-controller": "^1.0.1",
-    "@metamask/contract-metadata": "^2.1.0",
+    "@metamask/contract-metadata": "2.1.0",
     "@metamask/controller-utils": "^1.0.0",
     "@metamask/design-tokens": "^1.11.1",
     "@metamask/etherscan-link": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3997,6 +3997,11 @@
   dependencies:
     "@metamask/base-controller" "^1.1.1"
 
+"@metamask/contract-metadata@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-2.1.0.tgz#78f9e32afea61548922e57ef57ee6eb99abf35be"
+  integrity sha512-jPeoNmEonnmtzSIsBGAshy9SCFMkLfURB7d7pkEY1lmRtrhPYv3DTkMpffJciikaCPjyJ62eLWX/6Kme4CPvNg==
+
 "@metamask/contract-metadata@^1.31.0", "@metamask/contract-metadata@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-2.2.0.tgz#277764d0d56e37180ae7644a9d11eb96295b36fc"


### PR DESCRIPTION
Set `@metamask/contract-metadata` to fixed version `2.1.0`.