### PR TITLE
[FIX] catch all ios biometric errors

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -230,8 +230,6 @@ const createStyles = (colors) =>
   });
 
 const PASSCODE_NOT_SET_ERROR = 'Error: Passcode not set.';
-const IOS_DENY_BIOMETRIC_ERROR =
-  'The user name or passphrase you entered is not correct.';
 
 /**
  * View where users can set their password for the first time
@@ -384,7 +382,6 @@ class ChoosePassword extends PureComponent {
           );
         } catch (error) {
           if (Device.isIos) await this.handleRejectedOsBiometricPrompt(error);
-          throw error;
         }
       } else if (this.state.rememberMe) {
         await SecureKeychain.setGenericPassword(
@@ -448,15 +445,8 @@ class ChoosePassword extends PureComponent {
    * @param {*} error - error provide from try catch wrapping the biometric set password attempt
    */
   handleRejectedOsBiometricPrompt = async (error) => {
-    const biometryType = await SecureKeychain.getSupportedBiometryType();
-    if (error.toString().includes(IOS_DENY_BIOMETRIC_ERROR) && !biometryType) {
-      this.setState({
-        biometryType,
-        biometryChoice: true,
-      });
-      this.updateBiometryChoice();
-      throw Error(strings('choose_password.disable_biometric_error'));
-    }
+    this.updateBiometryChoice(false);
+    await SecureKeychain.resetGenericPassword();
   };
 
   /**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

iOS biometric errors during create wallet were causing a screen freeze and not allowing the user to proceed. This change allows the error to occur and the wallet to be created with the users manually entered password. 

**Screenshots/Recordings**

Uploading create-wallet--update.mov…

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
