### PR TITLE
feat: trigger walletconnect modal using approval controller

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -477,6 +477,7 @@ const RootRPCMethodsUI = (props) => {
       walletConnectRequestInfo.id,
       walletConnectRequestInfo.data,
     );
+    setWalletConnectRequestInfo(undefined);
   };
 
   const onWalletConnectSessionRejected = () => {
@@ -485,9 +486,11 @@ const RootRPCMethodsUI = (props) => {
       walletConnectRequestInfo.id,
       ethErrors.provider.userRejectedRequest(),
     );
+    setWalletConnectRequestInfo(undefined);
   };
 
   const renderWalletConnectSessionRequestModal = () => {
+    const meta = walletConnectRequestInfo?.data?.peerMeta || null;
     return (
       <Modal
         isVisible={showPendingApproval?.type === ApprovalTypes.WALLET_CONNECT}

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -488,10 +488,6 @@ const RootRPCMethodsUI = (props) => {
   };
 
   const renderWalletConnectSessionRequestModal = () => {
-    const meta = walletConnectRequestInfo?.data?.peerMeta || null;
-    // walletConnectRequestInfo is reset to undefined in onWalletConnectSessionApproval as soon as the approval happens
-    if (!meta) return;
-
     return (
       <Modal
         isVisible={showPendingApproval?.type === ApprovalTypes.WALLET_CONNECT}

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -97,6 +97,26 @@ const RootRPCMethodsUI = (props) => {
   const toggleDappTransactionModal = props.toggleDappTransactionModal;
   const setEtherTransaction = props.setEtherTransaction;
 
+  // Reject pending approval using MetaMask SDK.
+  const rejectPendingApproval = (id, error) => {
+    const { ApprovalController } = Engine.context;
+    try {
+      ApprovalController.reject(id, error);
+    } catch (error) {
+      Logger.error(error, 'Reject while rejecting pending connection request');
+    }
+  };
+
+  // Accept pending approval using MetaMask SDK.
+  const acceptPendingApproval = (id, requestData) => {
+    const { ApprovalController } = Engine.context;
+    try {
+      ApprovalController.accept(id, requestData);
+    } catch (err) {
+      // Ignore err if request already approved or doesn't exists.
+    }
+  };
+
   const showPendingApprovalModal = ({ type, origin }) => {
     InteractionManager.runAfterInteractions(() => {
       setShowPendingApproval({ type, origin });
@@ -117,12 +137,6 @@ const RootRPCMethodsUI = (props) => {
 
   const initializeWalletConnect = () => {
     WalletConnect.init();
-  };
-
-  const onWalletConnectSessionRequest = () => {
-    WalletConnect.hub.on('walletconnectSessionRequest', (peerInfo) => {
-      setWalletConnectRequestInfo(peerInfo);
-    });
   };
 
   const trackSwaps = useCallback(
@@ -458,25 +472,29 @@ const RootRPCMethodsUI = (props) => {
   };
 
   const onWalletConnectSessionApproval = () => {
-    const { peerId } = walletConnectRequestInfo;
-    setWalletConnectRequestInfo(undefined);
-    WalletConnect.hub.emit('walletconnectSessionRequest::approved', peerId);
+    setShowPendingApproval(false);
+    acceptPendingApproval(
+      walletConnectRequestInfo.id,
+      walletConnectRequestInfo.data,
+    );
   };
 
   const onWalletConnectSessionRejected = () => {
-    const peerId = walletConnectRequestInfo?.peerId;
-    setWalletConnectRequestInfo(undefined);
-    WalletConnect.hub.emit('walletconnectSessionRequest::rejected', peerId);
+    setShowPendingApproval(false);
+    rejectPendingApproval(
+      walletConnectRequestInfo.id,
+      ethErrors.provider.userRejectedRequest(),
+    );
   };
 
   const renderWalletConnectSessionRequestModal = () => {
-    const meta = walletConnectRequestInfo?.peerMeta || null;
+    const meta = walletConnectRequestInfo?.data?.peerMeta || null;
     // walletConnectRequestInfo is reset to undefined in onWalletConnectSessionApproval as soon as the approval happens
     if (!meta) return;
 
     return (
       <Modal
-        isVisible={!!meta}
+        isVisible={showPendingApproval?.type === ApprovalTypes.WALLET_CONNECT}
         animationIn="slideInUp"
         animationOut="slideOutDown"
         style={styles.bottomModal}
@@ -515,26 +533,6 @@ const RootRPCMethodsUI = (props) => {
     props.approveModalVisible && (
       <Approve modalVisible toggleApproveModal={props.toggleApproveModal} />
     );
-
-  // Reject pending approval using MetaMask SDK.
-  const rejectPendingApproval = (id, error) => {
-    const { ApprovalController } = Engine.context;
-    try {
-      ApprovalController.reject(id, error);
-    } catch (error) {
-      Logger.error(error, 'Reject while rejecting pending connection request');
-    }
-  };
-
-  // Accept pending approval using MetaMask SDK.
-  const acceptPendingApproval = (id, requestData) => {
-    const { ApprovalController } = Engine.context;
-    try {
-      ApprovalController.accept(id, requestData);
-    } catch (err) {
-      // Ignore err if request already approved or doesn't exists.
-    }
-  };
 
   const onAddCustomNetworkReject = () => {
     setShowPendingApproval(false);
@@ -766,6 +764,13 @@ const RootRPCMethodsUI = (props) => {
             origin: request.origin,
           });
           break;
+        case ApprovalTypes.WALLET_CONNECT:
+          setWalletConnectRequestInfo({ data: requestData, id: request.id });
+          showPendingApprovalModal({
+            type: ApprovalTypes.WALLET_CONNECT,
+            origin: request.origin,
+          });
+          break;
         default:
           break;
       }
@@ -776,7 +781,6 @@ const RootRPCMethodsUI = (props) => {
 
   useEffect(() => {
     initializeWalletConnect();
-    onWalletConnectSessionRequest();
 
     Engine.context.MessageManager.hub.on('unapprovedMessage', (messageParams) =>
       onUnapprovedMessage(messageParams, 'eth'),

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -30,6 +30,7 @@ export enum ApprovalTypes {
   ADD_ETHEREUM_CHAIN = 'ADD_ETHEREUM_CHAIN',
   SWITCH_ETHEREUM_CHAIN = 'SWITCH_ETHEREUM_CHAIN',
   REQUEST_PERMISSIONS = 'wallet_requestPermissions',
+  WALLET_CONNECT = 'WALLET_CONNECT',
 }
 
 interface RPCMethodsMiddleParameters {

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -1,5 +1,6 @@
 import RNWalletConnect from '@walletconnect/client';
 import { parseWalletConnectUri } from '@walletconnect/utils';
+import { v1 as random } from 'uuid';
 import Engine from './Engine';
 import Logger from '../util/Logger';
 // eslint-disable-next-line import/no-nodejs-modules
@@ -343,9 +344,10 @@ class WalletConnect {
   sessionRequest = async (peerInfo) => {
     const { ApprovalController } = Engine.context;
     try {
+      const { host } = new URL(peerInfo.peerMeta.url);
       return await ApprovalController.add({
-        id: peerInfo.peerId,
-        origin: 'walletconnect',
+        id: random(),
+        origin: host,
         requestData: peerInfo,
         type: ApprovalTypes.WALLET_CONNECT,
       });

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -11,6 +11,7 @@ import { WalletDevice } from '@metamask/transaction-controller';
 import BackgroundBridge from './BackgroundBridge/BackgroundBridge';
 import getRpcMethodMiddleware, {
   checkActiveAccountAndChainId,
+  ApprovalTypes,
 } from './RPCMethods/RPCMethodMiddleware';
 import { Linking } from 'react-native';
 import Minimizer from 'react-native-minimizer';
@@ -339,21 +340,19 @@ class WalletConnect {
     this.walletConnector = null;
   };
 
-  sessionRequest = (peerInfo) =>
-    new Promise((resolve, reject) => {
-      hub.emit('walletconnectSessionRequest', peerInfo);
-
-      hub.on('walletconnectSessionRequest::approved', (peerId) => {
-        if (peerInfo.peerId === peerId) {
-          resolve(true);
-        }
+  sessionRequest = async (peerInfo) => {
+    const { ApprovalController } = Engine.context;
+    try {
+      return await ApprovalController.addAndShowApprovalRequest({
+        id: peerInfo.peerId,
+        origin: 'walletconnect',
+        requestData: peerInfo,
+        type: ApprovalTypes.WALLET_CONNECT,
       });
-      hub.on('walletconnectSessionRequest::rejected', (peerId) => {
-        if (peerInfo.peerId === peerId) {
-          reject(new Error('walletconnectSessionRequest::rejected'));
-        }
-      });
-    });
+    } catch (error) {
+      throw new Error('WalletConnect session request rejected');
+    }
+  };
 }
 
 const instance = {

--- a/app/core/WalletConnect.js
+++ b/app/core/WalletConnect.js
@@ -343,7 +343,7 @@ class WalletConnect {
   sessionRequest = async (peerInfo) => {
     const { ApprovalController } = Engine.context;
     try {
-      return await ApprovalController.addAndShowApprovalRequest({
+      return await ApprovalController.add({
         id: peerInfo.peerId,
         origin: 'walletconnect',
         requestData: peerInfo,

--- a/app/core/WalletConnect.test.ts
+++ b/app/core/WalletConnect.test.ts
@@ -1,10 +1,23 @@
-import { v1 } from 'uuid';
 import RNWalletConnect from '@walletconnect/client';
-import WalletConnect from './WalletConnect';
 import Engine from './Engine';
 import { ApprovalTypes } from '../core/RPCMethods/RPCMethodMiddleware';
-
 import { flushPromises } from '../util/test/utils';
+
+const mockDappHost = 'metamask.io';
+const mockDappUrl = `https://${mockDappHost}`;
+const mockAutoSign = false;
+const mockRedirectUrl = `${mockDappUrl}/redirect`;
+const mockDappOrigin = 'origin';
+const mockRandomId = '139404b0-1dd2-11b2-b040-cb962b38df0e';
+const mockSessionRequest = {
+  params: [
+    {
+      peerMeta: {
+        url: mockDappUrl,
+      },
+    },
+  ],
+};
 
 jest.mock('@walletconnect/client');
 jest.mock('./Engine', () => ({
@@ -13,71 +26,87 @@ jest.mock('./Engine', () => ({
       isUnlocked: jest.fn().mockReturnValueOnce(true),
     },
     ApprovalController: {
-      add: jest.fn()
-    }
+      add: jest.fn(),
+    },
   },
 }));
-const mockRandomId = '139404b0-1dd2-11b2-b040-cb962b38df0e';
 jest.mock('uuid', () => ({
   v1: jest.fn(() => mockRandomId),
 }));
 
-const mockDappHost = 'metamask.io';
-const mockDappUrl = `https://${mockDappHost}`;
-const mockAutoSign = false;
-const mockRedirectUrl = `${mockDappUrl}/redirect`;
-const mockDappOrigin = 'origin';
-
-const mockSessionRequest = {
-  params: [
-    {
-      peerMeta: {
-        url: mockDappUrl,
-      }
-    }
-  ]
-};
-
 describe('WalletConnect', () => {
-  it('should add new approval on ', async () => {
-    const sessionRequestCallback = jest.fn().mockImplementationOnce((_, callback) => {
+  const walletConnectorSessionRequestCallbackMock = jest
+    .fn()
+    .mockImplementationOnce((_, callback) => {
       callback(null, mockSessionRequest);
     });
-    RNWalletConnect.mockImplementation(() => ({
-      on: sessionRequestCallback,
-    }));
+  const walletConnectorRejectSessionMock = jest.fn();
 
-    const expectedApprovalRequest = {
-      "id": mockRandomId,
-      "origin": mockDappHost,
-      "requestData": {
-        "autosign": mockAutoSign,
-        "peerMeta": {
-          "url": mockDappUrl,
+  RNWalletConnect.mockImplementation(() => ({
+    on: walletConnectorSessionRequestCallbackMock,
+    rejectSession: walletConnectorRejectSessionMock,
+  }));
+
+  it('should add new approval when new wallet connect session requested', async () => {
+    // We need to isolate modules to avoid persisting the state of WalletConnect singleton
+    jest.isolateModules(async () => {
+      // eslint-disable-next-line
+      const WalletConnect = require('./WalletConnect').default;
+      const expectedApprovalRequest = {
+        id: mockRandomId,
+        origin: mockDappHost,
+        requestData: {
+          autosign: mockAutoSign,
+          peerMeta: {
+            url: mockDappUrl,
+          },
+          redirectUrl: mockRedirectUrl,
+          requestOriginatedFrom: mockDappOrigin,
         },
-        "redirectUrl": mockRedirectUrl,
-        "requestOriginatedFrom": mockDappOrigin,
-      },
-      "type": ApprovalTypes.WALLET_CONNECT,
-    }
+        type: ApprovalTypes.WALLET_CONNECT,
+      };
 
-    const spyApprovalControllerAdd = jest.spyOn(Engine.context.ApprovalController, 'add');
+      const spyApprovalControllerAdd = jest.spyOn(
+        Engine.context.ApprovalController,
+        'add',
+      );
 
-    // Initialize WalletConnect
-    await WalletConnect.init();
+      // Initialize WalletConnect
+      await WalletConnect.init();
 
-    // WalletConnect.newSession will reproduce the same behavior as the DeeplinkHandler
-    // See app/core/DeeplinkManager.js, then sessionRequestCallback will be picked up immediately
-    await WalletConnect.newSession(
-      "URI",
-      mockRedirectUrl,
-      mockAutoSign,
-      "origin",
-    );
+      // WalletConnect.newSession will reproduce the same behavior as the DeeplinkHandler
+      // See app/core/DeeplinkManager.js, then walletConnectorSessionRequestCallbackMock will be picked up immediately
+      await WalletConnect.newSession(
+        'URI',
+        mockRedirectUrl,
+        mockAutoSign,
+        'origin',
+      );
 
-    await flushPromises();
+      await flushPromises();
 
-    expect(spyApprovalControllerAdd).toHaveBeenCalled();
-    expect(spyApprovalControllerAdd).toHaveBeenCalledWith(expectedApprovalRequest);
-  })
+      expect(spyApprovalControllerAdd).toHaveBeenCalled();
+      expect(spyApprovalControllerAdd).toHaveBeenCalledWith(
+        expectedApprovalRequest,
+      );
+    });
+  });
+  it('should call rejectSession when user rejects wallet connect session', async () => {
+    jest.isolateModules(async () => {
+      // eslint-disable-next-line
+      const WalletConnect = require('./WalletConnect').default;
+      Engine.context.ApprovalController.add.mockRejectedValueOnce();
+
+      await WalletConnect.init();
+      await WalletConnect.newSession(
+        'URI',
+        mockRedirectUrl,
+        mockAutoSign,
+        'origin',
+      );
+
+      await flushPromises();
+      expect(walletConnectorRejectSessionMock).toHaveBeenCalled();
+    });
+  });
 });

--- a/app/core/WalletConnect.test.ts
+++ b/app/core/WalletConnect.test.ts
@@ -1,0 +1,83 @@
+import { v1 } from 'uuid';
+import RNWalletConnect from '@walletconnect/client';
+import WalletConnect from './WalletConnect';
+import Engine from './Engine';
+import { ApprovalTypes } from '../core/RPCMethods/RPCMethodMiddleware';
+
+import { flushPromises } from '../util/test/utils';
+
+jest.mock('@walletconnect/client');
+jest.mock('./Engine', () => ({
+  context: {
+    KeyringController: {
+      isUnlocked: jest.fn().mockReturnValueOnce(true),
+    },
+    ApprovalController: {
+      add: jest.fn()
+    }
+  },
+}));
+const mockRandomId = '139404b0-1dd2-11b2-b040-cb962b38df0e';
+jest.mock('uuid', () => ({
+  v1: jest.fn(() => mockRandomId),
+}));
+
+const mockDappHost = 'metamask.io';
+const mockDappUrl = `https://${mockDappHost}`;
+const mockAutoSign = false;
+const mockRedirectUrl = `${mockDappUrl}/redirect`;
+const mockDappOrigin = 'origin';
+
+const mockSessionRequest = {
+  params: [
+    {
+      peerMeta: {
+        url: mockDappUrl,
+      }
+    }
+  ]
+};
+
+describe('WalletConnect', () => {
+  it('should add new approval on ', async () => {
+    const sessionRequestCallback = jest.fn().mockImplementationOnce((_, callback) => {
+      callback(null, mockSessionRequest);
+    });
+    RNWalletConnect.mockImplementation(() => ({
+      on: sessionRequestCallback,
+    }));
+
+    const expectedApprovalRequest = {
+      "id": mockRandomId,
+      "origin": mockDappHost,
+      "requestData": {
+        "autosign": mockAutoSign,
+        "peerMeta": {
+          "url": mockDappUrl,
+        },
+        "redirectUrl": mockRedirectUrl,
+        "requestOriginatedFrom": mockDappOrigin,
+      },
+      "type": ApprovalTypes.WALLET_CONNECT,
+    }
+
+    const spyApprovalControllerAdd = jest.spyOn(Engine.context.ApprovalController, 'add');
+
+    // Initialize WalletConnect
+    await WalletConnect.init();
+
+    // WalletConnect.newSession will reproduce the same behavior as the DeeplinkHandler
+    // See app/core/DeeplinkManager.js, then sessionRequestCallback will be picked up immediately
+    await WalletConnect.newSession(
+      "URI",
+      mockRedirectUrl,
+      mockAutoSign,
+      "origin",
+    );
+
+    await flushPromises();
+
+    expect(spyApprovalControllerAdd).toHaveBeenCalled();
+    expect(spyApprovalControllerAdd).toHaveBeenCalledWith(expectedApprovalRequest);
+  })
+});

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -1,0 +1,1 @@
+export const flushPromises = () => new Promise(setImmediate);

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -1,1 +1,2 @@
+//eslint-disable-next-line import/prefer-default-export
 export const flushPromises = () => new Promise(setImmediate);


### PR DESCRIPTION
**Description**

This PR aims to make WalletConnect use `ApprovalController` and its own accept/reject mechanism instead of `walletconnectSessionRequest` `walletconnectSessionRequest::approved` `walletconnectSessionRequest::rejected`.

UI flow of WalletConnect is not affected, only functional changes.

**Screenshots/Recordings**

https://user-images.githubusercontent.com/7644512/231426627-0e90b20c-54a9-49c9-bbb3-6f0bd6bc87ce.mp4

**Issue**
https://github.com/MetaMask/mobile-planning/issues/768

**Checklist**

* [X] There is a related GitHub issue
* [ ] Tests are included if applicable
* [X] Any added code is fully documented
