### PR TITLE
Extract test accounts to env vars

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -20,3 +20,10 @@ export MM_FOX_CODE="EXAMPLE_FOX_CODE"
 export MM_INFURA_PROJECT_ID="null"
 export IGNORE_BOXLOGS_DEVELOPMENT="false"
 export MM_SENTRY_DSN=""
+
+# ENV vars for e2e tests
+# defined as secrets to run on Bitrise CI
+# but have to be defined here for local tests
+export MM_TEST_ACCOUNT_SRP=""
+# address is the address of the first account generated from the previous SRP
+export MM_TEST_ACCOUNT_ADDRESS=""

--- a/README.md
+++ b/README.md
@@ -200,7 +200,20 @@ You should see the console for the website that is running inside the WebView
 yarn test:unit
 ```
 
-#### E2E Tests (iOS)
+#### E2E Tests
+
+##### Platforms
+
+E2E test are currently using a combination of Detox for iOS (e2e folder) and Appium for Android (wdio folder).
+Work is in progress to have both platforms using Detox.
+
+##### Test wallet
+
+E2E tests use a wallet able to access testnet and mainnet.
+On Bitrise CI, the wallet is created using the secret recovery phrase from secret env var.
+For local testing, the wallet is created using the secret recovery phrase from the `.js.env` file.
+
+##### iOS
 
 First, [follow the instructions here](https://github.com/wix/AppleSimulatorUtils) to install `applesimutils`. Then:
 
@@ -208,7 +221,7 @@ First, [follow the instructions here](https://github.com/wix/AppleSimulatorUtils
 yarn test:e2e:ios
 ```
 
