### PR TITLE
[REMOVE] sonar config from GH actions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           args: >
             -Dsonar.javascript.lcov.reportPaths=tests/coverage/lcov.info
-            -Dsonar.exclusions=android/,ios/,storybook/,sources/,scripts/,e2e/,wdio/
-            -Dsonar.tests=app/
-            -Dsonar.test.inclusions=**/*.test.*
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Their Sonar portal allows for configs to be populated. These values that could be updated in the portal have been removed. 

**Screenshots/Recordings**

NA

**Issue**

NA

**Checklist**

* [NA] There is a related GitHub issue
* [NA] Tests are included if applicable
* [NA] Any added code is fully documented
