### PR TITLE
[FIX]  Patch assets-controller to not use BigInt

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@eth-optimism/contracts": "0.0.0-2021919175625",
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/tx": "^3.2.1",
+    "@ethersproject/abi": "^5.7.0",
     "@exodus/react-native-payments": "git+https://github.com/MetaMask/react-native-payments.git#dbc8cbbed570892d2fea5e3d183bf243e062c1e5",
     "@keystonehq/bc-ur-registry-eth": "^0.7.7",
     "@keystonehq/metamask-airgapped-keyring": "^0.3.0",

--- a/patches/@metamask+assets-controllers+4.0.0.patch
+++ b/patches/@metamask+assets-controllers+4.0.0.patch
@@ -34,7 +34,7 @@ index 9ddbc28..2d12e33 100644
 -const abi_utils_1 = require("@metamask/abi-utils");
 +
 +// Revert to use @ethersproject/abi to fix BigInt compatibility issue
-+// Issue reported here - https://github.com/MetaMask/mobile-planning/issues/913
++// Issue reported here - https://github.com/MetaMask/metamask-mobile/issues/6307
 +// TODO - Remove patch once app is upgraded to RN 0.71.6
 +// const abi_utils_1 = require("@metamask/abi-utils");
 +const ethers_project_abi = require('@ethersproject/abi');

--- a/patches/@metamask+assets-controllers+4.0.0.patch
+++ b/patches/@metamask+assets-controllers+4.0.0.patch
@@ -82,7 +82,7 @@ index 9ddbc28..2d12e33 100644
              // Parse as string - treat empty string as failure
              try {
 -                const decoded = (0, abi_utils_1.decodeSingle)('string', result);
-+                // TODO - Remove patch once app is upgraded to RN 0.71.6
++                // TODO - Remove patch once app is upgraded to React Native 0.71.6
 +                const decoded = ethers_project_abi.abiCoder.decode(['string'], result)[0];
 +                // const decoded = (0, abi_utils_1.decodeSingle)('string', result);
 +                

--- a/patches/@metamask+assets-controllers+4.0.0.patch
+++ b/patches/@metamask+assets-controllers+4.0.0.patch
@@ -24,10 +24,25 @@ index 332c87d..c110f41 100644
       * Enumerate assets assigned to an owner.
       *
 diff --git a/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js b/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
-index 9ddbc28..acdc28a 100644
+index 9ddbc28..2d12e33 100644
 --- a/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
 +++ b/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
-@@ -57,6 +57,27 @@ class ERC20Standard {
+@@ -13,7 +13,13 @@ exports.ERC20Standard = void 0;
+ const contracts_1 = require("@ethersproject/contracts");
+ const metamask_eth_abis_1 = require("@metamask/metamask-eth-abis");
+ const ethereumjs_util_1 = require("ethereumjs-util");
+-const abi_utils_1 = require("@metamask/abi-utils");
++
++// Revert to use @ethersproject/abi to fix BigInt compatibility issue
++// Issue reported here - https://github.com/MetaMask/mobile-planning/issues/913
++// TODO - Remove patch once app is upgraded to RN 0.71.6
++// const abi_utils_1 = require("@metamask/abi-utils");
++const ethers_project_abi = require('@ethersproject/abi');
++
+ const controller_utils_1 = require("@metamask/controller-utils");
+ const utils_1 = require("@metamask/utils");
+ const assetsUtil_1 = require("../assetsUtil");
+@@ -57,6 +63,27 @@ class ERC20Standard {
              }
          });
      }
@@ -55,6 +70,25 @@ index 9ddbc28..acdc28a 100644
      /**
       * Query for symbol for a given ERC20 asset.
       *
+@@ -68,10 +95,16 @@ class ERC20Standard {
+             // Signature for calling `symbol()`
+             const payload = { to: address, data: '0x95d89b41' };
+             const result = yield this.provider.call(payload);
+-            (0, utils_1.assertIsStrictHexString)(result);
++
++            // TODO - Remove patch once app is upgraded to RN 0.71.6
++            // (0, utils_1.assertIsStrictHexString)(result);
++
+             // Parse as string - treat empty string as failure
+             try {
+-                const decoded = (0, abi_utils_1.decodeSingle)('string', result);
++                // TODO - Remove patch once app is upgraded to RN 0.71.6
++                const decoded = ethers_project_abi.abiCoder.decode(['string'], result)[0];
++                // const decoded = (0, abi_utils_1.decodeSingle)('string', result);
++                
+                 if ((decoded === null || decoded === void 0 ? void 0 : decoded.length) > 0) {
+                     return decoded;
+                 }
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js b/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js
 index 4ed4990..da18116 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js

--- a/patches/@metamask+assets-controllers+4.0.0.patch
+++ b/patches/@metamask+assets-controllers+4.0.0.patch
@@ -35,7 +35,7 @@ index 9ddbc28..2d12e33 100644
 +
 +// Revert to use @ethersproject/abi to fix BigInt compatibility issue
 +// Issue reported here - https://github.com/MetaMask/metamask-mobile/issues/6307
-+// TODO - Remove patch once app is upgraded to RN 0.71.6
++// TODO - Remove patch once app is upgraded to React Native 0.71.6
 +// const abi_utils_1 = require("@metamask/abi-utils");
 +const ethers_project_abi = require('@ethersproject/abi');
 +


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR patches @metamask/assets-controller to comment out BigInt related code for now. We will reintroduce it once RN 0.71.6 upgrade is finished.

**Screenshots/Recordings**

https://user-images.githubusercontent.com/10508597/235266188-944afddd-c7e9-45e1-a543-8821327cccd9.mov

**Issue**
### **Description**

Whenever I try to make an Approve tx, the app crashes with this errror `Can't find variable: BigInt`

**[only-android]**

After first [reporting it here](https://github.com/MetaMask/metamask-mobile/pull/5591#issuecomment-1516330068), we've seen that it's a separate issue, happening on the RC branch `6.4`

**Screenshots**

https://user-images.githubusercontent.com/54408225/233622389-0dfcab94-7154-41f3-9504-fec4edbb545a.mp4

**Steps to reproduce the behavior**

1. Go to the test dapp
2. Deploy the Collectibles contract
3. Mint a token
4. Click Approve
5. MM crashes with the error  `Can't find variable: BigInt`

- Device: Pixel
- OS: Android
- App Version: v6.4.0

Issue: #6307 

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
