### PR TITLE
[FIX] - Upgrading with deprecated test network selected

### DIFF
--- a/app/store/migrations.js
+++ b/app/store/migrations.js
@@ -11,6 +11,7 @@ import {
   DENIED,
   EXPLORED,
 } from '../constants/storage';
+import { GOERLI } from '../../app/constants/network';
 
 export const migrations = {
   // Needed after https://github.com/MetaMask/controllers/pull/152
@@ -63,7 +64,7 @@ export const migrations = {
       // If the current network does not have a chainId, switch to testnet.
       state.engine.backgroundState.NetworkController.provider = {
         ticker: 'ETH',
-        type: 'goerli',
+        type: GOERLI,
       };
     }
     return state;
@@ -91,7 +92,7 @@ export const migrations = {
       // If the current network does not have a chainId, switch to testnet.
       state.engine.backgroundState.NetworkController.provider = {
         ticker: 'ETH',
-        type: 'goerli',
+        type: GOERLI,
         chainId: NetworksChainId.goerli,
       };
     }
@@ -396,9 +397,9 @@ export const migrations = {
     // Deprecate rinkeby, ropsten and Kovan, any user that is on those we fallback to goerli
     if (chainId === '4' || chainId === '3' || chainId === '42') {
       state.engine.backgroundState.NetworkController.providerConfig = {
-        chainId: '5',
+        chainId: NetworksChainId.goerli,
         ticker: 'GoerliETH',
-        type: 'goerli',
+        type: GOERLI,
       };
     }
     return state;

--- a/app/store/migrations.js
+++ b/app/store/migrations.js
@@ -390,6 +390,19 @@ export const migrations = {
 
     return state;
   },
+  15: (state) => {
+    const chainId =
+      state.engine.backgroundState.NetworkController.providerConfig.chainId;
+    // Deprecate rinkeby, ropsten and Kovan, any user that is on those we fallback to goerli
+    if (chainId === '4' || chainId === '3' || chainId === '42') {
+      state.engine.backgroundState.NetworkController.providerConfig = {
+        chainId: '5',
+        ticker: 'GoerliETH',
+        type: 'goerli',
+      };
+    }
+    return state;
+  },
 };
 
-export const version = 14;
+export const version = 15;


### PR DESCRIPTION
**Description**
If the users were on deprecated test networks ('rinkeby', 'ropsten', 'kovan'), we added a migration to fallback to goerli since we do not support that test networks anymore.

**Screenshots/Recordings**
https://recordit.co/C7kpXoVVhf


**Issue**

Progresses #https://github.com/MetaMask/mobile-planning/issues/908

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
