### PR TITLE
Invalid URL: Remove blockexplorer when not defined

### DIFF
--- a/app/components/UI/ApproveTransactionReview/AddNickname/index.tsx
+++ b/app/components/UI/ApproveTransactionReview/AddNickname/index.tsx
@@ -22,7 +22,10 @@ import ShowBlockExplorer from '../ShowBlockExplorer';
 import { useTheme } from '../../../../util/theme';
 import createStyles from './styles';
 import { AddNicknameProps } from './types';
-import { validateAddressOrENS } from '../../../../util/address';
+import {
+  validateAddressOrENS,
+  shouldShowBlockExplorer,
+} from '../../../../util/address';
 import ErrorMessage from '../../../Views/SendFlow/ErrorMessage';
 import {
   CONTACT_ALREADY_SAVED,
@@ -49,6 +52,7 @@ const AddNickname = (props: AddNicknameProps) => {
     providerRpcTarget,
     addressBook,
     identities,
+    frequentRpcList,
   } = props;
 
   const [newNickname, setNewNickname] = useState(addressNickname);
@@ -148,6 +152,12 @@ const AddNickname = (props: AddNicknameProps) => {
     return errorMessage;
   };
 
+  const hasBlockExplorer = shouldShowBlockExplorer({
+    providerType,
+    providerRpcTarget,
+    frequentRpcList,
+  });
+
   return (
     <SafeAreaView style={styles.container}>
       {isBlockExplorerVisible ? (
@@ -196,12 +206,14 @@ const AddNickname = (props: AddNicknameProps) => {
                   style={styles.address}
                 />
               </TouchableOpacity>
-              <AntDesignIcon
-                style={styles.actionIcon}
-                name="export"
-                size={22}
-                onPress={toggleBlockExplorer}
-              />
+              {hasBlockExplorer && (
+                <AntDesignIcon
+                  style={styles.actionIcon}
+                  name="export"
+                  size={22}
+                  onPress={toggleBlockExplorer}
+                />
+              )}
             </View>
             <Text style={styles.label}>{strings('nickname.name')}</Text>
             <TextInput
@@ -252,6 +264,8 @@ const mapStateToProps = (state: any) => ({
   providerNetwork: selectNetwork(state),
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
   identities: state.engine.backgroundState.PreferencesController.identities,
+  frequentRpcList:
+    state.engine.backgroundState.PreferencesController.frequentRpcList,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/app/components/UI/ApproveTransactionReview/AddNickname/types.ts
+++ b/app/components/UI/ApproveTransactionReview/AddNickname/types.ts
@@ -2,6 +2,7 @@ export interface AddNicknameProps {
   closeModal: () => void;
   address: string;
   addressNickname: string;
+  frequentRpcList: any;
   nicknameExists: boolean;
   showModalAlert: (config: any) => void;
   providerType: string;

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -18,7 +18,11 @@ import {
   ENSCache,
   isDefaultAccountName,
 } from '../../util/ENSUtils';
-import { isMainnetByChainId } from '../../util/networks';
+import { RPC } from '../../constants/network';
+import {
+  isMainnetByChainId,
+  findBlockExplorerForRpc,
+} from '../../util/networks';
 import { collectConfusables } from '../../util/confusables';
 import {
   CONTACT_ALREADY_SAVED,
@@ -489,4 +493,15 @@ export const getTokenDetails = async (tokenAddress, userAddress, tokenId) => {
     decimals,
     standard,
   };
+};
+
+export const shouldShowBlockExplorer = ({
+  providerType,
+  providerRpcTarget,
+  frequentRpcList,
+}) => {
+  if (providerType === RPC) {
+    return findBlockExplorerForRpc(providerRpcTarget, frequentRpcList);
+  }
+  return true;
 };

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -6,6 +6,7 @@ import {
   isValidAddressInputViaQRCode,
   stripHexPrefix,
   getAddress,
+  shouldShowBlockExplorer,
 } from '.';
 
 describe('isENS', () => {
@@ -160,5 +161,58 @@ describe('getAddress', () => {
   it('should return null if address is invalid', async () => {
     const response = await getAddress(inValidAddress, '1');
     expect(response).toBe(null);
+  });
+});
+
+describe('shouldShowBlockExplorer', () => {
+  const frequentRpcList = [
+    {
+      chainId: '1',
+      nickname: 'Main Ethereum Network',
+      rpcUrl: 'https://mainnet.infura.io/v3/123',
+      rpcPrefs: {},
+    },
+  ];
+
+  it('returns true if provider type is not rpc', () => {
+    const providerType = 'mainnet';
+    const providerRpcTarget = frequentRpcList[0].rpcUrl;
+
+    const result = shouldShowBlockExplorer({
+      providerType,
+      providerRpcTarget,
+      frequentRpcList,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns block explorer URL if defined', () => {
+    const providerType = 'rpc';
+    const providerRpcTarget = frequentRpcList[0].rpcUrl;
+    const blockExplorerUrl = 'https://rpc.testnet.fantom.network';
+    frequentRpcList[0].rpcPrefs = { blockExplorerUrl };
+
+    const result = shouldShowBlockExplorer({
+      providerType,
+      providerRpcTarget,
+      frequentRpcList,
+    });
+
+    expect(result).toBe(blockExplorerUrl);
+  });
+
+  it('returns undefined if block explorer URL is not defined', () => {
+    const providerType = 'rpc';
+    const providerRpcTarget = frequentRpcList[0].rpcUrl;
+    frequentRpcList[0].rpcPrefs = {};
+
+    const result = shouldShowBlockExplorer({
+      providerType,
+      providerRpcTarget,
+      frequentRpcList,
+    });
+
+    expect(result).toBe(undefined);
   });
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

If I add a Network without a blockexplorer, when I proceed to interact with a Contract, if I go to Verify Contract Details and click the contract Address, I am able to go to the blockexplorer link, but since there is no blockexplorer URL set, the result is an error saying Invalid URL: undefined

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
_2. What is the improvement/solution?_

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6098 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
