### PR TITLE
On-ramp: use screen in on-ramp views tests

### DIFF
--- a/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/GetStarted/GetStarted.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 
 import GetStarted from './GetStarted';
@@ -84,8 +84,8 @@ describe('GetStarted', () => {
     mockUseFiatOnRampSDKValues = {
       ...mockuseFiatOnRampSDKInitialValues,
     };
-    const rendered = render(GetStarted);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(GetStarted);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly when sdkError is present', async () => {
@@ -93,8 +93,8 @@ describe('GetStarted', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       sdkError: new Error('sdkError'),
     };
-    const rendered = render(GetStarted);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(GetStarted);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly when getStarted is true', async () => {
@@ -102,8 +102,8 @@ describe('GetStarted', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       getStarted: true,
     };
-    const rendered = render(GetStarted);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(GetStarted);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('calls setOptions when rendering', async () => {
@@ -115,8 +115,8 @@ describe('GetStarted', () => {
     mockUseFiatOnRampSDKValues = {
       ...mockuseFiatOnRampSDKInitialValues,
     };
-    const rendered = render(GetStarted);
-    fireEvent.press(rendered.getByRole('button', { name: 'Get started' }));
+    render(GetStarted);
+    fireEvent.press(screen.getByRole('button', { name: 'Get started' }));
     expect(mockNavigate).toHaveBeenCalledWith(...createRegionsNavDetails());
     expect(mockUseFiatOnRampSDKValues.setGetStarted).toHaveBeenCalledWith(true);
   });
@@ -125,8 +125,8 @@ describe('GetStarted', () => {
     mockUseFiatOnRampSDKValues = {
       ...mockuseFiatOnRampSDKInitialValues,
     };
-    const rendered = render(GetStarted);
-    fireEvent.press(rendered.getByRole('button', { name: 'Cancel' }));
+    render(GetStarted);
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toBeCalledWith('ONRAMP_CANCELED', {
       chain_id_destination: '1',

--- a/app/components/UI/FiatOnRampAggregator/Views/PaymentMethods/PaymentMethods.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/PaymentMethods/PaymentMethods.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Country, Payment } from '@consensys/on-ramp-sdk';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 
 import PaymentMethods from './PaymentMethods';
@@ -173,16 +173,16 @@ describe('PaymentMethods View', () => {
   });
 
   it('renders correctly', async () => {
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with show back button false', async () => {
     mockUseParamsValues = {
       showBack: false,
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly while loading', async () => {
@@ -190,8 +190,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       isFetching: true,
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with null data', async () => {
@@ -199,8 +199,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       data: null,
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with empty data', async () => {
@@ -208,8 +208,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       data: [],
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with payment method with disclaimer', async () => {
@@ -217,8 +217,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       currentPaymentMethod: mockPaymentMethods[1] as Payment,
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('resets region and payment method id when pressing error view with empty data', async () => {
@@ -226,8 +226,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       data: [],
     };
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Reset Region' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Reset Region' }));
     expect(mockSetSelectedRegion).toBeCalledWith(null);
     expect(mockSetSelectedPaymentMethodId).toBeCalledWith(null);
   });
@@ -237,8 +237,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       data: [],
     };
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Reset Region' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Reset Region' }));
     expect(mockGoBack).toHaveBeenCalled();
   });
 
