### PR TITLE
[Fix] handle rejected os biometric prompt

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -380,7 +380,7 @@ class ChoosePassword extends PureComponent {
         try {
           await Authentication.newWalletAndKeychain(password, authType);
         } catch (error) {
-          if (Device.isIos) await this.handleRejectedOsBiometricPrompt(error);
+          if (Device.isIos) await this.handleRejectedOsBiometricPrompt();
         }
         this.keyringControllerPasswordSet = true;
         this.props.seedphraseNotBackedUp();
@@ -435,9 +435,23 @@ class ChoosePassword extends PureComponent {
    * This function handles the case when the user rejects the OS prompt for allowing use of biometrics.
    * If this occurs we will create the wallet automatically with password as the login method
    */
-  handleRejectedOsBiometricPrompt = async (error) => {
-    this.updateBiometryChoice(false);
-    await SecureKeychain.resetGenericPassword();
+  handleRejectedOsBiometricPrompt = async () => {
+    const newAuthData = await Authentication.componentAuthenticationType(
+      false,
+      false,
+    );
+    try {
+      await Authentication.newWalletAndKeychain(
+        this.state.password,
+        newAuthData,
+      );
+    } catch (err) {
+      throw Error(strings('choose_password.disable_biometric_error'));
+    }
+    this.setState({
+      biometryType: newAuthData.availableBiometryType,
+      biometryChoice: false,
+    });
   };
 
   /**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- wallet creation fails after a failed biometric attempt

_2. What is the improvement/solution?_
- This was not an issue in [Auth refactor](https://github.com/MetaMask/metamask-mobile/pull/5374).
- The problem here was that the [TEMPORARY fix for 6.1 got merged ](https://github.com/MetaMask/metamask-mobile/pull/5925/files) over my code from the authentication refactor which resulted in the password not being stored.
- simply reverting the `handleRejectedOsBiometricPrompt` to the logic from Auth refactor solved this issue.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

https://user-images.githubusercontent.com/22918444/225449054-ba9a82c3-31f4-4551-8b18-1bb4d623b3b2.MP4


**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/708

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
