### PR TITLE
[FIX] Appium: remove duplicate step onboarding

### DIFF
--- a/wdio/config/android.config.browserstack.js
+++ b/wdio/config/android.config.browserstack.js
@@ -12,7 +12,7 @@ config.capabilities = [
     noReset: false,
     fullReset: false,
     maxInstances: 1,
-    build: 'Android QA E2E Tests',
+    build: 'Android QA E2E Smoke Tests',
     device: process.env.BROWSERSTACK_DEVICE || 'Google Pixel 6',
     os_version: process.env.BROWSERSTACK_OS_VERSION || '12.0',
     app: process.env.BROWSERSTACK_APP_URL,
@@ -24,7 +24,7 @@ config.waitforTimeout = 10000;
 config.connectionRetryTimeout = 90000;
 config.connectionRetryCount = 3;
 config.cucumberOpts.tagExpression =
-  process.env.BROWSERSTACK_TAG_EXPRESSION || '@androidApp'; // pass tag to run tests specific to android
+  process.env.BROWSERSTACK_TAG_EXPRESSION || '@smoke'; // pass tag to run tests specific to android
 
 delete config.port;
 delete config.path;

--- a/wdio/config/android.config.browserstack.local.js
+++ b/wdio/config/android.config.browserstack.local.js
@@ -1,6 +1,6 @@
-import {removeSync} from 'fs-extra';
+import { removeSync } from 'fs-extra';
 import generateTestReports from '../../wdio/utils/generateTestReports';
-import {config} from '../../wdio.conf';
+import { config } from '../../wdio.conf';
 
 const browserstack = require('browserstack-local');
 
@@ -25,13 +25,13 @@ config.capabilities = [
 ];
 
 config.connectionRetryCount = 3;
-config.cucumberOpts.tagExpression = '@androidApp'; // pass tag to run tests specific to android
+config.cucumberOpts.tagExpression = '@smoke'; // pass tag to run tests specific to android
 config.onPrepare = function (config, capabilities) {
   removeSync('./wdio/reports');
   console.log('Connecting local');
   return new Promise((resolve, reject) => {
     exports.bs_local = new browserstack.Local();
-    exports.bs_local.start({key: config.key}, (error) => {
+    exports.bs_local.start({ key: config.key }, (error) => {
       if (error) return reject(error);
       console.log('Connected. Now testing...');
 
@@ -58,4 +58,4 @@ delete config.services;
 
 const _config = config;
 // eslint-disable-next-line import/prefer-default-export
-export {_config as config};
+export { _config as config };

--- a/wdio/config/android.config.debug.js
+++ b/wdio/config/android.config.debug.js
@@ -1,4 +1,4 @@
-import {config} from '../../wdio.conf';
+import { config } from '../../wdio.conf';
 
 // Appium capabilities
 // https://appium.io/docs/en/writing-running-appium/caps/
@@ -8,15 +8,15 @@ config.capabilities = [
     noReset: false,
     fullReset: false,
     maxInstances: 1,
-    deviceName: 'Android 11 - Pixel 4a API 3',
-    platformVersion: '11',
+    deviceName: 'Pixel 5 API 32',
+    platformVersion: '13',
     app: './android/app/build/outputs/apk/qa/debug/app-qa-debug.apk',
     automationName: 'uiautomator2',
   },
 ];
 
-config.cucumberOpts.tagExpression = '@androidApp'; // pass tag to run tests specific to android
+config.cucumberOpts.tagExpression = '@smoke'; // pass tag to run tests specific to android
 
 const _config = config;
 // eslint-disable-next-line import/prefer-default-export
-export {_config as config};
+export { _config as config };

--- a/wdio/step-definitions/onboarding.steps.js
+++ b/wdio/step-definitions/onboarding.steps.js
@@ -10,39 +10,6 @@ import SkipAccountSecurityModal from '../screen-objects/Modals/SkipAccountSecuri
 import OnboardingWizardModal from '../screen-objects/Modals/OnboardingWizardModal.js';
 import AddressBarScreen from '../screen-objects/BrowserObject/AddressBarScreen';
 
-Then(/^"([^"]*)?" is displayed/, async (text) => {
-  switch (text) {
-    case 'METAMASK':
-      await WelcomeScreen.waitForSplashAnimationToDisplay();
-      await WelcomeScreen.waitForSplashAnimationToNotExit();
-      break;
-    case 'Import an existing wallet or create a new one':
-      await OnboardingScreen.isScreenDescriptionVisible();
-      break;
-    case 'Import using Secret Recovery Phrase':
-      await OnboardingScreen.isImportWalletButtonVisible();
-      break;
-    case 'Create a new wallet':
-      await OnboardingScreen.isCreateNewWalletButtonVisible();
-      break;
-    case 'By proceeding, you agree to these Terms and Conditions.':
-      await OnboardingScreen.isTermsAndConditionsButtonVisible();
-      break;
-    case 'Help us improve MetaMask':
-      await MetaMetricsScreen.isScreenTitleVisible();
-      break;
-    case 'Import from seed':
-      await ImportFromSeedScreen.isScreenTitleVisible();
-      break;
-    case 'Welcome to your new wallet!':
-      await OnboardingWizardModal.isVisible();
-
-      break;
-    default:
-      throw new Error('Condition not found');
-  }
-});
-
 Then(/^"([^"]*)?" carousel item is displayed/, async (text) => {
   switch (text) {
     case 'Welcome to MetaMask':


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Removing duplicate step.  Cucumber does not execute duplicated steps.  Step now exist in `common-steps.js`

**Screenshots/Recordings**
browserstack [smoke test](https://app-automate.browserstack.com/dashboard/v2/public-build/M3VQRlVGMGRSbXBiZzQxQmx6YXBQTU9zWGF4WExXL2JhdEpCV01ORkQ4Q0loTmdOZjhLbDVUMm1VWFp2K25WY1o0QloyL2lISERRTkNrclBSUi93RGc9PS0tci9IRVJoQm1nYm5zZ2NFMEdtUVlSUT09--e4630923b6036ef705e371d229fbd3f4d360554e)
bitrise [reports](https://app.bitrise.io/build/94e412d6-c257-47ee-a06d-0db0fd055073?tab=tests)

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
