### PR TITLE
[FIX] Fix displaying balance on watch asset screen

### DIFF
--- a/app/components/UI/WatchAssetRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/WatchAssetRequest/__snapshots__/index.test.tsx.snap
@@ -1,17 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WatchAssetRequest should render correctly 1`] = `
-<WatchAssetRequest
-  dispatch={[Function]}
-  selectedAddress="0xe7E125654064EEa56229f273dA586F10DF96B0a1"
-  suggestedAssetMeta={
+<View
+  style={
     Object {
-      "asset": Object {
-        "address": "0x2",
-        "decimals": 0,
-        "symbol": "TKN",
-      },
+      "backgroundColor": "#FFFFFF",
+      "borderTopLeftRadius": 10,
+      "borderTopRightRadius": 10,
+      "minHeight": "50%",
+      "paddingBottom": 20,
     }
   }
-/>
+>
+  <View>
+    <Text
+      style={
+        Object {
+          "color": "#24272A",
+          "fontFamily": "EuclidCircularB-Bold",
+          "fontSize": 18,
+          "fontWeight": "600",
+          "marginHorizontal": 20,
+          "marginVertical": 12,
+          "textAlign": "center",
+        }
+      }
+    >
+      Add Suggested Token
+    </Text>
+  </View>
+  <ActionView
+    cancelTestID="request-signature-cancel-button"
+    cancelText="CANCEL"
+    confirmButtonMode="normal"
+    confirmTestID="request-signature-confirm-button"
+    confirmText="ADD TOKEN"
+    confirmed={false}
+    onConfirmPress={[Function]}
+    showCancelButton={true}
+    showConfirmButton={true}
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderTopColor": "#D6D9DC",
+          "borderTopWidth": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "margin": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+            }
+          }
+        >
+          Would you like to add this token?
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "flex-start",
+            "flex": 1,
+            "flexDirection": "row",
+            "marginHorizontal": 40,
+            "marginVertical": 30,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "column",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#24272A",
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontWeight": "600",
+                }
+              }
+            >
+              Token
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "paddingVertical": 10,
+                  }
+                }
+              >
+                <Connect(TokenImage)
+                  asset={
+                    Object {
+                      "address": "0x2",
+                      "decimals": 0,
+                      "symbol": "TKN",
+                    }
+                  }
+                />
+              </View>
+              <Text
+                style={
+                  Object {
+                    "color": "#24272A",
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 16,
+                    "fontWeight": "400",
+                    "paddingHorizontal": 10,
+                    "paddingTop": 25,
+                  }
+                }
+              >
+                TKN
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "column",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#24272A",
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontWeight": "600",
+                }
+              }
+            >
+              Balance
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#24272A",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "paddingHorizontal": 10,
+                  "paddingTop": 25,
+                }
+              }
+            >
+              0 TKN
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </ActionView>
+</View>
 `;

--- a/app/components/UI/WatchAssetRequest/index.js
+++ b/app/components/UI/WatchAssetRequest/index.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, View, Text, InteractionManager } from 'react-native';
-import { connect } from 'react-redux';
 import URL from 'url-parse';
 import ActionView from '../ActionView';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -97,10 +96,7 @@ const WatchAssetRequest = ({
   // TODO - Once TokensController is updated, interactingAddress should always be defined
   const { colors } = useTheme();
   const styles = createStyles(colors);
-  const [balance, _, error] = useTokenBalance(
-    asset.address,
-    interactingAddress,
-  );
+  const [balance, , error] = useTokenBalance(asset.address, interactingAddress);
   const balanceWithSymbol = error
     ? strings('transaction.failed')
     : `${renderFromTokenMinimalUnit(balance, asset.decimals)} ${asset.symbol}`;

--- a/app/components/UI/WatchAssetRequest/index.js
+++ b/app/components/UI/WatchAssetRequest/index.js
@@ -90,15 +90,20 @@ const createStyles = (colors) =>
 const WatchAssetRequest = ({
   suggestedAssetMeta,
   currentPageInformation,
-  selectedAddress,
   onCancel,
   onConfirm,
 }) => {
   const { asset, interactingAddress } = suggestedAssetMeta;
-  let [balance] = useTokenBalance(asset.address, selectedAddress);
-  balance = renderFromTokenMinimalUnit(balance, asset.decimals);
+  // TODO - Once TokensController is updated, interactingAddress should always be defined
   const { colors } = useTheme();
   const styles = createStyles(colors);
+  const [balance, _, error] = useTokenBalance(
+    asset.address,
+    interactingAddress,
+  );
+  const balanceWithSymbol = error
+    ? strings('transaction.failed')
+    : `${renderFromTokenMinimalUnit(balance, asset.decimals)} ${asset.symbol}`;
 
   useEffect(
     () => async () => {
@@ -197,9 +202,7 @@ const WatchAssetRequest = ({
               </View>
 
               <View style={styles.infoBalance}>
-                <Text style={styles.text}>
-                  {balance} {asset.symbol}
-                </Text>
+                <Text style={styles.text}>{balanceWithSymbol}</Text>
               </View>
             </View>
           </View>
@@ -223,18 +226,9 @@ WatchAssetRequest.propTypes = {
    */
   suggestedAssetMeta: PropTypes.object,
   /**
-   * Current public address
-   */
-  selectedAddress: PropTypes.string,
-  /**
    * Object containing current page title, url, and icon href
    */
   currentPageInformation: PropTypes.object,
 };
 
-const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
-});
-
-export default connect(mapStateToProps)(WatchAssetRequest);
+export default WatchAssetRequest;

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -587,7 +587,10 @@ export const getRpcMethodMiddleware = ({
         try {
           const permittedAccounts = await getPermittedAccounts(hostname);
           // This should return the current active account on the Dapp.
-          const interactingAddress = permittedAccounts?.[0];
+          const selectedAddress =
+            Engine.context.PreferencesController.state.selectedAddress;
+          // Fallback to wallet address if there is no connected account to Dapp.
+          const interactingAddress = permittedAccounts?.[0] || selectedAddress;
           const watchAssetResult = await TokensController.watchAsset(
             { address, symbol, decimals, image },
             type,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes showing the correct balance on the watch asset screen
Issue - https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/issues/gh/metamask/mobile-planning/712

**Screenshots/Recordings**

https://user-images.githubusercontent.com/10508597/225441560-3ef83170-18dd-4654-8d2b-da0d533729aa.mov

**Testing**
- Scenario: Watch asset screen should show correct token balance for the interacting account
  - Given I go the the Browser view and go to Uniswap
  - And I connect an account to Uniswap
  - When I swap ETH for UNI
  - And I tap `Add UNI` to trigger watch asset
  - Then I should see the correct balance for UNI

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
