### PR TITLE
[UI][MC] Update Tab bar styles

### DIFF
--- a/app/component-library/components/Texts/Text/Text.types.ts
+++ b/app/component-library/components/Texts/Text/Text.types.ts
@@ -14,7 +14,6 @@ export enum TextVariant {
   BodyLGMedium = 'sBodyLGMedium',
   BodyMD = 'sBodyMD',
   BodyMDBold = 'sBodyMDBold',
-  BodyLGMedium = 'sBodyLGMedium',
   BodySM = 'sBodySM',
   BodySMBold = 'sBodySMBold',
   BodyXS = 'sBodyXS',

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -6,7 +6,7 @@ import configureMockStore from 'redux-mock-store';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { createStackNavigator } from '@react-navigation/stack';
 import Engine from '../../../core/Engine';
-
+import ScrollableTabView from 'react-native-scrollable-tab-view';
 const mockEngine = Engine;
 
 jest.unmock('react-redux');
@@ -158,5 +158,9 @@ describe('Wallet', () => {
   it('should render scan qr icon', () => {
     // There is an open issue https://github.com/react-navigation/react-navigation/issues/9487
     // It's blocking the testing to the nav bar custom headear
+  });
+  it('should render ScrollableTabView', () => {
+    renderComponent(initialState);
+    expect(ScrollableTabView).toHaveBeenCalled();
   });
 });

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -7,6 +7,7 @@ import renderWithProvider from '../../../util/test/renderWithProvider';
 import { createStackNavigator } from '@react-navigation/stack';
 import Engine from '../../../core/Engine';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
+
 const mockEngine = Engine;
 
 jest.unmock('react-redux');
@@ -106,13 +107,17 @@ jest.mock('react-redux', () => ({
     .fn()
     .mockImplementation((callback) => callback(initialState)),
 }));
+
 jest.mock('react-native-scrollable-tab-view', () => {
-  const ScrollableTabView = () => <></>;
-  ScrollableTabView.defaultProps = {
+  const ScrollableTabViewMock = jest
+    .fn()
+    .mockImplementation(() => ScrollableTabViewMock);
+
+  ScrollableTabViewMock.defaultProps = {
     onChangeTab: jest.fn(),
     renderTabBar: jest.fn(),
   };
-  return ScrollableTabView;
+  return ScrollableTabViewMock;
 });
 
 const mockNavigate = jest.fn();

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -62,11 +62,11 @@ const createStyles = ({ colors, typography }: Theme) =>
       paddingBottom: 0,
     },
     tabBar: {
-      borderColor: colors.border.muted,
+      borderColor: colors.background.default,
       marginTop: 16,
     },
     textStyle: {
-      ...(typography.HeadingSM as TextStyle),
+      ...(typography.sBodyMD as TextStyle),
     },
     loader: {
       backgroundColor: colors.background.default,
@@ -246,8 +246,8 @@ const Wallet = ({ navigation }: any) => {
     () => (
       <DefaultTabBar
         underlineStyle={styles.tabUnderlineStyle}
-        activeTextColor={colors.text.default}
-        inactiveTextColor={colors.text.muted}
+        activeTextColor={colors.primary.default}
+        inactiveTextColor={colors.text.default}
         backgroundColor={colors.background.default}
         tabStyle={styles.tabStyle}
         textStyle={styles.textStyle}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -67,6 +67,7 @@ const createStyles = ({ colors, typography }: Theme) =>
     },
     textStyle: {
       ...(typography.sBodyMD as TextStyle),
+      fontWeight: '500',
     },
     loader: {
       backgroundColor: colors.background.default,


### PR DESCRIPTION
**Description**
Update the UI of 'Tokens' and NFTs Tabs.

**Screenshots/Recordings**

Scenario: Dark mode should be respected with this change
<img width="500" alt="image" src="https://user-images.githubusercontent.com/46944231/231488376-36f309a2-2a7a-4ce0-94e6-c70fae2e4600.png">

Scenario: Translations should be in for Tokens and NFTs
<img width="500" alt="image" src="https://user-images.githubusercontent.com/46944231/231488854-11aec57f-1cbd-4bea-ab7c-3c3764422c08.png">

Scenario: A user can toggle between the two controls
https://recordit.co/Wk86B4N3Wq

Scenario: The toggle state is persisted. A user can toggle to NFTs kill and relaunch the app. the app should open on the NFTs. The same should happen if a user toggles to NFTs and goes to any screen that is not the main wallet.
https://recordit.co/js9pM9v63z

**The tab is not persisted when the app is killed and opened.** 

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
