### PR TITLE
[FIX] #778 Sdk remember text color

### DIFF
--- a/app/components/UI/AccountApproval/index.js
+++ b/app/components/UI/AccountApproval/index.js
@@ -116,7 +116,7 @@ const createStyles = (colors, typography) =>
       height: 20,
       width: 20,
     },
-    rememberText: { paddingLeft: 10 },
+    rememberText: { paddingLeft: 10, color: colors.text.default },
     option: {
       flex: 1,
     },


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR fixes the text color for the remember text when approving SDK connections in dark mode
Original issue [#778](https://github.com/MetaMask/mobile-planning/issues/778)

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
