### PR TITLE
fix:  Network logo to represent first letter of network

### DIFF
--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
 import {
   selectChainId,
+  selectNickname,
   selectProviderType,
   selectTicker,
 } from '../../../selectors/networkController';
@@ -97,6 +98,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const actionSheet = useRef<ActionSheet>();
 
   const providerType = useSelector(selectProviderType);
+  const nickname = useSelector(selectNickname);
   const chainId = useSelector(selectChainId);
   const ticker = useSelector(selectTicker);
   const currentCurrency = useSelector(
@@ -266,7 +268,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
       return images[ticker];
     };
 
-    const badgeName = (isMainnet ? providerType : ticker) || '';
+    const badgeName = (isMainnet ? providerType : nickname) || '';
 
     return (
       <AssetElement

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -30,6 +30,7 @@ import { useTheme } from '../../../util/theme';
 import NotificationManager from '../../../core/NotificationManager';
 import {
   getDecimalChainId,
+  getNetworkNameFromProvider,
   getTestNetImageByChainId,
   isMainnetByChainId,
   isTestNet,
@@ -41,8 +42,7 @@ import {
 } from '../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
 import {
   selectChainId,
-  selectNickname,
-  selectProviderType,
+  selectProviderConfig,
   selectTicker,
 } from '../../../selectors/networkController';
 import { createDetectedTokensNavDetails } from '../../Views/DetectedTokens';
@@ -97,8 +97,10 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
 
   const actionSheet = useRef<ActionSheet>();
 
-  const providerType = useSelector(selectProviderType);
-  const nickname = useSelector(selectNickname);
+  const networkName = useSelector((state: EngineState) => {
+    const providerConfig = selectProviderConfig(state);
+    return getNetworkNameFromProvider(providerConfig);
+  });
   const chainId = useSelector(selectChainId);
   const ticker = useSelector(selectTicker);
   const currentCurrency = useSelector(
@@ -268,8 +270,6 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
       return images[ticker];
     };
 
-    const badgeName = (isMainnet ? providerType : nickname) || '';
-
     return (
       <AssetElement
         key={itemAddress || '0x'}
@@ -283,7 +283,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
             <Badge
               variant={BadgeVariant.Network}
               imageSource={NetworkBadgeSource()}
-              name={badgeName}
+              name={networkName}
             />
           }
         >

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -1,10 +1,6 @@
 import { createSelector } from 'reselect';
 import { EngineState } from './types';
-import {
-  ProviderConfig,
-  NetworkState,
-  NetworkType,
-} from '@metamask/network-controller';
+import { ProviderConfig, NetworkState } from '@metamask/network-controller';
 
 const selectNetworkControllerState = (state: EngineState) =>
   state?.engine?.backgroundState?.NetworkController;
@@ -24,7 +20,7 @@ export const selectChainId = createSelector(
   selectProviderConfig,
   (providerConfig: ProviderConfig) => providerConfig?.chainId,
 );
-export const selectProviderType: NetworkType = createSelector(
+export const selectProviderType = createSelector(
   selectProviderConfig,
   (providerConfig: ProviderConfig) => providerConfig?.type,
 );


### PR DESCRIPTION
**Description**
Tokens now have the first letter of the custom Network

**Screenshots/Recordings**
https://recordit.co/AbZ5MJUuMB


**Fallback when no internet**
I think it was a development bug (pool block error) on the first seconds of the record. Because when we do not have the connection on the wallet now I just can reproduce this screen:
<img width="250" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/46944231/ecb62f95-5c9f-4b33-95a4-af0594d1fe16">



**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
