### PR TITLE
applied fix: switching to rpc network redirects to linea

### DIFF
--- a/app/components/UI/NetworkList/index.js
+++ b/app/components/UI/NetworkList/index.js
@@ -257,7 +257,10 @@ export class NetworkList extends PureComponent {
 
     let rpc = frequentRpcList.find(({ rpcUrl }) => rpcUrl === rpcTarget);
 
-    if (!isLineaTestnetInFrequentRpcList) {
+    if (
+      !isLineaTestnetInFrequentRpcList &&
+      rpcTarget === LINEA_TESTNET_RPC_URL
+    ) {
       const url = new URLPARSE(LINEA_TESTNET_RPC_URL);
       const decimalChainId = getDecimalChainId(NETWORKS_CHAIN_ID.LINEA_TESTNET);
       PreferencesController.addToFrequentRpcList(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Replacement ticket for @VGau. Fixed issue that caused us to switch to the linea network instead of BNB.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/753

**Checklist**

* [X] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
