### PR TITLE
Add a selector for the conversion rate state

### DIFF
--- a/app/components/UI/AccountInfoCard/index.js
+++ b/app/components/UI/AccountInfoCard/index.js
@@ -17,6 +17,7 @@ import { QR_HARDWARE_WALLET_DEVICE } from '../../../constants/keyringTypes';
 import Device from '../../../util/device';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { selectTicker } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -220,8 +221,7 @@ class AccountInfoCard extends PureComponent {
 const mapStateToProps = (state) => ({
   accounts: state.engine.backgroundState.AccountTrackerController.accounts,
   identities: state.engine.backgroundState.PreferencesController.identities,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   ticker: selectTicker(state),

--- a/app/components/UI/AssetOverview/index.js
+++ b/app/components/UI/AssetOverview/index.js
@@ -47,6 +47,7 @@ import {
   selectChainId,
   selectTicker,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 import { createWebviewNavDetails } from '../../Views/SimpleWebview';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { TOKEN_ASSET_OVERVIEW } from '../../../../wdio/screen-objects/testIDs/Screens/TokenOverviewScreen.testIds';
@@ -406,8 +407,7 @@ class AssetOverview extends PureComponent {
 
 const mapStateToProps = (state) => ({
   accounts: state.engine.backgroundState.AccountTrackerController.accounts,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   primaryCurrency: state.settings.primaryCurrency,

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -27,6 +27,7 @@ import {
   selectChainId,
   selectTicker,
 } from '../../../../selectors/networkController';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const WINDOW_WIDTH = Dimensions.get('window').width;
 const ACTION_CANCEL = 'cancel';
@@ -440,8 +441,7 @@ const mapStateToProps = (state) => ({
   collectibleContracts: collectibleContractsSelector(state),
   contractExchangeRates:
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   primaryCurrency: state.settings.primaryCurrency,

--- a/app/components/UI/PaymentRequest/index.js
+++ b/app/components/UI/PaymentRequest/index.js
@@ -59,6 +59,7 @@ import {
   REQUEST_SEARCH_ASSET_INPUT,
   REQUEST_SEARCH_SCREEN,
 } from '../../../../wdio/screen-objects/testIDs/Screens/RequestToken.testIds';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const KEYBOARD_OFFSET = 120;
 const createStyles = (colors) =>
@@ -878,8 +879,7 @@ class PaymentRequest extends PureComponent {
 PaymentRequest.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   contractExchangeRates:

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -83,6 +83,7 @@ import {
   selectTicker,
 } from '../../../selectors/networkController';
 import { resetTransaction, setRecipient } from '../../../actions/transaction';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const POLLING_INTERVAL = 30000;
 const SLIPPAGE_BUCKETS = {
@@ -2346,8 +2347,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.PreferencesController.selectedAddress,
   balances:
     state.engine.backgroundState.TokenBalancesController.contractBalances,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   isInPolling: state.engine.backgroundState.SwapsController.isInPolling,

--- a/app/components/UI/Swaps/components/GasEditModal.js
+++ b/app/components/UI/Swaps/components/GasEditModal.js
@@ -23,6 +23,7 @@ import {
   selectChainId,
   selectTicker,
 } from '../../../../selectors/networkController';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const GAS_OPTIONS = AppConstants.GAS_OPTIONS;
 
@@ -547,8 +548,7 @@ GasEditModal.propTypes = {
 const mapStateToProps = (state) => ({
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   nativeCurrency:
     state.engine.backgroundState.CurrencyRateController.nativeCurrency,
   ticker: selectTicker(state),

--- a/app/components/UI/Swaps/components/QuotesModal.js
+++ b/app/components/UI/Swaps/components/QuotesModal.js
@@ -28,6 +28,7 @@ import Text from '../../../Base/Text';
 import Title from '../../../Base/Title';
 import Ratio from './Ratio';
 import { useTheme } from '../../../../util/theme';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors, shadows) =>
   StyleSheet.create({
@@ -525,8 +526,7 @@ QuotesModal.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   quoteValues: state.engine.backgroundState.SwapsController.quoteValues,

--- a/app/components/UI/Swaps/components/TokenSelectModal.js
+++ b/app/components/UI/Swaps/components/TokenSelectModal.js
@@ -50,6 +50,7 @@ import {
 import Analytics from '../../../../core/Analytics/Analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useTheme } from '../../../../util/theme';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -556,8 +557,7 @@ TokenSelectModal.propTypes = {
 
 const mapStateToProps = (state) => ({
   accounts: state.engine.backgroundState.AccountTrackerController.accounts,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   selectedAddress:

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -74,6 +74,7 @@ import {
   selectProviderConfig,
 } from '../../../selectors/networkController';
 import AccountSelector from '../FiatOnRampAggregator/components/AccountSelector';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -998,8 +999,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.PreferencesController.selectedAddress,
   balances:
     state.engine.backgroundState.TokenBalancesController.contractBalances,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   tokenExchangeRates:
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
   currentCurrency:

--- a/app/components/UI/Tokens/index.js
+++ b/app/components/UI/Tokens/index.js
@@ -48,6 +48,7 @@ import { selectChainId } from '../../../selectors/networkController';
 import { createDetectedTokensNavDetails } from '../../Views/DetectedTokens';
 import { allowedToBuy } from '../FiatOnRampAggregator';
 import Routes from '../../../constants/navigation/Routes';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -523,8 +524,7 @@ const mapStateToProps = (state) => ({
   chainId: selectChainId(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   primaryCurrency: state.settings.primaryCurrency,
   tokenBalances:
     state.engine.backgroundState.TokenBalancesController.contractBalances,

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -42,6 +42,7 @@ import {
   selectProviderType,
   selectTicker,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -887,8 +888,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.GasFeeController.gasEstimateType,
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   nativeCurrency:
     state.engine.backgroundState.CurrencyRateController.nativeCurrency,
   primaryCurrency: state.settings.primaryCurrency,

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -30,6 +30,7 @@ import {
   selectChainId,
   selectTicker,
 } from '../../../../selectors/networkController';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -423,8 +424,7 @@ const mapStateToProps = (state) => ({
   ),
   contractExchangeRates:
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   primaryCurrency: state.settings.primaryCurrency,

--- a/app/components/UI/TransactionReview/TransactionReviewData/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewData/index.js
@@ -11,6 +11,7 @@ import { ThemeContext, mockTheme } from '../../../../util/theme';
 import ClipboardManager from '../../../../core/ClipboardManager';
 import { showAlert } from '../../../../actions/alert';
 import GlobalAlert from '../../../../components/UI/GlobalAlert';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -179,8 +180,7 @@ class TransactionReviewData extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   contractExchangeRates:

--- a/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewFeeCard/index.js
@@ -17,6 +17,7 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 import FadeAnimationView from '../../FadeAnimationView';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import { selectChainId } from '../../../../selectors/networkController';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -386,8 +387,7 @@ class TransactionReviewFeeCard extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   chainId: selectChainId(state),

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -47,6 +47,7 @@ import {
   selectTicker,
 } from '../../../../selectors/networkController';
 import { createBrowserNavDetails } from '../../../Views/Browser';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -710,8 +711,7 @@ class TransactionReviewInformation extends PureComponent {
 
 const mapStateToProps = (state) => ({
   network: selectNetwork(state),
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   contractExchangeRates:

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -54,6 +54,7 @@ import {
 } from '../../../selectors/networkController';
 import ApproveTransactionHeader from '../ApproveTransactionHeader';
 import AppConstants from '../../../core/AppConstants';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const POLLING_INTERVAL_ESTIMATED_L1_FEE = 30000;
 
@@ -596,8 +597,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   contractExchangeRates:
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   ticker: selectTicker(state),
   chainId: selectChainId(state),
   showHexData: state.settings.showHexData,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -45,6 +45,7 @@ import {
   selectChainId,
   selectProviderType,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -742,8 +743,7 @@ const mapStateToProps = (state) => ({
   collectibleContracts: collectibleContractsSelector(state),
   contractExchangeRates:
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   selectedAddress:

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -42,6 +42,7 @@ import {
 } from '../../../../selectors/networkController';
 import ShowBlockExplorer from '../../../UI/ApproveTransactionReview/ShowBlockExplorer';
 import createStyles from './styles';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -758,8 +759,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   nativeCurrency:
     state.engine.backgroundState.CurrencyRateController.nativeCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
   network: selectNetwork(state),
   providerType: selectProviderType(state),

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -33,6 +33,7 @@ import {
   selectRpcTarget,
 } from '../../../selectors/networkController';
 import Routes from '../../../constants/navigation/Routes';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -422,8 +423,7 @@ Asset.contextType = ThemeContext;
 const mapStateToProps = (state) => ({
   swapsTransactions:
     state.engine.backgroundState.TransactionController.swapsTransactions || {},
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   selectedAddress:

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -32,6 +32,7 @@ import { useTheme } from '../../../util/theme';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import Routes from '../../../constants/navigation/Routes';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -103,10 +104,7 @@ const AssetDetails = (props: Props) => {
     (state: any) =>
       state.engine.backgroundState.TokensController.tokens as TokenType[],
   );
-  const conversionRate = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.CurrencyRateController.conversionRate,
-  );
+  const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(
     (state: any) =>
       state.engine.backgroundState.CurrencyRateController.currentCurrency,

--- a/app/components/Views/DetectedTokens/components/Token.tsx
+++ b/app/components/Views/DetectedTokens/components/Token.tsx
@@ -15,6 +15,7 @@ import {
   renderFromTokenMinimalUnit,
 } from '../../../../util/number';
 import { useTheme } from '../../../../util/theme';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -95,10 +96,7 @@ const Token = ({ token, selected, toggleSelected }: Props) => {
     (state: any) =>
       state.engine.backgroundState.TokenBalancesController.contractBalances,
   );
-  const conversionRate = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.CurrencyRateController.conversionRate,
-  );
+  const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(
     (state: any) =>
       state.engine.backgroundState.CurrencyRateController.currentCurrency,

--- a/app/components/Views/GasEducationCarousel/index.js
+++ b/app/components/Views/GasEducationCarousel/index.js
@@ -32,6 +32,7 @@ import TransactionTypes from '../../../core/TransactionTypes';
 import { formatCurrency, getTransactionFee } from '../../../util/confirm-tx';
 import Logger from '../../../util/Logger';
 import { selectTicker } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const IMAGE_3_RATIO = 281 / 354;
 const IMAGE_2_RATIO = 353 / 416;
@@ -432,8 +433,7 @@ GasEducationCarousel.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   nativeCurrency:

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -90,6 +90,7 @@ import {
   selectTicker,
 } from '../../../../selectors/networkController';
 import { PREFIX_HEX_STRING } from '../../../../constants/transaction';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const KEYBOARD_OFFSET = Device.isSmallDevice() ? 80 : 120;
 
@@ -1379,8 +1380,7 @@ const mapStateToProps = (state, ownProps) => ({
   collectibleContracts: collectibleContractsSelector(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   providerType: selectProviderType(state),
   primaryCurrency: state.settings.primaryCurrency,
   selectedAddress:

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -94,6 +94,7 @@ import {
 } from '../../../../selectors/networkController';
 import generateTestId from '../../../../../wdio/utils/generateTestId';
 import { COMFIRM_TXN_AMOUNT } from '../../../../../wdio/screen-objects/testIDs/Screens/TransactionConfirm.testIds';
+import { selectConversionRate } from '../../../../selectors/currencyRateController';
 
 const EDIT = 'edit';
 const EDIT_NONCE = 'edit_nonce';
@@ -1270,8 +1271,7 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.TokenRatesController.contractExchangeRates,
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   network: selectNetwork(state),
   providerType: selectProviderType(state),
   showHexData: state.settings.showHexData,

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -24,6 +24,7 @@ import {
   selectNetwork,
   selectProviderType,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -207,8 +208,7 @@ TransactionsView.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  conversionRate:
-    state.engine.backgroundState.CurrencyRateController.conversionRate,
+  conversionRate: selectConversionRate(state),
   currentCurrency:
     state.engine.backgroundState.CurrencyRateController.currentCurrency,
   selectedAddress:

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -47,6 +47,7 @@ import {
   selectProviderConfig,
   selectTicker,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
@@ -96,10 +97,7 @@ const Wallet = ({ navigation }: any) => {
   /**
    * ETH to current currency conversion rate
    */
-  const conversionRate = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.CurrencyRateController.conversionRate,
-  );
+  const conversionRate = useSelector(selectConversionRate);
   /**
    * Currency code of the currently-active currency
    */

--- a/app/components/hooks/useAccounts/useAccounts.ts
+++ b/app/components/hooks/useAccounts/useAccounts.ts
@@ -22,6 +22,7 @@ import {
   selectTicker,
   selectNetwork,
 } from '../../../selectors/networkController';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 
 /**
  * Hook that returns both wallet accounts and ens name information.
@@ -51,10 +52,7 @@ const useAccounts = ({
       state.engine.backgroundState.AccountTrackerController.accounts,
     isEqual,
   );
-  const conversionRate = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.CurrencyRateController.conversionRate,
-  );
+  const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(
     (state: any) =>
       state.engine.backgroundState.CurrencyRateController.currentCurrency,

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -60,6 +60,7 @@ import {
   unrestrictedMethods,
 } from './Permissions/specifications.js';
 import { backupVault } from './BackupVault';
+import { selectConversionRate } from '../selectors/currencyRateController';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -639,10 +640,11 @@ class Engine {
     } = this.context;
     const { selectedAddress } = PreferencesController.state;
     const { currentCurrency } = CurrencyRateController.state;
-    const conversionRate =
-      CurrencyRateController.state.conversionRate === null
-        ? 0
-        : CurrencyRateController.state.conversionRate;
+    const conversionRate = selectConversionRate({
+      engine: {
+        backgroundState: this.datamodel.state,
+      },
+    });
     const { accounts } = AccountTrackerController.state;
     const { tokens } = TokensController.state;
     let ethFiat = 0;
@@ -912,23 +914,13 @@ export default {
       PermissionController,
     } = instance.datamodel.state;
 
-    // normalize `null` currencyRate to `0`
-    // TODO: handle `null` currencyRate by hiding fiat values instead
-    const modifiedCurrencyRateControllerState = {
-      ...CurrencyRateController,
-      conversionRate:
-        CurrencyRateController.conversionRate === null
-          ? 0
-          : CurrencyRateController.conversionRate,
-    };
-
     return {
       AccountTrackerController,
       AddressBookController,
       AssetsContractController,
       NftController,
       TokenListController,
-      CurrencyRateController: modifiedCurrencyRateControllerState,
+      CurrencyRateController,
       KeyringController,
       PersonalMessageManager,
       NetworkController,

--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -12,6 +12,7 @@ import {
   LegacyProps,
 } from './types';
 import { selectTicker } from '../../selectors/networkController';
+import { selectConversionRate } from '../../selectors/currencyRateController';
 
 /**
  *
@@ -53,7 +54,7 @@ export const useDataStore = () => {
       state.engine.backgroundState.GasFeeController.gasFeeEstimates,
       state.engine.backgroundState.GasFeeController.gasEstimateType,
       state.engine.backgroundState.TokenRatesController.contractExchangeRates,
-      state.engine.backgroundState.CurrencyRateController.conversionRate,
+      selectConversionRate(state),
       state.engine.backgroundState.CurrencyRateController.currentCurrency,
       state.engine.backgroundState.CurrencyRateController.nativeCurrency,
       state.engine.backgroundState.AccountTrackerController.accounts,

--- a/app/selectors/currencyRateController.test.ts
+++ b/app/selectors/currencyRateController.test.ts
@@ -1,0 +1,178 @@
+import { selectConversionRate } from './currencyRateController';
+import { EngineState } from './types';
+
+function getDefaultEngineState(): EngineState {
+  return {
+    engine: {
+      backgroundState: {
+        AccountTrackerController: { accounts: {} },
+        AddressBookController: { addressBook: {} },
+        AssetsContractController: {},
+        CurrencyRateController: {
+          conversionDate: 0,
+          conversionRate: 0,
+          currentCurrency: 'usd',
+          nativeCurrency: 'ETH',
+          pendingCurrentCurrency: null,
+          pendingNativeCurrency: null,
+          usdConversionRate: null,
+        },
+        GasFeeController: {
+          gasFeeEstimates: {},
+          estimatedGasFeeTimeBounds: {},
+          gasEstimateType: 'none',
+        },
+        KeyringController: { keyrings: [] },
+        NetworkController: {
+          network: 'loading',
+          isCustomNetwork: false,
+          providerConfig: {
+            type: 'mainnet',
+            chainId: '1',
+          },
+          properties: {},
+        },
+        NftController: {
+          allNftContracts: {},
+          allNfts: {},
+          ignoredNfts: [],
+        },
+        NftDetectionController: {},
+        PersonalMessageManager: {
+          unapprovedMessages: {},
+          unapprovedMessagesCount: 0,
+        },
+        PhishingController: {
+          listState: {
+            allowlist: [],
+            blocklist: [],
+            fuzzylist: [],
+            tolerance: 2,
+            version: 2,
+            name: 'Metamask',
+            lastUpdated: 0,
+          },
+          whitelist: [],
+          hotlistLastFetched: 0,
+          stalelistLastFetched: 0,
+        },
+        PreferencesController: {
+          disabledRpcMethodPreferences: {
+            eth_sign: false,
+          },
+          featureFlags: {},
+          frequentRpcList: [],
+          identities: {},
+          ipfsGateway: 'https://ipfs.io/ipfs/',
+          lostIdentities: {},
+          openSeaEnabled: false,
+          selectedAddress: '',
+          useNftDetection: false,
+          useTokenDetection: true,
+        },
+        SwapsController: {
+          quotes: {},
+          quoteValues: {},
+          fetchParams: {
+            slippage: 0,
+            sourceToken: '',
+            sourceAmount: 0,
+            destinationToken: '',
+            walletAddress: '',
+          },
+          fetchParamsMetaData: {
+            sourceTokenInfo: {
+              decimals: 0,
+              address: '',
+              symbol: '',
+            },
+            destinationTokenInfo: {
+              decimals: 0,
+              address: '',
+              symbol: '',
+            },
+          },
+          topAggSavings: null,
+          aggregatorMetadata: null,
+          tokens: null,
+          topAssets: null,
+          approvalTransaction: null,
+          aggregatorMetadataLastFetched: 0,
+          quotesLastFetched: 0,
+          topAssetsLastFetched: 0,
+          error: { key: null, description: null },
+          topAggId: null,
+          tokensLastFetched: 0,
+          isInPolling: false,
+          pollingCyclesLeft: 0,
+          quoteRefreshSeconds: null,
+          usedGasEstimate: null,
+          usedCustomGas: null,
+          chainCache: {},
+        },
+        TokenBalancesController: {
+          contractBalances: {},
+        },
+        TokenDetectionController: {},
+        TokenListController: {
+          tokenList: {},
+          tokensChainsCache: {},
+          preventPollingOnNetworkRestart: false,
+        },
+        TokenRatesController: {
+          contractExchangeRates: {},
+        },
+        TokensController: {
+          tokens: [],
+          ignoredTokens: [],
+          detectedTokens: [],
+          allTokens: {},
+          allIgnoredTokens: {},
+          allDetectedTokens: {},
+          suggestedAssets: [],
+        },
+        TransactionController: {
+          transactions: [],
+          methodData: {},
+        },
+        TypedMessageManager: {
+          unapprovedMessages: {},
+          unapprovedMessagesCount: 0,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Return mock engine state with the specified mock values.
+ *
+ * @param options - Options
+ * @param options.conversionRate - The currency rate controller conversion rate.
+ */
+function getMockEngineState({
+  conversionRate,
+}: { conversionRate?: number | null } = {}): EngineState {
+  const engineState = getDefaultEngineState();
+  if (conversionRate !== undefined) {
+    engineState.engine.backgroundState.CurrencyRateController.conversionRate =
+      conversionRate;
+  }
+  return engineState;
+}
+
+describe('currencyRateController', () => {
+  describe('selectConversionRate', () => {
+    it('selects the conversion rate', () => {
+      expect(
+        selectConversionRate(getMockEngineState({ conversionRate: 10 })),
+      ).toBe(10);
+    });
+
+    it('returns zero if the conversion rate is null', () => {
+      expect(
+        selectConversionRate(getMockEngineState({ conversionRate: null })),
+      ).toBe(0);
+    });
+  });
+});

--- a/app/selectors/currencyRateController.ts
+++ b/app/selectors/currencyRateController.ts
@@ -1,0 +1,23 @@
+import { createSelector } from 'reselect';
+import { EngineState } from './types';
+
+const selectCurrencyRateControllerState = (state: EngineState) =>
+  state?.engine?.backgroundState?.CurrencyRateController;
+
+/**
+ * Select the conversion rate for the current network.
+ *
+ * `null` is being normalized to `0` here as a workaround for certain UI components not handling
+ * `null` appropriately.
+ *
+ * TODO: Handle `null` currencyRate by hiding fiat values instead.
+ */
+// Using a named export because we will be adding more selectors soon
+// eslint-disable-next-line import/prefer-default-export
+export const selectConversionRate = createSelector(
+  selectCurrencyRateControllerState,
+  (currencyRateControllerState) =>
+    currencyRateControllerState?.conversionRate === null
+      ? 0
+      : currencyRateControllerState?.conversionRate,
+);

--- a/app/selectors/types.ts
+++ b/app/selectors/types.ts
@@ -1,27 +1,57 @@
-import {
+import type {
   AccountTrackerState,
   CurrencyRateState,
-  NftDetectionController,
   NftState,
   TokenBalancesState,
-  TokenDetectionController,
   TokenListState,
   TokenRatesState,
   TokensState,
 } from '@metamask/assets-controllers';
-import SwapsController from '@metamask/swaps-controller';
-import { NetworkState } from '@metamask/network-controller';
-import { AddressBookState } from '@metamask/address-book-controller';
-import { BaseState } from '@metamask/base-controller';
-import { KeyringMemState } from '@metamask/keyring-controller';
-import { PreferencesState } from '@metamask/preferences-controller';
-import { PhishingState } from '@metamask/phishing-controller';
-import { TransactionState } from '@metamask/transaction-controller';
-import { GasFeeController } from '@metamask/gas-fee-controller';
-import {
-  PersonalMessageParams,
-  TypedMessageManager,
-} from '@metamask/message-manager';
+import type { SwapsState } from '@metamask/swaps-controller/dist/SwapsController';
+import type { NetworkState } from '@metamask/network-controller';
+import type { AddressBookState } from '@metamask/address-book-controller';
+import type { BaseState } from '@metamask/base-controller';
+import type { KeyringState } from '@metamask/keyring-controller';
+import type { PreferencesState } from '@metamask/preferences-controller';
+import type { PhishingState } from '@metamask/phishing-controller';
+import type { TransactionState } from '@metamask/transaction-controller';
+import type { GasFeeState } from '@metamask/gas-fee-controller';
+import type { PersonalMessage, TypedMessage } from '@metamask/message-manager';
+import type { Json } from '@metamask/controller-utils';
+
+/**
+ * Represents and contains data about a signing type signature request.
+ *
+ * TODO: Export this type from `@metamask/message-manager`.
+ *
+ * @property id - An id to track and identify the message object
+ * @property type - The json-prc signing method for which a signature request has been made.
+ * A 'Message' which always has a signing type
+ * @property rawSig - Raw data of the signature request
+ * @property securityProviderResponse - Response from a security provider, whether it is malicious or not
+ */
+export interface AbstractMessage {
+  id: string;
+  time: number;
+  status: string;
+  type: string;
+  rawSig?: string;
+  securityProviderResponse?: Map<string, Json>;
+}
+
+/**
+ * Message Manager state
+ *
+ * TODO: Export this type from `@metamask/message-manager`.
+ *
+ * @property unapprovedMessages - A collection of all Messages in the 'unapproved' state
+ * @property unapprovedMessagesCount - The count of all Messages in this.unapprovedMessages
+ */
+export interface MessageManagerState<M extends AbstractMessage>
+  extends BaseState {
+  unapprovedMessages: { [key: string]: M };
+  unapprovedMessagesCount: number;
+}
 
 export interface EngineState {
   engine: {
@@ -29,23 +59,23 @@ export interface EngineState {
       AccountTrackerController: AccountTrackerState;
       AddressBookController: AddressBookState;
       AssetsContractController: BaseState;
-      NftController: NftState;
-      TokenListController: TokenListState;
       CurrencyRateController: CurrencyRateState;
-      KeyringController: KeyringMemState;
-      PersonalMessageManager: PersonalMessageParams;
+      GasFeeController: GasFeeState;
+      KeyringController: KeyringState;
       NetworkController: NetworkState;
-      PreferencesController: PreferencesState;
+      NftController: NftState;
+      NftDetectionController: BaseState;
+      PersonalMessageManager: MessageManagerState<PersonalMessage>;
       PhishingController: PhishingState;
+      PreferencesController: PreferencesState;
+      SwapsController: SwapsState;
       TokenBalancesController: TokenBalancesState;
+      TokenDetectionController: BaseState;
+      TokenListController: TokenListState;
       TokenRatesController: TokenRatesState;
-      TransactionController: TransactionState;
-      TypedMessageManager: TypedMessageManager;
-      SwapsController: SwapsController;
-      GasFeeController: GasFeeController;
       TokensController: TokensState;
-      TokenDetectionController: TokenDetectionController;
-      NftDetectionController: NftDetectionController;
+      TransactionController: TransactionState;
+      TypedMessageManager: MessageManagerState<TypedMessage>;
     };
   };
 }


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `conversionRate` state from the `CurrencyRateController` is now accessed nearly exclusively from a selector.

This refactor was completed to further the goal of moving all background state access to selectors for ease of maintenance. It will also help with handling conversion rate e2e testing on localhost.

**Issue**

Tangentially related to https://github.com/MetaMask/mobile-planning/issues/765

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
