### PR TITLE
[FIX] Fix address bar input on iOS

### DIFF
--- a/app/components/Views/BrowserUrlModal/BrowserUrlModal.tsx
+++ b/app/components/Views/BrowserUrlModal/BrowserUrlModal.tsx
@@ -69,6 +69,7 @@ const BrowserUrlModal = () => {
         }
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const triggerClose = useCallback(() => dismissModal(), [dismissModal]);

--- a/app/components/Views/BrowserUrlModal/BrowserUrlModal.tsx
+++ b/app/components/Views/BrowserUrlModal/BrowserUrlModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -55,19 +55,21 @@ const BrowserUrlModal = () => {
     inputRef.current?.focus?.();
   }, []);
 
-  InteractionManager.runAfterInteractions(() => {
-    // Needed to focus the input after modal renders on Android
-    inputRef.current?.focus?.();
-    // Needed to manually selectTextOnFocus on iOS
-    // https://github.com/facebook/react-native/issues/30585
-    if (Device.isIos()) {
-      if (inputRef.current && autocompleteValue) {
-        inputRef.current.setNativeProps({
-          selection: { start: 0, end: autocompleteValue.length },
-        });
+  useEffect(() => {
+    InteractionManager.runAfterInteractions(() => {
+      // Needed to focus the input after modal renders on Android
+      inputRef.current?.focus?.();
+      // Needed to manually selectTextOnFocus on iOS
+      // https://github.com/facebook/react-native/issues/30585
+      if (Device.isIos()) {
+        if (inputRef.current && autocompleteValue) {
+          inputRef.current.setNativeProps({
+            selection: { start: 0, end: autocompleteValue.length },
+          });
+        }
       }
-    }
-  });
+    });
+  }, []);
 
   const triggerClose = useCallback(() => dismissModal(), [dismissModal]);
   const triggerOnSubmit = useCallback(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR fixes the re-focusing of the address bar input on the browser for iOS (when you delete text)
Addresses [#757](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/issues/gh/metamask/mobile-planning/757)

**Screenshots/Recordings**

https://user-images.githubusercontent.com/10508597/228614834-3f2242ca-49e3-4e52-b5b0-624869778ace.mov

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
