### PR TITLE
fix: prevent undefined title

### DIFF
--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -86,12 +86,13 @@ export default class WebsiteIcon extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
     const apiLogoUrl = { uri: icon || this.getIconUrl(url) };
-    const title =
-      typeof this.props.title === 'string'
-        ? this.props.title.substr(0, 1)
-        : getHost(url).substr(0, 1);
-
-    if (renderIconUrlError && title) {
+    let title = '';
+    if (typeof this.props.title === 'string' && this.props.title.length > 1) {
+      title = this.props.title.substring(0, 1);
+    } else if (url) {
+      title = getHost(url).substring(0, 1);
+    }
+    if (renderIconUrlError) {
       return (
         <View style={viewStyle}>
           <View style={[styles.fallback, style]}>


### PR DESCRIPTION
Fixes issue when title is not defined.

![image](https://user-images.githubusercontent.com/9333845/226401855-cd2a9578-59b9-4146-8214-d4dbc25852d5.png)

**To reproduce the issue:**

- Go to app.uniswap.org from the Chrome browser
- Initiate a connection with Metamask
- Start a swap from Eth to an ERC20 token
- Sign the transaction
- See the error

Expected behavior: App should work normally after signing a transaction

Fixes: #5989 
Also related to: #5957 that's been fixed on the iOS SDK side