### PR TITLE
[FIX] Force Bitrise to build with intel medium stack machine

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -636,7 +636,7 @@ app:
 meta:
   bitrise.io:
     stack: osx-xcode-14.2.x-ventura
-
+    machine_type_id: g2.4core
 trigger_map:
   - push_branch: release/*
     workflow: start_e2e_tests


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR sets the Bitrise stack machine to use Intel medium by setting the `machine_type_id` in bitrise.yml
Example of build using updated yml file - https://app.bitrise.io/build/3daf8456-8a2a-411d-9375-50599d0865b7
We'll need to move to M1 by 2023-06-15

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
