### PR TITLE
[FIX] [6.6.0] - User can no longer edit account name to be an empty edit string

### DIFF
--- a/app/components/Views/EditAccountName/EditAccountName.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.tsx
@@ -143,7 +143,7 @@ const EditAccountName = () => {
               ? { ...styles.saveButton, ...styles.saveButtonDisabled }
               : styles.saveButton
           }
-          disabled={!accountName?.length}
+          disabled={!accountName?.length || accountName?.trim() === ''}
           {...generateTestId(Platform, 'save-button')}
         />
       </View>


### PR DESCRIPTION
**Description**
The user could edit the account name to be an empty string.

**Proposed Solution**
The user no longer can confirm the name of the account if it is an empty string

**Screenshots/Recordings**
https://recordit.co/aFO2DqsGzk

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
