### PR TITLE
deps/security: vm2@3.9.11->3.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "**/elliptic": "^6.5.4",
     "**/y18n": "^3.2.2",
     "pubnub/**/netmask": "^2.0.1",
-    "**/vm2": "3.9.11",
+    "**/vm2": "3.9.15",
     "**/optimist/minimist": "^1.2.5",
     "react-native-level-fs/**/bl": "^1.2.3",
     "react-native-level-fs/**/semver": "^4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24147,10 +24147,10 @@ vm-browserify@1.1.2:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vm2@3.9.11, vm2@^3.9.3:
-  version "3.9.11"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
-  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
+vm2@3.9.15, vm2@^3.9.3:
+  version "3.9.15"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.15.tgz#c544e6a9bc31e4e40d2e5f532342cf799ea56a6e"
+  integrity sha512-XqNqknHGw2avJo13gbIwLNZUumvrSHc9mLqoadFZTpo3KaNEJoe1I0lqTFhRXmXD7WkLyG01aaraXdXT0pa4ag==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
CVE-2023-29017 / [GHSA-7jxr-cg7f-gpgv](https://github.com/patriksimek/vm2/security/advisories/GHSA-7jxr-cg7f-gpgv)


- [npmdiff:3.9.11...3.9.15](https://npm-diff.app/vm2@3.9.11...vm2@3.9.15)
- [git:3.9.11...3.9.15](https://github.com/patriksimek/vm2/compare/3.9.11...3.9.15)
- [Changelog](https://github.com/patriksimek/vm2/blob/master/CHANGELOG.md)