### PR TITLE
[FIX] Remove select address as a prop on App index.js

### DIFF
--- a/app/components/Nav/App/__snapshots__/index.test.tsx.snap
+++ b/app/components/Nav/App/__snapshots__/index.test.tsx.snap
@@ -3,13 +3,11 @@
 exports[`App should render correctly when logged in 1`] = `
 <App
   dispatch={[Function]}
-  selectedAddress="0x1"
 />
 `;
 
 exports[`App should render correctly when logged in 2`] = `
 <App
   dispatch={[Function]}
-  selectedAddress="0x1"
 />
 `;

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -210,7 +210,7 @@ const VaultRecoveryFlow = () => (
   </Stack.Navigator>
 );
 
-const App = ({ selectedAddress, userLoggedIn }) => {
+const App = ({ userLoggedIn }) => {
   const animationRef = useRef(null);
   const animationNameRef = useRef(null);
   const opacity = useRef(new Animated.Value(1)).current;
@@ -239,6 +239,8 @@ const App = ({ selectedAddress, userLoggedIn }) => {
   useEffect(() => {
     if (prevNavigator.current || !navigator) return;
     const appTriggeredAuth = async () => {
+      const { PreferencesController } = Engine.context;
+      const selectedAddress = PreferencesController.state.selectedAddress;
       const existingUser = await AsyncStorage.getItem(EXISTING_USER);
       try {
         if (existingUser && selectedAddress) {
@@ -269,7 +271,7 @@ const App = ({ selectedAddress, userLoggedIn }) => {
       }
     };
     appTriggeredAuth();
-  }, [navigator, selectedAddress]);
+  }, [navigator]);
 
   const handleDeeplink = useCallback(({ error, params, uri }) => {
     if (error) {
@@ -579,8 +581,6 @@ const App = ({ selectedAddress, userLoggedIn }) => {
 
 const mapStateToProps = (state) => ({
   userLoggedIn: state.user.userLoggedIn,
-  selectedAddress:
-    state.engine.backgroundState?.PreferencesController?.selectedAddress,
 });
 
 export default connect(mapStateToProps)(App);

--- a/app/components/Nav/App/index.test.tsx
+++ b/app/components/Nav/App/index.test.tsx
@@ -11,13 +11,6 @@ describe('App', () => {
       user: {
         loggedIn: true,
       },
-      engine: {
-        backgroundState: {
-          PreferencesController: {
-            selectedAddress: '0x1',
-          },
-        },
-      },
     };
 
     const wrapper = shallow(<App />, {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes the bug where the account sheet re-renders after the mutation of an account. This includes creating, importing, or removing. The solution was to remove `selectedAddress` from the props to prevent re-render triggers.

**Screenshots/Recordings**

Reach out to @Cal-L on slack for video

**Issue**
#5911 

**Testing**
- Scenario: Account sheet should be on multi-select after the creation of an account
   - Given I am on the Browser view
   - When I tap on the right button on the Nav bar
   - And I tap on `Connect more accounts`
   - And I tap on `Create a new account`
   - Then a new account should be created
   - And we should still be on the account multi-select screen
 
- Scenario: Repeat the above scenario but import an account or remove instead

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
