### PR TITLE
Remove inactive IPFS gateways

### DIFF
--- a/app/util/ipfs-gateways.json
+++ b/app/util/ipfs-gateways.json
@@ -15,105 +15,14 @@
     "label": "https://ipfs.infura.io/ipfs/"
   },
   {
-    "value": "https://rx14.co.uk/ipfs/",
-    "key": 3,
-    "label": "https://rx14.co.uk/ipfs/"
-  },
-  {
-    "value": "https://ninetailed.ninja/ipfs/",
-    "key": 4,
-    "label": "https://ninetailed.ninja/ipfs/"
-  },
-  {
-    "value": "https://upload.global/ipfs/",
-    "key": 5,
-    "label": "https://upload.global/ipfs/"
-  },
-  {
-    "value": "https://ipfs.jes.xxx/ipfs/",
-    "key": 6,
-    "label": "https://ipfs.jes.xxx/ipfs/"
-  },
-  {
-    "value": "https://catalunya.network/ipfs/",
-    "key": 7,
-    "label": "https://catalunya.network/ipfs/"
-  },
-  {
-    "value": "https://siderus.io/ipfs/",
-    "key": 8,
-    "label": "https://siderus.io/ipfs/"
-  },
-  {
-    "value": "https://ipfs.eternum.io/ipfs/",
-    "key": 9,
-    "label": "https://ipfs.eternum.io/ipfs/"
-  },
-  {
     "value": "https://hardbin.com/ipfs/",
     "key": 10,
     "label": "https://hardbin.com/ipfs/"
   },
   {
-    "value": "https://ipfs.macholibre.org/ipfs/",
-    "key": 11,
-    "label": "https://ipfs.macholibre.org/ipfs/"
-  },
-  {
-    "value": "https://ipfs.works/ipfs/",
-    "key": 12,
-    "label": "https://ipfs.works/ipfs/"
-  },
-  {
-    "value": "https://ipfs.wa.hle.rs/ipfs/",
-    "key": 13,
-    "label": "https://ipfs.wa.hle.rs/ipfs/"
-  },
-  {
-    "value": "https://api.wisdom.sh/ipfs/",
-    "key": 14,
-    "label": "https://api.wisdom.sh/ipfs/"
-  },
-  {
-    "value": "https://gateway.blocksec.com/ipfs/",
-    "key": 15,
-    "label": "https://gateway.blocksec.com/ipfs/"
-  },
-  {
-    "value": "https://ipfs.renehsz.com/ipfs/",
-    "key": 16,
-    "label": "https://ipfs.renehsz.com/ipfs/"
-  },
-  {
     "value": "https://cloudflare-ipfs.com/ipfs/",
     "key": 17,
     "label": "https://cloudflare-ipfs.com/ipfs/"
-  },
-  { "value": "https://ipns.co/", "key": 18, "label": "https://ipns.co/" },
-  {
-    "value": "https://ipfs.netw0rk.io/ipfs/",
-    "key": 19,
-    "label": "https://ipfs.netw0rk.io/ipfs/"
-  },
-  {
-    "value": "https://gateway.swedneck.xyz/ipfs/",
-    "key": 20,
-    "label": "https://gateway.swedneck.xyz/ipfs/"
-  },
-  {
-    "value": "https://ipfs.mrh.io/ipfs/",
-    "key": 21,
-    "label": "https://ipfs.mrh.io/ipfs/"
-  },
-  {
-    "value": "https://gateway.originprotocol.com/ipfs/",
-    "key": 22,
-    "label": "https://gateway.originprotocol.com/ipfs/"
-  },
-  {
-    "value": "https://ipfs.dapps.earth/ipfs/",
-    "key": 23,
-    "label": "https://ipfs.dapps.earth/ipfs/"
   },
   {
     "value": "https://gateway.pinata.cloud/ipfs/",
@@ -121,44 +30,9 @@
     "label": "https://gateway.pinata.cloud/ipfs/"
   },
   {
-    "value": "https://ipfs.doolta.com/ipfs/",
-    "key": 25,
-    "label": "https://ipfs.doolta.com/ipfs/"
-  },
-  {
-    "value": "https://ipfs.sloppyta.co/ipfs/",
-    "key": 26,
-    "label": "https://ipfs.sloppyta.co/ipfs/"
-  },
-  {
-    "value": "https://ipfs.busy.org/ipfs/",
-    "key": 27,
-    "label": "https://ipfs.busy.org/ipfs/"
-  },
-  {
     "value": "https://ipfs.greyh.at/ipfs/",
     "key": 28,
     "label": "https://ipfs.greyh.at/ipfs/"
-  },
-  {
-    "value": "https://gateway.serph.network/ipfs/",
-    "key": 29,
-    "label": "https://gateway.serph.network/ipfs/"
-  },
-  {
-    "value": "https://jorropo.ovh/ipfs/",
-    "key": 30,
-    "label": "https://jorropo.ovh/ipfs/"
-  },
-  {
-    "value": "https://ipfs.deo.moe/ipfs/",
-    "key": 31,
-    "label": "https://ipfs.deo.moe/ipfs/"
-  },
-  {
-    "value": "https://gateway.temporal.cloud/ipfs/",
-    "key": 32,
-    "label": "https://gateway.temporal.cloud/ipfs/"
   },
   {
     "value": "https://ipfs.fooock.com/ipfs/",


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
This pull request removes IPFS gateways which are no longer up and serving over HTTPs. This is to clear out stale records which are no longer relevant to the MetaMask Mobile Application. I did not remove records for IPFS providers which were still up, but returned an incorrect response when testing if they were active. 

**Issue**

https://github.com/MetaMask/mobile-planning/issues/766

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

**For reviewers**

Visit each provider and view that it is down.

<details> <summary> List  with clickable links for all downed providers </summary> 

{
    "value": "https://rx14.co.uk/ipfs/",
    "key": 3,
    "label": "https://rx14.co.uk/ipfs/"
  },
  {
    "value": "https://ninetailed.ninja/ipfs/",
    "key": 4,
    "label": "https://ninetailed.ninja/ipfs/"
  },
  {
    "value": "https://upload.global/ipfs/",
    "key": 5,
    "label": "https://upload.global/ipfs/"
  },
  {
    "value": "https://ipfs.jes.xxx/ipfs/",
    "key": 6,
    "label": "https://ipfs.jes.xxx/ipfs/"
  },
  {
    "value": "https://catalunya.network/ipfs/",
    "key": 7,
    "label": "https://catalunya.network/ipfs/"
  },
  {
    "value": "https://siderus.io/ipfs/",
    "key": 8,
    "label": "https://siderus.io/ipfs/"
  },
  {
    "value": "https://ipfs.eternum.io/ipfs/",
    "key": 9,
    "label": "https://ipfs.eternum.io/ipfs/"
  },
{
    "value": "https://ipfs.macholibre.org/ipfs/",
    "key": 11,
    "label": "https://ipfs.macholibre.org/ipfs/"
  },
  {
    "value": "https://ipfs.works/ipfs/",
    "key": 12,
    "label": "https://ipfs.works/ipfs/"
  },
  {
    "value": "https://ipfs.wa.hle.rs/ipfs/",
    "key": 13,
    "label": "https://ipfs.wa.hle.rs/ipfs/"
  },
  {
    "value": "https://api.wisdom.sh/ipfs/",
    "key": 14,
    "label": "https://api.wisdom.sh/ipfs/"
  },
  {
    "value": "https://gateway.blocksec.com/ipfs/",
    "key": 15,
    "label": "https://gateway.blocksec.com/ipfs/"
  },
  {
    "value": "https://ipfs.renehsz.com/ipfs/",
    "key": 16,
    "label": "https://ipfs.renehsz.com/ipfs/"
  },
  { "value": "https://ipns.co/", "key": 18, "label": "https://ipns.co/" },
  {
    "value": "https://ipfs.netw0rk.io/ipfs/",
    "key": 19,
    "label": "https://ipfs.netw0rk.io/ipfs/"
  },
  {
    "value": "https://gateway.swedneck.xyz/ipfs/",
    "key": 20,
    "label": "https://gateway.swedneck.xyz/ipfs/"
  },
  {
    "value": "https://ipfs.mrh.io/ipfs/",
    "key": 21,
    "label": "https://ipfs.mrh.io/ipfs/"
  },
  {
    "value": "https://gateway.originprotocol.com/ipfs/",
    "key": 22,
    "label": "https://gateway.originprotocol.com/ipfs/"
  },
  {
    "value": "https://ipfs.dapps.earth/ipfs/",
    "key": 23,
    "label": "https://ipfs.dapps.earth/ipfs/"
  },
{
    "value": "https://ipfs.doolta.com/ipfs/",
    "key": 25,
    "label": "https://ipfs.doolta.com/ipfs/"
  },
  {
    "value": "https://ipfs.sloppyta.co/ipfs/",
    "key": 26,
    "label": "https://ipfs.sloppyta.co/ipfs/"
  },
  {
    "value": "https://ipfs.busy.org/ipfs/",
    "key": 27,
    "label": "https://ipfs.busy.org/ipfs/"
  },
{
    "value": "https://gateway.serph.network/ipfs/",
    "key": 29,
    "label": "https://gateway.serph.network/ipfs/"
  },
  {
    "value": "https://jorropo.ovh/ipfs/",
    "key": 30,
    "label": "https://jorropo.ovh/ipfs/"
  },
  {
    "value": "https://ipfs.deo.moe/ipfs/",
    "key": 31,
    "label": "https://ipfs.deo.moe/ipfs/"
  },
  {
    "value": "https://gateway.temporal.cloud/ipfs/",
    "key": 32,
    "label": "https://gateway.temporal.cloud/ipfs/"
  },
</details>