### PR TITLE
Invalid Address when clicking the Etherscan Token Link for ERC721 Approve screen

### DIFF
--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -39,6 +39,7 @@ import {
   selectNetwork,
   selectProviderType,
   selectTicker,
+  selectRpcTarget,
 } from '../../../../selectors/networkController';
 import ShowBlockExplorer from '../../../UI/ApproveTransactionReview/ShowBlockExplorer';
 import createStyles from './styles';
@@ -118,6 +119,8 @@ class Approve extends PureComponent {
      * The current network of the app
      */
     network: PropTypes.string,
+    frequentRpcList: PropTypes.array,
+    providerRpcTarget: PropTypes.string,
   };
 
   state = {
@@ -537,8 +540,10 @@ class Approve extends PureComponent {
     });
   };
 
-  setIsBlockExplorerVisible = (val) => {
-    this.setState({ isBlockExplorerVisible: val });
+  setIsBlockExplorerVisible = () => {
+    this.setState({
+      isBlockExplorerVisible: !this.state.isBlockExplorerVisible,
+    });
   };
 
   render = () => {
@@ -570,6 +575,8 @@ class Approve extends PureComponent {
       primaryCurrency,
       chainId,
       providerType,
+      providerRpcTarget,
+      frequentRpcList,
     } = this.props;
 
     const selectedGasObject = {
@@ -641,10 +648,12 @@ class Approve extends PureComponent {
           <ShowBlockExplorer
             setIsBlockExplorerVisible={this.setIsBlockExplorerVisible}
             type={providerType}
-            contractAddress={transaction.to}
+            address={transaction.to}
             headerWrapperStyle={styles.headerWrapper}
             headerTextStyle={styles.headerText}
             iconStyle={styles.icon}
+            providerRpcTarget={providerRpcTarget}
+            frequentRpcList={frequentRpcList}
           />
         ) : (
           <KeyboardAwareScrollView
@@ -763,6 +772,9 @@ const mapStateToProps = (state) => ({
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
   network: selectNetwork(state),
   providerType: selectProviderType(state),
+  providerRpcTarget: selectRpcTarget(state),
+  frequentRpcList:
+    state.engine.backgroundState.PreferencesController.frequentRpcList,
 });
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
When I click on the ERC721 token name from the Approve screen, we land on the Etherscan Invalid Address page.

**Screenshots/Recordings**
Before:
https://recordit.co/yKuQVM1Hr2

After:
http://recordit.co/gZUsWpPooY

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6055 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
