### PR TITLE
[FIX] Appium: Notify appium server test is done

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -345,11 +345,11 @@ export const config = {
    * @param {Array.<Object>} capabilities list of capabilities details
    * @param {Array.<String>} specs List of spec file paths that ran
    */
-  // after: function (result, capabilities) {
-  // if (capabilities.bundleId) {
-  //   driver.terminateApp(capabilities.bundleId)
-  // }
-  // },
+  after: function (result, capabilities) {
+    if (capabilities.bundleId) {
+      driver.terminateApp(capabilities.bundleId);
+    }
+  },
   /**
    * Gets executed right after terminating the webdriver session.
    * @param {Object} config wdio configuration object


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Some tests will fail after test run even if all steps pass which causes issues with results and reports.  This was due to our wdio automation not notifying appium that the test has completed, which would cause some callbacks to fail after the test because the callbacks refer to a test sessionID that no longer exist because the sessionID was terminated after the test.  You can see the bug by looking at the bitrise logs that is linked to the issue reported.

This change will notify appium that a sessionID has completed and any outstanding callbacks that reference sessionID's that no longer exist will be handled by appium and no failure/error is generated after the test.  

Fixes: reporting a failed test after test run even though all test steps passed, reporting the test correctly.
Fixes: callbacks that refer to a terminated/expired test sessionID to be handle without reporting a failure.

**Screenshots/Recordings**
Bitrise [report](https://addons-testing.bitrise.io/builds/b0d7e4c0-b983-4e12-9cfa-4db11b186d5d/summary?status=failed) for all test.
Smoke test on [browserstack](https://app-automate.browserstack.com/dashboard/v2/public-build/eVlDRXdFM0dhMUVnN05lcWViKzdXSjdERm5LcUdPeXpmZ2o3VUZrRWxkaHZNc2VDaE5QWGtuby9xbEd2UUZJbFhZOG1RaVFFZjNkWFNUWjk1WUNVd1E9PS0tTUJMM1FtVTVpL0dDMUowcFZZUE0wZz09--29aa6c44ef783f0fcf917744d888c620e9cede0c) with CreateNewWallet.feature that was consistently getting the error.  All smoke tests pass ![image](https://user-images.githubusercontent.com/6626407/236707379-f1a1026e-2b8a-4acc-a6b5-647906ceb99d.png).


**Issue**

Progresses #[949](https://github.com/MetaMask/mobile-planning/issues/949)
Progresses #5845 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
