### PR TITLE
[FIX] [6.4.0] Token rate undefined handled properly

### DIFF
--- a/app/components/UI/AssetElement/index.tsx
+++ b/app/components/UI/AssetElement/index.tsx
@@ -8,6 +8,10 @@ import SkeletonText from '../FiatOnRampAggregator/components/SkeletonText';
 import { TokenI } from '../Tokens/types';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { getAssetTestId } from '../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
+import {
+  TOKEN_BALANCE_LOADING,
+  TOKEN_RATE_UNDEFINED,
+} from '../Tokens/constants';
 
 interface AssetElementProps {
   children?: React.ReactNode;
@@ -70,10 +74,12 @@ const AssetElement: React.FC<AssetElementProps> = ({
       {balance && (
         <Text
           variant={
-            !asset?.balanceError ? TextVariant.BodyLGMedium : TextVariant.BodySM
+            asset?.balanceError || asset.balanceFiat === TOKEN_RATE_UNDEFINED
+              ? TextVariant.BodySM
+              : TextVariant.BodyLGMedium
           }
         >
-          {balance === 'loading' ? (
+          {balance === TOKEN_BALANCE_LOADING ? (
             <SkeletonText thin style={styles.skeleton} />
           ) : (
             balance

--- a/app/components/UI/Tokens/constants.ts
+++ b/app/components/UI/Tokens/constants.ts
@@ -1,0 +1,2 @@
+export const TOKEN_RATE_UNDEFINED = 'tokenRateUndefined';
+export const TOKEN_BALANCE_LOADING = 'tokenBalanceLoading';

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -62,6 +62,7 @@ import SkeletonText from '../../../components/UI/FiatOnRampAggregator/components
 import { allowedToBuy } from '../FiatOnRampAggregator';
 import Routes from '../../../constants/navigation/Routes';
 import { TokenI, TokensI } from './types';
+import { TOKEN_BALANCE_LOADING, TOKEN_RATE_UNDEFINED } from './constants';
 
 const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const { colors, themeAppearance } = useTheme();
@@ -158,9 +159,11 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const handleBalance = (asset: TokenI) => {
     const itemAddress: string = safeToChecksumAddress(asset.address) || '';
 
+    // When the exchange rate of a token is not found, the return is undefined
+    // We fallback to the TOKEN_RATE_UNDEFINED to handle it properly
     const exchangeRate =
       itemAddress in tokenExchangeRates
-        ? tokenExchangeRates[itemAddress]
+        ? tokenExchangeRates[itemAddress] || TOKEN_RATE_UNDEFINED
         : undefined;
 
     const balance =
@@ -171,8 +174,8 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
 
     if (!balance && !asset.isETH) {
       return {
-        balanceFiat: 'loading',
-        balanceValueFormatted: 'loading',
+        balanceFiat: TOKEN_BALANCE_LOADING,
+        balanceValueFormatted: TOKEN_BALANCE_LOADING,
       };
     }
 
@@ -180,7 +183,13 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
 
     if (!conversionRate || !exchangeRate)
       return {
-        balanceFiat: asset.isETH ? asset.balanceFiat : 'loading',
+        balanceFiat: asset.isETH ? asset.balanceFiat : TOKEN_BALANCE_LOADING,
+        balanceValueFormatted,
+      };
+
+    if (exchangeRate === TOKEN_RATE_UNDEFINED)
+      return {
+        balanceFiat: asset.isETH ? asset.balanceFiat : TOKEN_RATE_UNDEFINED,
         balanceValueFormatted,
       };
 
@@ -213,6 +222,11 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
 
     if (asset?.balanceError) {
       mainBalance = asset.symbol;
+      secondaryBalance = strings('wallet.unable_to_load');
+    }
+
+    if (balanceFiat === TOKEN_RATE_UNDEFINED) {
+      mainBalance = balanceValueFormatted;
       secondaryBalance = strings('wallet.unable_to_load');
     }
 
@@ -262,7 +276,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
           </Text>
 
           <Text variant={TextVariant.BodyMD} style={styles.balanceFiat}>
-            {mainBalance === 'loading' ? (
+            {mainBalance === TOKEN_BALANCE_LOADING ? (
               <SkeletonText thin style={styles.skeleton} />
             ) : (
               mainBalance


### PR DESCRIPTION
**Description**
This PR aims to fix a bug that came out of the new token list, certain tokens doesn't have token rates, and that would show a skeleton loader for ever. This PR handle that use case and show a error message instead.
https://www.screencast.com/t/ZEXY2BEESjjf

**Test steps (Used IOS Simulator for those steps)**
* Detected token on different networks (Mainnet, Polygon and Binance)  - https://recordit.co/RqUmz3cC89
* Imported custom token on Fujii testnet  - https://recordit.co/KYxhfEMoG2
* Imported auto complete and custom token on Polygon Mainnet - https://recordit.co/TfaBjuW3k1
* Imported TON from coingecko website (https://www.coingecko.com/en/coins/toncoin) - https://recordit.co/GH79CCuYDC
 

**Solution**
**Screenshots/Recordings**
https://recordit.co/vWBBw9q7co


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