@@ -250,16 +250,16 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       data: [],
     };
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Reset Region' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Reset Region' }));
     expect(mockReset).toBeCalledWith({
       routes: [{ name: Routes.FIAT_ON_RAMP_AGGREGATOR.REGION }],
     });
   });
 
   it('navigates and tracks event on cancel button press', async () => {
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Cancel' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toBeCalledWith('ONRAMP_CANCELED', {
       chain_id_destination: '1',
@@ -268,18 +268,16 @@ describe('PaymentMethods View', () => {
   });
 
   it('selects payment method on press', async () => {
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Debit or Credit' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Debit or Credit' }));
     expect(mockSetSelectedPaymentMethodId).toBeCalledWith(
       '/payments/debit-credit-card',
     );
   });
 
   it('navigates to amount to buy on continue button press', async () => {
-    const rendered = render(PaymentMethods);
-    fireEvent.press(
-      rendered.getByRole('button', { name: 'Continue to amount' }),
-    );
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Continue to amount' }));
     expect(mockNavigate).toHaveBeenCalledWith(...createAmountToBuyNavDetails());
     expect(mockTrackEvent).toHaveBeenCalledWith(
       'ONRAMP_CONTINUE_TO_AMOUNT_CLICKED',
@@ -301,8 +299,8 @@ describe('PaymentMethods View', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       sdkError: new Error('sdkError'),
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('navigates to home when clicking sdKError button', async () => {
@@ -310,9 +308,9 @@ describe('PaymentMethods View', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       sdkError: new Error('sdkError'),
     };
-    const rendered = render(PaymentMethods);
+    render(PaymentMethods);
     fireEvent.press(
-      rendered.getByRole('button', { name: 'Return to Home Screen' }),
+      screen.getByRole('button', { name: 'Return to Home Screen' }),
     );
     expect(mockPop).toBeCalledTimes(1);
   });
@@ -322,8 +320,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       error: 'Test error',
     };
-    const rendered = render(PaymentMethods);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(PaymentMethods);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('queries payment methods again with error', async () => {
@@ -331,8 +329,8 @@ describe('PaymentMethods View', () => {
       ...mockUsePaymentMethodsInitialValues,
       error: 'Test error',
     };
-    const rendered = render(PaymentMethods);
-    fireEvent.press(rendered.getByRole('button', { name: 'Try again' }));
+    render(PaymentMethods);
+    fireEvent.press(screen.getByRole('button', { name: 'Try again' }));
     expect(mockQueryGetPaymentMethods).toBeCalledTimes(1);
   });
 });

--- a/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
+++ b/app/components/UI/FiatOnRampAggregator/Views/Regions/Regions.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Country } from '@consensys/on-ramp-sdk';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 
 import Regions from './Regions';
 import useRegions from '../../hooks/useRegions';
 import { OnRampSDK } from '../../sdk';
 import { Region } from '../../types';
-import { fireEvent } from '@testing-library/react-native';
 import { createPaymentMethodsNavDetails } from '../PaymentMethods/PaymentMethods';
 import Routes from '../../../../../constants/navigation/Routes';
 
@@ -137,8 +137,8 @@ describe('Regions View', () => {
   });
 
   it('renders correctly', async () => {
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly while loading', async () => {
@@ -146,8 +146,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       isFetching: true,
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with no data', async () => {
@@ -155,8 +155,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       data: null,
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with selectedRegion', async () => {
@@ -164,29 +164,29 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       selectedRegion: mockRegionsData[0] as Country,
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders regions modal when pressing select button', async () => {
-    const rendered = render(Regions);
-    const selectRegionButton = rendered.getByRole('button', {
+    render(Regions);
+    const selectRegionButton = screen.getByRole('button', {
       name: 'Select your region',
     });
     fireEvent.press(selectRegionButton);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('calls setSelectedRegion when pressing a region', async () => {
-    const rendered = render(Regions);
+    render(Regions);
     const regionToPress = mockRegionsData[0] as Region;
     // First show region modal
-    const selectRegionButton = rendered.getByRole('button', {
+    const selectRegionButton = screen.getByRole('button', {
       name: 'Select your region',
     });
     fireEvent.press(selectRegionButton);
     // Then detect region selection buttons
-    const regionButton = rendered.getByRole('button', {
+    const regionButton = screen.getByRole('button', {
       name: regionToPress.name,
     });
     fireEvent.press(regionButton);
@@ -198,8 +198,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       selectedRegion: mockRegionsData[0] as Country,
     };
-    const rendered = render(Regions);
-    fireEvent.press(rendered.getByRole('button', { name: 'Continue' }));
+    render(Regions);
+    fireEvent.press(screen.getByRole('button', { name: 'Continue' }));
     expect(mockNavigate).toHaveBeenCalledWith(
       ...createPaymentMethodsNavDetails(),
     );
@@ -209,8 +209,8 @@ describe('Regions View', () => {
     mockUseFiatOnRampSDKValues = {
       ...mockuseFiatOnRampSDKInitialValues,
     };
-    const rendered = render(Regions);
-    fireEvent.press(rendered.getByRole('button', { name: 'Cancel' }));
+    render(Regions);
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
     expect(mockPop).toHaveBeenCalled();
     expect(mockTrackEvent).toBeCalledWith('ONRAMP_CANCELED', {
       chain_id_destination: '1',
@@ -219,8 +219,8 @@ describe('Regions View', () => {
   });
 
   it('has continue button disabled', async () => {
-    const rendered = render(Regions);
-    const continueButton = rendered.getByRole('button', { name: 'Continue' });
+    render(Regions);
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
     expect(continueButton.props.disabled).toBe(true);
   });
 
@@ -229,8 +229,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       unsupportedRegion: mockRegionsData[1] as Region,
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with sdkError', async () => {
@@ -238,8 +238,8 @@ describe('Regions View', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       sdkError: new Error('sdkError'),
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('navigates to home when clicking sdKError button', async () => {
@@ -247,9 +247,9 @@ describe('Regions View', () => {
       ...mockuseFiatOnRampSDKInitialValues,
       sdkError: new Error('sdkError'),
     };
-    const rendered = render(Regions);
+    render(Regions);
     fireEvent.press(
-      rendered.getByRole('button', { name: 'Return to Home Screen' }),
+      screen.getByRole('button', { name: 'Return to Home Screen' }),
     );
     expect(mockPop).toBeCalledTimes(1);
   });
@@ -259,8 +259,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       error: 'Test error',
     };
-    const rendered = render(Regions);
-    expect(rendered.toJSON()).toMatchSnapshot();
+    render(Regions);
+    expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('queries countries again with error', async () => {
@@ -268,8 +268,8 @@ describe('Regions View', () => {
       ...mockuseRegionsInitialValues,
       error: 'Test error',
     };
-    const rendered = render(Regions);
-    fireEvent.press(rendered.getByRole('button', { name: 'Try again' }));
+    render(Regions);
+    fireEvent.press(screen.getByRole('button', { name: 'Try again' }));
     expect(mockQueryGetCountries).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

This PR refactors the on-ramp tests to use `screen: RenderResult` instead of the returned value of `render(...)` as recommended here https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen 

**Screenshots/Recordings**

~~_If applicable, add screenshots and/or recordings to visualize the before and after of your change_~~

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
