### PR TITLE
[FIX] Alert when open external url on in app browser

### DIFF
--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useContext } from 'react';
+import React, { useEffect, useRef, useContext, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { View, Dimensions, Platform } from 'react-native';
 import PropTypes from 'prop-types';
@@ -69,6 +69,7 @@ const Browser = (props) => {
       ? AvatarAccountType.Blockies
       : AvatarAccountType.JazzIcon,
   );
+  const [isDeeplink, setIsDeeplink] = useState(false);
 
   //frequentRpcList has all the rpcs added by the user. We add 1 more to account the Ethereum Main Network
   const nonTestnetNetworks = props.frequentRpcList.length + 1;
@@ -225,6 +226,7 @@ const Browser = (props) => {
       if (newTabUrl && deeplinkTimestamp) {
         // Open url from deeplink.
         newTab(newTabUrl);
+        setIsDeeplink(true);
       } else if (existingTabId) {
         const existingTab = tabs.find((tab) => tab.id === existingTabId);
         if (existingTab) {
@@ -356,6 +358,7 @@ const Browser = (props) => {
         updateTabInfo={updateTabInfo}
         showTabs={showTabs}
         newTab={newTab}
+        isDeeplink={isDeeplink}
       />
     ));
 

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -31,7 +31,6 @@ import onUrlSubmit, {
   isTLD,
   protocolAllowList,
   getAlertMessage,
-  allowLinkOpen,
   getUrlObj,
 } from '../../../util/browser';
 import {


### PR DESCRIPTION
**Description**
The alert was not being prompted when the deep link was pressed and the in-app browser was opening the URL

Instead, now it prompts the alert when the page starts loading (not preventing the page from loading, but preventing the user to navigate).

**Proposal Solution**
We should have two actions, "close" and "continue", this way we could prevent everything from happening on that loaded page, until one Alert option it's pressed.

**Recording**
https://recordit.co/4xFfwEtgaC


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
