### PR TITLE
[UPDATE] yarn audit config and providing excluded reasoning

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,3 +1,3 @@
 GHSA-p8p7-x288-28g6
- #excluded due NOTE: This vulnerability only affects products that are no longer supported by the maintainer. and there is no current patch
+ # excluded due NOTE: This vulnerability only affects products that are no longer supported by the maintainer. and there is no current patch
  # improved-yarn-audit advisory exclusions

--- a/.iyarc
+++ b/.iyarc
@@ -1,2 +1,3 @@
-# improved-yarn-audit advisory exclusions
-1085140, 1085135
+GHSA-p8p7-x288-28g6
+ #excluded due NOTE: This vulnerability only affects products that are no longer supported by the maintainer. and there is no current patch
+ # improved-yarn-audit advisory exclusions


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This is a fix and update to the `.iyarc` file used for excluding yarn audit elements. Old audits that were no longer valid have been removed.

A new audit was added for exclusion per the warning we are maintain our project and there is currently no patch. 
(Ref: https://github.com/advisories/GHSA-p8p7-x288-28g6)

**Screenshots/Recordings**

NA

**Issue**

Progresses #???

**Checklist**

* [NA] There is a related GitHub issue
* [NA] Tests are included if applicable
* [NA] Any added code is fully documented
