### PR TITLE
[FIX] Detox: wallet-tests.spec.js

### DIFF
--- a/e2e/resources/collectibles.json
+++ b/e2e/resources/collectibles.json
@@ -1,6 +1,6 @@
 {
-  "erc1155tokenAddress": "0xCBBA076Cd4c35432203F71fc5CaeEBA38C25aa2C",
-  "erc1155tokenID": "2",
-  "erc1155collectionName": "Soccer Cats",
-  "erc1155tokenName": "Soccer Cats Spain"
+  "erc1155tokenAddress": "0x306d717D109e0995e0f56027Eb93D9C1d5686dE1",
+  "erc1155tokenID": "179",
+  "erc1155collectionName": "Refinable721",
+  "erc1155tokenName": "Refinable721 #179"
 }

--- a/e2e/resources/collectibles.json
+++ b/e2e/resources/collectibles.json
@@ -1,0 +1,6 @@
+{
+  "erc1155tokenAddress": "0xCBBA076Cd4c35432203F71fc5CaeEBA38C25aa2C",
+  "erc1155tokenID": "2",
+  "erc1155collectionName": "Soccer Cats",
+  "erc1155tokenName": "Soccer Cats Spain"
+}

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -1,20 +1,17 @@
 'use strict';
 import TestHelpers from '../helpers';
-
 import WalletView from '../pages/WalletView';
 import AccountListView from '../pages/AccountListView';
 import ImportAccountView from '../pages/ImportAccountView';
-
 import DrawerView from '../pages/Drawer/DrawerView';
-
 import AddCustomTokenView from '../pages/AddCustomTokenView';
 import ImportTokensView from '../pages/ImportTokensView';
-
 import NetworkListModal from '../pages/modals/NetworkListModal';
 import RequestPaymentModal from '../pages/modals/RequestPaymentModal';
 import NetworkEducationModal from '../pages/modals/NetworkEducationModal';
 import { importWalletWithRecoveryPhrase } from '../viewHelper';
 import Accounts from '../../wdio/helpers/Accounts';
