### PR TITLE
test: Approve default ERC20 token from a dapp

### DIFF
--- a/wdio/features/Confirmations/ApproveERC20.feature
+++ b/wdio/features/Confirmations/ApproveERC20.feature
@@ -1,0 +1,26 @@
+@androidApp
+@confirmations
+@regression
+
+Feature: Approving an ERC20 token from a dapp
+  A user should be able to approve an ERC20 token from a dapp.
+
+  Scenario: Import wallet
+    Given the app displayed the splash animation
+    And I have imported my wallet
+    And I tap No Thanks on the Enable security check screen
+    And I tap No thanks on the onboarding welcome tutorial
+  
+  Scenario: Approve an ERC20 token from a dapp with default amount
+    Given Ganache server is started
+    And I close the Whats New modal
+    And Ganache network is selected
+    And ERC20 token contract is deployed
+    When I navigate to the browser
+    And I am on Home MetaMask website
+    And I navigate to "test-dapp-erc20"
+    And I connect my active wallet to the test dapp
+    And I scroll to the ERC20 section
+    And I approve ERC20 tokens
+    Then the transaction is submitted with Transaction Complete! toast appearing
+    Then Ganache server is stopped

--- a/wdio/screen-objects/BrowserObject/ExternalWebsitesScreen.js
+++ b/wdio/screen-objects/BrowserObject/ExternalWebsitesScreen.js
@@ -81,6 +81,10 @@ class ExternalWebsitesScreen {
     return Selectors.getXpathElementByText('TRANSFER TOKENS');
   }
 
+  get testDappApproveTokens() {
+    return Selectors.getXpathElementByText('APPROVE TOKENS');
+  }
+
   async tapHomeFavoritesButton() {
     const element = await this.homeFavoriteButton;
     await element.waitForEnabled();
@@ -134,6 +138,12 @@ class ExternalWebsitesScreen {
     const element = await this.testDappTransferTokens;
     await element.waitForEnabled();
     await Gestures.waitAndTap(this.testDappTransferTokens);
+  }
+
+  async tapDappApproveTokens() {
+    const element = await this.testDappApproveTokens;
+    await element.waitForEnabled();
+    await Gestures.waitAndTap(this.testDappApproveTokens);
   }
 
   async tapUniswapMetaMaskWalletButton() {

--- a/wdio/screen-objects/Modals/AccountApprovalModal.js
+++ b/wdio/screen-objects/Modals/AccountApprovalModal.js
@@ -45,6 +45,10 @@ class AccountApprovalModal {
     await Gestures.tapTextByXpath('Confirm'); // needed for browser specific tests
   }
 
+  async tapApproveButtonByText() {
+    await Gestures.tapTextByXpath('Approve'); // needed for browser specific tests
+  }
+
   async isVisible() {
     const modalContainer = await this.modalContainer;
     await modalContainer.waitForDisplayed();

--- a/wdio/step-definitions/browser-steps.js
+++ b/wdio/step-definitions/browser-steps.js
@@ -401,12 +401,18 @@ When(/^I connect my active wallet to the test dapp$/, async () => {
 });
 
 When(/^I scroll to the ERC20 section$/, async () => {
-  await Gestures.swipeUp(0.8);
+  await Gestures.swipeUp(1);
 });
 
 When(/^I transfer ERC20 tokens$/, async () => {
   await ExternalWebsitesScreen.tapDappTransferTokens();
   await AccountApprovalModal.tapConfirmButtonByText();
+  await AccountApprovalModal.waitForDisappear();
+});
+
+When(/^I approve ERC20 tokens$/, async () => {
+  await ExternalWebsitesScreen.tapDappApproveTokens();
+  await AccountApprovalModal.tapApproveButtonByText();
   await AccountApprovalModal.waitForDisappear();
 });
 


### PR DESCRIPTION
## Description
This PR adds a test for Approving an ERC20 token from a dapp with default amount.

## Screenshots/Recordings

![image](https://github.com/MetaMask/metamask-mobile/assets/54408225/bc6cc2bb-2166-4a05-86d7-2c6ff5dcf35c)



Successful run in Bitrise: https://app.bitrise.io/build/21505f05-8039-4065-85c4-4bcad313cac6

![image](https://github.com/MetaMask/metamask-mobile/assets/54408225/6c8917ae-d03d-4116-918d-29e5a856c97a)

**Issue**

- Progresses https://github.com/MetaMask/mobile-planning/issues/991

**Checklist**

* [X] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented
