### PR TITLE
[FIX] [6.4.0] Tokens image size

### DIFF
--- a/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
@@ -347,10 +347,10 @@ exports[`Tokens should hide zero balance tokens when setting is on 1`] = `
                                       undefined,
                                       undefined,
                                       Object {
-                                        "borderRadius": 12,
-                                        "height": 24,
+                                        "borderRadius": 16,
+                                        "height": 32,
                                         "overflow": "hidden",
-                                        "width": 24,
+                                        "width": 32,
                                       },
                                     ]
                                   }
@@ -373,10 +373,10 @@ exports[`Tokens should hide zero balance tokens when setting is on 1`] = `
                                     style={
                                       Array [
                                         Object {
-                                          "borderRadius": 12,
-                                          "height": 24,
+                                          "borderRadius": 16,
+                                          "height": 32,
                                           "overflow": "hidden",
-                                          "width": 24,
+                                          "width": 32,
                                         },
                                         Object {
                                           "backgroundColor": "#eee",
@@ -510,10 +510,10 @@ exports[`Tokens should hide zero balance tokens when setting is on 1`] = `
                                 style={
                                   Object {
                                     "backgroundColor": "#FFFFFF",
-                                    "borderRadius": 12,
-                                    "height": 24,
+                                    "borderRadius": 16,
+                                    "height": 32,
                                     "overflow": "hidden",
-                                    "width": 24,
+                                    "width": 32,
                                   }
                                 }
                               >
@@ -1061,10 +1061,10 @@ exports[`Tokens should render correctly 1`] = `
                                       undefined,
                                       undefined,
                                       Object {
-                                        "borderRadius": 12,
-                                        "height": 24,
+                                        "borderRadius": 16,
+                                        "height": 32,
                                         "overflow": "hidden",
-                                        "width": 24,
+                                        "width": 32,
                                       },
                                     ]
                                   }
@@ -1087,10 +1087,10 @@ exports[`Tokens should render correctly 1`] = `
                                     style={
                                       Array [
                                         Object {
-                                          "borderRadius": 12,
-                                          "height": 24,
+                                          "borderRadius": 16,
+                                          "height": 32,
                                           "overflow": "hidden",
-                                          "width": 24,
+                                          "width": 32,
                                         },
                                         Object {
                                           "backgroundColor": "#eee",
@@ -1224,10 +1224,10 @@ exports[`Tokens should render correctly 1`] = `
                                 style={
                                   Object {
                                     "backgroundColor": "#FFFFFF",
-                                    "borderRadius": 12,
-                                    "height": 24,
+                                    "borderRadius": 16,
+                                    "height": 32,
                                     "overflow": "hidden",
-                                    "width": 24,
+                                    "width": 32,
                                   }
                                 }
                               >
@@ -1775,10 +1775,10 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                                       undefined,
                                       undefined,
                                       Object {
-                                        "borderRadius": 12,
-                                        "height": 24,
+                                        "borderRadius": 16,
+                                        "height": 32,
                                         "overflow": "hidden",
-                                        "width": 24,
+                                        "width": 32,
                                       },
                                     ]
                                   }
@@ -1801,10 +1801,10 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                                     style={
                                       Array [
                                         Object {
-                                          "borderRadius": 12,
-                                          "height": 24,
+                                          "borderRadius": 16,
+                                          "height": 32,
                                           "overflow": "hidden",
-                                          "width": 24,
+                                          "width": 32,
                                         },
                                         Object {
                                           "backgroundColor": "#eee",
@@ -1938,10 +1938,10 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                                 style={
                                   Object {
                                     "backgroundColor": "#FFFFFF",
-                                    "borderRadius": 12,
-                                    "height": 24,
+                                    "borderRadius": 16,
+                                    "height": 32,
                                     "overflow": "hidden",
-                                    "width": 24,
+                                    "width": 32,
                                   }
                                 }
                               >
@@ -2086,10 +2086,10 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                                 style={
                                   Object {
                                     "backgroundColor": "#FFFFFF",
-                                    "borderRadius": 12,
-                                    "height": 24,
+                                    "borderRadius": 16,
+                                    "height": 32,
                                     "overflow": "hidden",
-                                    "width": 24,
+                                    "width": 32,
                                   }
                                 }
                               >

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -246,7 +246,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
               variant={AvatarVariants.Token}
               name={asset.symbol}
               imageSource={{ uri: asset.image }}
-              size={AvatarSize.Sm}
+              size={AvatarSize.Md}
             />
           )}
         </BadgeWrapper>

--- a/app/components/UI/Tokens/styles.ts
+++ b/app/components/UI/Tokens/styles.ts
@@ -61,9 +61,9 @@ const createStyles = (colors: Colors) =>
       textTransform: 'capitalize',
     },
     ethLogo: {
-      width: 24,
-      height: 24,
-      borderRadius: 12,
+      width: 32,
+      height: 32,
+      borderRadius: 16,
       overflow: 'hidden',
     },
     emptyText: {


### PR DESCRIPTION
**Description**
This PR only changes the token image size.

**Screenshots/Recordings**
https://recordit.co/wJVbAWtIEB

|  Before | After  |
|---|---|
| <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/232145853-6a3f572f-9a70-49f5-83d8-7acc1a8486eb.png"> |  <img width="250" alt="image" src="https://user-images.githubusercontent.com/46944231/232145483-96b2e8e2-9260-479e-ba88-045b19f101a7.png">|


**Issue**

Progresses #https://github.com/metamask/mobile-planning/issues/875

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
