### PR TITLE
Bump approval-controller to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@keystonehq/metamask-airgapped-keyring": "^0.3.0",
     "@keystonehq/ur-decoder": "^0.6.1",
     "@metamask/address-book-controller": "^1.0.1",
-    "@metamask/approval-controller": "^1.0.1",
+    "@metamask/approval-controller": "^1.1.0",
     "@metamask/assets-controllers": "^3.0.1",
     "@metamask/base-controller": "^1.1.1",
     "@metamask/composable-controller": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,6 +3937,17 @@
     immer "^9.0.6"
     nanoid "^3.1.31"
 
+"@metamask/approval-controller@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/approval-controller/-/approval-controller-1.1.0.tgz#1f0c89ffa3a60600f69886ffb9a8bd06ef823b32"
+  integrity sha512-6RFPMUayRDxe1ZrkDPIqPNSQ10pMUB1uGr8c52X7gm+EEaS3OnZV4qLMASvwpu7gNQe5dFiCZPypRHlM5qiq+A==
+  dependencies:
+    "@metamask/base-controller" "^1.1.2"
+    "@metamask/controller-utils" "^2.0.0"
+    eth-rpc-errors "^4.0.0"
+    immer "^9.0.6"
+    nanoid "^3.1.31"
+
 "@metamask/assets-controllers@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/assets-controllers/-/assets-controllers-3.0.1.tgz#0dff14dd0b9f5be5037b45eab9669f16ae5fd302"


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This PR aims to upgrade `@metamask/approval-controller` to version `1.1.0`. It will make the `updateRequestState` method available helping whenever is necessary to update the request state of the approval as is advised in [the confirmations guidelines](https://github.com/MetaMask/metamask-mobile/blob/chore/728-confirmations-guidelines/docs/confirmations.md#1-create-approval-request).

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**
resolves: https://github.com/MetaMask/mobile-planning/issues/764

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
