### PR TITLE
[FIX] Prevent adding non supported tokens on networks

### DIFF
--- a/app/constants/error.ts
+++ b/app/constants/error.ts
@@ -48,3 +48,7 @@ export const VAULT_BACKUP_FAILED_UNDEFINED =
   'Unable to backup vault as it is undefined';
 export const VAULT_FAILED_TO_GET_VAULT_FROM_BACKUP =
   'getVaultFromBackup failed to retrieve vault';
+
+// RPCMethodMiddleware
+export const TOKEN_NOT_SUPPORTED_FOR_NETWORK =
+  'This token is not supported on this network';


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR addresses [#917](https://github.com/MetaMask/mobile-planning/issues/917). The correct behavior is that you should not be able to add a non-supported token while on certain networks through the watch asset flow (clicking on the MM icon from Dapps). Non-supported here means that the token address does not exist on the network that you are currently on. Follow steps listed in original issue to test for fix.

**Screenshots/Recordings**

Video of fix in thread - https://consensys.slack.com/archives/C029JG63136/p1682348127958249?thread_ts=1682111629.402559&cid=C029JG63136

**Issue**
[#917](https://github.com/MetaMask/mobile-planning/issues/917)

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
