### PR TITLE
Account Icon matches User's Preferred Identicon

### DIFF
--- a/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.test.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.test.tsx
@@ -18,6 +18,7 @@ describe('AccountBalance', () => {
         accountBalanceLabel={''}
         accountAddress={ACCOUNT_BALANCE_TEST_ID}
         badgeProps={BADGE_PROPS}
+        useBlockieIcon={false}
       />,
     );
     const singleSelectComponent = wrapper.findWhere(

--- a/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.tsx
@@ -13,6 +13,7 @@ const AccountBalance = ({
   accountBalanceLabel,
   accountAddress,
   badgeProps,
+  useBlockieIcon,
 }: AccountBalanceProps) => (
   <Card style={styles.container} testID={ACCOUNT_BALANCE_TEST_ID}>
     <AccountBase
@@ -23,6 +24,7 @@ const AccountBalance = ({
       accountBalanceLabel={accountBalanceLabel}
       accountAddress={accountAddress}
       badgeProps={badgeProps}
+      useBlockieIcon={useBlockieIcon}
     />
   </Card>
 );

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
@@ -18,6 +18,7 @@ describe('AccountBase', () => {
         accountBalanceLabel={''}
         accountAddress={TEST_ACCOUNT_ADDRESS}
         badgeProps={BADGE_PROPS}
+        useBlockieIcon={false}
       />,
     );
     const singleSelectComponent = wrapper.findWhere(

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
@@ -5,6 +5,7 @@ import Text, { TextVariant } from '../../../components/Texts/Text';
 import BadgeWrapper from '../../../components/Badges/BadgeWrapper';
 import Badge from '../../../../component-library/components/Badges/Badge';
 import Avatar, { AvatarVariants } from '../../../components/Avatars/Avatar';
+import { AvatarAccountType } from '../../../components/Avatars/Avatar/variants/AvatarAccount';
 import {
   ACCOUNT_BALANCE_AVATAR_TEST_ID,
   ACCOUNT_BASE_TEST_ID,
@@ -19,15 +20,22 @@ const AccountBase = ({
   accountBalanceLabel,
   accountAddress,
   badgeProps,
+  useBlockieIcon,
 }: AccountBaseProps) => (
   <View style={styles.body} testID={ACCOUNT_BASE_TEST_ID}>
     <View style={styles.container}>
       <BadgeWrapper
         badgeElement={<Badge {...badgeProps} />}
         style={styles.badgeWrapper}
+        testID={ACCOUNT_BALANCE_AVATAR_TEST_ID}
       >
         <Avatar
           variant={AvatarVariants.Account}
+          type={
+            useBlockieIcon
+              ? AvatarAccountType.Blockies
+              : AvatarAccountType.JazzIcon
+          }
           testID={ACCOUNT_BALANCE_AVATAR_TEST_ID}
           accountAddress={accountAddress}
         />

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.types.ts
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.types.ts
@@ -30,4 +30,8 @@ export interface AccountBaseProps {
    * Avatar wrapper props
    */
   badgeProps: BadgeProps;
+  /**
+   * account identicon
+   */
+  useBlockieIcon: boolean;
 }

--- a/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
+++ b/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
@@ -72,6 +72,10 @@ const ApproveTransactionHeader = ({
   const networkProvider = useSelector(selectProviderConfig);
   const networkName = getNetworkNameFromProvider(networkProvider);
 
+  const useBlockieIcon = useSelector(
+    (state: any) => state.settings.useBlockieIcon,
+  );
+
   useEffect(() => {
     const { ticker } = network;
     const weiBalance = activeAddress
@@ -158,6 +162,7 @@ const ApproveTransactionHeader = ({
           name: networkName,
           imageSource: networkImage,
         }}
+        useBlockieIcon={useBlockieIcon}
       />
     </View>
   );


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
The account icon should match the user's preferred identicon. See [issue](https://github.com/MetaMask/mobile-planning/issues/894)

Steps:
* Go to metamask test dapp
* Send an EIP1559 transaction
* Notice that the account icon is not the same as the sender icon (still it's the same account)

**Screenshots/Recordings**
Before: 
![image](https://user-images.githubusercontent.com/29962968/233076000-c20d6ba7-4f71-4d84-891c-16b84d8837ca.png)

After: http://recordit.co/vOtElnCTgq

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/894

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
