### PR TITLE
Fix terms of use checkbox test id

### DIFF
--- a/app/component-library/components/Checkbox/Checkbox.tsx
+++ b/app/component-library/components/Checkbox/Checkbox.tsx
@@ -2,11 +2,9 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, Platform } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 // External dependencies.
-import { CHECKBOX_ICON_ID } from '../../../../wdio/screen-objects/testIDs/Common.testIds';
-import generateTestId from '../../../../wdio/utils/generateTestId';
 import Icon from '../Icons/Icon';
 import { useStyles } from '../../hooks';
 
@@ -15,9 +13,9 @@ import { CheckboxProps } from './Checkbox.types';
 import styleSheet from './Checkbox.styles';
 import {
   CHECKBOX_ICON_TESTID,
-  DEFAULT_CHECKBOX_ISINDETERMINATE_ICONNAME,
-  DEFAULT_CHECKBOX_ISCHECKED_ICONNAME,
   DEFAULT_CHECKBOX_ICONSIZE,
+  DEFAULT_CHECKBOX_ISCHECKED_ICONNAME,
+  DEFAULT_CHECKBOX_ISINDETERMINATE_ICONNAME,
 } from './Checkbox.constants';
 
 const Checkbox = ({
@@ -47,7 +45,6 @@ const Checkbox = ({
     <TouchableOpacity style={styles.base} {...props} disabled={isDisabled}>
       {iconName && (
         <Icon
-          {...generateTestId(Platform, CHECKBOX_ICON_ID)}
           testID={CHECKBOX_ICON_TESTID}
           name={iconName}
           size={DEFAULT_CHECKBOX_ICONSIZE}

--- a/app/component-library/components/Modals/ModalMandatory/ModalMandatory.tsx
+++ b/app/component-library/components/Modals/ModalMandatory/ModalMandatory.tsx
@@ -32,6 +32,7 @@ import { MandatoryModalProps } from './ModalMandatory.types';
 import stylesheet from './ModalMandatory.styles';
 import generateTestId from '../../../../../wdio/utils/generateTestId';
 import {
+  TERMS_OF_USE_CHECKBOX_ICON_ID,
   TERMS_OF_USE_SCROLL_END_ARROW_BUTTON_ID,
   TERMS_OF_USE_WEBVIEW_ID,
 } from '../../../../../wdio/screen-objects/testIDs/Components/TermsOfUse.testIds';
@@ -231,6 +232,7 @@ const ModalMandatory = ({ route }: MandatoryModalProps) => {
           style={styles.checkboxContainer}
           onPress={handleSelect}
           activeOpacity={1}
+          {...generateTestId(Platform, TERMS_OF_USE_CHECKBOX_ICON_ID)}
         >
           <Checkbox isChecked={isCheckboxSelected} />
           <Text style={styles.checkboxText}>{checkboxText}</Text>

--- a/e2e/pages/modals/TermsOfUseModal.js
+++ b/e2e/pages/modals/TermsOfUseModal.js
@@ -1,7 +1,7 @@
 import TestHelpers from '../../helpers';
-import { CHECKBOX_ICON_ID } from '../../../wdio/screen-objects/testIDs/Common.testIds';
 import {
   TERMS_OF_USE_ACCEPT_BUTTON_ID,
+  TERMS_OF_USE_CHECKBOX_ICON_ID,
   TERMS_OF_USE_SCREEN_ID,
   TERMS_OF_USE_SCROLL_END_ARROW_BUTTON_ID,
 } from '../../../wdio/screen-objects/testIDs/Components/TermsOfUse.testIds';
@@ -16,7 +16,7 @@ export default class TermsOfUseModal {
   }
 
   static async tapAgreeCheckBox() {
-    await TestHelpers.waitAndTap(CHECKBOX_ICON_ID);
+    await TestHelpers.waitAndTap(TERMS_OF_USE_CHECKBOX_ICON_ID);
   }
 
   static async tapScrollEndButton() {

--- a/wdio/screen-objects/Modals/TermOfUseScreen.js
+++ b/wdio/screen-objects/Modals/TermOfUseScreen.js
@@ -1,7 +1,7 @@
 import Selectors from '../../helpers/Selectors';
-import { CHECKBOX_ICON_ID } from '../testIDs/Common.testIds';
 import {
   TERMS_OF_USE_ACCEPT_BUTTON_ID,
+  TERMS_OF_USE_CHECKBOX_ICON_ID,
   TERMS_OF_USE_SCREEN_ID,
   TERMS_OF_USE_SCROLL_END_ARROW_BUTTON_ID,
   TERMS_OF_USE_WEBVIEW_ID,
@@ -14,7 +14,7 @@ class TermOfUseScreen {
   }
 
   get checkbox() {
-    return Selectors.getElementByPlatform(CHECKBOX_ICON_ID);
+    return Selectors.getElementByPlatform(TERMS_OF_USE_CHECKBOX_ICON_ID);
   }
 
   get scrollEndArrowButton() {

--- a/wdio/screen-objects/testIDs/Common.testIds.js
+++ b/wdio/screen-objects/testIDs/Common.testIds.js
@@ -1,5 +1,3 @@
-export const CHECKBOX_ICON_ID = 'checkbox';
-
 export const TOAST_ID = 'toast';
 
 export const ANDROID_PROGRESS_BAR = 'android.widget.ProgressBar';

--- a/wdio/screen-objects/testIDs/Components/TermsOfUse.testIds.js
+++ b/wdio/screen-objects/testIDs/Components/TermsOfUse.testIds.js
@@ -6,3 +6,5 @@ export const TERMS_OF_USE_SCROLL_END_ARROW_BUTTON_ID =
   'terms-of-use-scroll-end-arrow-button-id';
 
 export const TERMS_OF_USE_WEBVIEW_ID = 'terms-of-use-webview-id';
+
+export const TERMS_OF_USE_CHECKBOX_ICON_ID = 'terms-of-use-checkbox';


### PR DESCRIPTION
**Description**
Appium and Detox test cases failed when trying to click the checkbox from the Terms of Use modal. The testID was moved to another element to fix this issue. Detox and Appium test cases now are passing

**Screenshots/Recordings**
![image](https://user-images.githubusercontent.com/22276767/233739862-1074a58c-ac50-4020-a613-43ed5ec81905.png)
![image](https://user-images.githubusercontent.com/22276767/233739898-535a44a2-89a3-4f53-8f96-d2f004440dfb.png)

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
