### PR TITLE
[FIX] Send ETH displays Collectible as predefault value in the Amount screen and undefined balance

### DIFF
--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.test.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.test.tsx
@@ -20,6 +20,13 @@ jest.mock('@react-navigation/native', () => ({
 
 const initialState = {
   settings: {},
+  transaction: {
+    selectedAsset: {
+      address: '0x0',
+      decimals: 18,
+      symbol: 'ETH',
+    },
+  },
   engine: {
     backgroundState: {
       AccountTrackerController: {

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { hexToBN } from '@metamask/controller-utils';
@@ -44,7 +44,15 @@ const SendFlowAddressFrom = ({
   );
   const [accountBalance, setAccountBalance] = useState('');
 
+  const dispatch = useDispatch();
+
+  const selectedAssetAction = useCallback(
+    (selectedAsset: any) => dispatch(setSelectedAsset(selectedAsset)),
+    [dispatch],
+  );
+
   useEffect(() => {
+    selectedAssetAction(getEther(ticker as string));
     async function getAccount() {
       const ens = await doENSReverseLookup(selectedAddress, network);
       const balance = `${renderFromWei(
@@ -62,13 +70,9 @@ const SendFlowAddressFrom = ({
     ticker,
     network,
     identities,
+    selectedAssetAction,
     fromAccountBalanceState,
   ]);
-
-  const dispatch = useDispatch();
-
-  const selectedAssetAction = (selectedAsset: any) =>
-    dispatch(setSelectedAsset(selectedAsset));
 
   const onSelectAccount = async (address: string) => {
     const { name } = identities[address];
@@ -78,7 +82,7 @@ const SendFlowAddressFrom = ({
     const ens = await doENSReverseLookup(address);
     const accName = ens || name;
     const balanceIsZero = hexToBN(accounts[address].balance).isZero();
-    selectedAssetAction(getEther(ticker));
+    selectedAssetAction(getEther(ticker as string));
     setAccountAddress(address);
     setAccountName(accName);
     setAccountBalance(balance);

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -4,7 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { hexToBN } from '@metamask/controller-utils';
 import { useNavigation } from '@react-navigation/native';
 
-import { setSelectedAsset } from '../../../../actions/transaction';
+import {
+  newAssetTransaction,
+  setSelectedAsset,
+} from '../../../../actions/transaction';
 import Routes from '../../../../constants/navigation/Routes';
 import {
   selectNetwork,
@@ -46,13 +49,30 @@ const SendFlowAddressFrom = ({
 
   const dispatch = useDispatch();
 
+  const selectedAsset = useSelector(
+    (state: any) => state.transaction.selectedAsset,
+  );
+
   const selectedAssetAction = useCallback(
-    (selectedAsset: any) => dispatch(setSelectedAsset(selectedAsset)),
+    (asset: any) => dispatch(setSelectedAsset(asset)),
+    [dispatch],
+  );
+
+  const newAssetTransactionAction = useCallback(
+    (asset: any) => dispatch(newAssetTransaction(asset)),
     [dispatch],
   );
 
   useEffect(() => {
-    selectedAssetAction(getEther(ticker as string));
+    if (selectedAsset.isETH || Object.keys(selectedAsset).length === 0) {
+      newAssetTransactionAction(getEther(ticker as string));
+      selectedAssetAction(getEther(ticker as string));
+    } else {
+      newAssetTransactionAction(selectedAsset);
+    }
+  }, [newAssetTransactionAction, selectedAssetAction, ticker]);
+
+  useEffect(() => {
     async function getAccount() {
       const ens = await doENSReverseLookup(selectedAddress, network);
       const balance = `${renderFromWei(
@@ -70,7 +90,6 @@ const SendFlowAddressFrom = ({
     ticker,
     network,
     identities,
-    selectedAssetAction,
     fromAccountBalanceState,
   ]);
 

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { hexToBN } from '@metamask/controller-utils';
@@ -63,14 +63,24 @@ const SendFlowAddressFrom = ({
     [dispatch],
   );
 
+  const selectedAssetRef = useRef(selectedAsset);
+
   useEffect(() => {
-    if (selectedAsset.isETH || Object.keys(selectedAsset).length === 0) {
+    if (
+      selectedAssetRef.current.isETH ||
+      Object.keys(selectedAssetRef.current).length === 0
+    ) {
       newAssetTransactionAction(getEther(ticker as string));
       selectedAssetAction(getEther(ticker as string));
     } else {
-      newAssetTransactionAction(selectedAsset);
+      newAssetTransactionAction(selectedAssetRef.current);
     }
-  }, [newAssetTransactionAction, selectedAssetAction, ticker]);
+  }, [
+    newAssetTransactionAction,
+    selectedAssetAction,
+    selectedAssetRef.current,
+    ticker,
+  ]);
 
   useEffect(() => {
     async function getAccount() {

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -75,12 +75,7 @@ const SendFlowAddressFrom = ({
     } else {
       newAssetTransactionAction(selectedAssetRef.current);
     }
-  }, [
-    newAssetTransactionAction,
-    selectedAssetAction,
-    selectedAssetRef.current,
-    ticker,
-  ]);
+  }, [newAssetTransactionAction, selectedAssetAction, ticker]);
 
   useEffect(() => {
     async function getAccount() {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->
**Description**
Whenever we install MetaMask for the first time (update into the release 6.5) when I click to Send, I can see how the selected token is Collectible instead of ETH. Also we see how there is an undefined value in the Balance.

**Screenshots/Recordings**

**Before**
https://user-images.githubusercontent.com/54408225/236208836-d75ecf6c-7837-4d0c-a952-69b2114ad03d.mp4

**After**
http://recordit.co/z3MLmaqYLe

**Issue**

Fixes: #6331 

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
