### PR TITLE
[e2e] Reveal PK tests

### DIFF
--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -56,6 +56,15 @@ import {
   SECRET_RECOVERY_PHRASE_NEXT_BUTTON_ID,
   SECRET_RECOVERY_PHRASE_TEXT,
 } from '../../../../wdio/screen-objects/testIDs/Screens/RevelSecretRecoveryPhrase.testIds';
+import {
+  PRIVATE_KEY_PASSWORD_INPUT_BOX_ID,
+  PRIVATE_KEY_TOUCHABLE_BOX_ID,
+  PRIVATE_KEY_CANCEL_BUTTON_ID,
+  PRIVATE_KEY_CONTAINER_ID,
+  PRIVATE_KEY_LONG_PRESS_BUTTON_ID,
+  PRIVATE_KEY_NEXT_BUTTON_ID,
+  PRIVATE_KEY_TEXT,
+} from '../../../../wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds'
 
 const PRIVATE_KEY = 'private_key';
 
@@ -339,7 +348,10 @@ const RevealPrivateCredential = ({
             selectTextOnFocus
             style={styles.seedPhrase}
             editable={false}
-            {...generateTestId(Platform, SECRET_RECOVERY_PHRASE_TEXT)}
+            {...generateTestId(Platform, (isPrivateKey
+              ? SECRET_RECOVERY_PHRASE_TEXT
+              : PRIVATE_KEY_TEXT)
+              )}
             placeholderTextColor={colors.text.muted}
             keyboardAppearance={themeAppearance}
           />
@@ -353,7 +365,9 @@ const RevealPrivateCredential = ({
               }
               {...generateTestId(
                 Platform,
-                REVEAL_SECRET_RECOVERY_PHRASE_TOUCHABLE_BOX_ID,
+                (isPrivateKey
+                  ? REVEAL_SECRET_RECOVERY_PHRASE_TOUCHABLE_BOX_ID
+                  : PRIVATE_KEY_TOUCHABLE_BOX_ID)
               )}
               style={styles.clipboardButton}
             />
@@ -387,7 +401,11 @@ const RevealPrivateCredential = ({
         secureTextEntry
         onSubmitEditing={tryUnlock}
         keyboardAppearance={themeAppearance}
-        {...generateTestId(Platform, PASSWORD_INPUT_BOX_ID)}
+        {...generateTestId(Platform, PRIVATE_KEY_PASSWORD_INPUT_BOX_ID
+          // (isPrivateKey
+          //   ?  PASSWORD_INPUT_BOX_ID
+          //   :  PRIVATE_KEY_PASSWORD_INPUT_BOX_ID)
+          )}
       />
       <Text style={styles.warningText} testID={'password-warning'}>
         {warningIncorrectPassword}
@@ -461,9 +479,11 @@ const RevealPrivateCredential = ({
             })}
             onLongPress={() => revealCredential(privCredentialName)}
             {...generateTestId(
-              Platform,
-              SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID,
-            )}
+              Platform, PRIVATE_KEY_LONG_PRESS_BUTTON_ID
+              // (isPrivateKey 
+              // ? SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID
+              // : PRIVATE_KEY_LONG_PRESS_BUTTON_ID)
+            )} 
           />
         </>
       }
@@ -522,7 +542,10 @@ const RevealPrivateCredential = ({
   return (
     <View
       style={[styles.wrapper]}
-      {...generateTestId(Platform, SECRET_RECOVERY_PHRASE_CONTAINER_ID)}
+      {...generateTestId(Platform, (isPrivateKey
+        ? SECRET_RECOVERY_PHRASE_CONTAINER_ID
+        : PRIVATE_KEY_CONTAINER_ID)
+        )}
     >
       <ActionView
         cancelText={
@@ -535,8 +558,14 @@ const RevealPrivateCredential = ({
         onConfirmPress={() => tryUnlock()}
         showConfirmButton={!unlocked}
         confirmDisabled={!enableNextButton()}
-        cancelTestID={SECRET_RECOVERY_PHRASE_CANCEL_BUTTON_ID}
-        confirmTestID={SECRET_RECOVERY_PHRASE_NEXT_BUTTON_ID}
+        cancelTestID={
+          (isPrivateKey
+            ? SECRET_RECOVERY_PHRASE_CANCEL_BUTTON_ID
+            : PRIVATE_KEY_CANCEL_BUTTON_ID)}
+        confirmTestID={
+          (isPrivateKey
+          ? SECRET_RECOVERY_PHRASE_NEXT_BUTTON_ID
+          : PRIVATE_KEY_NEXT_BUTTON_ID)}
       >
         <>
           <View style={[styles.rowWrapper, styles.normalText]}>

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -64,7 +64,7 @@ import {
   PRIVATE_KEY_LONG_PRESS_BUTTON_ID,
   PRIVATE_KEY_NEXT_BUTTON_ID,
   PRIVATE_KEY_TEXT,
-} from '../../../../wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds'
+} from '../../../../wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds';
 
 const PRIVATE_KEY = 'private_key';
 
@@ -367,7 +367,7 @@ const RevealPrivateCredential = ({
                 Platform,
                 (isPrivateKey
                   ? REVEAL_SECRET_RECOVERY_PHRASE_TOUCHABLE_BOX_ID
-                  : PRIVATE_KEY_TOUCHABLE_BOX_ID)
+                  : PRIVATE_KEY_TOUCHABLE_BOX_ID),
               )}
               style={styles.clipboardButton}
             />
@@ -480,10 +480,10 @@ const RevealPrivateCredential = ({
             onLongPress={() => revealCredential(privCredentialName)}
             {...generateTestId(
               Platform, PRIVATE_KEY_LONG_PRESS_BUTTON_ID
-              // (isPrivateKey 
+              // (isPrivateKey
               // ? SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID
               // : PRIVATE_KEY_LONG_PRESS_BUTTON_ID)
-            )} 
+            )}
           />
         </>
       }

--- a/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
@@ -13,7 +13,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { createStyles } from './styles';
 import Routes from '../../../../../../constants/navigation/Routes';
 import generateTestId from '../../../../../../../wdio/utils/generateTestId';
-import { SHOW_PRIVATE_KEY_BUTTON_ID } from '../../../../../../../app/constants/test-ids'
+import { SHOW_PRIVATE_KEY_BUTTON_ID } from '../../../../../../../app/constants/test-ids';
 // '../../../../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
 
 const testIds = {

--- a/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import Button, {
@@ -12,6 +12,9 @@ import { useTheme } from '../../../../../../util/theme';
 import { strings } from '../../../../../../../locales/i18n';
 import { createStyles } from './styles';
 import Routes from '../../../../../../constants/navigation/Routes';
+import generateTestId from '../../../../../../../wdio/utils/generateTestId';
+import { SHOW_PRIVATE_KEY_BUTTON_ID } from '../../../../../../../app/constants/test-ids'
+// '../../../../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
 
 const testIds = {
   section: 'reveal-private-key-section',
@@ -66,6 +69,7 @@ const RevealPrivateKey = () => {
         variant={ButtonVariants.Primary}
         onPress={goToExportPrivateKey}
         style={styles.confirm}
+        {...generateTestId(Platform, SHOW_PRIVATE_KEY_BUTTON_ID)}
       />
     </View>
   );

--- a/app/constants/test-ids.js
+++ b/app/constants/test-ids.js
@@ -25,6 +25,8 @@ export const CONFIRM_CHANGE_PASSWORD_INPUT_BOX_ID =
   'private-credential-password-input-field';
 
 export const REVEAL_SECRET_RECOVERY_PHRASE_BUTTON_ID = 'reveal-seed-button';
+export const SHOW_PRIVATE_KEY_BUTTON_ID = 'show-private-key-button';
+export const PRIVATE_KEY_PASSWORD_INPUT_BOX_ID ='show-private-key-password-input'
 
 export const SUBMIT_BUTTON_ID = 'submit-button';
 export const BACK_ARROW_BUTTON_ID = 'burger-menu-title-back-arrow-button';

--- a/app/constants/test-ids.js
+++ b/app/constants/test-ids.js
@@ -26,7 +26,7 @@ export const CONFIRM_CHANGE_PASSWORD_INPUT_BOX_ID =
 
 export const REVEAL_SECRET_RECOVERY_PHRASE_BUTTON_ID = 'reveal-seed-button';
 export const SHOW_PRIVATE_KEY_BUTTON_ID = 'show-private-key-button';
-export const PRIVATE_KEY_PASSWORD_INPUT_BOX_ID ='show-private-key-password-input'
+export const PRIVATE_KEY_PASSWORD_INPUT_BOX_ID = 'show-private-key-password-input';
 
 export const SUBMIT_BUTTON_ID = 'submit-button';
 export const BACK_ARROW_BUTTON_ID = 'burger-menu-title-back-arrow-button';

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.js
@@ -4,6 +4,7 @@ import {
   CHANGE_PASSWORD_BUTTON_ID,
   CHANGE_PASSWORD_TITLE_ID,
   REVEAL_SECRET_RECOVERY_PHRASE_BUTTON_ID,
+  SHOW_PRIVATE_KEY_BUTTON_ID,
 } from '../../../../../app/constants/test-ids';
 import { SECURITY_PRIVACY_REMEMBER_ME_TOGGLE } from '../../../../../wdio/screen-objects/testIDs/Screens/SecurityPrivacy.testIds';
 
@@ -13,6 +14,10 @@ const METAMETRICS_SWITCH_ID = 'metametrics-switch';
 export default class SecurityAndPrivacy {
   static async tapRevealSecretRecoveryPhrase() {
     await TestHelpers.tap(REVEAL_SECRET_RECOVERY_PHRASE_BUTTON_ID);
+  }
+
+  static async tapShowPrivateKey() {
+    await TestHelpers.tap(SHOW_PRIVATE_KEY_BUTTON_ID);
   }
 
   static async tapChangePasswordButton() {
@@ -33,17 +38,6 @@ export default class SecurityAndPrivacy {
     }
   }
 
-  static async scrollToBottomOfView() {
-    // Scroll to the bottom
-    if (device.getPlatform() === 'android') {
-      await TestHelpers.swipe(SECURITY_SETTINGS_SCROLL_ID, 'up', 'fast');
-      await TestHelpers.delay(1000);
-    } else {
-      await TestHelpers.swipe(CHANGE_PASSWORD_TITLE_ID, 'up', 'fast', 0.9);
-    }
-    //await TestHelpers.swipe(PRIVACY_MODE_SECTION_ID, 'up', 'fast');
-  }
-
   static async scrollToTurnOnRememberMe() {
     // Scroll to the bottom
     if (device.getPlatform() === 'android') {
@@ -51,6 +45,27 @@ export default class SecurityAndPrivacy {
       await TestHelpers.delay(1000);
     } else {
       await TestHelpers.swipe(CHANGE_PASSWORD_TITLE_ID, 'up', 'slow', 0.6);
+    }
+    //await TestHelpers.swipe(PRIVACY_MODE_SECTION_ID, 'up', 'fast');
+  }
+
+  static async scrollToShowPrivateKeyFor() {
+    // Scroll to the bottom
+    if (device.getPlatform() === 'android') {
+      await TestHelpers.swipe(SECURITY_SETTINGS_SCROLL_ID, 'up', 'slow');
+      await TestHelpers.delay(1000);
+    } else {
+      await TestHelpers.swipe(CHANGE_PASSWORD_TITLE_ID, 'up', 'slow', 0.8);
+    }
+  }
+
+  static async scrollToBottomOfView() {
+    // Scroll to the bottom
+    if (device.getPlatform() === 'android') {
+      await TestHelpers.swipe(SECURITY_SETTINGS_SCROLL_ID, 'up', 'fast');
+      await TestHelpers.delay(1000);
+    } else {
+      await TestHelpers.swipe(CHANGE_PASSWORD_TITLE_ID, 'up', 'fast', 0.9);
     }
     //await TestHelpers.swipe(PRIVACY_MODE_SECTION_ID, 'up', 'fast');
   }

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
@@ -1,6 +1,6 @@
 import TestHelpers from '../../../../helpers';
 import messages from '../../../../../locales/languages/en.json';
-import { 
+import {
   PRIVATE_KEY_PASSWORD_INPUT_BOX_ID,
  } from '../../../../../app/constants/test-ids';
 import {

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
@@ -1,0 +1,59 @@
+import TestHelpers from '../../../../helpers';
+import messages from '../../../../../locales/languages/en.json';
+import { 
+  PRIVATE_KEY_PASSWORD_INPUT_BOX_ID,
+ } from '../../../../../app/constants/test-ids';
+import {
+  PASSWORD_WARNING_ID,
+  PRIVATE_KEY_TOUCHABLE_BOX_ID,
+  PRIVATE_KEY_CONTAINER_ID,
+  PRIVATE_KEY_TEXT,
+  SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID
+  } from '../../../../../wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds';
+
+const PASSWORD_WARNING = messages.reveal_credential.warning_incorrect_password;
+
+export default class ShowPrivateKey {
+  static async enterPassword(password) {
+    await TestHelpers.typeTextAndHideKeyboard(PRIVATE_KEY_PASSWORD_INPUT_BOX_ID, password);
+  }
+
+  static async enterIncorrectPassword(incorrectPassword) {
+    await TestHelpers.typeTextAndHideKeyboard(PRIVATE_KEY_PASSWORD_INPUT_BOX_ID, incorrectPassword);
+  }
+
+  static async longPressAndHoldToRevealPrivateKey (SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID) {
+    await TestHelpers.tapAndLongPress(SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID);
+    return element(by.id('SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID')).longPress(2000);
+  }
+
+
+  static async isVisible() {
+    await TestHelpers.checkIfVisible(PRIVATE_KEY_CONTAINER_ID);
+  }
+
+  static async isNotVisible() {
+    await TestHelpers.checkIfNotVisible(PRIVATE_KEY_CONTAINER_ID);
+  }
+
+  static async passwordWarningIsVisible() {
+    await TestHelpers.checkIfHasText(PASSWORD_WARNING_ID, PASSWORD_WARNING);
+  }
+
+  static async passwordInputIsNotVisible() {
+    await TestHelpers.checkIfNotVisible(PRIVATE_KEY_PASSWORD_INPUT_BOX_ID);
+  }
+
+  static async isPrivateKeyTouchableBoxVisible() {
+    await TestHelpers.checkIfVisible(
+      PRIVATE_KEY_TOUCHABLE_BOX_ID,
+    );
+  }
+
+  static async isPrivateKeyTextCorrect(Correct_Private_Key_Text) {
+    await TestHelpers.checkIfHasText(
+      PRIVATE_KEY_TEXT,
+      Correct_Private_Key_Text,
+    );
+  }
+}

--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey.js
@@ -8,7 +8,7 @@ import {
   PRIVATE_KEY_TOUCHABLE_BOX_ID,
   PRIVATE_KEY_CONTAINER_ID,
   PRIVATE_KEY_TEXT,
-  SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID
+  PRIVATE_KEY_LONG_PRESS_BUTTON_ID
   } from '../../../../../wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds';
 
 const PASSWORD_WARNING = messages.reveal_credential.warning_incorrect_password;
@@ -22,9 +22,9 @@ export default class ShowPrivateKey {
     await TestHelpers.typeTextAndHideKeyboard(PRIVATE_KEY_PASSWORD_INPUT_BOX_ID, incorrectPassword);
   }
 
-  static async longPressAndHoldToRevealPrivateKey (SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID) {
-    await TestHelpers.tapAndLongPress(SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID);
-    return element(by.id('SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID')).longPress(2000);
+  static async longPressAndHoldToRevealPrivateKey (PRIVATE_KEY_LONG_PRESS_BUTTON_ID) {
+    await TestHelpers.tapAndLongPress(PRIVATE_KEY_LONG_PRESS_BUTTON_ID);
+    return element(by.id('PRIVATE_KEY_LONG_PRESS_BUTTON_ID')).longPress(2000);
   }
 
 

--- a/e2e/specs/accounts/reveal-private-key.spec.js
+++ b/e2e/specs/accounts/reveal-private-key.spec.js
@@ -17,11 +17,6 @@ describe(Smoke('Wallet Tests'), () => {
   const GOERLI = 'Goerli Test Network';
   const ETHEREUM = 'Ethereum Main Network';
 
-  // This key is for testing private key import only
-  // I should NEVER hold any eth or token
-  const TEST_PRIVATE_KEY =
-    'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
-
   const validAccount = Accounts.getValidAccount();
 
   beforeEach(() => {

--- a/e2e/specs/accounts/reveal-private-key.spec.js
+++ b/e2e/specs/accounts/reveal-private-key.spec.js
@@ -1,0 +1,55 @@
+'use strict';
+import { Smoke } from '../../tags';
+
+import TestHelpers from '../../helpers';
+import LoginView from '../../pages/LoginView';
+import WalletView from '../../pages/WalletView';
+import AccountListView from '../../pages/AccountListView';
+import DrawerView from '../../pages/Drawer/DrawerView';
+import SettingsView from '../../pages/Drawer/Settings/SettingsView';
+import SecurityAndPrivacy from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView'
+import { importWalletWithRecoveryPhrase } from '../../viewHelper';
+import Accounts from '../../../wdio/helpers/Accounts';
+import { PRIVATE_KEY_PASSWORD_INPUT_BOX_ID } from '../../../app/constants/test-ids' 
+import ShowPrivateKey from '../../pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey';
+
+describe(Smoke('Wallet Tests'), () => {
+  const GOERLI = 'Goerli Test Network';
+  const ETHEREUM = 'Ethereum Main Network';
+
+  // This key is for testing private key import only
+  // I should NEVER hold any eth or token
+  const TEST_PRIVATE_KEY =
+    'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
+
+  const validAccount = Accounts.getValidAccount();
+
+  beforeEach(() => {
+    jest.setTimeout(200000);
+  });
+
+  it('should import wallet and go to the wallet view', async () => {
+    await importWalletWithRecoveryPhrase();
+  }); 
+
+  it('should present error with invalid password', async () => {
+    await WalletView.tapDrawerButton(); 
+    await DrawerView.isVisible();
+    await DrawerView.tapSettings();
+    //should there be assertions here?  isVisible does not yet exist on this view
+    await SettingsView.tapSecurityAndPrivacy();
+    //should there be assertions here?  isVisible does not yet exist on this view
+    await SecurityAndPrivacy.scrollToShowPrivateKeyFor();
+    TestHelpers.delay(1000);
+    await SecurityAndPrivacy.tapShowPrivateKey();
+    await ShowPrivateKey.enterIncorrectPassword(validAccount.incorrectPassword,);
+    await ShowPrivateKey.passwordWarningIsVisible();
+  });
+
+  it('should reveal private key', async () => {
+    await TestHelpers.clearField(PRIVATE_KEY_PASSWORD_INPUT_BOX_ID);
+    await ShowPrivateKey.enterPassword(validAccount.password);
+    await ShowPrivateKey.longPressAndHoldToRevealPrivateKey();
+    await ShowPrivateKey.isPrivateKeyTextCorrect();
+  });
+});

--- a/e2e/specs/accounts/reveal-private-key.spec.js
+++ b/e2e/specs/accounts/reveal-private-key.spec.js
@@ -25,10 +25,10 @@ describe(Smoke('Wallet Tests'), () => {
 
   it('should import wallet and go to the wallet view', async () => {
     await importWalletWithRecoveryPhrase();
-  }); 
+  });
 
   it('should present error with invalid password', async () => {
-    await WalletView.tapDrawerButton(); 
+    await WalletView.tapDrawerButton();
     await DrawerView.isVisible();
     await DrawerView.tapSettings();
     //should there be assertions here?  isVisible does not yet exist on this view

--- a/e2e/specs/accounts/reveal-private-key.spec.js
+++ b/e2e/specs/accounts/reveal-private-key.spec.js
@@ -7,10 +7,10 @@ import WalletView from '../../pages/WalletView';
 import AccountListView from '../../pages/AccountListView';
 import DrawerView from '../../pages/Drawer/DrawerView';
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
-import SecurityAndPrivacy from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView'
+import SecurityAndPrivacy from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
 import Accounts from '../../../wdio/helpers/Accounts';
-import { PRIVATE_KEY_PASSWORD_INPUT_BOX_ID } from '../../../app/constants/test-ids' 
+import { PRIVATE_KEY_PASSWORD_INPUT_BOX_ID } from '../../../app/constants/test-ids';
 import ShowPrivateKey from '../../pages/Drawer/Settings/SecurityAndPrivacy/ShowPrivateKey';
 
 describe(Smoke('Wallet Tests'), () => {

--- a/wdio/helpers/Accounts.js
+++ b/wdio/helpers/Accounts.js
@@ -9,11 +9,12 @@ class Accounts {
   static getValidAccount() {
     return {
       // A correct BIP39 SRP that can be used for testing. Requires the var to be set in the environment.
-      seedPhrase: process.env.MM_TEST_ACCOUNT_SRP || 'undefined SRP env var',
+      seedPhrase: process.env.MM_TEST_ACCOUNT_SRP, // || 'undefined SRP env var',
       // Ethereum address for 1st account of derived on the seed that can be used for testing. Requires the var to be set in the environment.
       address:
-        process.env.MM_TEST_ACCOUNT_ADDRESS || 'undefined address env var',
+        process.env.MM_TEST_ACCOUNT_ADDRESS, // || 'undefined address env var',
       password: CORRECT_PASSWORD,
+      incorrectPassword: INCORRECT_PASSWORD,
     };
   }
 
@@ -27,8 +28,8 @@ class Accounts {
   static getAccountPrivateKey() {
     return {
       keys:
-        process.env.MM_TEST_ACCOUNT_PRIVATE_KEY ||
-        'undefined Private key env var',
+        process.env.MM_TEST_ACCOUNT_PRIVATE_KEY, // ||
+        //'undefined Private key env var', 
     };
   }
 

--- a/wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds.js
+++ b/wdio/screen-objects/testIDs/Screens/ShowPrivateKey.testIds.js
@@ -1,0 +1,8 @@
+export const PRIVATE_KEY_CONTAINER_ID = 'show-private-key-credential-screen';
+export const PRIVATE_KEY_PASSWORD_INPUT_BOX_ID = 'show-private-key-password-input';
+export const PASSWORD_WARNING_ID = 'password-warning';
+export const PRIVATE_KEY_TOUCHABLE_BOX_ID = 'private-key-credential-touchable';
+export const PRIVATE_KEY_TEXT = 'private-key-credential-text';
+export const PRIVATE_KEY_CANCEL_BUTTON_ID = 'show-private-key-credential-cancel-button';
+export const PRIVATE_KEY_NEXT_BUTTON_ID = 'show-private-key-credential-next-button';
+export const PRIVATE_KEY_LONG_PRESS_BUTTON_ID = 'show-private-key-long-press-button';


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Adding e2e detox tests for show private key.  Still need to resolve proper testId generation and tap and hold to reveal.

**Screenshots/Recordings**



**Issue**

Progresses #[960](https://github.com/MetaMask/mobile-planning/issues/960)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [ ] Any added code is fully documented
