### PR TITLE
[FIX] Invalid title error on Wallet Connect v1

### DIFF
--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -86,10 +86,13 @@ export default class WebsiteIcon extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
     const apiLogoUrl = { uri: icon || this.getIconUrl(url) };
-    const title =
-      typeof this.props.title === 'string'
-        ? this.props.title.substr(0, 1)
-        : getHost(url).substr(0, 1);
+    let title = this.props.title;
+    if (this.props.title) {
+      title =
+        typeof this.props.title === 'string'
+          ? this.props.title.substr(0, 1)
+          : getHost(url).substr(0, 1);
+    }
 
     if (renderIconUrlError && title) {
       return (


### PR DESCRIPTION
FIX wallet connect v1 integration when title is missing

Fixes [938](https://github.com/MetaMask/mobile-planning/issues/938)