+import Collectibles from '../resources/collectibles.json';
 
 describe('Wallet Tests', () => {
   const GOERLI = 'Goerli Test Network';
@@ -28,7 +25,6 @@ describe('Wallet Tests', () => {
   const BLT_TOKEN_ADDRESS = '0x107c4504cd79c5d2696ea0030a8dd4e92601b82e';
 
   const validAccount = Accounts.getValidAccount();
-  const tokenOwner = Accounts.getERC1155Token();
 
   beforeEach(() => {
     jest.setTimeout(200000);
@@ -124,18 +120,18 @@ describe('Wallet Tests', () => {
     await WalletView.tapImportNFTButton();
 
     await AddCustomTokenView.isVisible();
-    await AddCustomTokenView.typeInNFTAddress(tokenOwner.erc1155token);
-    await AddCustomTokenView.typeInNFTIdentifier(tokenOwner.erc1155tokenID);
+    await AddCustomTokenView.typeInNFTAddress(Collectibles.erc1155tokenAddress);
+    await AddCustomTokenView.typeInNFTIdentifier(Collectibles.erc1155tokenID);
 
     await WalletView.isVisible();
     // Wait for asset to load
     await TestHelpers.delay(3000);
 
-    await WalletView.isNFTVisibleInWallet(tokenOwner.erc1155collectionName);
-    // Tap on Crypto Kitty
-    await WalletView.tapOnNFTInWallet(tokenOwner.erc1155collectionName);
+    await WalletView.isNFTVisibleInWallet(Collectibles.erc1155collectionName);
+    // Tap on Collectible
+    await WalletView.tapOnNFTInWallet(Collectibles.erc1155collectionName);
 
-    await WalletView.isNFTNameVisible(tokenOwner.erc1155tokenName);
+    await WalletView.isNFTNameVisible(Collectibles.erc1155tokenName);
 
     await WalletView.scrollUpOnNFTsTab();
   });

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -24,12 +24,11 @@ describe('Wallet Tests', () => {
   // I should NEVER hold any eth or token
   const TEST_PRIVATE_KEY =
     'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
-  const COLLECTIBLE_CONTRACT_ADDRESS =
-    '0x306d717D109e0995e0f56027Eb93D9C1d5686dE1';
-  const COLLECTIBLE_IDENTIFIER = '179';
+
   const BLT_TOKEN_ADDRESS = '0x107c4504cd79c5d2696ea0030a8dd4e92601b82e';
 
   const validAccount = Accounts.getValidAccount();
+  const tokenOwner = Accounts.getERC1155Token();
 
   beforeEach(() => {
     jest.setTimeout(200000);
@@ -87,9 +86,6 @@ describe('Wallet Tests', () => {
 
     await RequestPaymentModal.closeRequestModal();
 
-    await DrawerView.isVisible();
-    await DrawerView.closeDrawer();
-
     await WalletView.isVisible();
   });
 
@@ -128,18 +124,18 @@ describe('Wallet Tests', () => {
     await WalletView.tapImportNFTButton();
 
     await AddCustomTokenView.isVisible();
-    await AddCustomTokenView.typeInNFTAddress(COLLECTIBLE_CONTRACT_ADDRESS);
-    await AddCustomTokenView.typeInNFTIdentifier(COLLECTIBLE_IDENTIFIER);
+    await AddCustomTokenView.typeInNFTAddress(tokenOwner.erc1155token);
+    await AddCustomTokenView.typeInNFTIdentifier(tokenOwner.erc1155tokenID);
 
     await WalletView.isVisible();
     // Wait for asset to load
     await TestHelpers.delay(3000);
 
-    await WalletView.isNFTVisibleInWallet('Refinable721');
+    await WalletView.isNFTVisibleInWallet(tokenOwner.erc1155collectionName);
     // Tap on Crypto Kitty
-    await WalletView.tapOnNFTInWallet('Refinable721');
+    await WalletView.tapOnNFTInWallet(tokenOwner.erc1155collectionName);
 
-    await WalletView.isNFTNameVisible('Refinable721 #179');
+    await WalletView.isNFTNameVisible(tokenOwner.erc1155tokenName);
 
     await WalletView.scrollUpOnNFTsTab();
   });

--- a/wdio/helpers/Accounts.js
+++ b/wdio/helpers/Accounts.js
@@ -5,6 +5,10 @@ const CORRECT_PASSWORD = `12345678`;
 const SHORT_PASSWORD = `1234567`;
 
 const INCORRECT_PASSWORD = `12345679`;
+const ERC_1155_TOKEN = `0xCBBA076Cd4c35432203F71fc5CaeEBA38C25aa2C`;
+const ERC_1155_TOKEN_ID = `2`;
+const ERC_1155_COLLECTION_NAME = `Soccer Cats`;
+const ERC_1155_TOKEN_NAME = `Soccer Cats Spain`;
 
 class Accounts {
   static getValidAccount() {
@@ -37,6 +41,15 @@ class Accounts {
     const account = Accounts.getValidAccount();
     account.password = SHORT_PASSWORD;
     return account;
+  }
+
+  static getERC1155Token() {
+    return {
+      erc1155token: ERC_1155_TOKEN,
+      erc1155tokenID: ERC_1155_TOKEN_ID,
+      erc1155collectionName: ERC_1155_COLLECTION_NAME,
+      erc1155tokenName: ERC_1155_TOKEN_NAME,
+    };
   }
 }
 

--- a/wdio/helpers/Accounts.js
+++ b/wdio/helpers/Accounts.js
@@ -3,12 +3,7 @@ const INCORRECT_SECRET_RECOVERY_PHRASE =
   'gain lemon refuse sunny identify diesel hand endless first involve wink size';
 const CORRECT_PASSWORD = `12345678`;
 const SHORT_PASSWORD = `1234567`;
-
 const INCORRECT_PASSWORD = `12345679`;
-const ERC_1155_TOKEN = `0xCBBA076Cd4c35432203F71fc5CaeEBA38C25aa2C`;
-const ERC_1155_TOKEN_ID = `2`;
-const ERC_1155_COLLECTION_NAME = `Soccer Cats`;
-const ERC_1155_TOKEN_NAME = `Soccer Cats Spain`;
 
 class Accounts {
   static getValidAccount() {
@@ -41,15 +36,6 @@ class Accounts {
     const account = Accounts.getValidAccount();
     account.password = SHORT_PASSWORD;
     return account;
-  }
-
-  static getERC1155Token() {
-    return {
-      erc1155token: ERC_1155_TOKEN,
-      erc1155tokenID: ERC_1155_TOKEN_ID,
-      erc1155collectionName: ERC_1155_COLLECTION_NAME,
-      erc1155tokenName: ERC_1155_TOKEN_NAME,
-    };
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Fixed `wallet-tests.spec.js`
- refactored NFT steps
- removed steps for validating drawer view that doesn't happen anymore with UI changes
- added ERC-1155 token info to `Accounts.js`

**Screenshots/Recordings**
![image](https://user-images.githubusercontent.com/6626407/233757232-864054f0-73c1-4de9-9656-9457cb3fbe01.png)


**Issue**
ERC-1155 token data needs to be updated for the bitrise SRP wallet that owns an ERC-1155 token.  This can be easily done now by updating `Account.js` ERC-1155 token data.

The token data that existed prior to these changes was failing during test with error indicating account is not the owner.

Progresses #???

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
