### PR TITLE
ci(validation): PR Title Validation Run on Every Edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,6 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
-  pr-linter:
-    runs-on: ubuntu-latest
-    steps:
-      # v5.2.0
-      - name: Conventional Commit Validation PR Title
-        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   scripts:
     runs-on: ubuntu-20.04
     needs: setup
@@ -105,6 +97,6 @@ jobs:
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04
-    needs: [setup, scripts, tests, check-workflows, pr-linter]
+    needs: [setup, scripts, tests, check-workflows]
     steps:
       - run: echo "Great success!"

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened,closed,synchronize,edited]
+    types: [opened,synchronize,edited]
 
 jobs:
   pr-title-linter:

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -1,7 +1,7 @@
 name: "Conventional Commit Validation PR Title"
 on:
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened,closed,synchronize,edited]
 
 jobs:
   setup:

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -4,11 +4,10 @@ on:
     types: [opened,closed,synchronize,edited]
 
 jobs:
-  setup:
+  pr-title-linter:
     runs-on: ubuntu-latest
     steps:
       # v5.2.0
-      - name: Conventional Commit Validation PR Title
         uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -7,7 +7,7 @@ jobs:
   pr-title-linter:
     runs-on: ubuntu-latest
     steps:
-      # v5.2.0
-        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # v5.2.0
+    - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -1,0 +1,14 @@
+name: "Conventional Commit Validation PR Title"
+on:
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      # v5.2.0
+      - name: Conventional Commit Validation PR Title
+        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -1,6 +1,8 @@
 name: "Conventional Commit Validation PR Title"
 on:
-  pull_request_target:
+  pull_request:
+    branches:
+      - main
     types: [opened,closed,synchronize,edited]
 
 jobs:

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened,synchronize,edited]
+    types: [opened,edited]
 
 jobs:
   pr-title-linter:


### PR DESCRIPTION
**Description**

This PR moves the PR validation action into a separate file so it can be run whenever the PR is edited.

```
[pr-title-linter](https://github.com/MetaMask/metamask-mobile/actions/runs/5123779027/jobs/9214773033#step:2:6)
Unknown release type "wrongformat" found in pull request title "wrongformat(validation): PR Title Validation Run on Every Edit". 

Available types:
 - feat: A new feature
 - fix: A bug fix
 - docs: Documentation only changes
 - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - refactor: A code change that neither fixes a bug nor adds a feature
 - perf: A code change that improves performance
 - test: Adding missing tests or correcting existing tests
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 - chore: Other changes that don't modify src or test files
 - revert: Reverts a previous commit
```

**Screenshots/Recordings**

NA

**Issue**

Progresses #???

**Checklist**

* [NA] There is a related GitHub issue
* [NA] Tests are included if applicable
* [NA] Any added code is fully documented
