### PR TITLE
Improve processing of redirection URL

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -500,7 +500,6 @@ export const BrowserTab = (props) => {
       const prefixedUrl = prefixUrlWithProtocol(url);
       const { hostname, query, pathname } = new URL(prefixedUrl);
       let urlToGo = prefixedUrl;
-      urlToGo = sanitizeUrlInput(urlToGo);
       const isEnsUrl = isENSUrl(url);
       const { current } = webviewRef;
       if (isEnsUrl) {
@@ -523,7 +522,9 @@ export const BrowserTab = (props) => {
         } else {
           current &&
             current.injectJavaScript(
-              `(function(){window.location.href = '${urlToGo}' })()`,
+              `(function(){window.location.href = '${sanitizeUrlInput(
+                urlToGo,
+              )}' })()`,
             );
         }
 


### PR DESCRIPTION
## Summary 

This pull request just adds an extra layer of support to ensure that we do not end up in a situation where URL processing does not occur this is done by making it absolute last thing that happens before a redirect.

## Testing steps

* Create a folder, and in that folder create a file called `index.html`
* Add the following contents to that file
```html
<html>
    <body>
        <a href="https://metamask.io">Regular Link</a>
        <a href="https://bitsofcode.eth">ENS Link</a>
    </body>
</html>
```
* Run `python3 -m http.server 9000` to serve this static file
* In the MM Mobile app visit `localhost:9000` and visit the page you created. Ensure both links work as expected.