### PR TITLE
fix: Account balance for signature screen is 0

### DIFF
--- a/app/components/UI/AccountInfoCard/index.js
+++ b/app/components/UI/AccountInfoCard/index.js
@@ -128,6 +128,7 @@ class AccountInfoCard extends PureComponent {
     ticker: PropTypes.string,
     transaction: PropTypes.object,
     activeTabUrl: PropTypes.string,
+    asset: PropTypes.object,
   };
 
   state = {
@@ -156,6 +157,7 @@ class AccountInfoCard extends PureComponent {
       fromAddress: rawFromAddress,
       transaction,
       activeTabUrl,
+      asset,
     } = this.props;
 
     const fromAddress = safeToChecksumAddress(rawFromAddress);
@@ -179,10 +181,7 @@ class AccountInfoCard extends PureComponent {
         origin={transaction.origin}
         url={activeTabUrl}
         from={rawFromAddress}
-        asset={{
-          isETH: true,
-          symbol: 'ETH',
-        }}
+        asset={asset}
       />
     ) : (
       <View style={styles.accountInformation}>

--- a/app/components/UI/AccountInfoCard/index.js
+++ b/app/components/UI/AccountInfoCard/index.js
@@ -179,6 +179,10 @@ class AccountInfoCard extends PureComponent {
         origin={transaction.origin}
         url={activeTabUrl}
         from={rawFromAddress}
+        asset={{
+          isETH: true,
+          symbol: 'ETH',
+        }}
       />
     ) : (
       <View style={styles.accountInformation}>

--- a/app/components/UI/SignatureRequest/index.js
+++ b/app/components/UI/SignatureRequest/index.js
@@ -237,7 +237,11 @@ class SignatureRequest extends PureComponent {
     return (
       <View style={styles.actionViewChild}>
         <View style={styles.accountInfoCardWrapper}>
-          <AccountInfoCard operation="signing" fromAddress={fromAddress} />
+          <AccountInfoCard
+            operation="signing"
+            fromAddress={fromAddress}
+            asset={{ isETH: true, symbol: 'ETH' }}
+          />
         </View>
         <TouchableOpacity
           style={styles.children}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
The `ApproveTransactionHeader` is missing a prop, `asset` for Signature modal. This causes the account balance to be returned as 0. And since transaction is undefined for signatures, I added this object {isETH: true, symbol: 'ETH'} for this fix. Will follow up on Slack.

**Screenshots/Recordings**
http://recordit.co/dg74mfvKUb

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
