### PR TITLE
Use Node environment for e2e tests

### DIFF
--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.constants.ts
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.constants.ts
@@ -11,5 +11,3 @@ export const TEST_REMOTE_IMAGE_SOURCE: ImageSourcePropType = {
 
 /* eslint-disable-next-line */
 export const TEST_LOCAL_IMAGE_SOURCE: ImageSourcePropType = require('../../../../../../images/ethereum.png');
-
-export const NETWORK_AVATAR_IMAGE_ID = 'network-avatar-image';

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.test.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.test.tsx
@@ -7,8 +7,8 @@ import { AvatarSize } from '../../Avatar.types';
 
 // Internal dependencies.
 import AvatarNetwork from './AvatarNetwork';
+import { NETWORK_AVATAR_IMAGE_ID } from '../../../../../../constants/test-ids';
 import {
-  NETWORK_AVATAR_IMAGE_ID,
   TEST_LOCAL_IMAGE_SOURCE,
   TEST_NETWORK_NAME,
   TEST_REMOTE_IMAGE_SOURCE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
@@ -12,7 +12,7 @@ import { useStyles } from '../../../../../hooks';
 
 // Internal dependencies.
 import { AvatarNetworkProps } from './AvatarNetwork.types';
-import { NETWORK_AVATAR_IMAGE_ID } from './AvatarNetwork.constants';
+import { NETWORK_AVATAR_IMAGE_ID } from './../../../../../../constants/test-ids';
 import stylesheet from './AvatarNetwork.styles';
 import generateTestId from '../../../../../../../wdio/utils/generateTestId';
 

--- a/app/component-library/components/Cells/Cell/Cell.constants.ts
+++ b/app/component-library/components/Cells/Cell/Cell.constants.ts
@@ -9,10 +9,6 @@ export const TEST_CELL_SECONDARY_TEXT =
 export const TEST_CELL_TERTIARY_TEXT = 'Updated 1 sec ago';
 export const TEST_TAG_LABEL_TEXT = 'Imported';
 
-export const CELL_DISPLAY_TEST_ID = 'cell-display';
-export const CELL_MULTI_SELECT_TEST_ID = 'cell-multi-select';
-export const CELL_SELECT_TEST_ID = 'cell-select';
-
 export const TEST_AVATAR_PROPS: AvatarProps = {
   variant: AvatarVariants.Account,
   accountAddress: TEST_ACCOUNT_ADDRESS,

--- a/app/component-library/components/Cells/Cell/Cell.test.tsx
+++ b/app/component-library/components/Cells/Cell/Cell.test.tsx
@@ -4,14 +4,14 @@ import { shallow } from 'enzyme';
 
 // Internal dependencies.
 import Cell from './Cell';
+import { TEST_AVATAR_PROPS, TEST_CELL_TITLE } from './Cell.constants';
+import { CellVariants } from './Cell.types';
+
 import {
-  TEST_AVATAR_PROPS,
-  TEST_CELL_TITLE,
   CELL_DISPLAY_TEST_ID,
   CELL_MULTI_SELECT_TEST_ID,
   CELL_SELECT_TEST_ID,
-} from './Cell.constants';
-import { CellVariants } from './Cell.types';
+} from '../../../../constants/test-ids';
 
 describe('Cell - Snapshot', () => {
   it('should render CellDisplay given the type Display', () => {

--- a/app/component-library/components/Cells/Cell/Cell.tsx
+++ b/app/component-library/components/Cells/Cell/Cell.tsx
@@ -12,7 +12,7 @@ import {
   CELL_DISPLAY_TEST_ID,
   CELL_MULTI_SELECT_TEST_ID,
   CELL_SELECT_TEST_ID,
-} from './Cell.constants';
+} from '../../../../constants/test-ids';
 
 const Cell = (cellProps: CellProps) => {
   switch (cellProps.variant) {

--- a/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.constants.ts
+++ b/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.constants.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const CELL_DISPLAY_TEST_ID = 'cell-display';

--- a/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.test.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.test.tsx
@@ -8,7 +8,7 @@ import { CellVariants } from '../../Cell.types';
 
 // Internal dependencies.
 import CellDisplay from './CellDisplay';
-import { CELL_DISPLAY_TEST_ID } from './CellDisplay.constants';
+import { CELL_DISPLAY_TEST_ID } from '../../../../../../constants/test-ids';
 
 describe('CellDisplay - Snapshot', () => {
   it('should render default settings correctly', () => {

--- a/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellDisplay/CellDisplay.tsx
@@ -9,7 +9,7 @@ import CellBase from '../../foundation/CellBase';
 import Card from '../../../../Cards/Card';
 
 // Internal dependencies.
-import { CELL_DISPLAY_TEST_ID } from './CellDisplay.constants';
+import { CELL_DISPLAY_TEST_ID } from '../../../../../../constants/test-ids';
 import styleSheet from './CellDisplay.styles';
 import { CellDisplayProps } from './CellDisplay.types';
 

--- a/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.constants.ts
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.constants.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const CELL_MULTI_SELECT_TEST_ID = 'cell-multi-select';

--- a/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.test.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.test.tsx
@@ -8,7 +8,7 @@ import { CellVariants } from '../../Cell.types';
 
 // Internal dependencies.
 import CellMultiselect from './CellMultiselect';
-import { CELL_MULTI_SELECT_TEST_ID } from './CellMultiselect.constants';
+import { CELL_MULTI_SELECT_TEST_ID } from '../../../../../../constants/test-ids';
 
 describe('CellMultiselect - Snapshot', () => {
   it('should render default settings correctly', () => {

--- a/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiselect/CellMultiselect.tsx
@@ -9,7 +9,7 @@ import MultiselectItem from '../../../../Select/Multiselect/MultiselectItem';
 import CellBase from '../../foundation/CellBase';
 
 // Internal dependencies.
-import { CELL_MULTI_SELECT_TEST_ID } from './CellMultiselect.constants';
+import { CELL_MULTI_SELECT_TEST_ID } from '../../../../../../constants/test-ids';
 import styleSheet from './CellMultiselect.styles';
 import { CellMultiselectProps } from './CellMultiselect.types';
 

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants.ts
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const CELL_SELECT_TEST_ID = 'cell-account-select';

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.test.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.test.tsx
@@ -8,7 +8,7 @@ import { CellVariants } from '../../Cell.types';
 
 // Internal dependencies.
 import CellSelect from './CellSelect';
-import { CELL_SELECT_TEST_ID } from './CellSelect.constants';
+import { CELL_SELECT_TEST_ID } from '../../../../../../constants/test-ids';
 
 describe('CellSelect - Snapshot', () => {
   it('should render default settings correctly', () => {

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.tsx
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.tsx
@@ -11,7 +11,7 @@ import SelectItem from '../../../../Select/Select/SelectItem';
 import CellBase from '../../foundation/CellBase';
 
 // Internal dependencies.
-import { CELL_SELECT_TEST_ID } from './CellSelect.constants';
+import { CELL_SELECT_TEST_ID } from '../../../../../../constants/test-ids';
 import styleSheet from './CellSelect.styles';
 import { CellSelectProps } from './CellSelect.types';
 import generateTestId from '../../../../../../../wdio/utils/generateTestId';

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/__snapshots__/CellSelect.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/__snapshots__/CellSelect.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`CellSelect - Snapshot should render default settings correctly 1`] = `
   isSelected={false}
   onPress={[Function]}
   style={Object {}}
-  testID="cell-account-select"
+  testID="cell-select"
   variant="Select"
 >
   <CellBase
@@ -26,7 +26,7 @@ exports[`CellSelect - Snapshot should render the proper selected state 1`] = `
   isSelected={true}
   onPress={[Function]}
   style={Object {}}
-  testID="cell-account-select"
+  testID="cell-select"
   variant="Select"
 >
   <CellBase

--- a/app/constants/test-ids.js
+++ b/app/constants/test-ids.js
@@ -60,6 +60,9 @@ export const INPUT_NETWORK_NAME = 'input-network-name';
 export const ADDRESS_BOOK_NEXT_BUTTON = 'address-book-next-button';
 
 // Design System test ids
+export const CELL_DISPLAY_TEST_ID = 'cell-display';
+export const CELL_MULTI_SELECT_TEST_ID = 'cell-multi-select';
+export const CELL_SELECT_TEST_ID = 'cell-select';
 export const FAVICON_AVATAR_IMAGE_ID = 'favicon-avatar-image';
 export const NETWORK_AVATAR_IMAGE_ID = 'network-avatar-image';
 export const CHECKBOX_ICON_ID = 'checkbox-icon';

--- a/e2e/config.json
+++ b/e2e/config.json
@@ -1,11 +1,8 @@
 {
   "rootDir": "../",
   "setupFilesAfterEnv": ["./e2e/init.js"],
-  "preset": "react-native",
+  "testEnvironment": "node",
   "forceExit": true,
-  "transform": {
-    "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
-  },
   "reporters": [
     "default",
     [

--- a/e2e/pages/AccountListView.js
+++ b/e2e/pages/AccountListView.js
@@ -7,9 +7,9 @@ import {
 } from '../../wdio/screen-objects/testIDs/Components/AccountListComponent.testIds';
 import { CELL_SELECT_TEST_ID } from '../../app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants';
 
-import { strings } from '../../locales/i18n';
+import messages from '../../locales/languages/en.json';
 
-const REMOVE_IMPORTED_ACCOUNT_TEXT = strings('accounts.yes_remove_it');
+const REMOVE_IMPORTED_ACCOUNT_TEXT = messages.accounts.yes_remove_it;
 
 export default class AccountListView {
   static async tapCreateAccountButton() {

--- a/e2e/pages/AccountListView.js
+++ b/e2e/pages/AccountListView.js
@@ -5,7 +5,7 @@ import {
   CREATE_ACCOUNT_BUTTON_ID,
   IMPORT_ACCOUNT_BUTTON_ID,
 } from '../../wdio/screen-objects/testIDs/Components/AccountListComponent.testIds';
-import { CELL_SELECT_TEST_ID } from '../../app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants';
+import { CELL_SELECT_TEST_ID } from '../../app/constants/test-ids';
 
 import messages from '../../locales/languages/en.json';
 

--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -1,6 +1,6 @@
 import TestHelpers from '../../helpers';
 import messages from '../../../locales/languages/en.json';
-import { NETWORK_AVATAR_IMAGE_ID } from '../../../app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.constants';
+import { NETWORK_AVATAR_IMAGE_ID } from '../../../app/constants/test-ids';
 import { MULTI_TAB_ADD_BUTTON } from '../../../wdio/screen-objects/testIDs/BrowserScreen/MultiTab.testIds';
 import {
   BROWSER_SCREEN_ID,

--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../helpers';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 import { NETWORK_AVATAR_IMAGE_ID } from '../../../app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.constants';
 import { MULTI_TAB_ADD_BUTTON } from '../../../wdio/screen-objects/testIDs/BrowserScreen/MultiTab.testIds';
 import {
@@ -19,10 +19,10 @@ import { NOTIFICATION_TITLE } from '../../../wdio/screen-objects/testIDs/Compone
 
 const ANDROID_BROWSER_WEBVIEW_ID = 'browser-webview';
 const ANDROID_CLEAR_INPUT_BUTTON_ID = 'cancel-url-button';
-const RETURN_HOME_TEXT = strings('webview_error.return_home');
-const BACK_TO_SAFETY_TEXT = strings('phishing.back_to_safety');
-const REVOKE_ALL_ACCOUNTS_TEXT = strings('toast.revoked_all');
-const CONNECTED_ACCOUNTS_TEXT = strings('toast.connected_and_active');
+const RETURN_HOME_TEXT = messages.webview_error.return_home;
+const BACK_TO_SAFETY_TEXT = messages.phishing.back_to_safety;
+const REVOKE_ALL_ACCOUNTS_TEXT = messages.toast.revoked_all;
+const CONNECTED_ACCOUNTS_TEXT = messages.toast.connected_and_active;
 
 export default class Browser {
   static async tapUrlInputBox() {

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ChangePasswordView.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ChangePasswordView.js
@@ -8,9 +8,9 @@ import {
   RESET_PASSWORD_ANDROID_TERM_CHECKBOX_ID,
 } from '../../../../../wdio/screen-objects/testIDs/Screens/ChangePasswordScreensIDs.testIds';
 
-import { strings } from '../../../../../locales/i18n';
+import messages from '../../../../../locales/languages/en.json';
 
-const CHANGE_PASSWORD_TEXT = strings('manual_backup_step_1.confirm_password');
+const CHANGE_PASSWORD_TEXT = messages.manual_backup_step_1.confirm_password;
 
 export default class ChangePasswordView {
   static async typeInConfirmPasswordInputBox(PASSWORD) {

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/RevealSecretRecoveryPhrase.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/RevealSecretRecoveryPhrase.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../../../helpers';
-import { strings } from '../../../../../locales/i18n';
+import messages from '../../../../../locales/languages/en.json';
 
 const SECRET_RECOVERY_PHRASE_CONTAINER_ID = 'reveal-private-credential-screen';
 const PASSWORD_INPUT_BOX_ID = 'private-credential-password-text-input';
@@ -8,8 +8,7 @@ const REVEAL_SECRET_RECOVERY_PHRASE_TOUCHABLE_BOX_ID =
   'private-credential-touchable';
 const SECRET_RECOVERY_PHRASE_TEXT = 'private-credential-text';
 
-// this way if the strings ever change the tests will not break :)
-const PASSWORD_WARNING = strings('reveal_credential.unknown_error');
+const PASSWORD_WARNING = messages.reveal_credential.unknown_error;
 
 export default class RevealSecretRecoveryPhrase {
   static async enterPassword(password) {

--- a/e2e/pages/Onboarding/ImportWalletView.js
+++ b/e2e/pages/Onboarding/ImportWalletView.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../helpers';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 
 import {
   CREATE_PASSWORD_INPUT_BOX_ID,
@@ -13,12 +13,9 @@ import { IMPORT_FROM_SEED_SCREEN_SEED_PHRASE_INPUT_ID } from '../../../wdio/scre
 const REMEMBER_ME_ID = 'remember-me-toggle';
 const CREATE_PASSWORD_BUTTON_ID = 'submit-button';
 
-// use i18n for these
-// this way if the strings ever change the tests will not break :)
-const Incorrect_Password_Length = strings(
-  'import_from_seed.password_length_error',
-);
-const Invalid_Seed_Error = strings('import_from_seed.invalid_seed_phrase');
+const Incorrect_Password_Length =
+  messages.import_from_seed.password_length_error;
+const Invalid_Seed_Error = messages.import_from_seed.invalid_seed_phrase;
 
 export default class ImportWalletView {
   static async enterPassword(password) {

--- a/e2e/pages/Onboarding/OnboardingView.js
+++ b/e2e/pages/Onboarding/OnboardingView.js
@@ -1,12 +1,12 @@
 import { WALLET_SETUP_CREATE_NEW_WALLET_BUTTON_ID } from '../../../wdio/screen-objects/testIDs/Screens/WalletSetupScreen.testIds';
 import TestHelpers from '../../helpers';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 import { NOTIFICATION_TITLE } from '../../../wdio/screen-objects/testIDs/Components/Notification.testIds';
 
 const ONBOARDING_SCREEN_ID = 'onboarding-screen';
 const IMPORT_FROM_SEED_BUTTON_ID =
   'wallet-setup-screen-import-from-seed-button-id';
-const DeletePasswordString = strings('onboarding.your_wallet');
+const DeletePasswordString = messages.onboarding.your_wallet;
 
 export default class OnboardingView {
   static async tapCreateWallet() {

--- a/e2e/pages/modals/ConnectModal.js
+++ b/e2e/pages/modals/ConnectModal.js
@@ -4,20 +4,17 @@ import {
   CANCEL_BUTTON_ID,
   CONNECT_BUTTON_ID,
 } from '../../../app/constants/test-ids';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 
-const CONNECT_MULTIPLE_ACCOUNTS_STRING = strings(
-  'accounts.connect_multiple_accounts',
-);
-const CONNECT_MULTIPLE_ACCOUNTS_CREATE_ACCOUNT_TEXT = strings(
-  'accounts.create_new_account',
-);
+const CONNECT_MULTIPLE_ACCOUNTS_STRING =
+  messages.accounts.connect_multiple_accounts;
+const CONNECT_MULTIPLE_ACCOUNTS_CREATE_ACCOUNT_TEXT =
+  messages.accounts.create_new_account;
 
-const CONNECT_MULTIPLE_ACCOUNTS_IMPORT_ACCOUNT_TEXT = strings(
-  'accounts.import_account',
-);
+const CONNECT_MULTIPLE_ACCOUNTS_IMPORT_ACCOUNT_TEXT =
+  messages.accounts.import_account;
 
-const SELECT_ALL_TEXT = strings('accounts.select_all');
+const SELECT_ALL_TEXT = messages.accounts.select_all;
 
 export default class ConnectModal {
   static async tapCancelButton() {

--- a/e2e/pages/modals/ConnectedAccountsModal.js
+++ b/e2e/pages/modals/ConnectedAccountsModal.js
@@ -1,13 +1,13 @@
 import TestHelpers from '../../helpers';
 import {
   CANCEL_BUTTON_ID,
+  CELL_SELECT_TEST_ID,
   CONNECT_BUTTON_ID,
 } from '../../../app/constants/test-ids';
 import {
   CONNECTED_ACCOUNTS_MODAL_CONTAINER,
   CONNECTED_ACCOUNTS_MODAL_NETWORK_PICKER_ID,
 } from '../../../wdio/screen-objects/testIDs/Components/ConnectedAccountsModal.testIds';
-import { CELL_SELECT_TEST_ID } from '../../../app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants';
 
 import messages from '../../../locales/languages/en.json';
 

--- a/e2e/pages/modals/ConnectedAccountsModal.js
+++ b/e2e/pages/modals/ConnectedAccountsModal.js
@@ -9,12 +9,12 @@ import {
 } from '../../../wdio/screen-objects/testIDs/Components/ConnectedAccountsModal.testIds';
 import { CELL_SELECT_TEST_ID } from '../../../app/component-library/components/Cells/Cell/variants/CellSelect/CellSelect.constants';
 
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 
-const CONNECTED_ACCOUNTS_PERMISSION_LINK_TEXT = strings('accounts.permissions');
-const CONNECTED_ACCOUNTS_REVOKE_LINK_TEXT = strings('accounts.revoke');
+const CONNECTED_ACCOUNTS_PERMISSION_LINK_TEXT = messages.accounts.permissions;
+const CONNECTED_ACCOUNTS_REVOKE_LINK_TEXT = messages.accounts.revoke;
 
-const CONNECTED_ACCOUNTS_REVOKE_ALL_TEXT = strings('accounts.revoke_all');
+const CONNECTED_ACCOUNTS_REVOKE_ALL_TEXT = messages.accounts.revoke_all;
 
 export default class ConnectedAccountsModal {
   static async tapCancelButton() {

--- a/e2e/pages/modals/NetworkAddedModal.js
+++ b/e2e/pages/modals/NetworkAddedModal.js
@@ -3,9 +3,9 @@ import {
   NEW_NETWORK_ADDED_CLOSE_BUTTON_ID,
   NEW_NETWORK_ADDED_SWITCH_TO_NETWORK_BUTTON_ID,
 } from '../../../app/constants/test-ids';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 
-const switchToNetworkText = strings('networks.new_network');
+const switchToNetworkText = messages.networks.new_network;
 
 export default class NetworkAddedModal {
   static async tapSwitchToNetwork() {

--- a/e2e/pages/modals/NetworkEducationModal.js
+++ b/e2e/pages/modals/NetworkEducationModal.js
@@ -4,9 +4,9 @@ import {
   NETWORK_EDUCATION_MODAL_CLOSE_BUTTON_ID,
   NETWORK_EDUCATION_MODAL_NETWORK_NAME_ID,
 } from '../../../wdio/screen-objects/testIDs/Components/NetworkEducationModalTestIds';
-import { strings } from '../../../locales/i18n';
+import messages from '../../../locales/languages/en.json';
 
-const manuallyAddTokenText = strings('network_information.add_token');
+const manuallyAddTokenText = messages.network_information.add_token;
 export default class NetworkEducationModal {
   static async tapGotItButton() {
     await TestHelpers.tap(NETWORK_EDUCATION_MODAL_CLOSE_BUTTON_ID);


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The Jest configuration used for Detox e2e tests has been updated to use a Node.js environment rather than React Native presets. This was a requirement for using Ganache as part of e2e tests (it was incompatible with some of the global changes introduced by the React Native environment).

The Jest process doesn't need to execute any React Native code directly as part of the e2e test suite. The only direct reference today was via the `i18n` module, which was accessed to retrieve localized messages. All such references were updated to use the JSON file directly, to avoid importing React Native libraries.

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/765

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
