### PR TITLE
[IMPROVEMENT] -  Route Support Page to In-App Browser to allow Dapp Connections

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -807,10 +807,13 @@ class DrawerView extends PureComponent {
   };
 
   showHelp = () => {
-    this.goToBrowserUrl(
-      'https://support.metamask.io',
-      strings('drawer.metamask_support'),
-    );
+    this.props.navigation.navigate(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: {
+        newTabUrl: 'https://support.metamask.io',
+        timestamp: Date.now(),
+      },
+    });
     this.trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_GET_HELP);
   };
 

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -815,6 +815,7 @@ class DrawerView extends PureComponent {
       },
     });
     this.trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_GET_HELP);
+    this.hideDrawer();
   };
 
   goToBrowserUrl(url, title) {


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The MetaMask Support page has added new functionality via the MetaMask Activity Dapp. This page use to load in a plain WebView which did not allow for `window.ethereum` be present so the Dapp Connect MetaMask. This PR routes the support page to open in the MM browser.

**Screenshots/Recordings**
- Test Case: Click link and open in MM browser - https://recordit.co/NsMnQ7P2b0

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
