### PR TITLE
feat: Add disabled prop on base button

### DIFF
--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: {
   vars: ButtonBaseStyleSheetVars;
 }) => {
   const { vars, theme } = params;
-  const { style, size, labelColor, width } = vars;
+  const { style, size, labelColor, width, disabled } = vars;
   const isAutoSize: boolean = size === ButtonSize.Auto;
   let widthObject;
   switch (width) {
@@ -44,6 +44,7 @@ const styleSheet = (params: {
         justifyContent: 'center',
         borderRadius: isAutoSize ? 0 : Number(size) / 2,
         paddingHorizontal: isAutoSize ? 0 : 16,
+        opacity: disabled ? 0.5 : 1,
         ...widthObject,
       } as ViewStyle,
       style,

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: {
   vars: ButtonBaseStyleSheetVars;
 }) => {
   const { vars, theme } = params;
-  const { style, size, labelColor, width, disabled } = vars;
+  const { style, size, labelColor, width, isDisabled } = vars;
   const isAutoSize: boolean = size === ButtonSize.Auto;
   let widthObject;
   switch (width) {
@@ -44,7 +44,7 @@ const styleSheet = (params: {
         justifyContent: 'center',
         borderRadius: isAutoSize ? 0 : Number(size) / 2,
         paddingHorizontal: isAutoSize ? 0 : 16,
-        opacity: disabled ? 0.5 : 1,
+        ...(isDisabled && { opacity: 0.5 }),
         ...widthObject,
       } as ViewStyle,
       style,

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.test.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.test.tsx
@@ -25,7 +25,7 @@ describe('ButtonBase', () => {
   it('should render correctly when disabled', () => {
     const wrapper = shallow(
       <ButtonBase
-        disabled
+        isDisabled
         startIconName={IconName.Bank}
         size={ButtonSize.Md}
         label={'Click me!'}

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.test.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.test.tsx
@@ -21,4 +21,17 @@ describe('ButtonBase', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render correctly when disabled', () => {
+    const wrapper = shallow(
+      <ButtonBase
+        disabled
+        startIconName={IconName.Bank}
+        size={ButtonSize.Md}
+        label={'Click me!'}
+        onPress={() => null}
+      />,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
@@ -34,6 +34,7 @@ const ButtonBase = ({
     size,
     labelColor,
     width,
+    disabled: props.disabled,
   });
   return (
     <TouchableOpacity

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
@@ -27,6 +27,7 @@ const ButtonBase = ({
   style,
   labelColor,
   width = DEFAULT_BUTTONBASE_WIDTH,
+  isDisabled,
   ...props
 }: ButtonBaseProps) => {
   const { styles } = useStyles(styleSheet, {
@@ -34,10 +35,11 @@ const ButtonBase = ({
     size,
     labelColor,
     width,
-    disabled: props.disabled,
+    isDisabled,
   });
   return (
     <TouchableOpacity
+      disabled={isDisabled}
       activeOpacity={0.5}
       onPress={onPress}
       style={styles.base}

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.types.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.types.ts
@@ -49,7 +49,7 @@ export interface ButtonBaseProps extends TouchableOpacityProps {
  */
 export type ButtonBaseStyleSheetVars = Pick<
   ButtonBaseProps,
-  'style' | 'labelColor'
+  'style' | 'labelColor' | 'disabled'
 > & {
   size: ButtonSize;
   width: ButtonWidthTypes | number;

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.types.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.types.ts
@@ -42,6 +42,10 @@ export interface ButtonBaseProps extends TouchableOpacityProps {
    * Optional param to control the width of the button.
    */
   width?: ButtonWidthTypes | number;
+  /**
+   * Optional param to disable the button.
+   */
+  isDisabled?: boolean;
 }
 
 /**
@@ -49,7 +53,7 @@ export interface ButtonBaseProps extends TouchableOpacityProps {
  */
 export type ButtonBaseStyleSheetVars = Pick<
   ButtonBaseProps,
-  'style' | 'labelColor' | 'disabled'
+  'style' | 'labelColor' | 'isDisabled'
 > & {
   size: ButtonSize;
   width: ButtonWidthTypes | number;

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/README.md
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/README.md
@@ -70,6 +70,16 @@ Optional param to control the width of the button.
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
 | [ButtonWidthTypes](../../Button.types.ts) or number                  | No                                                      |      ButtonWidthTypes.Auto                                                   |
 
+### `isDisabled`
+
+Optional boolean to disable the button.
+
+Disabled button do not trigger the onPress handler and have reduced (50%) opacity.
+
+| <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
+| :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
+| boolean                                             | No                                                      | false                                                   |
+
 ## Usage
 
 ```javascript
@@ -82,5 +92,6 @@ Optional param to control the width of the button.
   onPress={SAMPLE_ONPRESS_HANDLER}
   isDanger
   width={ButtonWidthTypes.Auto}
+  isDisabled
 />;
 ```

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
@@ -13,6 +13,49 @@ exports[`ButtonBase should render correctly 1`] = `
       "flexDirection": "row",
       "height": 40,
       "justifyContent": "center",
+      "opacity": 1,
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <Icon
+    color="#24272A"
+    name="Bank"
+    size="16"
+    style={
+      Object {
+        "marginRight": 8,
+      }
+    }
+  />
+  <Text
+    style={
+      Object {
+        "color": "#24272A",
+      }
+    }
+    variant="sBodyMD"
+  >
+    Click me!
+  </Text>
+</TouchableOpacity>
+`;
+
+exports[`ButtonBase should render correctly when disabled 1`] = `
+<TouchableOpacity
+  activeOpacity={0.5}
+  disabled={true}
+  onPress={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "#F2F4F6",
+      "borderRadius": 20,
+      "flexDirection": "row",
+      "height": 40,
+      "justifyContent": "center",
+      "opacity": 0.5,
       "paddingHorizontal": 16,
     }
   }

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/__snapshots__/ButtonBase.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`ButtonBase should render correctly 1`] = `
       "flexDirection": "row",
       "height": 40,
       "justifyContent": "center",
-      "opacity": 1,
       "paddingHorizontal": 16,
     }
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

- Add a `isDisabled` prop that changes the opacity of a button: default value when enabled (for backward compat) and 0.5 when disabled.
- map `isDisabled` prop to existing `disabled` prop from `TouchableWithoutFeedbackProps`
- update snapshot tests
- update readme

**Issue**

fixes #6475 

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
