### PR TITLE
Added a shim for BigInt

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "babel-plugin-transform-inline-environment-variables": "0.4.3",
     "babel-plugin-transform-remove-console": "6.9.4",
     "base-64": "1.0.0",
+    "big-int": "^0.0.6",
     "bignumber.js": "^9.0.1",
     "buffer": "5.2.1",
     "compare-versions": "^3.6.0",

--- a/shim.js
+++ b/shim.js
@@ -42,3 +42,4 @@ if (typeof localStorage !== 'undefined') {
 // If using the crypto shim, uncomment the following line to ensure
 // crypto is loaded first, so it can populate global.crypto
 // require('crypto')
+if (typeof BigInt === 'undefined') global.BigInt = require('big-integer');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8427,6 +8427,11 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
+big-int@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/big-int/-/big-int-0.0.6.tgz#6203bba2a2e6a8a76b480bd269bbc7b0c7defcce"
+  integrity sha512-pZqaIaokMooq6YfKHAezWZigcARydjTLubkRh3cbaEtJwoCXvhmQu80mhwZq8Synv8khZjKq6M8GNM4cICRioQ==
+
 big-integer@1.6.x, big-integer@^1.6.17:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

`@metamask/utils` was added by https://github.com/MetaMask/metamask-mobile/pull/5968

This causes an error about BigInt not being present. 

**Screenshots/Recordings**

![image](https://user-images.githubusercontent.com/1787231/226724918-12cfe197-f32b-4c82-b72c-b2824a56ffeb.png)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
