### PR TITLE
Add GitHub Action to block PRs with "DONOTMERGE" label

### DIFF
--- a/.github/workflows/ci-all-branches.yml
+++ b/.github/workflows/ci-all-branches.yml
@@ -1,6 +1,6 @@
 # Fails the pull request if it has the "DO-NOT-MERGE" label
 
-name: ci / all branches
+name: ci / check all branches
 
 on:
   pull_request:

--- a/.github/workflows/ci-all-branches.yml
+++ b/.github/workflows/ci-all-branches.yml
@@ -1,0 +1,17 @@
+# Fails the pull request if it has the "DO-NOT-MERGE" label
+
+name: ci / all branches
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  do-not-merge:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'DONOTMERGE') }}
+    steps:
+      - name: 'Check for label "DONOTMERGE"' 
+        run: |
+          echo 'This check fails PRs with the "DONOTMERGE" label to block merging'
+          exit 1


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR makes PRs with "DONOTMERGE" label unmergable. Creates a new github action file to apply checks to all PRs, including PRs merging to branches that are not the `main` branch

similar extension GH Action PR here: https://github.com/MetaMask/metamask-extension/pull/18724

**Screenshots/Recordings**

<img width="776" alt="Screen Shot 2023-04-21 at 12 19 36 PM" src="https://user-images.githubusercontent.com/20778143/233673858-8401b2fe-39d8-4ed6-ba45-247995322d40.png">

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