-#### E2E Tests (Android)
+##### Android
 
 ```bash
 yarn test:e2e:android

--- a/e2e/specs/contract-nickname.failing.js
+++ b/e2e/specs/contract-nickname.failing.js
@@ -24,18 +24,23 @@ import WhatsNewModal from '../pages/modals/WhatsNewModal';
 import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 
 import TestHelpers from '../helpers';
-
-const SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just raven';
-const PASSWORD = `12345678`;
-const APPROVAL_DEEPLINK_URL =
-  'https://metamask.app.link/send/0x326C977E6efc84E512bB9C30f76E30c160eD06FB@5/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=5e8';
-const CONTRACT_NICK_NAME_TEXT = 'Ace RoMaIn';
-const GOERLI = 'Goerli Test Network';
-
-/* BROKEN. We need to revisit. Deep linking to a contract address does not work on a sim. */
+import Accounts from "../../wdio/helpers/Accounts";
 
 describe('Adding Contract Nickname', () => {
+
+  const APPROVAL_DEEPLINK_URL =
+    'https://metamask.app.link/send/0x326C977E6efc84E512bB9C30f76E30c160eD06FB@5/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=5e8';
+  const CONTRACT_NICK_NAME_TEXT = 'Ace RoMaIn';
+  const GOERLI = 'Goerli Test Network';
+
+  //FIXME Deep linking to a contract address does not work on a sim.
+
+  let validAccount;
+
+  beforeAll( () => {
+    validAccount = Accounts.getValidAccount();
+  });
+
   beforeEach(() => {
     jest.setTimeout(150000);
   });
@@ -54,9 +59,9 @@ describe('Adding Contract Nickname', () => {
   });
 
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
-    await ImportWalletView.enterSecretRecoveryPhrase(SECRET_RECOVERY_PHRASE);
-    await ImportWalletView.enterPassword(PASSWORD);
-    await ImportWalletView.reEnterPassword(PASSWORD);
+    await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
+    await ImportWalletView.enterPassword(validAccount.password);
+    await ImportWalletView.reEnterPassword(validAccount.password);
     await WalletView.isVisible();
   });
 
@@ -128,7 +133,7 @@ describe('Adding Contract Nickname', () => {
     await LoginView.isVisible();
     await LoginView.toggleRememberMe();
 
-    await LoginView.enterPassword(PASSWORD);
+    await LoginView.enterPassword(validAccount.password);
     await WalletView.isVisible();
   });
   it('should deep link to the approval modal', async () => {

--- a/e2e/specs/contract-nickname.failing.js
+++ b/e2e/specs/contract-nickname.failing.js
@@ -24,10 +24,9 @@ import WhatsNewModal from '../pages/modals/WhatsNewModal';
 import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 
 import TestHelpers from '../helpers';
-import Accounts from "../../wdio/helpers/Accounts";
+import Accounts from '../../wdio/helpers/Accounts';
 
 describe('Adding Contract Nickname', () => {
-
   const APPROVAL_DEEPLINK_URL =
     'https://metamask.app.link/send/0x326C977E6efc84E512bB9C30f76E30c160eD06FB@5/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=5e8';
   const CONTRACT_NICK_NAME_TEXT = 'Ace RoMaIn';
@@ -37,7 +36,7 @@ describe('Adding Contract Nickname', () => {
 
   let validAccount;
 
-  beforeAll( () => {
+  beforeAll(() => {
     validAccount = Accounts.getValidAccount();
   });
 

--- a/e2e/specs/deeplinks.spec.js
+++ b/e2e/specs/deeplinks.spec.js
@@ -8,12 +8,11 @@ import ImportWalletView from '../pages/Onboarding/ImportWalletView';
 
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import ConnectModal from '../pages/modals/ConnectModal';
-//import NetworkEducationModal from '../pages/modals/NetworkEducationModal';
 import NetworkApprovalModal from '../pages/modals/NetworkApprovalModal';
 import NetworkAddedModal from '../pages/modals/NetworkAddedModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
 
-import { Browser } from '../pages/Drawer/Browser';
+import {Browser} from '../pages/Drawer/Browser';
 import DrawerView from '../pages/Drawer/DrawerView';
 import NetworkView from '../pages/Drawer/Settings/NetworksView';
 import SettingsView from '../pages/Drawer/Settings/SettingsView';
@@ -27,9 +26,6 @@ import WalletView from '../pages/WalletView';
 
 import Accounts from '../../wdio/helpers/Accounts';
 
-const SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just raven';
-const PASSWORD = `12345678`;
 
 const BINANCE_RPC_URL = 'https://bsc-dataseed1.binance.org';
 
@@ -50,9 +46,14 @@ const networkNotFoundText = 'Network not found';
 const networkErrorBodyMessage =
   'Network with chain id 56 not found in your wallet. Please add the network first.';
 
-const validAccount = Accounts.getValidAccount();
-
 describe('Deep linking Tests', () => {
+
+  let validAccount;
+
+  beforeAll( () => {
+    validAccount = Accounts.getValidAccount();
+  });
+
   beforeEach(() => {
     jest.setTimeout(150000);
   });
@@ -73,8 +74,8 @@ describe('Deep linking Tests', () => {
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
     //await ImportWalletView.toggleRememberMe();
     await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
-    await ImportWalletView.enterPassword(PASSWORD);
-    await ImportWalletView.reEnterPassword(PASSWORD);
+    await ImportWalletView.enterPassword(validAccount.password);
+    await ImportWalletView.reEnterPassword(validAccount.password);
     await WalletView.isVisible();
   });
 
@@ -133,7 +134,7 @@ describe('Deep linking Tests', () => {
     await LoginView.isVisible();
     await LoginView.toggleRememberMe();
 
-    await LoginView.enterPassword(PASSWORD);
+    await LoginView.enterPassword(validAccount.password);
     await WalletView.isVisible();
   });
 
@@ -184,7 +185,6 @@ describe('Deep linking Tests', () => {
 
     await NetworkApprovalModal.isVisible();
     await NetworkApprovalModal.isDisplayNameVisible('Polygon Mainnet');
-    //await NetworkApprovalModal.isNetworkURLVisible(POLYGON_RPC_URL);
     await NetworkApprovalModal.isChainIDVisible('137');
 
     await NetworkApprovalModal.tapApproveButton();
@@ -198,7 +198,7 @@ describe('Deep linking Tests', () => {
   });
 
   it('should deep link to the send flow on matic', async () => {
-    await TestHelpers.openDeepLink(POLYGON_DEEPLINK_URL);
+    await TestHelpers.openDeepLink(POLYGON_DEEPLINK_URL); //FIXME: this is failing on iOS simulator
 
     await TestHelpers.delay(4500);
     await TransactionConfirmationView.isVisible();

--- a/e2e/specs/deeplinks.spec.js
+++ b/e2e/specs/deeplinks.spec.js
@@ -25,6 +25,8 @@ import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/Secu
 
 import WalletView from '../pages/WalletView';
 
+import Accounts from '../../wdio/helpers/Accounts';
+
 const SECRET_RECOVERY_PHRASE =
   'fold media south add since false relax immense pause cloth just raven';
 const PASSWORD = `12345678`;
@@ -48,6 +50,8 @@ const networkNotFoundText = 'Network not found';
 const networkErrorBodyMessage =
   'Network with chain id 56 not found in your wallet. Please add the network first.';
 
+const validAccount = Accounts.getValidAccount();
+
 describe('Deep linking Tests', () => {
   beforeEach(() => {
     jest.setTimeout(150000);
@@ -68,7 +72,7 @@ describe('Deep linking Tests', () => {
 
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
     //await ImportWalletView.toggleRememberMe();
-    await ImportWalletView.enterSecretRecoveryPhrase(SECRET_RECOVERY_PHRASE);
+    await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
     await WalletView.isVisible();

--- a/e2e/specs/deeplinks.spec.js
+++ b/e2e/specs/deeplinks.spec.js
@@ -12,7 +12,7 @@ import NetworkApprovalModal from '../pages/modals/NetworkApprovalModal';
 import NetworkAddedModal from '../pages/modals/NetworkAddedModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
 
-import {Browser} from '../pages/Drawer/Browser';
+import { Browser } from '../pages/Drawer/Browser';
 import DrawerView from '../pages/Drawer/DrawerView';
 import NetworkView from '../pages/Drawer/Settings/NetworksView';
 import SettingsView from '../pages/Drawer/Settings/SettingsView';
@@ -25,7 +25,6 @@ import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/Secu
 import WalletView from '../pages/WalletView';
 
 import Accounts from '../../wdio/helpers/Accounts';
-
 
 const BINANCE_RPC_URL = 'https://bsc-dataseed1.binance.org';
 
@@ -47,10 +46,9 @@ const networkErrorBodyMessage =
   'Network with chain id 56 not found in your wallet. Please add the network first.';
 
 describe('Deep linking Tests', () => {
-
   let validAccount;
 
-  beforeAll( () => {
+  beforeAll(() => {
     validAccount = Accounts.getValidAccount();
   });
 

--- a/e2e/specs/delete-wallet.spec.js
+++ b/e2e/specs/delete-wallet.spec.js
@@ -23,13 +23,14 @@ import WhatsNewModal from '../pages/modals/WhatsNewModal';
 import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 import Accounts from '../../wdio/helpers/Accounts';
 
-const validAccount = Accounts.getValidAccount();
-
-const SECRET_RECOVERY_PHRASE =
-  'ketchup width ladder rent cheap eye torch employ quantum evidence artefact render protect delay wrap identify valley umbrella yard ridge wool swap differ kidney';
-const PASSWORD = `12345678`;
-
 describe('Import wallet with 24 word SRP, change password then delete wallet flow', () => {
+
+  let validAccount;
+
+  beforeAll( () => {
+    validAccount = Accounts.getValidAccount();
+  });
+
   beforeEach(() => {
     jest.setTimeout(150000);
   });
@@ -50,8 +51,8 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
   it('should import wallet with valid secret recovery phrase and password', async () => {
     await ImportWalletView.clearSecretRecoveryPhraseInputBox();
     await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
-    await ImportWalletView.enterPassword(PASSWORD);
-    await ImportWalletView.reEnterPassword(PASSWORD);
+    await ImportWalletView.enterPassword(validAccount.password);
+    await ImportWalletView.reEnterPassword(validAccount.password);
   });
   it('Should dismiss Automatic Security checks screen', async () => {
     await TestHelpers.delay(3500);
@@ -99,7 +100,7 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
     await SecurityAndPrivacyView.tapChangePasswordButton();
 
     await ChangePasswordView.isVisible();
-    await ChangePasswordView.typeInConfirmPasswordInputBox(PASSWORD);
+    await ChangePasswordView.typeInConfirmPasswordInputBox(validAccount.password);
     //await ChangePasswordView.tapConfirmButton();
   });
 

--- a/e2e/specs/delete-wallet.spec.js
+++ b/e2e/specs/delete-wallet.spec.js
@@ -21,6 +21,9 @@ import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import DeleteWalletModal from '../pages/modals/DeleteWalletModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
 import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
+import Accounts from '../../wdio/helpers/Accounts';
+
+const validAccount = Accounts.getValidAccount();
 
 const SECRET_RECOVERY_PHRASE =
   'ketchup width ladder rent cheap eye torch employ quantum evidence artefact render protect delay wrap identify valley umbrella yard ridge wool swap differ kidney';
@@ -46,7 +49,7 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
 
   it('should import wallet with valid secret recovery phrase and password', async () => {
     await ImportWalletView.clearSecretRecoveryPhraseInputBox();
-    await ImportWalletView.enterSecretRecoveryPhrase(SECRET_RECOVERY_PHRASE);
+    await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
     await ImportWalletView.enterPassword(PASSWORD);
     await ImportWalletView.reEnterPassword(PASSWORD);
   });

--- a/e2e/specs/delete-wallet.spec.js
+++ b/e2e/specs/delete-wallet.spec.js
@@ -24,10 +24,9 @@ import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityC
 import Accounts from '../../wdio/helpers/Accounts';
 
 describe('Import wallet with 24 word SRP, change password then delete wallet flow', () => {
-
   let validAccount;
 
-  beforeAll( () => {
+  beforeAll(() => {
     validAccount = Accounts.getValidAccount();
   });
 
@@ -100,7 +99,9 @@ describe('Import wallet with 24 word SRP, change password then delete wallet flo
     await SecurityAndPrivacyView.tapChangePasswordButton();
 
     await ChangePasswordView.isVisible();
-    await ChangePasswordView.typeInConfirmPasswordInputBox(validAccount.password);
+    await ChangePasswordView.typeInConfirmPasswordInputBox(
+      validAccount.password,
+    );
     //await ChangePasswordView.tapConfirmButton();
   });
 

--- a/e2e/specs/import-seed-phrase.spec.js
+++ b/e2e/specs/import-seed-phrase.spec.js
@@ -6,29 +6,27 @@ import OnboardingView from '../pages/Onboarding/OnboardingView';
 import OnboardingCarouselView from '../pages/Onboarding/OnboardingCarouselView';
 import ImportWalletView from '../pages/Onboarding/ImportWalletView';
 
-//import SecurityAndPrivacy from '../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
-//import RevealSecretRecoveryPhrase from '../pages/Drawer/Settings/SecurityAndPrivacy/RevealSecretRecoveryPhrase';
-
 import MetaMetricsOptIn from '../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../pages/WalletView';
 import LoginView from '../pages/LoginView';
 import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityChecksView';
 
-//import DrawerView from '../pages/Drawer/DrawerView';
-//import SettingsView from '../pages/Drawer/Settings/SettingsView';
-
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
-
-const INCORRECT_SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just falcon';
-const CORRECT_SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just raven';
-const CORRECT_PASSWORD = `12345678`;
-const SHORT_PASSWORD = `1234567`;
-const INCORRECT_PASSWORD = `12345679`;
+import Accounts from "../../wdio/helpers/Accounts";
 
 describe('Import seedphrase flow', () => {
+
+  let validAccount;
+  let invalidAccount
+  let shortPasswordAccount;
+
+  beforeAll( () => {
+    validAccount = Accounts.getValidAccount();
+    invalidAccount = Accounts.getInvalidAccount();
+    shortPasswordAccount = Accounts.getShortPasswordAccount();
+  });
+
   beforeEach(() => {
     jest.setTimeout(150000);
   });
@@ -48,10 +46,10 @@ describe('Import seedphrase flow', () => {
 
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
     await ImportWalletView.enterSecretRecoveryPhrase(
-      INCORRECT_SECRET_RECOVERY_PHRASE,
+      invalidAccount.seedPhrase,
     );
-    await ImportWalletView.enterPassword(INCORRECT_PASSWORD);
-    await ImportWalletView.reEnterPassword(INCORRECT_PASSWORD);
+    await ImportWalletView.enterPassword(invalidAccount.password);
+    await ImportWalletView.reEnterPassword(invalidAccount.password);
     await ImportWalletView.secretRecoveryPhraseErrorIsVisible();
     await ImportWalletView.tapOKAlertButton();
 
@@ -61,17 +59,17 @@ describe('Import seedphrase flow', () => {
   it('should import wallet with valid secret recovery phrase but short password', async () => {
     await ImportWalletView.clearSecretRecoveryPhraseInputBox();
     await ImportWalletView.enterSecretRecoveryPhrase(
-      CORRECT_SECRET_RECOVERY_PHRASE,
+      shortPasswordAccount.seedPhrase,
     );
-    await ImportWalletView.enterPassword(SHORT_PASSWORD);
-    await ImportWalletView.reEnterPassword(SHORT_PASSWORD);
+    await ImportWalletView.enterPassword(shortPasswordAccount.password);
+    await ImportWalletView.reEnterPassword(shortPasswordAccount.password);
     await ImportWalletView.passwordLengthErrorIsVisible();
     await ImportWalletView.tapOKAlertButton();
   });
 
   it('should import wallet with valid secret recovery phrase and password', async () => {
-    await ImportWalletView.enterPassword(CORRECT_PASSWORD);
-    await ImportWalletView.reEnterPassword(CORRECT_PASSWORD);
+    await ImportWalletView.enterPassword(validAccount.password);
+    await ImportWalletView.reEnterPassword(validAccount.password);
     await WalletView.isVisible();
   });
 
@@ -132,10 +130,10 @@ describe('Import seedphrase flow', () => {
 
     // Check that we are on login screen
     await LoginView.isVisible();
-    await LoginView.enterPassword(SHORT_PASSWORD);
+    await LoginView.enterPassword(shortPasswordAccount.password);
     await LoginView.isLoginErrorVisible();
 
-    await LoginView.enterPassword(CORRECT_PASSWORD);
+    await LoginView.enterPassword(shortPasswordAccount.password);
 
     await WalletView.isVisible();
   });

--- a/e2e/specs/import-seed-phrase.spec.js
+++ b/e2e/specs/import-seed-phrase.spec.js
@@ -13,15 +13,14 @@ import EnableAutomaticSecurityChecksView from '../pages/EnableAutomaticSecurityC
 
 import OnboardingWizardModal from '../pages/modals/OnboardingWizardModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
-import Accounts from "../../wdio/helpers/Accounts";
+import Accounts from '../../wdio/helpers/Accounts';
 
 describe('Import seedphrase flow', () => {
-
   let validAccount;
-  let invalidAccount
+  let invalidAccount;
   let shortPasswordAccount;
 
-  beforeAll( () => {
+  beforeAll(() => {
     validAccount = Accounts.getValidAccount();
     invalidAccount = Accounts.getInvalidAccount();
     shortPasswordAccount = Accounts.getShortPasswordAccount();
@@ -45,9 +44,7 @@ describe('Import seedphrase flow', () => {
   });
 
   it('should attempt to import wallet with invalid secret recovery phrase', async () => {
-    await ImportWalletView.enterSecretRecoveryPhrase(
-      invalidAccount.seedPhrase,
-    );
+    await ImportWalletView.enterSecretRecoveryPhrase(invalidAccount.seedPhrase);
     await ImportWalletView.enterPassword(invalidAccount.password);
     await ImportWalletView.reEnterPassword(invalidAccount.password);
     await ImportWalletView.secretRecoveryPhraseErrorIsVisible();

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -26,23 +26,23 @@ import WhatsNewModal from '../pages/modals/WhatsNewModal';
 
 import Accounts from '../../wdio/helpers/Accounts';
 
-
 describe('Wallet Tests', () => {
-
   const GOERLI = 'Goerli Test Network';
   const ETHEREUM = 'Ethereum Main Network';
 
   // This key is for testing private key import only
   // I should NEVER hold any eth or token
-  const TEST_PRIVATE_KEY = 'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
-  const COLLECTIBLE_CONTRACT_ADDRESS = '0x306d717D109e0995e0f56027Eb93D9C1d5686dE1';
+  const TEST_PRIVATE_KEY =
+    'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
+  const COLLECTIBLE_CONTRACT_ADDRESS =
+    '0x306d717D109e0995e0f56027Eb93D9C1d5686dE1';
   const COLLECTIBLE_IDENTIFIER = '179';
   const BLT_TOKEN_ADDRESS = '0x107c4504cd79c5d2696ea0030a8dd4e92601b82e';
   const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
 
   let validAccount;
 
-  beforeAll( () => {
+  beforeAll(() => {
     validAccount = Accounts.getValidAccount();
   });
 
@@ -172,7 +172,8 @@ describe('Wallet Tests', () => {
     await NetworkEducationModal.isNotVisible();
   });
 
-  it('should add a collectible', async () => {//FIXME: this is failing on iOS simulator
+  it('should add a collectible', async () => {
+    //FIXME: this is failing on iOS simulator
     await WalletView.isVisible();
     // Tap on COLLECTIBLES tab
     await WalletView.tapNftTab();

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -24,21 +24,28 @@ import RequestPaymentModal from '../pages/modals/RequestPaymentModal';
 import NetworkEducationModal from '../pages/modals/NetworkEducationModal';
 import WhatsNewModal from '../pages/modals/WhatsNewModal';
 
-const SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just raven';
-const PASSWORD = `12345678`;
-const TEST_PUBLIC_ADDRESS = '0xd3B9Cbea7856AECf4A6F7c3F4E8791F79cBeeD62';
-const GOERLI = 'Goerli Test Network';
-const ETHEREUM = 'Ethereum Main Network';
-const COLLECTIBLE_CONTRACT_ADDRESS =
-  '0x306d717D109e0995e0f56027Eb93D9C1d5686dE1';
-const COLLECTIBLE_IDENTIFIER = '179';
-const BLT_TOKEN_ADDRESS = '0x107c4504cd79c5d2696ea0030a8dd4e92601b82e';
-const TEST_PRIVATE_KEY =
-  'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
-const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
+import Accounts from '../../wdio/helpers/Accounts';
+
 
 describe('Wallet Tests', () => {
+
+  const GOERLI = 'Goerli Test Network';
+  const ETHEREUM = 'Ethereum Main Network';
+
+  // This key is for testing private key import only
+  // I should NEVER hold any eth or token
+  const TEST_PRIVATE_KEY = 'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
+  const COLLECTIBLE_CONTRACT_ADDRESS = '0x306d717D109e0995e0f56027Eb93D9C1d5686dE1';
+  const COLLECTIBLE_IDENTIFIER = '179';
+  const BLT_TOKEN_ADDRESS = '0x107c4504cd79c5d2696ea0030a8dd4e92601b82e';
+  const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
+
+  let validAccount;
+
+  beforeAll( () => {
+    validAccount = Accounts.getValidAccount();
+  });
+
   beforeEach(() => {
     jest.setTimeout(200000);
   });
@@ -58,9 +65,9 @@ describe('Wallet Tests', () => {
 
   it('should import wallet with secret recovery phrase', async () => {
     await ImportWalletView.clearSecretRecoveryPhraseInputBox();
-    await ImportWalletView.enterSecretRecoveryPhrase(SECRET_RECOVERY_PHRASE);
-    await ImportWalletView.enterPassword(PASSWORD);
-    await ImportWalletView.reEnterPassword(PASSWORD);
+    await ImportWalletView.enterSecretRecoveryPhrase(validAccount.seedPhrase);
+    await ImportWalletView.enterPassword(validAccount.password);
+    await ImportWalletView.reEnterPassword(validAccount.password);
     await WalletView.isVisible();
   });
 
@@ -141,7 +148,7 @@ describe('Wallet Tests', () => {
     await DrawerView.tapOnAddFundsButton();
 
     await RequestPaymentModal.isVisible();
-    await RequestPaymentModal.isPublicAddressCorrect(TEST_PUBLIC_ADDRESS);
+    await RequestPaymentModal.isPublicAddressCorrect(validAccount.address);
 
     // Close Receive screen and go back to wallet screen
     await RequestPaymentModal.closeRequestModal();
@@ -165,7 +172,7 @@ describe('Wallet Tests', () => {
     await NetworkEducationModal.isNotVisible();
   });
 
-  it('should add a collectible', async () => {
+  it('should add a collectible', async () => {//FIXME: this is failing on iOS simulator
     await WalletView.isVisible();
     // Tap on COLLECTIBLES tab
     await WalletView.tapNftTab();

--- a/wdio/helpers/Accounts.js
+++ b/wdio/helpers/Accounts.js
@@ -1,7 +1,5 @@
-const INCORRECT_SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just falcon';
-const CORRECT_SECRET_RECOVERY_PHRASE =
-  'fold media south add since false relax immense pause cloth just raven';
+// This is an incorrect BIP39 SRP. It uses words not in the BIP39 wordlist.
+const INCORRECT_SECRET_RECOVERY_PHRASE = 'gain lemon refuse sunny identify diesel hand endless first involve wink size';
 const CORRECT_PASSWORD = `12345678`;
 const SHORT_PASSWORD = `1234567`;
 const INCORRECT_PASSWORD = `12345679`;
@@ -9,7 +7,10 @@ const INCORRECT_PASSWORD = `12345679`;
 class Accounts {
   static getValidAccount() {
     return {
-      seedPhrase: process.env.WALLET_KEYS,
+      // A correct BIP39 SRP that can be used for testing. Requires the var to be set in the environment.
+      seedPhrase: process.env.MM_TEST_ACCOUNT_SRP || 'undefined SRP env var',
+      // Ethereum address for 1st account of derived on the seed that can be used for testing. Requires the var to be set in the environment.
+      address: process.env.MM_TEST_ACCOUNT_ADDRESS || 'undefined address env var',
       password: CORRECT_PASSWORD,
     };
   }
@@ -22,10 +23,9 @@ class Accounts {
   }
 
   static getShortPasswordAccount() {
-    return {
-      seedPhrase: process.env.WALLET_KEYS,
-      password: SHORT_PASSWORD,
-    };
+    const account = Accounts.getValidAccount();
+    account.password = SHORT_PASSWORD;
+    return account;
   }
 }
 

--- a/wdio/helpers/Accounts.js
+++ b/wdio/helpers/Accounts.js
@@ -9,7 +9,7 @@ const INCORRECT_PASSWORD = `12345679`;
 class Accounts {
   static getValidAccount() {
     return {
-      seedPhrase: CORRECT_SECRET_RECOVERY_PHRASE,
+      seedPhrase: process.env.WALLET_KEYS,
       password: CORRECT_PASSWORD,
     };
   }
@@ -23,7 +23,7 @@ class Accounts {
 
   static getShortPasswordAccount() {
     return {
-      seedPhrase: CORRECT_SECRET_RECOVERY_PHRASE,
+      seedPhrase: process.env.WALLET_KEYS,
       password: SHORT_PASSWORD,
     };
   }


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Extract test accounts SRP and matching addresses to ENV vars that will be provided as secrets in CI. 

_1. What is the reason for the change?_
  - test accounts are automatically drained from any test ETH as SRP is public...
_2. What is the improvement/solution?_
  - move infos to env vars
  - setup `MM_TEST_ACCOUNT_SRP` and `MM_TEST_ACCOUNT_ADDRESS` **secret** vars in Bitrise (not env vars).
  - test all tests are passing with the new test account

NOTE: It requires to move tokens and collectibles to this new account

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses MetaMask/mobile-planning#672

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
