### PR TITLE
[MC 0.5][FEATURE] Account selector on swaps screen

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/components/AccountSelector.tsx
+++ b/app/components/UI/FiatOnRampAggregator/components/AccountSelector.tsx
@@ -44,7 +44,10 @@ const AccountSelector = () => {
     <SelectorButton onPress={openAccountSelector} style={styles.selector}>
       <Identicon diameter={15} address={selectedAddress} />
       <Text style={styles.accountText} primary centered numberOfLines={1}>
-        {identities[selectedAddress]?.name} (
+        {identities[selectedAddress]?.name.length > 13
+          ? `${identities[selectedAddress]?.name.substr(0, 13)}...`
+          : identities[selectedAddress]?.name}
+        (
         <EthereumAddress address={selectedAddress} type={'short'} />)
       </Text>
     </SelectorButton>

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -76,6 +76,8 @@ import {
   selectChainId,
   selectProviderConfig,
 } from '../../../selectors/networkController';
+import AccountSelector from '../FiatOnRampAggregator/components/AccountSelector';
+import { set } from 'lodash';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -88,6 +90,12 @@ const createStyles = (colors) =>
     content: {
       flexGrow: 1,
       justifyContent: 'center',
+    },
+    accountSelector: {
+      width: '100%',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: 16,
     },
     keypad: {
       flexGrow: 1,
@@ -380,6 +388,17 @@ function SwapsAmountView({
     })();
   }, [isTokenInBalances, selectedAddress, sourceToken]);
 
+  useEffect(() => {
+    setAmount('0');
+    setSourceToken(
+      swapsTokens?.find((token) =>
+        toLowerCaseEquals(token.address, initialSource),
+      ),
+    );
+    setDestinationToken(null);
+    setSlippage(AppConstants.SWAPS.DEFAULT_SLIPPAGE);
+  }, [selectedAddress, swapsTokens, initialSource]);
+
   const hasInvalidDecimals = useMemo(() => {
     if (sourceToken) {
       return amount?.split('.')[1]?.length > sourceToken.decimals;
@@ -627,6 +646,9 @@ function SwapsAmountView({
       keyboardShouldPersistTaps="handled"
     >
       <View style={styles.content}>
+        <View style={styles.accountSelector}>
+          <AccountSelector />
+        </View>
         <View
           style={[styles.tokenButtonContainer, disabledView && styles.disabled]}
           pointerEvents={disabledView ? 'none' : 'auto'}

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -77,7 +77,6 @@ import {
   selectProviderConfig,
 } from '../../../selectors/networkController';
 import AccountSelector from '../FiatOnRampAggregator/components/AccountSelector';
-import { set } from 'lodash';
 
 const createStyles = (colors) =>
   StyleSheet.create({

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -194,6 +194,8 @@ function SwapsAmountView({
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
+  const previousSelectedAddress = useRef();
+
   const explorer = useBlockExplorer(providerConfig, frequentRpcList);
   const initialSource = route.params?.sourceToken ?? SWAPS_NATIVE_ADDRESS;
   const [amount, setAmount] = useState('0');
@@ -390,14 +392,17 @@ function SwapsAmountView({
    * Reset the state when account changes
    */
   useEffect(() => {
-    setAmount('0');
-    setSourceToken(
-      swapsTokens?.find((token) =>
-        toLowerCaseEquals(token.address, initialSource),
-      ),
-    );
-    setDestinationToken(null);
-    setSlippage(AppConstants.SWAPS.DEFAULT_SLIPPAGE);
+    if (selectedAddress !== previousSelectedAddress.current) {
+      setAmount('0');
+      setSourceToken(
+        swapsTokens?.find((token) =>
+          toLowerCaseEquals(token.address, initialSource),
+        ),
+      );
+      setDestinationToken(null);
+      setSlippage(AppConstants.SWAPS.DEFAULT_SLIPPAGE);
+      previousSelectedAddress.current = selectedAddress;
+    }
   }, [selectedAddress, swapsTokens, initialSource]);
 
   const hasInvalidDecimals = useMemo(() => {

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -92,7 +92,6 @@ const createStyles = (colors) =>
     },
     accountSelector: {
       width: '100%',
-      justifyContent: 'center',
       alignItems: 'center',
       marginBottom: 16,
     },
@@ -387,6 +386,9 @@ function SwapsAmountView({
     })();
   }, [isTokenInBalances, selectedAddress, sourceToken]);
 
+  /**
+   * Reset the state when account changes
+   */
   useEffect(() => {
     setAmount('0');
     setSourceToken(


### PR DESCRIPTION
**Description**
This PR aims to add account selector to the swaps screen, the reason for this it's when the user uses the new wallet action button (button on the center of the bottom tab menu), they can be on a dapp with a different selected address, that way if they try to swap, they will understand which account are they using

**Test Steps**
* Go to swaps
* Change the account on account selector
* Notice every time you change the account, the swap state reset to the initial state

**Screenshots/Recordings**
Ability to switch accounts on Swaps screen: https://recordit.co/SnpmupJKI3
Account shown on Swaps screen is not synced with the active Dapp accounts: https://recordit.co/BzWPZtujiA
Account change on Swaps screen reset the swap screen: https://recordit.co/RrwuwcJUcT

Removing imported account via the swaps screen: https://recordit.co/Va4ZTyDTmQ
creating an account with a long name then going to the swaps view: https://recordit.co/z0WBeOZTmg
Import account via the account selector from dapp connect modal via the browser then remove the imported account via the swaps account selector: https://recordit.co/OK7YaukMnU

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
