### PR TITLE
[FIX] Fix SRP reveal screen

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -161,7 +161,6 @@ const WalletTabStackFlow = () => (
     <Stack.Screen
       name="RevealPrivateCredentialView"
       component={RevealPrivateCredential}
-      options={RevealPrivateCredential.navigationOptions}
     />
   </Stack.Navigator>
 );
@@ -387,7 +386,6 @@ const SettingsFlow = () => (
     <Stack.Screen
       name="RevealPrivateCredentialView"
       component={RevealPrivateCredential}
-      options={RevealPrivateCredential.navigationOptions}
     />
     <Stack.Screen
       name="WalletConnectSessionsView"

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -64,7 +64,7 @@ const ActivityView = () => {
   const renderTabBar = () => (hasOrders ? <TabBar /> : <View />);
 
   return (
-    <ErrorBoundary view="ActivityView">
+    <ErrorBoundary navigation={navigation} view="ActivityView">
       <View style={styles.wrapper}>
         <ScrollableTabView
           renderTabBar={renderTabBar}

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1363,7 +1363,7 @@ export const BrowserTab = (props) => {
    * Main render
    */
   return (
-    <ErrorBoundary view="BrowserTab">
+    <ErrorBoundary navigation={props.navigation} view="BrowserTab">
       <View
         style={[styles.wrapper, !isTabActive && styles.hide]}
         {...(Device.isAndroid() ? { collapsable: false } : {})}

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -69,7 +69,6 @@ import {
 import { LoginOptionsSwitch } from '../../UI/LoginOptionsSwitch';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { scale } from 'react-native-size-matters';
-import SecureKeychain from '../../../core/SecureKeychain';
 
 const createStyles = (colors) =>
   StyleSheet.create({

--- a/app/components/Views/ErrorBoundary/index.js
+++ b/app/components/Views/ErrorBoundary/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import {
-  SafeAreaView,
   Text,
   TouchableOpacity,
   View,
@@ -17,8 +16,10 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { strings } from '../../../../locales/i18n';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import ClipboardManager from '../../../core/ClipboardManager';
-import { useTheme } from '../../../util/theme';
+import { ThemeContext, useTheme } from '../../../util/theme';
 import { ROOT } from './constants';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getNavigationOptionsTitle } from '../../../components/UI/Navbar';
 
 // eslint-disable-next-line import/no-commonjs
 const metamaskErrorImage = require('../../../images/metamask-error.png');
@@ -107,67 +108,63 @@ const Fallback = (props) => {
   const styles = createStyles(colors);
 
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.content}>
-        <View style={styles.header}>
-          <Image source={metamaskErrorImage} style={styles.errorImage} />
-          <Text style={styles.title}>{strings('error_screen.title')}</Text>
-          <Text style={styles.subtitle}>
-            {strings('error_screen.subtitle')}
+    <ScrollView style={styles.content}>
+      <View style={styles.header}>
+        <Image source={metamaskErrorImage} style={styles.errorImage} />
+        <Text style={styles.title}>{strings('error_screen.title')}</Text>
+        <Text style={styles.subtitle}>{strings('error_screen.subtitle')}</Text>
+      </View>
+      <View style={styles.errorContainer}>
+        <Text style={styles.error}>{props.errorMessage}</Text>
+      </View>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.button} onPress={props.resetError}>
+          <Text style={styles.buttonText}>
+            <Icon name="refresh" size={15} />
+            {'  '}
+            {strings('error_screen.try_again_button')}
           </Text>
-        </View>
-        <View style={styles.errorContainer}>
-          <Text style={styles.error}>{props.errorMessage}</Text>
-        </View>
-        <View style={styles.header}>
-          <TouchableOpacity style={styles.button} onPress={props.resetError}>
-            <Text style={styles.buttonText}>
-              <Icon name="refresh" size={15} />
-              {'  '}
-              {strings('error_screen.try_again_button')}
-            </Text>
-          </TouchableOpacity>
-        </View>
-        <View style={styles.textContainer}>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.textContainer}>
+        <Text style={styles.text}>
+          <Text>{strings('error_screen.submit_ticket_1')}</Text>
+        </Text>
+        <View style={styles.reportTextContainer}>
           <Text style={styles.text}>
-            <Text>{strings('error_screen.submit_ticket_1')}</Text>
+            <Icon name="mobile-phone" size={20} />
+            {'  '}
+            {strings('error_screen.submit_ticket_2')}
           </Text>
-          <View style={styles.reportTextContainer}>
-            <Text style={styles.text}>
-              <Icon name="mobile-phone" size={20} />
-              {'  '}
-              {strings('error_screen.submit_ticket_2')}
-            </Text>
 
-            <Text style={[styles.reportStep, styles.text]}>
-              <Icon name="copy" size={14} />
-              {'  '}
-              <Text onPress={props.copyErrorToClipboard} style={styles.link}>
-                {strings('error_screen.submit_ticket_3')}
-              </Text>{' '}
-              {strings('error_screen.submit_ticket_4')}
-            </Text>
-
-            <Text style={[styles.reportStep, styles.text]}>
-              <Icon name="send-o" size={14} />
-              {'  '}
-              {strings('error_screen.submit_ticket_5')}{' '}
-              <Text onPress={props.openTicket} style={styles.link}>
-                {strings('error_screen.submit_ticket_6')}
-              </Text>{' '}
-              {strings('error_screen.submit_ticket_7')}
-            </Text>
-          </View>
-          <Text style={styles.text}>
-            {strings('error_screen.save_seedphrase_1')}{' '}
-            <Text onPress={props.showExportSeedphrase} style={styles.link}>
-              {strings('error_screen.save_seedphrase_2')}
+          <Text style={[styles.reportStep, styles.text]}>
+            <Icon name="copy" size={14} />
+            {'  '}
+            <Text onPress={props.copyErrorToClipboard} style={styles.link}>
+              {strings('error_screen.submit_ticket_3')}
             </Text>{' '}
-            {strings('error_screen.save_seedphrase_3')}
+            {strings('error_screen.submit_ticket_4')}
+          </Text>
+
+          <Text style={[styles.reportStep, styles.text]}>
+            <Icon name="send-o" size={14} />
+            {'  '}
+            {strings('error_screen.submit_ticket_5')}{' '}
+            <Text onPress={props.openTicket} style={styles.link}>
+              {strings('error_screen.submit_ticket_6')}
+            </Text>{' '}
+            {strings('error_screen.submit_ticket_7')}
           </Text>
         </View>
-      </ScrollView>
-    </SafeAreaView>
+        <Text style={styles.text}>
+          {strings('error_screen.save_seedphrase_1')}{' '}
+          <Text onPress={props.showExportSeedphrase} style={styles.link}>
+            {strings('error_screen.save_seedphrase_2')}
+          </Text>{' '}
+          {strings('error_screen.save_seedphrase_3')}
+        </Text>
+      </View>
+    </ScrollView>
   );
 };
 
@@ -230,25 +227,36 @@ class ErrorBoundary extends Component {
     Linking.openURL(url);
   };
 
+  renderWithSafeArea = (children) => {
+    const colors = this.context.colors || mockTheme.colors;
+    const styles = createStyles(colors);
+
+    return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;
+  };
+
   render() {
-    return this.state.backupSeedphrase ? (
-      <RevealPrivateCredential
-        credentialName={'seed_phrase'}
-        cancel={this.cancelExportSeedphrase}
-        hasNavigation={this.props.view !== ROOT}
-      />
-    ) : this.state.error ? (
-      <Fallback
-        errorMessage={this.getErrorMessage()}
-        resetError={this.resetError}
-        showExportSeedphrase={this.showExportSeedphrase}
-        copyErrorToClipboard={this.copyErrorToClipboard}
-        openTicket={this.openTicket}
-      />
-    ) : (
-      this.props.children
-    );
+    return this.state.backupSeedphrase
+      ? this.renderWithSafeArea(
+          <RevealPrivateCredential
+            credentialName={'seed_phrase'}
+            cancel={this.cancelExportSeedphrase}
+            navigation={this.props.navigation}
+          />,
+        )
+      : this.state.error
+      ? this.renderWithSafeArea(
+          <Fallback
+            errorMessage={this.getErrorMessage()}
+            resetError={this.resetError}
+            showExportSeedphrase={this.showExportSeedphrase}
+            copyErrorToClipboard={this.copyErrorToClipboard}
+            openTicket={this.openTicket}
+          />,
+        )
+      : this.props.children;
   }
 }
+
+ErrorBoundary.contextType = ThemeContext;
 
 export default ErrorBoundary;

--- a/app/components/Views/ErrorBoundary/index.js
+++ b/app/components/Views/ErrorBoundary/index.js
@@ -16,10 +16,8 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { strings } from '../../../../locales/i18n';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import ClipboardManager from '../../../core/ClipboardManager';
-import { ThemeContext, useTheme } from '../../../util/theme';
-import { ROOT } from './constants';
+import { mockTheme, ThemeContext, useTheme } from '../../../util/theme';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getNavigationOptionsTitle } from '../../../components/UI/Navbar';
 
 // eslint-disable-next-line import/no-commonjs
 const metamaskErrorImage = require('../../../images/metamask-error.png');
@@ -185,6 +183,7 @@ class ErrorBoundary extends Component {
       PropTypes.node,
     ]),
     view: PropTypes.string.isRequired,
+    navigation: PropTypes.object,
   };
 
   static getDerivedStateFromError(error) {

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -444,7 +444,7 @@ class Login extends PureComponent {
     );
 
     return (
-      <ErrorBoundary view="Login">
+      <ErrorBoundary navigation={this.props.navigation} view="Login">
         <SafeAreaView style={styles.mainWrapper}>
           <KeyboardAwareScrollView
             style={styles.wrapper}

--- a/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
+++ b/app/components/Views/Quiz/SRPQuiz/SRPQuiz.tsx
@@ -70,7 +70,7 @@ const SRPQuiz = () => {
     trackEvent(MetaMetricsEvents.REVEAL_SRP_CTA);
     navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
       credentialName: 'seed_phrase',
-      hasNavigation: true,
+      shouldUpdateNav: true,
     });
   }, [navigation]);
 

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from 'react';
 import {
   Dimensions,
-  SafeAreaView,
   View,
   Text,
   TextInput,
@@ -46,6 +45,7 @@ import { strings } from '../../../../locales/i18n';
 import { isQRHardwareAccount } from '../../../util/address';
 import AppConstants from '../../../core/AppConstants';
 import { createStyles } from './styles';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const PRIVATE_KEY = 'private_key';
 
@@ -73,6 +73,7 @@ const RevealPrivateCredential = ({
     useState<string>('');
   const [clipboardEnabled, setClipboardEnabled] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+  const safeArea = useSafeAreaInsets();
 
   const selectedAddress = useSelector(
     (state: any) =>
@@ -83,7 +84,7 @@ const RevealPrivateCredential = ({
   const dispatch = useDispatch();
 
   const { colors, themeAppearance } = useTheme();
-  const styles = createStyles(colors);
+  const styles = createStyles(colors, safeArea);
 
   const privateCredentialName = credentialName || route.params.credentialName;
 
@@ -499,10 +500,7 @@ const RevealPrivateCredential = ({
   );
 
   return (
-    <SafeAreaView
-      style={styles.wrapper}
-      testID={'reveal-private-credential-screen'}
-    >
+    <View style={[styles.wrapper]} testID={'reveal-private-credential-screen'}>
       <ActionView
         cancelText={
           unlocked
@@ -542,7 +540,7 @@ const RevealPrivateCredential = ({
         isSRP={privateCredentialName !== PRIVATE_KEY}
         hasNavigation={hasNavigation}
       />
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -1,12 +1,17 @@
 /* eslint-disable import/prefer-default-export */
 import { StyleSheet } from 'react-native';
+import { EdgeInsets } from 'react-native-safe-area-context';
 import { fontStyles, colors as importedColors } from '../../../styles/common';
 
-export const createStyles = (colors: any) =>
-  StyleSheet.create({
+export const createStyles = (colors: any, safeArea: EdgeInsets) => {
+  const { bottom, top } = safeArea;
+
+  return StyleSheet.create({
     wrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
+      paddingTop: top,
+      paddingBottom: bottom,
     },
     normalText: {
       color: colors.text.default,
@@ -122,3 +127,4 @@ export const createStyles = (colors: any) =>
       borderColor: colors.border.muted,
     },
   });
+};

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -1,17 +1,12 @@
 /* eslint-disable import/prefer-default-export */
 import { StyleSheet } from 'react-native';
-import { EdgeInsets } from 'react-native-safe-area-context';
 import { fontStyles, colors as importedColors } from '../../../styles/common';
 
-export const createStyles = (colors: any, safeArea: EdgeInsets) => {
-  const { bottom, top } = safeArea;
-
+export const createStyles = (colors: any) => {
   return StyleSheet.create({
     wrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
-      paddingTop: top,
-      paddingBottom: bottom,
     },
     normalText: {
       color: colors.text.default,

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -2,8 +2,8 @@
 import { StyleSheet } from 'react-native';
 import { fontStyles, colors as importedColors } from '../../../styles/common';
 
-export const createStyles = (colors: any) => {
-  return StyleSheet.create({
+export const createStyles = (colors: any) =>
+  StyleSheet.create({
     wrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
@@ -122,4 +122,3 @@ export const createStyles = (colors: any) => {
       borderColor: colors.border.muted,
     },
   });
-};

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -490,7 +490,7 @@ class Settings extends PureComponent {
     trackEvent(MetaMetricsEvents.REVEAL_PRIVATE_KEY_INITIATED);
     this.props.navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
       credentialName: 'private_key',
-      hasNavigation: true,
+      shouldUpdateNav: true,
     });
   };
 

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -360,7 +360,7 @@ const Wallet = ({ navigation }: any) => {
   );
 
   return (
-    <ErrorBoundary view="Wallet">
+    <ErrorBoundary navigation={navigation} view="Wallet">
       <View style={baseStyles.flexGrow} {...generateTestId('wallet-screen')}>
         <ScrollView
           style={styles.wrapper}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR fixes both the padding issue + interaction of the SRP reveal screen bug found in 6.2.0 regression
https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/issues/gh/metamask/mobile-planning/720

**Screenshots/Recordings**

Reach out to @Cal-L for videos

**Testing**
There are three main scenarios that the reveal credentials screen affects (the first 3 scenarios. 3 and 4 are essentially the same scenario)

- Scenario: Should be able to recover SRP when something errors out on the Root boundary
  - Given I am on the Login screen
  - And I enter the password and log in
  - When the app errors out and displays the Root error boundary
  - Then I should be able to follow the flow to reveal the SRP

- Scenario: Should be able to recover SRP when something errors out on the Activity boundary
  - Given I am on the Wallet view
  - And I open the drawer and tap on Activity
  - When the app errors out and displays the ActivityView error boundary
  - Then I should be able to follow the flow to reveal the SRP

- Scenario: Should be able to reveal SRP from the settings flow
  - Given I am on the Settings view
  - And I open Security & Privacy
  - When I tap on Reveal Secret Recovery Phrase
  - And I pass the quiz
  - Then I should be able to follow the flow to reveal the SRP

- Scenario: Should be able to reveal private key from the settings flow
  - Given I am on the Settings view
  - And I open Security & Privacy
  - When I tap on Show private key
  - Then I should be able to follow the flow to reveal my private key

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
