### PR TITLE
[Flask] Use permissions controller as source of truth for Snaps Permissions UI

### DIFF
--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -69,10 +69,7 @@ const SnapSettings = () => {
           />
         </View>
         <View style={styles.itemPaddedContainer}>
-          <SnapPermissions
-            permissions={snap.initialPermissions}
-            installedAt={snap.versionHistory[0].date}
-          />
+          <SnapPermissions snapId={snap.id} />
         </View>
         <View style={styles.removeSection}>
           <Text variant={TextVariant.HeadingMD}>

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -9,6 +9,15 @@ import {
   SNAP_SETTINGS_REMOVE_BUTTON,
 } from '../../../../../constants/test-ids';
 import Engine from '../../../../../core/Engine';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import {
+  PermissionConstraint,
+  SubjectPermissions,
+} from '@metamask/permission-controller';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -93,6 +102,67 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   createNavigationDetails: jest.fn(),
 }));
 
+const mockDate = 1684964145490;
+const mockDate2 = 1686081721987;
+
+const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+  'endowment:network-access': {
+    id: 'Bjj3InYtb6U4ak-uja0f_',
+    parentCapability: 'endowment:network-access',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate,
+  },
+  'endowment:rpc': {
+    id: 'Zma-vejrSvLtHmLrbSBAX',
+    parentCapability: 'endowment:rpc',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: [
+      {
+        type: 'rpcOrigin',
+        value: {
+          dapps: true,
+          snaps: true,
+        },
+      },
+    ],
+    date: mockDate2,
+  },
+  snap_confirm: {
+    id: 'tVtSEUjc48Ab-gF6UI7X3',
+    parentCapability: 'snap_confirm',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate2,
+  },
+  snap_manageState: {
+    id: 'BKbg3uDSHHu0D1fCUTOmS',
+    parentCapability: 'snap_manageState',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate2,
+  },
+  snap_getBip44Entropy: {
+    id: 'MuqnOW-7BRg94sRDmVnDK',
+    parentCapability: 'snap_getBip44Entropy',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: [
+      {
+        type: 'permittedCoinTypes',
+        value: [
+          {
+            coinType: 1,
+          },
+          {
+            coinType: 461,
+          },
+        ],
+      },
+    ],
+    date: mockDate2,
+  },
+};
+
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -105,9 +175,28 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+const engineState = {
+  engine: {
+    backgroundState: {
+      PermissionController: {
+        subjects: {
+          'npm:@chainsafe/filsnap': {
+            permissions: mockPermissions,
+          },
+        },
+      },
+    },
+  },
+};
+
 describe('SnapSettings', () => {
   it('renders correctly', () => {
-    const { getByTestId, getAllByTestId } = render(<SnapSettings />);
+    const { getAllByTestId, getByTestId } = renderWithProvider(
+      <SnapSettings />,
+      {
+        state: engineState,
+      },
+    );
 
     const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
     const description = getByTestId(SNAP_DETAILS_CELL);
@@ -116,14 +205,16 @@ describe('SnapSettings', () => {
     expect(removeButton).toBeTruthy();
     expect(description).toBeTruthy();
     expect(permissionContainer).toBeTruthy();
-    expect(permissions.length).toBe(5);
+    expect(permissions.length).toBe(7);
     expect(removeButton.props.children[1].props.children).toBe(
       'Remove Filsnap',
     );
   });
 
   it('remove snap and goes back when Remove button is pressed', async () => {
-    const { getByTestId } = render(<SnapSettings />);
+    const { getByTestId } = renderWithProvider(<SnapSettings />, {
+      state: engineState,
+    });
 
     const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
     fireEvent(removeButton, 'onPress');

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import { SemVerVersion, Status } from '@metamask/snaps-utils';
 import SnapSettings from '../SnapSettings';
 import {
@@ -14,10 +14,6 @@ import {
   PermissionConstraint,
   SubjectPermissions,
 } from '@metamask/permission-controller';
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {

--- a/app/components/Views/Snaps/SnapsSettingsList/test/SnapSettingsList.test.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/test/SnapSettingsList.test.tsx
@@ -6,10 +6,6 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { SNAP_ElEMENT } from '../../../../../constants/test-ids';
 import { createSnapSettingsNavDetails } from '../../SnapSettings/SnapSettings';
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
@@ -1,0 +1,41 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+/**
+ *
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    permissionCell: {
+      borderRadius: 10,
+      borderWidth: 0,
+    },
+    cellBase: {
+      flexDirection: 'row',
+    },
+    cellBaseInfo: {
+      flex: 1,
+      alignItems: 'flex-start',
+    },
+    secondaryText: {
+      color: colors.text.alternative,
+    },
+    iconWrapper: {
+      marginTop: 16,
+      marginRight: 16,
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      backgroundColor: colors.background.alternative,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+  });
+};
+export default styleSheet;

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import stylesheet from './SnapPermissionCell.styles';
@@ -16,16 +16,23 @@ import Card from '../../../../../component-library/components/Cards/Card';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import { strings } from '../../../../../../locales/i18n';
+import { toDateFormat } from '../../../../../util/date';
 
 interface SnapPermissionCellProps {
   title: string;
-  secondaryText: string;
+  date: number;
 }
 
-const SnapPermissionCell = ({
-  title,
-  secondaryText,
-}: SnapPermissionCellProps) => {
+const SnapPermissionCell = ({ title, date }: SnapPermissionCellProps) => {
+  const snapInstalledDate: string = useMemo(
+    () =>
+      strings('app_settings.snaps.snap_permissions.approved_date', {
+        date: toDateFormat(date),
+      }),
+    [date],
+  );
+
   const { styles } = useStyles(stylesheet, {});
   return (
     <Card style={styles.permissionCell}>
@@ -51,7 +58,7 @@ const SnapPermissionCell = ({
             variant={TextVariant.BodyMD}
             style={styles.secondaryText}
           >
-            {secondaryText}
+            {snapInstalledDate}
           </Text>
         </View>
       </View>

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View } from 'react-native';
+import { useStyles } from '../../../../hooks/useStyles';
+import stylesheet from './SnapPermissionCell.styles';
+import {
+  SNAP_PERMISSIONS_DATE,
+  SNAP_PERMISSIONS_TITLE,
+  SNAP_PERMISSION_CELL,
+} from '../../../../../constants/test-ids';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import Card from '../../../../../component-library/components/Cards/Card';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+
+interface SnapPermissionCellProps {
+  title: string;
+  secondaryText: string;
+}
+
+const SnapPermissionCell = ({
+  title,
+  secondaryText,
+}: SnapPermissionCellProps) => {
+  const { styles } = useStyles(stylesheet, {});
+  return (
+    <Card style={styles.permissionCell}>
+      <View testID={SNAP_PERMISSION_CELL} style={styles.cellBase}>
+        <View style={styles.iconWrapper}>
+          <Icon
+            name={IconName.Key}
+            size={IconSize.Md}
+            color={IconColor.Muted}
+          />
+        </View>
+        <View style={styles.cellBaseInfo}>
+          <Text
+            testID={SNAP_PERMISSIONS_TITLE}
+            numberOfLines={2}
+            variant={TextVariant.HeadingSMRegular}
+          >
+            {title}
+          </Text>
+          <Text
+            testID={SNAP_PERMISSIONS_DATE}
+            numberOfLines={1}
+            variant={TextVariant.BodyMD}
+            style={styles.secondaryText}
+          >
+            {secondaryText}
+          </Text>
+        </View>
+      </View>
+    </Card>
+  );
+};
+
+export default React.memo(SnapPermissionCell);

--- a/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import SnapPermissionCell from './SnapPermissionCell';
+
+export { SnapPermissionCell };

--- a/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
@@ -10,7 +10,7 @@ import {
 describe('SnapPermissionCell', () => {
   const defaultProps = {
     title: 'Permission Title',
-    secondaryText: 'Permission Date',
+    date: 1686005090788,
   };
 
   const setup = (props = defaultProps) => {
@@ -32,13 +32,13 @@ describe('SnapPermissionCell', () => {
 
     expect(permissionCell).toBeDefined();
     expect(permissionTitle.props.children).toEqual(defaultProps.title);
-    expect(permissionDate.props.children).toEqual(defaultProps.secondaryText);
+    expect(permissionDate.props.children).toEqual(defaultProps.date);
   });
 
   test('displays custom title and secondary text', () => {
     const customProps = {
       title: 'Custom Title',
-      secondaryText: 'Custom Date',
+      secondaryText: 1686005090788,
     };
     const { permissionTitle, permissionDate } = setup(customProps);
 

--- a/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import SnapPermissionCell from '../SnapPermissionCell';
+import {
+  SNAP_PERMISSIONS_DATE,
+  SNAP_PERMISSIONS_TITLE,
+  SNAP_PERMISSION_CELL,
+} from '../../../../../../constants/test-ids';
+
+describe('SnapPermissionCell', () => {
+  const defaultProps = {
+    title: 'Permission Title',
+    secondaryText: 'Permission Date',
+  };
+
+  const setup = (props = defaultProps) => {
+    const utils = render(<SnapPermissionCell {...props} />);
+    const permissionCell = utils.getByTestId(SNAP_PERMISSION_CELL);
+    const permissionTitle = utils.getByTestId(SNAP_PERMISSIONS_TITLE);
+    const permissionDate = utils.getByTestId(SNAP_PERMISSIONS_DATE);
+
+    return {
+      ...utils,
+      permissionCell,
+      permissionTitle,
+      permissionDate,
+    };
+  };
+
+  test('renders correctly', () => {
+    const { permissionCell, permissionTitle, permissionDate } = setup();
+
+    expect(permissionCell).toBeDefined();
+    expect(permissionTitle.props.children).toEqual(defaultProps.title);
+    expect(permissionDate.props.children).toEqual(defaultProps.secondaryText);
+  });
+
+  test('displays custom title and secondary text', () => {
+    const customProps = {
+      title: 'Custom Title',
+      secondaryText: 'Custom Date',
+    };
+    const { permissionTitle, permissionDate } = setup(customProps);
+
+    expect(permissionTitle.props.children).toEqual(customProps.title);
+    expect(permissionDate.props.children).toEqual(customProps.secondaryText);
+  });
+});

--- a/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
@@ -30,19 +30,22 @@ describe('SnapPermissionCell', () => {
   test('renders correctly', () => {
     const { permissionCell, permissionTitle, permissionDate } = setup();
 
+    const expectedDate = 'Approved on Jun 5 at 6:44 pm';
+
     expect(permissionCell).toBeDefined();
     expect(permissionTitle.props.children).toEqual(defaultProps.title);
-    expect(permissionDate.props.children).toEqual(defaultProps.date);
+    expect(permissionDate.props.children).toEqual(expectedDate);
   });
 
   test('displays custom title and secondary text', () => {
     const customProps = {
       title: 'Custom Title',
-      secondaryText: 1686005090788,
+      date: 1686005090788,
     };
+    const expectedDate = 'Approved on Jun 5 at 6:44 pm';
     const { permissionTitle, permissionDate } = setup(customProps);
 
     expect(permissionTitle.props.children).toEqual(customProps.title);
-    expect(permissionDate.props.children).toEqual(customProps.secondaryText);
+    expect(permissionDate.props.children).toEqual(expectedDate);
   });
 });

--- a/app/components/Views/Snaps/components/SnapPermissions/README.md
+++ b/app/components/Views/Snaps/components/SnapPermissions/README.md
@@ -1,71 +1,144 @@
 #  SnapPermissions
 
+  
+
 The SnapPermissions component is used to display permissions granted to a certain Snap. All permissions will be rendered as a list with each permission displayed as a Card with a title and the installation date of the Snap.
+
+  
 
   
 
 ##  Props
 
-The SnapPermissions component expects two props:
+  
 
- 1. `permissions`: An object of permissions granted to the Snap. The
-    object is expected to conform to the [SnapPermissions from @metamask/snaps-utils](https://github.com/MetaMask/snaps/blob/ef885f4cf80a19ecc5b5e523f12e4c4c248cc766/packages/snaps-utils/src/manifest/validation.ts#L160).
-2. `installedAt`: A number representing the Unix timestamp when the Snap was installed.
+The SnapPermissions component expects one prop:
 
   
 
-## Functionality
+1.  `snapId`: A string that the component will use to query the permission controller for the specified snap.
+
+  
+
+##  Functionality
+
 This component derives human-readable titles for the provided permissions list and maps them to their corresponding cards. The snap methods/permissions and their human-readable counterparts can be found in [this document](https://www.notion.so/bac3299d2c5241c599d2e5e7986e72f7?v=ef742a61bd844435b7171bd2e90b447e).
 
-### Protocol Derivation
+  
+
+###  Protocol Derivation
+
 There are a few snap permissions that are protocol specific. Each of these protocols are displayed as a separate permission in the list and contain the human-readable protocol name in the title.
 
-#### These permissions are:
-- `snap_getBip44Entropy`
-- `snap_getBip32Entropy'`
-- `snap_getBip32PublicKey`
+  
 
-#### SLIP-0044
+####  These permissions are:
+
+-  `snap_getBip44Entropy`
+
+-  `snap_getBip32Entropy'`
+
+-  `snap_getBip32PublicKey`
+
+  
+
+####  SLIP-0044
+
 The `Bip44` permission follows the [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#registered-coin-types) standard and maps `coin type` as a number to human-readable symbols and names. These mapping can be found [here](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#registered-coin-types). MetaMask uses the [@metamask/slip44](https://github.com/MetaMask/slip44) utility library to maintain these mappings.
-##### Example
+
+#####  Example
+
 The permission...
+
 ```JSON
 {
-	snap_getBip44Entropy: [
-		{ coinType:  0 },
-		{ coinType:  2 },
-	]
+  "snap_getBip44Entropy": {
+    "id": "TDDl8FTScrkgzs-sQ4ep0",
+    "parentCapability": "snap_getBip44Entropy",
+    "invoker": "npm:@chainsafe/filsnap",
+    "caveats": [
+      {
+        "type": "permittedCoinTypes",
+        "value": [
+          {
+            "coinType": 1
+          },
+          {
+            "coinType": 2
+          }
+        ]
+      }
+    ],
+    "date": 1686015956781
+  }
 }
 ```
-renders the titles `Control your Bitcoin accounts and assets` and `Control your Litecoin accounts and assets` respectively. 
 
-#### BIP 32
-The `snap_getBip32Entropy` and `snap_getBip32PublicKey` rely on a different mapping to derive their protocols.  For these permissions, we compare their `path` and `curve` to the [SNAPS_DERIVATION_PATHS](https://github.com/MetaMask/metamask-extension/blob/49f8052b157374370ac71373708933c6e639944e/shared/constants/snaps.ts#L52). The mobile app uses a copy of this object that can be found in `app/constants/snaps.ts`.
-##### Example
+renders the titles `Control your Bitcoin accounts and assets` and `Control your Litecoin accounts and assets` respectively.
+
+  
+
+####  BIP 32
+
+The `snap_getBip32Entropy` and `snap_getBip32PublicKey` rely on a different mapping to derive their protocols. For these permissions, we compare their `path` and `curve` to the [SNAPS_DERIVATION_PATHS](https://github.com/MetaMask/metamask-extension/blob/49f8052b157374370ac71373708933c6e639944e/shared/constants/snaps.ts#L52). The mobile app uses a copy of this object that can be found in `app/constants/snaps.ts`.
+
+#####  Example
+
 The permission...
+
 ```json
 {
-	snap_getBip32Entropy: [
-		{
-			path: ['m',  `44'`,  `0'`],
-			curve:  'ed25519',
-		},
-		{
-			path: ['m',  `44'`,  `1'`],
-			curve:  'secp256k1',
-		},
-	]
+  "snap_getBip32Entropy": {
+    "id": "j8TJuxqEtJZbIqjd2bqsq",
+    "parentCapability": "snap_getBip32Entropy",
+    "invoker": "npm:@metamask/test-snap-bip32",
+    "caveats": [
+      {
+        "type": "permittedDerivationPaths",
+        "value": [
+          {
+            "path": [
+              "m",
+              "44'",
+              "0'"
+            ],
+            "curve": "secp256k1"
+          },
+          {
+            "path": [
+              "m",
+              "44'",
+              "0'"
+            ],
+            "curve": "ed25519"
+          }
+        ]
+      }
+    ],
+    "date": 1686083278257
+  }
 }
-```
-renders the titles `Control your Test BIP-32 Path (ed25519) accounts and assets` and `Control your Test BIP-32 Path (secp256k1) accounts and assets` respectively.
 
-## Usage
+```
+
+renders the titles `Control your Bitcoin Legacy accounts and assets` and `Control your Test BIP-32 Path (ed25519) accounts and assets` respectively.
+
+  
+
+##  Usage
+
+  
 
 The `SnapPermissions` component can be used as a regular React component in JSX:
-```jsx
-<SnapPermissions  permissions={permissions}  installedAt={installedAt} />
-```
-Where permissions is an object of the `SnapPermissions` type and installedAt is a Unix timestamp representing the installation time of the Snap.
 
-## Testing
+```jsx
+
+<SnapPermissions snapId='@metamask/test-snap' />
+
+```
+
+  
+
+##  Testing
+
 All of this complex logic is tested in the `SnapPermissions/test/SnapPermission.test.tsx` file and can be run with the command `yarn jest SnapPermissions/test/SnapPermission.test.tsx` from the root of the mobile directory.

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '../../../../../util/theme/models';
 
 /**
  *
@@ -8,37 +7,10 @@ import { Theme } from '../../../../../util/theme/models';
  * @param params.vars Inputs that the style sheet depends on.
  * @returns StyleSheet object.
  */
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
-  const { colors } = theme;
-  return StyleSheet.create({
+const styleSheet = () =>
+  StyleSheet.create({
     section: {
       paddingTop: 32,
     },
-    permissionCell: {
-      borderRadius: 10,
-      borderWidth: 0,
-    },
-    cellBase: {
-      flexDirection: 'row',
-    },
-    cellBaseInfo: {
-      flex: 1,
-      alignItems: 'flex-start',
-    },
-    secondaryText: {
-      color: colors.text.alternative,
-    },
-    iconWrapper: {
-      marginTop: 16,
-      marginRight: 16,
-      width: 32,
-      height: 32,
-      borderRadius: 16,
-      backgroundColor: colors.background.alternative,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
   });
-};
 export default styleSheet;

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -113,64 +113,71 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
 
       for (const key in permissionsList) {
         const date = permissionsList[key].date;
-        if (key === rpcPermission) {
-          const rpcPermissions = permissionsList[key].caveats?.find(
-            (caveat) => caveat.type === 'rpcOrigin',
-          )?.value as Record<string, boolean> | undefined;
-          if (rpcPermissions) {
-            for (const rpcKey in rpcPermissions) {
-              if (rpcPermissions[rpcKey] === true) {
-                const title = strings(
-                  `app_settings.snaps.snap_permissions.human_readable_permission_titles.endowment:rpc.${rpcKey}`,
-                );
-                permissionsData.push({ label: title, date });
+
+        switch (key) {
+          case rpcPermission: {
+            const rpcPermissions = permissionsList[key].caveats?.find(
+              (caveat) => caveat.type === 'rpcOrigin',
+            )?.value as Record<string, boolean> | undefined;
+            if (rpcPermissions) {
+              for (const rpcKey in rpcPermissions) {
+                if (rpcPermissions[rpcKey] === true) {
+                  const title = strings(
+                    `app_settings.snaps.snap_permissions.human_readable_permission_titles.endowment:rpc.${rpcKey}`,
+                  );
+                  permissionsData.push({ label: title, date });
+                }
               }
             }
+            break;
           }
-        } else if (key === getBip44EntropyPermission) {
-          const coinTypes = permissionsList[key].caveats?.find(
-            (caveat) => caveat.type === 'permittedCoinTypes',
-          )?.value as { coinType: number }[] | undefined;
-          if (coinTypes) {
-            for (const coinType of coinTypes) {
-              const protocolName = coinTypeToProtocolName(coinType.coinType);
-              if (protocolName) {
+          case getBip44EntropyPermission: {
+            const coinTypes = permissionsList[key].caveats?.find(
+              (caveat) => caveat.type === 'permittedCoinTypes',
+            )?.value as { coinType: number }[] | undefined;
+            if (coinTypes) {
+              for (const coinType of coinTypes) {
+                const protocolName = coinTypeToProtocolName(coinType.coinType);
+                if (protocolName) {
+                  const title = strings(
+                    'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip44Entropy',
+                    { protocol: protocolName },
+                  );
+                  permissionsData.push({ label: title, date });
+                }
+              }
+            }
+            break;
+          }
+          case getBip32EntropyPermission:
+          case getBip32PublicKeyPermission: {
+            const permittedDerivationPaths = permissionsList[key].caveats?.[0]
+              .value as SnapsDerivationPath[];
+            if (permittedDerivationPaths) {
+              for (const permittedPath of permittedDerivationPaths) {
+                const derivedProtocolName = getSnapDerivationPathName(
+                  permittedPath.path,
+                  permittedPath.curve,
+                );
+                const protocolName =
+                  derivedProtocolName ??
+                  `${permittedPath.path.join('/')} (${permittedPath.curve})`;
+
                 const title = strings(
-                  'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip44Entropy',
+                  `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
                   { protocol: protocolName },
                 );
                 permissionsData.push({ label: title, date });
               }
             }
+            break;
           }
-        } else if (
-          key === getBip32EntropyPermission ||
-          key === getBip32PublicKeyPermission
-        ) {
-          const permittedDerivationPaths = permissionsList[key].caveats?.[0]
-            .value as SnapsDerivationPath[];
-          if (permittedDerivationPaths) {
-            for (const permittedPath of permittedDerivationPaths) {
-              const derivedProtocolName = getSnapDerivationPathName(
-                permittedPath.path,
-                permittedPath.curve,
-              );
-              const protocolName =
-                derivedProtocolName ??
-                `${permittedPath.path.join('/')} (${permittedPath.curve})`;
-
-              const title = strings(
-                `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
-                { protocol: protocolName },
-              );
-              permissionsData.push({ label: title, date });
-            }
+          default: {
+            const title = strings(
+              `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
+            );
+            permissionsData.push({ label: title, date });
           }
-        } else {
-          const title = strings(
-            `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
-          );
-          permissionsData.push({ label: title, date });
         }
       }
 

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -18,6 +18,7 @@ import lodash from 'lodash';
 import { useStyles } from '../../../../../component-library/hooks';
 import { SnapPermissionCell } from '../SnapPermissionCell';
 import { useSelector } from 'react-redux';
+import { PermissionType } from '@metamask/permission-controller';
 
 interface SnapPermissionsProps {
   snapId: string;
@@ -96,16 +97,25 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
    *
    * @returns An array of strings, where each string is a human-readable title for a permission.
    */
-  const derivePermissionsTitles = useCallback(
+
+  interface SnapPermissionData {
+    label: string;
+    date: number;
+  }
+
+  const derivePermissionsTitles: (
+    permissionsList: PermissionType,
+  ) => SnapPermissionData[] = useCallback(
     (permissionsList: SnapPermissionsType) => {
       const rpcPermission = 'endowment:rpc';
       const getBip44EntropyPermission = 'snap_getBip44Entropy';
       const getBip32EntropyPermission = 'snap_getBip32Entropy';
       const getBip32PublicKeyPermission = 'snap_getBip32PublicKey';
 
-      const permissionsStrings: string[] = [];
+      const permissionsData: SnapPermissionData[] = [];
 
       for (const key in permissionsList) {
+        const date = permissionsList[key].date;
         if (key === rpcPermission) {
           const rpcPermissions = permissionsList[key] as {
             [key: string]: boolean | undefined;
@@ -115,7 +125,7 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
               const title = strings(
                 `app_settings.snaps.snap_permissions.human_readable_permission_titles.endowment:rpc.${rpcKey}`,
               );
-              permissionsStrings.push(title);
+              permissionsData.push({ label: title, date });
             }
           }
         } else if (key === getBip44EntropyPermission) {
@@ -126,7 +136,7 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
                 'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip44Entropy',
                 { protocol: protocolName },
               );
-              permissionsStrings.push(title);
+              permissionsData.push({ label: title, date });
             }
           }
         } else if (key === getBip32EntropyPermission && permissionsList[key]) {
@@ -145,7 +155,7 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
                 'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip32Entropy',
                 { protocol: protocolName },
               );
-              permissionsStrings.push(title);
+              permissionsData.push({ label: title, date });
             }
           }
         } else if (
@@ -167,23 +177,23 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
                 'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip32PublicKey',
                 { protocol: protocolName },
               );
-              permissionsStrings.push(title);
+              permissionsData.push({ label: title, date });
             }
           }
         } else {
           const title = strings(
             `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
           );
-          permissionsStrings.push(title);
+          permissionsData.push({ label: title, date });
         }
       }
 
-      return permissionsStrings;
+      return permissionsData;
     },
     [],
   );
 
-  const permissionsToRender: string[] = useMemo(
+  const permissionsToRender: SnapPermissionData[] = useMemo(
     () => derivePermissionsTitles(permissionsFromController),
     [derivePermissionsTitles, permissionsFromController],
   );
@@ -196,7 +206,7 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
         )}
       </Text>
       {permissionsToRender.map((item, index) => (
-        <SnapPermissionCell title={item} date={1686005090788} key={index} />
+        <SnapPermissionCell title={item.label} date={item.date} key={index} />
       ))}
     </View>
   );

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -139,6 +139,12 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
     [],
   );
 
+  const isSnapsDerivationPath = (object: any): object is SnapsDerivationPath =>
+    typeof object === 'object' &&
+    object !== null &&
+    'path' in object &&
+    'curve' in object;
+
   const handleBip32PermissionTitles = useCallback(
     (
       permissionsList: SubjectPermissions<PermissionConstraint>,
@@ -147,24 +153,25 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
         | typeof RestrictedMethods.snap_getBip32PublicKey,
     ) => {
       const bip32Data: SnapPermissionData[] = [];
-      const permittedDerivationPaths = permissionsList[key].caveats?.[0]
-        .value as SnapsDerivationPath[];
+      const permittedDerivationPaths = permissionsList[key].caveats?.[0].value;
       const date = permissionsList[key].date;
-      if (permittedDerivationPaths) {
+      if (permittedDerivationPaths && Array.isArray(permittedDerivationPaths)) {
         for (const permittedPath of permittedDerivationPaths) {
-          const derivedProtocolName = getSnapDerivationPathName(
-            permittedPath.path,
-            permittedPath.curve,
-          );
-          const protocolName =
-            derivedProtocolName ??
-            `${permittedPath.path.join('/')} (${permittedPath.curve})`;
+          if (isSnapsDerivationPath(permittedPath)) {
+            const derivedProtocolName = getSnapDerivationPathName(
+              permittedPath.path,
+              permittedPath.curve,
+            );
+            const protocolName =
+              derivedProtocolName ??
+              `${permittedPath.path.join('/')} (${permittedPath.curve})`;
 
-          const title = strings(
-            `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
-            { protocol: protocolName },
-          );
-          bip32Data.push({ label: title, date });
+            const title = strings(
+              `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
+              { protocol: protocolName },
+            );
+            bip32Data.push({ label: title, date });
+          }
         }
       }
       return bip32Data;

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -46,7 +46,7 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
 
   console.log(
     'Snaps/ permissionsState: ',
-    JSON.stringify(permissionsFromController),
+    JSON.stringify(permissionsState, null, 2),
   );
 
   /**

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -5,19 +5,8 @@ import slip44 from '@metamask/slip44';
 import type { SupportedCurve } from '@metamask/key-tree';
 import stylesheet from './SnapPermissions.styles';
 import { toDateFormat } from '../../../../../util/date';
-import {
-  SNAP_PERMISSIONS,
-  SNAP_PERMISSIONS_DATE,
-  SNAP_PERMISSIONS_TITLE,
-  SNAP_PERMISSION_CELL,
-} from '../../../../../constants/test-ids';
+import { SNAP_PERMISSIONS } from '../../../../../constants/test-ids';
 import { strings } from '../../../../../../locales/i18n';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
-import Card from '../../../../../component-library/components/Cards/Card';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -28,6 +17,7 @@ import {
 } from '../../../../../constants/snaps';
 import lodash from 'lodash';
 import { useStyles } from '../../../../../component-library/hooks';
+import { SnapPermissionCell } from '../SnapPermissionCell';
 
 interface SnapPermissionsProps {
   permissions: SnapPermissionsType;
@@ -190,41 +180,6 @@ const SnapPermissions = ({
     [derivePermissionsTitles, permissions],
   );
 
-  const renderPermissionCell = (
-    title: string,
-    secondaryText: string,
-    key: number,
-  ) => (
-    <Card key={key} style={styles.permissionCell}>
-      <View testID={SNAP_PERMISSION_CELL} style={styles.cellBase}>
-        <View style={styles.iconWrapper}>
-          <Icon
-            name={IconName.Key}
-            size={IconSize.Md}
-            color={IconColor.Muted}
-          />
-        </View>
-        <View style={styles.cellBaseInfo}>
-          <Text
-            testID={SNAP_PERMISSIONS_TITLE}
-            numberOfLines={2}
-            variant={TextVariant.HeadingSMRegular}
-          >
-            {title}
-          </Text>
-          <Text
-            testID={SNAP_PERMISSIONS_DATE}
-            numberOfLines={1}
-            variant={TextVariant.BodyMD}
-            style={styles.secondaryText}
-          >
-            {secondaryText}
-          </Text>
-        </View>
-      </View>
-    </Card>
-  );
-
   return (
     <View testID={SNAP_PERMISSIONS} style={styles.section}>
       <Text variant={TextVariant.HeadingMD}>
@@ -232,9 +187,13 @@ const SnapPermissions = ({
           'app_settings.snaps.snap_permissions.permission_section_title',
         )}
       </Text>
-      {permissionsToRender.map((item, key) =>
-        renderPermissionCell(item, snapInstalledDate, key),
-      )}
+      {permissionsToRender.map((item, index) => (
+        <SnapPermissionCell
+          title={item}
+          secondaryText={snapInstalledDate}
+          key={index}
+        />
+      ))}
     </View>
   );
 };

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -4,7 +4,6 @@ import { SnapPermissions as SnapPermissionsType } from '@metamask/snaps-utils';
 import slip44 from '@metamask/slip44';
 import type { SupportedCurve } from '@metamask/key-tree';
 import stylesheet from './SnapPermissions.styles';
-import { toDateFormat } from '../../../../../util/date';
 import { SNAP_PERMISSIONS } from '../../../../../constants/test-ids';
 import { strings } from '../../../../../../locales/i18n';
 import Text, {
@@ -18,23 +17,32 @@ import {
 import lodash from 'lodash';
 import { useStyles } from '../../../../../component-library/hooks';
 import { SnapPermissionCell } from '../SnapPermissionCell';
+import { useSelector } from 'react-redux';
 
 interface SnapPermissionsProps {
-  permissions: SnapPermissionsType;
-  installedAt: number;
+  snapId: string;
 }
 
-const SnapPermissions = ({
-  permissions,
-  installedAt,
-}: SnapPermissionsProps) => {
+const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
   const { styles } = useStyles(stylesheet, {});
-  const snapInstalledDate: string = useMemo(
-    () =>
-      strings('app_settings.snaps.snap_permissions.approved_date', {
-        date: toDateFormat(installedAt),
-      }),
-    [installedAt],
+
+  const permissionsState = useSelector(
+    (state: any) => state.engine.backgroundState.PermissionController,
+  );
+
+  function getPermissionSubjects(state: any) {
+    return state.subjects || {};
+  }
+
+  function getPermissions(state: any, origin: any) {
+    return getPermissionSubjects(state)[origin]?.permissions;
+  }
+
+  const permissionsFromController = getPermissions(permissionsState, snapId);
+
+  console.log(
+    'Snaps/ permissionsState: ',
+    JSON.stringify(permissionsFromController),
   );
 
   /**
@@ -176,8 +184,8 @@ const SnapPermissions = ({
   );
 
   const permissionsToRender: string[] = useMemo(
-    () => derivePermissionsTitles(permissions),
-    [derivePermissionsTitles, permissions],
+    () => derivePermissionsTitles(permissionsFromController),
+    [derivePermissionsTitles, permissionsFromController],
   );
 
   return (
@@ -188,11 +196,7 @@ const SnapPermissions = ({
         )}
       </Text>
       {permissionsToRender.map((item, index) => (
-        <SnapPermissionCell
-          title={item}
-          secondaryText={snapInstalledDate}
-          key={index}
-        />
+        <SnapPermissionCell title={item} date={1686005090788} key={index} />
       ))}
     </View>
   );

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -116,34 +116,38 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
 
         switch (key) {
           case rpcPermission: {
-            const rpcPermissions = permissionsList[key].caveats?.find(
-              (caveat) => caveat.type === 'rpcOrigin',
-            )?.value as Record<string, boolean> | undefined;
-            if (rpcPermissions) {
-              for (const rpcKey in rpcPermissions) {
-                if (rpcPermissions[rpcKey] === true) {
-                  const title = strings(
-                    `app_settings.snaps.snap_permissions.human_readable_permission_titles.endowment:rpc.${rpcKey}`,
-                  );
-                  permissionsData.push({ label: title, date });
+            const rpcPermissionsCaveats = permissionsList[key].caveats;
+            if (rpcPermissionsCaveats) {
+              for (const caveat of rpcPermissionsCaveats) {
+                const rpcPermissions = caveat.value as Record<string, boolean>;
+                for (const rpcKey in rpcPermissions) {
+                  if (rpcPermissions[rpcKey] === true) {
+                    const title = strings(
+                      `app_settings.snaps.snap_permissions.human_readable_permission_titles.endowment:rpc.${rpcKey}`,
+                    );
+                    permissionsData.push({ label: title, date });
+                  }
                 }
               }
             }
             break;
           }
           case getBip44EntropyPermission: {
-            const coinTypes = permissionsList[key].caveats?.find(
-              (caveat) => caveat.type === 'permittedCoinTypes',
-            )?.value as { coinType: number }[] | undefined;
-            if (coinTypes) {
-              for (const coinType of coinTypes) {
-                const protocolName = coinTypeToProtocolName(coinType.coinType);
-                if (protocolName) {
-                  const title = strings(
-                    'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip44Entropy',
-                    { protocol: protocolName },
+            const coinTypeCaveats = permissionsList[key].caveats;
+            if (coinTypeCaveats) {
+              for (const caveat of coinTypeCaveats) {
+                const coinTypes = caveat.value as { coinType: number }[];
+                for (const coinType of coinTypes) {
+                  const protocolName = coinTypeToProtocolName(
+                    coinType.coinType,
                   );
-                  permissionsData.push({ label: title, date });
+                  if (protocolName) {
+                    const title = strings(
+                      'app_settings.snaps.snap_permissions.human_readable_permission_titles.snap_getBip44Entropy',
+                      { protocol: protocolName },
+                    );
+                    permissionsData.push({ label: title, date });
+                  }
                 }
               }
             }

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
-import { SnapPermissions as SnapPermissionsType } from '@metamask/snaps-utils';
 import slip44 from '@metamask/slip44';
 import type { SupportedCurve } from '@metamask/key-tree';
 import stylesheet from './SnapPermissions.styles';
@@ -43,11 +42,6 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
   }
 
   const permissionsFromController = getPermissions(permissionsState, snapId);
-
-  console.log(
-    'Snaps/ permissionsState: ',
-    JSON.stringify(permissionsState, null, 2),
-  );
 
   /**
    * Gets the name of the SLIP-44 protocol corresponding to the specified
@@ -153,34 +147,23 @@ const SnapPermissions = ({ snapId }: SnapPermissionsProps) => {
           key === getBip32EntropyPermission ||
           key === getBip32PublicKeyPermission
         ) {
-          console.log('Snaps/ entered getBip32EntropyPermission 1', key);
           const permittedDerivationPaths = permissionsList[key].caveats?.[0]
             .value as SnapsDerivationPath[];
           if (permittedDerivationPaths) {
-            console.log(
-              'Snaps/ entered getBip32EntropyPermission 2',
-              JSON.stringify(permittedDerivationPaths),
-            );
             for (const permittedPath of permittedDerivationPaths) {
-              console.log(
-                'Snaps/ entered getBip32EntropyPermission 3',
-                JSON.stringify(permittedPath),
-              );
-              const pathName = getSnapDerivationPathName(
+              const derivedProtocolName = getSnapDerivationPathName(
                 permittedPath.path,
                 permittedPath.curve,
               );
-              console.log(
-                'Snaps/ entered getBip32EntropyPermission 4',
-                pathName,
+              const protocolName =
+                derivedProtocolName ??
+                `${permittedPath.path.join('/')} (${permittedPath.curve})`;
+
+              const title = strings(
+                `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
+                { protocol: protocolName },
               );
-              if (pathName) {
-                const title = strings(
-                  `app_settings.snaps.snap_permissions.human_readable_permission_titles.${key}`,
-                  { protocol: pathName },
-                );
-                permissionsData.push({ label: title, date });
-              }
+              permissionsData.push({ label: title, date });
             }
           }
         } else {

--- a/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
 import SnapPermissions from '../SnapPermissions';
 import {
   SNAP_PERMISSIONS_DATE,
@@ -39,6 +38,59 @@ describe('SnapPermissions', () => {
     `Control your ${protocol} accounts and assets`;
   const snapGetEntropyTitle = 'Derive arbitrary keys unique to this snap';
   const endowmentKeyringTitle = 'endowment:keyring';
+
+  const mockCoinTypes = [
+    { coinType: 0 }, // Bitcoin
+    { coinType: 1 }, // Testnet (all coins)
+    { coinType: 2 }, // Litecoin
+    { coinType: 3 }, // Dogecoin
+    { coinType: 4 }, // Reddcoin
+    { coinType: 5 }, // Dash
+    { coinType: 6 }, // Peercoin
+    { coinType: 7 }, // Namecoin
+    { coinType: 8 }, // Feathercoin
+    { coinType: 9 }, // Counterparty
+    { coinType: 10 }, // 0x8000000a	BLK	Blackcoin
+    { coinType: 11 }, //	0x8000000b	NSR	NuShares
+    { coinType: 12 }, // 0x8000000c	NBT	NuBits
+    { coinType: 13 }, // 0x8000000d	MZC	Mazacoin
+    { coinType: 14 }, // 0x8000000e	VIA	Viacoin
+    { coinType: 15 }, //	0x8000000f	XCH	ClearingHouse
+    { coinType: 16 }, //	0x80000010	RBY	Rubycoin
+    { coinType: 17 }, //	0x80000011	GRS	Groestlcoin
+    { coinType: 18 }, //	0x80000012	DGC	Digitalcoin
+    { coinType: 19 }, // 0x80000013	CCN	Cannacoin
+    { coinType: 20 }, //	0x80000014	DGB	DigiByte
+    { coinType: 21 }, //	0x80000015		Open Assets
+    { coinType: 22 }, //	0x80000016	MONA	Monacoin
+    { coinType: 23 }, //	0x80000017	CLAM	Clams
+    { coinType: 24 }, //	0x80000018	XPM	Primecoin
+    { coinType: 25 }, //	0x80000019	NEOS	Neoscoin
+    { coinType: 26 }, //	0x8000001a	JBS	Jumbucks
+    { coinType: 27 }, //	0x8000001b	ZRC	ziftrCOIN
+    { coinType: 28 }, //	0x8000001c	VTC	Vertcoin
+    { coinType: 29 }, //0x8000001d	NXT	NXT
+    { coinType: 30 }, //	0x8000001e	BURST	Burst
+    { coinType: 31 }, //	0x8000001f	MUE	MonetaryUnit
+    { coinType: 32 }, //	0x80000020	ZOOM	Zoom
+    { coinType: 33 }, //	0x80000021	VASH	Virtual Cash
+    { coinType: 34 }, //	0x80000022	CDN	Canada eCoin
+    { coinType: 35 }, //	0x80000023	SDC	ShadowCash
+    { coinType: 36 }, //	0x80000024	PKB	ParkByte
+    { coinType: 37 }, //	0x80000025	PND	Pandacoin
+    { coinType: 38 }, //	0x80000026	START	StartCOIN
+    { coinType: 39 }, //	0x80000027	MOIN	MOIN
+    { coinType: 40 }, //	0x80000028	EXP	Expanse
+    { coinType: 41 }, //	0x80000029	EMC2	Einsteinium
+    { coinType: 42 }, //	0x8000002a	DCR	Decred
+    { coinType: 43 }, //	0x8000002b	XEM	NEM
+    { coinType: 44 }, //	0x8000002c	PART	Particl
+    { coinType: 45 }, // 0x8000002d	ARG	Argentum (dead)
+    { coinType: 46 }, //	0x8000002e		Libertas
+    { coinType: 47 }, //	0x8000002f		Posw coin
+    { coinType: 48 }, //	0x80000030	SHR	Shreeji
+    { coinType: 49 }, //	0x80000031	GCR	Global Currency Reserve (GCRcoin)
+  ];
 
   const mockCurves:
     | SnapPermissionsType['snap_getBip32Entropy']
@@ -437,494 +489,692 @@ describe('SnapPermissions', () => {
     expect(permissionCellDates[1].props.children).toBe(expectedDate2);
   });
 
-  // it('renders correct permissions cells for endowment:rpc when both dapps and snaps are permitted', () => {
-  //   const permissions: SnapPermissionsType = {
-  //     'endowment:rpc': {
-  //       dapps: true,
-  //       snaps: true,
-  //     },
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  it('renders correct permissions cells for endowment:rpc when both dapps and snaps are permitted', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:rpc': {
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: true,
+              snaps: true,
+            },
+          },
+        ],
+        date: mockDate2,
+      },
+    };
 
-  //   expect(permissionCells.length).toBe(2);
-  //   expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
-  //   expect(permissionCells[1].props.children).toBe(rpcSnapsTitle);
-  // });
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  // it('only renders snap rpc permission when only snaps are permitted', () => {
-  //   const permissions: SnapPermissionsType = {
-  //     'endowment:rpc': {
-  //       dapps: false,
-  //       snaps: true,
-  //     },
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  //   expect(permissionCells.length).toBe(1);
-  //   expect(permissionCells[0].props.children).toBe(rpcSnapsTitle);
-  // });
+    expect(permissionCells.length).toBe(2);
+    expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
+    expect(permissionCells[1].props.children).toBe(rpcSnapsTitle);
+  });
 
-  // it('only renders dapps rpc permission when only dapps are permitted', () => {
-  //   const permissions: SnapPermissionsType = {
-  //     'endowment:rpc': {
-  //       dapps: true,
-  //       snaps: false,
-  //     },
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  it('only renders snap rpc permission when only snaps are permitted', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:rpc': {
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              snaps: true,
+            },
+          },
+        ],
+        date: mockDate2,
+      },
+    };
 
-  //   expect(permissionCells.length).toBe(1);
-  //   expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
-  // });
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  // it('does not render rpc permissions when both snaps and dapps are false', () => {
-  //   const permissions: SnapPermissionsType = {
-  //     'endowment:rpc': {
-  //       dapps: false,
-  //       snaps: false,
-  //     },
-  //   };
-  //   const { queryAllByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCells = queryAllByTestId(SNAP_PERMISSIONS_TITLE);
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  //   expect(permissionCells.length).toBe(0);
-  // });
+    expect(permissionCells.length).toBe(1);
+    expect(permissionCells[0].props.children).toBe(rpcSnapsTitle);
+  });
 
-  // it('renders the correct permissions snap_getBip44Entropy with specified protocols', () => {
-  //   const mockPermissions: SnapPermissionsType = {
-  //     snap_getBip44Entropy: [
-  //       { coinType: 0 }, // Bitcoin
-  //       { coinType: 1 }, // Testnet (all coins)
-  //       { coinType: 2 }, // Litecoin
-  //       { coinType: 3 }, // Dogecoin
-  //       { coinType: 4 }, // Reddcoin
-  //       { coinType: 5 }, // Dash
-  //       { coinType: 6 }, // Peercoin
-  //       { coinType: 7 }, // Namecoin
-  //       { coinType: 8 }, // Feathercoin
-  //       { coinType: 9 }, // Counterparty
-  //       { coinType: 10 }, // 0x8000000a	BLK	Blackcoin
-  //       { coinType: 11 }, //	0x8000000b	NSR	NuShares
-  //       { coinType: 12 }, // 0x8000000c	NBT	NuBits
-  //       { coinType: 13 }, // 0x8000000d	MZC	Mazacoin
-  //       { coinType: 14 }, // 0x8000000e	VIA	Viacoin
-  //       { coinType: 15 }, //	0x8000000f	XCH	ClearingHouse
-  //       { coinType: 16 }, //	0x80000010	RBY	Rubycoin
-  //       { coinType: 17 }, //	0x80000011	GRS	Groestlcoin
-  //       { coinType: 18 }, //	0x80000012	DGC	Digitalcoin
-  //       { coinType: 19 }, // 0x80000013	CCN	Cannacoin
-  //       { coinType: 20 }, //	0x80000014	DGB	DigiByte
-  //       { coinType: 21 }, //	0x80000015		Open Assets
-  //       { coinType: 22 }, //	0x80000016	MONA	Monacoin
-  //       { coinType: 23 }, //	0x80000017	CLAM	Clams
-  //       { coinType: 24 }, //	0x80000018	XPM	Primecoin
-  //       { coinType: 25 }, //	0x80000019	NEOS	Neoscoin
-  //       { coinType: 26 }, //	0x8000001a	JBS	Jumbucks
-  //       { coinType: 27 }, //	0x8000001b	ZRC	ziftrCOIN
-  //       { coinType: 28 }, //	0x8000001c	VTC	Vertcoin
-  //       { coinType: 29 }, //0x8000001d	NXT	NXT
-  //       { coinType: 30 }, //	0x8000001e	BURST	Burst
-  //       { coinType: 31 }, //	0x8000001f	MUE	MonetaryUnit
-  //       { coinType: 32 }, //	0x80000020	ZOOM	Zoom
-  //       { coinType: 33 }, //	0x80000021	VASH	Virtual Cash
-  //       { coinType: 34 }, //	0x80000022	CDN	Canada eCoin
-  //       { coinType: 35 }, //	0x80000023	SDC	ShadowCash
-  //       { coinType: 36 }, //	0x80000024	PKB	ParkByte
-  //       { coinType: 37 }, //	0x80000025	PND	Pandacoin
-  //       { coinType: 38 }, //	0x80000026	START	StartCOIN
-  //       { coinType: 39 }, //	0x80000027	MOIN	MOIN
-  //       { coinType: 40 }, //	0x80000028	EXP	Expanse
-  //       { coinType: 41 }, //	0x80000029	EMC2	Einsteinium
-  //       { coinType: 42 }, //	0x8000002a	DCR	Decred
-  //       { coinType: 43 }, //	0x8000002b	XEM	NEM
-  //       { coinType: 44 }, //	0x8000002c	PART	Particl
-  //       { coinType: 45 }, // 0x8000002d	ARG	Argentum (dead)
-  //       { coinType: 46 }, //	0x8000002e		Libertas
-  //       { coinType: 47 }, //	0x8000002f		Posw coin
-  //       { coinType: 48 }, //	0x80000030	SHR	Shreeji
-  //       { coinType: 49 }, //	0x80000031	GCR	Global Currency Reserve (GCRcoin)
-  //     ],
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  it('only renders dapps rpc permission when only dapps are permitted', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:rpc': {
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: true,
+            },
+          },
+        ],
+        date: mockDate2,
+      },
+    };
 
-  //   expect(permissionCellTitles.length).toBe(50);
-  //   expect(permissionCellTitles[0].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Bitcoin'),
-  //   );
-  //   expect(permissionCellTitles[1].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Test Networks'),
-  //   );
-  //   expect(permissionCellTitles[2].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Litecoin'),
-  //   );
-  //   expect(permissionCellTitles[3].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Dogecoin'),
-  //   );
-  //   expect(permissionCellTitles[4].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Reddcoin'),
-  //   );
-  //   expect(permissionCellTitles[5].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Dash'),
-  //   );
-  //   expect(permissionCellTitles[6].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Peercoin'),
-  //   );
-  //   expect(permissionCellTitles[7].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Namecoin'),
-  //   );
-  //   expect(permissionCellTitles[8].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Feathercoin'),
-  //   );
-  //   expect(permissionCellTitles[9].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Counterparty'),
-  //   );
-  //   expect(permissionCellTitles[10].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Blackcoin'),
-  //   );
-  //   expect(permissionCellTitles[11].props.children).toBe(
-  //     snapGetBip44EntropyTitle('NuShares'),
-  //   );
-  //   expect(permissionCellTitles[12].props.children).toBe(
-  //     snapGetBip44EntropyTitle('NuBits'),
-  //   );
-  //   expect(permissionCellTitles[13].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Mazacoin'),
-  //   );
-  //   expect(permissionCellTitles[14].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Viacoin'),
-  //   );
-  //   expect(permissionCellTitles[15].props.children).toBe(
-  //     snapGetBip44EntropyTitle('ClearingHouse'),
-  //   );
-  //   expect(permissionCellTitles[16].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Rubycoin'),
-  //   );
-  //   expect(permissionCellTitles[17].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Groestlcoin'),
-  //   );
-  //   expect(permissionCellTitles[18].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Digitalcoin'),
-  //   );
-  //   expect(permissionCellTitles[19].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Cannacoin'),
-  //   );
-  //   expect(permissionCellTitles[20].props.children).toBe(
-  //     snapGetBip44EntropyTitle('DigiByte'),
-  //   );
-  //   expect(permissionCellTitles[21].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Open Assets'),
-  //   );
-  //   expect(permissionCellTitles[22].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Monacoin'),
-  //   );
-  //   expect(permissionCellTitles[23].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Clams'),
-  //   );
-  //   expect(permissionCellTitles[24].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Primecoin'),
-  //   );
-  //   expect(permissionCellTitles[25].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Neoscoin'),
-  //   );
-  //   expect(permissionCellTitles[26].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Jumbucks'),
-  //   );
-  //   expect(permissionCellTitles[27].props.children).toBe(
-  //     snapGetBip44EntropyTitle('ziftrCOIN'),
-  //   );
-  //   expect(permissionCellTitles[28].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Vertcoin'),
-  //   );
-  //   expect(permissionCellTitles[29].props.children).toBe(
-  //     snapGetBip44EntropyTitle('NXT'),
-  //   );
-  //   expect(permissionCellTitles[30].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Burst'),
-  //   );
-  //   expect(permissionCellTitles[31].props.children).toBe(
-  //     snapGetBip44EntropyTitle('MonetaryUnit'),
-  //   );
-  //   expect(permissionCellTitles[32].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Zoom'),
-  //   );
-  //   expect(permissionCellTitles[33].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Virtual Cash'),
-  //   );
-  //   expect(permissionCellTitles[34].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Canada eCoin'),
-  //   );
-  //   expect(permissionCellTitles[35].props.children).toBe(
-  //     snapGetBip44EntropyTitle('ShadowCash'),
-  //   );
-  //   expect(permissionCellTitles[36].props.children).toBe(
-  //     snapGetBip44EntropyTitle('ParkByte'),
-  //   );
-  //   expect(permissionCellTitles[37].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Pandacoin'),
-  //   );
-  //   expect(permissionCellTitles[38].props.children).toBe(
-  //     snapGetBip44EntropyTitle('StartCOIN'),
-  //   );
-  //   expect(permissionCellTitles[39].props.children).toBe(
-  //     snapGetBip44EntropyTitle('MOIN'),
-  //   );
-  //   expect(permissionCellTitles[40].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Expanse'),
-  //   );
-  //   expect(permissionCellTitles[41].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Einsteinium'),
-  //   );
-  //   expect(permissionCellTitles[42].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Decred'),
-  //   );
-  //   expect(permissionCellTitles[43].props.children).toBe(
-  //     snapGetBip44EntropyTitle('NEM'),
-  //   );
-  //   expect(permissionCellTitles[44].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Particl'),
-  //   );
-  //   expect(permissionCellTitles[45].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Argentum (dead)'),
-  //   );
-  //   expect(permissionCellTitles[46].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Libertas'),
-  //   );
-  //   expect(permissionCellTitles[47].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Posw coin'),
-  //   );
-  //   expect(permissionCellTitles[48].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Shreeji'),
-  //   );
-  //   expect(permissionCellTitles[49].props.children).toBe(
-  //     snapGetBip44EntropyTitle('Global Currency Reserve (GCRcoin)'),
-  //   );
-  // });
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  // it('renders the correct permissions titles for snap_getBip32Entropy with specified protocols', () => {
-  //   const mockPermissions: SnapPermissionsType = {
-  //     snap_getBip32Entropy: mockCurves,
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  //   expect(permissionCellTitles.length).toBe(20);
-  //   expect(permissionCellTitles[0].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Test BIP-32 Path (ed25519)'),
-  //   );
-  //   expect(permissionCellTitles[1].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Test BIP-32 Path (secp256k1)'),
-  //   );
-  //   expect(permissionCellTitles[2].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Legacy'),
-  //   );
-  //   expect(permissionCellTitles[3].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Nested SegWit'),
-  //   );
-  //   expect(permissionCellTitles[4].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Testnet Nested SegWit'),
-  //   );
-  //   expect(permissionCellTitles[5].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Native SegWit'),
-  //   );
-  //   expect(permissionCellTitles[6].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Testnet Native SegWit'),
-  //   );
-  //   expect(permissionCellTitles[7].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Solana'),
-  //   );
-  //   expect(permissionCellTitles[8].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Litecoin'),
-  //   );
-  //   expect(permissionCellTitles[9].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Dogecoin'),
-  //   );
-  //   expect(permissionCellTitles[10].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Ethereum'),
-  //   );
-  //   expect(permissionCellTitles[11].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Atom'),
-  //   );
-  //   expect(permissionCellTitles[12].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Bitcoin Cash'),
-  //   );
-  //   expect(permissionCellTitles[13].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Binance (BNB)'),
-  //   );
-  //   expect(permissionCellTitles[14].props.children).toBe(
-  //     snapGetBip32EntropyTitle('THORChain (RUNE)'),
-  //   );
-  //   expect(permissionCellTitles[15].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Terra (LUNA)'),
-  //   );
-  //   expect(permissionCellTitles[16].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Kava'),
-  //   );
-  //   expect(permissionCellTitles[17].props.children).toBe(
-  //     snapGetBip32EntropyTitle('Secret Network'),
-  //   );
-  //   expect(permissionCellTitles[18].props.children).toBe(
-  //     snapGetBip32EntropyTitle('NEAR Protocol'),
-  //   );
-  //   expect(permissionCellTitles[19].props.children).toBe(
-  //     snapGetBip32EntropyTitle('NEAR Protocol Testnet'),
-  //   );
-  // });
+    expect(permissionCells.length).toBe(1);
+    expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
+  });
 
-  // it('renders the correct default text for snap_getBip32Entropy with invalid curves', () => {
-  //   const invalidMockPermissions: SnapPermissionsType = {
-  //     snap_getBip32Entropy: [
-  //       {
-  //         path: ['m', "44'", "0'", '0'],
-  //         curve: 'secp256k1',
-  //       },
-  //       {
-  //         path: ['m', "44'", "0'", '3'],
-  //         curve: 'ed25519',
-  //       },
-  //     ],
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions
-  //       permissions={invalidMockPermissions}
-  //       installedAt={mockDate}
-  //     />,
-  //   );
-  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  it('does not render rpc permissions when both snaps and dapps are false', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:rpc': {
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: false,
+              snaps: false,
+            },
+          },
+        ],
+        date: mockDate2,
+      },
+    };
 
-  //   expect(permissionCellTitles.length).toBe(2);
-  //   expect(permissionCellTitles[0].props.children).toBe(
-  //     snapGetBip32EntropyTitle("m/44'/0'/0 (secp256k1)"),
-  //   );
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  //   expect(permissionCellTitles[1].props.children).toBe(
-  //     snapGetBip32EntropyTitle("m/44'/0'/3 (ed25519)"),
-  //   );
-  // });
+    const { queryAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCells = queryAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  // it('renders the correct default text for snap_getBip32PublicKey with invalid curves', () => {
-  //   const invalidMockPermissions: SnapPermissionsType = {
-  //     snap_getBip32PublicKey: [
-  //       {
-  //         path: ['m', "44'", "0'", '0'],
-  //         curve: 'secp256k1',
-  //       },
-  //       {
-  //         path: ['m', "44'", "0'", '3'],
-  //         curve: 'ed25519',
-  //       },
-  //     ],
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions
-  //       permissions={invalidMockPermissions}
-  //       installedAt={mockDate}
-  //     />,
-  //   );
-  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+    expect(permissionCells.length).toBe(0);
+  });
 
-  //   expect(permissionCellTitles.length).toBe(2);
-  //   expect(permissionCellTitles[0].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle("m/44'/0'/0 (secp256k1)"),
-  //   );
+  it('renders the correct permissions snap_getBip44Entropy with specified protocols', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      snap_getBip44Entropy: {
+        id: 'MuqnOW-7BRg94sRDmVnDK',
+        parentCapability: 'snap_getBip44Entropy',
+        invoker: 'npm:@metamask/test-snap-bip44',
+        caveats: [
+          {
+            type: 'permittedCoinTypes',
+            value: mockCoinTypes,
+          },
+        ],
+        date: mockDate2,
+      },
+    };
 
-  //   expect(permissionCellTitles[1].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle("m/44'/0'/3 (ed25519)"),
-  //   );
-  // });
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  // it('renders the correct permissions titles for snap_getBip32PublicKey with specified protocols', () => {
-  //   const mockPermissions: SnapPermissionsType = {
-  //     snap_getBip32PublicKey: mockCurves,
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  //   expect(permissionCellTitles.length).toBe(20);
-  //   expect(permissionCellTitles[0].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Test BIP-32 Path (ed25519)'),
-  //   );
-  //   expect(permissionCellTitles[1].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Test BIP-32 Path (secp256k1)'),
-  //   );
-  //   expect(permissionCellTitles[2].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Legacy'),
-  //   );
-  //   expect(permissionCellTitles[3].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Nested SegWit'),
-  //   );
-  //   expect(permissionCellTitles[4].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Testnet Nested SegWit'),
-  //   );
-  //   expect(permissionCellTitles[5].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Native SegWit'),
-  //   );
-  //   expect(permissionCellTitles[6].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Testnet Native SegWit'),
-  //   );
-  //   expect(permissionCellTitles[7].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Solana'),
-  //   );
-  //   expect(permissionCellTitles[8].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Litecoin'),
-  //   );
-  //   expect(permissionCellTitles[9].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Dogecoin'),
-  //   );
-  //   expect(permissionCellTitles[10].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Ethereum'),
-  //   );
-  //   expect(permissionCellTitles[11].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Atom'),
-  //   );
-  //   expect(permissionCellTitles[12].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Bitcoin Cash'),
-  //   );
-  //   expect(permissionCellTitles[13].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Binance (BNB)'),
-  //   );
-  //   expect(permissionCellTitles[14].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('THORChain (RUNE)'),
-  //   );
-  //   expect(permissionCellTitles[15].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Terra (LUNA)'),
-  //   );
-  //   expect(permissionCellTitles[16].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Kava'),
-  //   );
-  //   expect(permissionCellTitles[17].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('Secret Network'),
-  //   );
-  //   expect(permissionCellTitles[18].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('NEAR Protocol'),
-  //   );
-  //   expect(permissionCellTitles[19].props.children).toBe(
-  //     snapGetBip32PublicKeyTitle('NEAR Protocol Testnet'),
-  //   );
-  // });
+    expect(permissionCellTitles.length).toBe(50);
+    expect(permissionCellTitles[0].props.children).toBe(
+      snapGetBip44EntropyTitle('Bitcoin'),
+    );
+    expect(permissionCellTitles[1].props.children).toBe(
+      snapGetBip44EntropyTitle('Test Networks'),
+    );
+    expect(permissionCellTitles[2].props.children).toBe(
+      snapGetBip44EntropyTitle('Litecoin'),
+    );
+    expect(permissionCellTitles[3].props.children).toBe(
+      snapGetBip44EntropyTitle('Dogecoin'),
+    );
+    expect(permissionCellTitles[4].props.children).toBe(
+      snapGetBip44EntropyTitle('Reddcoin'),
+    );
+    expect(permissionCellTitles[5].props.children).toBe(
+      snapGetBip44EntropyTitle('Dash'),
+    );
+    expect(permissionCellTitles[6].props.children).toBe(
+      snapGetBip44EntropyTitle('Peercoin'),
+    );
+    expect(permissionCellTitles[7].props.children).toBe(
+      snapGetBip44EntropyTitle('Namecoin'),
+    );
+    expect(permissionCellTitles[8].props.children).toBe(
+      snapGetBip44EntropyTitle('Feathercoin'),
+    );
+    expect(permissionCellTitles[9].props.children).toBe(
+      snapGetBip44EntropyTitle('Counterparty'),
+    );
+    expect(permissionCellTitles[10].props.children).toBe(
+      snapGetBip44EntropyTitle('Blackcoin'),
+    );
+    expect(permissionCellTitles[11].props.children).toBe(
+      snapGetBip44EntropyTitle('NuShares'),
+    );
+    expect(permissionCellTitles[12].props.children).toBe(
+      snapGetBip44EntropyTitle('NuBits'),
+    );
+    expect(permissionCellTitles[13].props.children).toBe(
+      snapGetBip44EntropyTitle('Mazacoin'),
+    );
+    expect(permissionCellTitles[14].props.children).toBe(
+      snapGetBip44EntropyTitle('Viacoin'),
+    );
+    expect(permissionCellTitles[15].props.children).toBe(
+      snapGetBip44EntropyTitle('ClearingHouse'),
+    );
+    expect(permissionCellTitles[16].props.children).toBe(
+      snapGetBip44EntropyTitle('Rubycoin'),
+    );
+    expect(permissionCellTitles[17].props.children).toBe(
+      snapGetBip44EntropyTitle('Groestlcoin'),
+    );
+    expect(permissionCellTitles[18].props.children).toBe(
+      snapGetBip44EntropyTitle('Digitalcoin'),
+    );
+    expect(permissionCellTitles[19].props.children).toBe(
+      snapGetBip44EntropyTitle('Cannacoin'),
+    );
+    expect(permissionCellTitles[20].props.children).toBe(
+      snapGetBip44EntropyTitle('DigiByte'),
+    );
+    expect(permissionCellTitles[21].props.children).toBe(
+      snapGetBip44EntropyTitle('Open Assets'),
+    );
+    expect(permissionCellTitles[22].props.children).toBe(
+      snapGetBip44EntropyTitle('Monacoin'),
+    );
+    expect(permissionCellTitles[23].props.children).toBe(
+      snapGetBip44EntropyTitle('Clams'),
+    );
+    expect(permissionCellTitles[24].props.children).toBe(
+      snapGetBip44EntropyTitle('Primecoin'),
+    );
+    expect(permissionCellTitles[25].props.children).toBe(
+      snapGetBip44EntropyTitle('Neoscoin'),
+    );
+    expect(permissionCellTitles[26].props.children).toBe(
+      snapGetBip44EntropyTitle('Jumbucks'),
+    );
+    expect(permissionCellTitles[27].props.children).toBe(
+      snapGetBip44EntropyTitle('ziftrCOIN'),
+    );
+    expect(permissionCellTitles[28].props.children).toBe(
+      snapGetBip44EntropyTitle('Vertcoin'),
+    );
+    expect(permissionCellTitles[29].props.children).toBe(
+      snapGetBip44EntropyTitle('NXT'),
+    );
+    expect(permissionCellTitles[30].props.children).toBe(
+      snapGetBip44EntropyTitle('Burst'),
+    );
+    expect(permissionCellTitles[31].props.children).toBe(
+      snapGetBip44EntropyTitle('MonetaryUnit'),
+    );
+    expect(permissionCellTitles[32].props.children).toBe(
+      snapGetBip44EntropyTitle('Zoom'),
+    );
+    expect(permissionCellTitles[33].props.children).toBe(
+      snapGetBip44EntropyTitle('Virtual Cash'),
+    );
+    expect(permissionCellTitles[34].props.children).toBe(
+      snapGetBip44EntropyTitle('Canada eCoin'),
+    );
+    expect(permissionCellTitles[35].props.children).toBe(
+      snapGetBip44EntropyTitle('ShadowCash'),
+    );
+    expect(permissionCellTitles[36].props.children).toBe(
+      snapGetBip44EntropyTitle('ParkByte'),
+    );
+    expect(permissionCellTitles[37].props.children).toBe(
+      snapGetBip44EntropyTitle('Pandacoin'),
+    );
+    expect(permissionCellTitles[38].props.children).toBe(
+      snapGetBip44EntropyTitle('StartCOIN'),
+    );
+    expect(permissionCellTitles[39].props.children).toBe(
+      snapGetBip44EntropyTitle('MOIN'),
+    );
+    expect(permissionCellTitles[40].props.children).toBe(
+      snapGetBip44EntropyTitle('Expanse'),
+    );
+    expect(permissionCellTitles[41].props.children).toBe(
+      snapGetBip44EntropyTitle('Einsteinium'),
+    );
+    expect(permissionCellTitles[42].props.children).toBe(
+      snapGetBip44EntropyTitle('Decred'),
+    );
+    expect(permissionCellTitles[43].props.children).toBe(
+      snapGetBip44EntropyTitle('NEM'),
+    );
+    expect(permissionCellTitles[44].props.children).toBe(
+      snapGetBip44EntropyTitle('Particl'),
+    );
+    expect(permissionCellTitles[45].props.children).toBe(
+      snapGetBip44EntropyTitle('Argentum (dead)'),
+    );
+    expect(permissionCellTitles[46].props.children).toBe(
+      snapGetBip44EntropyTitle('Libertas'),
+    );
+    expect(permissionCellTitles[47].props.children).toBe(
+      snapGetBip44EntropyTitle('Posw coin'),
+    );
+    expect(permissionCellTitles[48].props.children).toBe(
+      snapGetBip44EntropyTitle('Shreeji'),
+    );
+    expect(permissionCellTitles[49].props.children).toBe(
+      snapGetBip44EntropyTitle('Global Currency Reserve (GCRcoin)'),
+    );
+  });
 
-  // it('renders correctly with no permissions', () => {
-  //   const permissions = {};
-  //   const { queryByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   expect(queryByTestId(SNAP_PERMISSION_CELL)).toBeNull();
-  // });
+  it('renders the correct permissions titles for snap_getBip32Entropy with specified protocols', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      snap_getBip32Entropy: {
+        id: 'j8TJuxqEtJZbIqjd2bqsq',
+        parentCapability: 'snap_getBip32Entropy',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: mockCurves,
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+    expect(permissionCellTitles.length).toBe(20);
+    expect(permissionCellTitles[0].props.children).toBe(
+      snapGetBip32EntropyTitle('Test BIP-32 Path (ed25519)'),
+    );
+    expect(permissionCellTitles[1].props.children).toBe(
+      snapGetBip32EntropyTitle('Test BIP-32 Path (secp256k1)'),
+    );
+    expect(permissionCellTitles[2].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Legacy'),
+    );
+    expect(permissionCellTitles[3].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Nested SegWit'),
+    );
+    expect(permissionCellTitles[4].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Testnet Nested SegWit'),
+    );
+    expect(permissionCellTitles[5].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Native SegWit'),
+    );
+    expect(permissionCellTitles[6].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Testnet Native SegWit'),
+    );
+    expect(permissionCellTitles[7].props.children).toBe(
+      snapGetBip32EntropyTitle('Solana'),
+    );
+    expect(permissionCellTitles[8].props.children).toBe(
+      snapGetBip32EntropyTitle('Litecoin'),
+    );
+    expect(permissionCellTitles[9].props.children).toBe(
+      snapGetBip32EntropyTitle('Dogecoin'),
+    );
+    expect(permissionCellTitles[10].props.children).toBe(
+      snapGetBip32EntropyTitle('Ethereum'),
+    );
+    expect(permissionCellTitles[11].props.children).toBe(
+      snapGetBip32EntropyTitle('Atom'),
+    );
+    expect(permissionCellTitles[12].props.children).toBe(
+      snapGetBip32EntropyTitle('Bitcoin Cash'),
+    );
+    expect(permissionCellTitles[13].props.children).toBe(
+      snapGetBip32EntropyTitle('Binance (BNB)'),
+    );
+    expect(permissionCellTitles[14].props.children).toBe(
+      snapGetBip32EntropyTitle('THORChain (RUNE)'),
+    );
+    expect(permissionCellTitles[15].props.children).toBe(
+      snapGetBip32EntropyTitle('Terra (LUNA)'),
+    );
+    expect(permissionCellTitles[16].props.children).toBe(
+      snapGetBip32EntropyTitle('Kava'),
+    );
+    expect(permissionCellTitles[17].props.children).toBe(
+      snapGetBip32EntropyTitle('Secret Network'),
+    );
+    expect(permissionCellTitles[18].props.children).toBe(
+      snapGetBip32EntropyTitle('NEAR Protocol'),
+    );
+    expect(permissionCellTitles[19].props.children).toBe(
+      snapGetBip32EntropyTitle('NEAR Protocol Testnet'),
+    );
+  });
+
+  it('renders the correct default text for snap_getBip32Entropy with invalid curves', () => {
+    const invalidMockPermissions: SubjectPermissions<PermissionConstraint> = {
+      snap_getBip32Entropy: {
+        id: 'j8TJuxqEtJZbIqjd2bqsq',
+        parentCapability: 'snap_getBip32Entropy',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: [
+              {
+                path: ['m', "44'", "0'", '0'],
+                curve: 'secp256k1',
+              },
+              {
+                path: ['m', "44'", "0'", '3'],
+                curve: 'ed25519',
+              },
+            ],
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: invalidMockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+    expect(permissionCellTitles.length).toBe(2);
+    expect(permissionCellTitles[0].props.children).toBe(
+      snapGetBip32EntropyTitle("m/44'/0'/0 (secp256k1)"),
+    );
+
+    expect(permissionCellTitles[1].props.children).toBe(
+      snapGetBip32EntropyTitle("m/44'/0'/3 (ed25519)"),
+    );
+  });
+
+  it('renders the correct default text for snap_getBip32PublicKey with invalid curves', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      snap_getBip32PublicKey: {
+        id: 'j8TJuxqEtJZbIqjd2bqsq',
+        parentCapability: 'snap_getBip32Entropy',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: [
+              {
+                path: ['m', "44'", "0'", '0'],
+                curve: 'secp256k1',
+              },
+              {
+                path: ['m', "44'", "0'", '3'],
+                curve: 'ed25519',
+              },
+            ],
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+    expect(permissionCellTitles.length).toBe(2);
+    expect(permissionCellTitles[0].props.children).toBe(
+      snapGetBip32PublicKeyTitle("m/44'/0'/0 (secp256k1)"),
+    );
+
+    expect(permissionCellTitles[1].props.children).toBe(
+      snapGetBip32PublicKeyTitle("m/44'/0'/3 (ed25519)"),
+    );
+  });
+
+  it('renders the correct permissions titles for snap_getBip32PublicKey with specified protocols', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      snap_getBip32PublicKey: {
+        id: 'j8TJuxqEtJZbIqjd2bqsq',
+        parentCapability: 'snap_getBip32Entropy',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: mockCurves,
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+    expect(permissionCellTitles.length).toBe(20);
+    expect(permissionCellTitles[0].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Test BIP-32 Path (ed25519)'),
+    );
+    expect(permissionCellTitles[1].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Test BIP-32 Path (secp256k1)'),
+    );
+    expect(permissionCellTitles[2].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Legacy'),
+    );
+    expect(permissionCellTitles[3].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Nested SegWit'),
+    );
+    expect(permissionCellTitles[4].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Testnet Nested SegWit'),
+    );
+    expect(permissionCellTitles[5].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Native SegWit'),
+    );
+    expect(permissionCellTitles[6].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Testnet Native SegWit'),
+    );
+    expect(permissionCellTitles[7].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Solana'),
+    );
+    expect(permissionCellTitles[8].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Litecoin'),
+    );
+    expect(permissionCellTitles[9].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Dogecoin'),
+    );
+    expect(permissionCellTitles[10].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Ethereum'),
+    );
+    expect(permissionCellTitles[11].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Atom'),
+    );
+    expect(permissionCellTitles[12].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Bitcoin Cash'),
+    );
+    expect(permissionCellTitles[13].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Binance (BNB)'),
+    );
+    expect(permissionCellTitles[14].props.children).toBe(
+      snapGetBip32PublicKeyTitle('THORChain (RUNE)'),
+    );
+    expect(permissionCellTitles[15].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Terra (LUNA)'),
+    );
+    expect(permissionCellTitles[16].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Kava'),
+    );
+    expect(permissionCellTitles[17].props.children).toBe(
+      snapGetBip32PublicKeyTitle('Secret Network'),
+    );
+    expect(permissionCellTitles[18].props.children).toBe(
+      snapGetBip32PublicKeyTitle('NEAR Protocol'),
+    );
+    expect(permissionCellTitles[19].props.children).toBe(
+      snapGetBip32PublicKeyTitle('NEAR Protocol Testnet'),
+    );
+  });
+
+  it('renders correctly with no permissions', () => {
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: {},
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { queryByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    expect(queryByTestId(SNAP_PERMISSION_CELL)).toBeNull();
+  });
 });

--- a/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
@@ -12,10 +12,6 @@ import {
   PermissionConstraint,
 } from '@metamask/permission-controller';
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
 describe('SnapPermissions', () => {
   const mockSnapId = '@metamask/mock-snap';
   const mockDate = 1684964145490;
@@ -179,6 +175,22 @@ describe('SnapPermissions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  const mockEngineState = (
+    mockPermissions: SubjectPermissions<PermissionConstraint>,
+  ) => ({
+    engine: {
+      backgroundState: {
+        PermissionController: {
+          subjects: {
+            '@metamask/mock-snap': {
+              permissions: mockPermissions,
+            },
+          },
+        },
+      },
+    },
   });
 
   it('renders permissions correctly', () => {
@@ -462,23 +474,10 @@ describe('SnapPermissions', () => {
         date: mockDate2,
       },
     };
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
 
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
 
@@ -507,24 +506,9 @@ describe('SnapPermissions', () => {
         date: mockDate2,
       },
     };
-
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -551,23 +535,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -593,23 +563,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -636,23 +592,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { queryAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCells = queryAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -675,23 +617,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -864,23 +792,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -972,23 +886,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: invalidMockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(invalidMockPermissions) },
     );
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -1027,23 +927,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -1073,23 +959,9 @@ describe('SnapPermissions', () => {
       },
     };
 
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: mockPermissions,
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { getAllByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState(mockPermissions) },
     );
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
@@ -1157,23 +1029,9 @@ describe('SnapPermissions', () => {
   });
 
   it('renders correctly with no permissions', () => {
-    const engineState = {
-      engine: {
-        backgroundState: {
-          PermissionController: {
-            subjects: {
-              '@metamask/mock-snap': {
-                permissions: {},
-              },
-            },
-          },
-        },
-      },
-    };
-
     const { queryByTestId } = renderWithProvider(
       <SnapPermissions snapId={mockSnapId} />,
-      { state: engineState },
+      { state: mockEngineState({}) },
     );
     expect(queryByTestId(SNAP_PERMISSION_CELL)).toBeNull();
   });

--- a/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
@@ -385,24 +385,57 @@ describe('SnapPermissions', () => {
     );
   });
 
-  // it('renders correct installed date', () => {
-  //   const permissions: SnapPermissionsType = {
-  //     'endowment:network-access': {},
-  //     'endowment:rpc': {
-  //       dapps: true,
-  //       snaps: true,
-  //     },
-  //   };
-  //   const { getAllByTestId } = render(
-  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-  //   );
-  //   const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
+  it('renders correct installed date', () => {
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:long-running': {
+        id: 'Bjj3InYtb6U4ak-uja0f_',
+        parentCapability: 'endowment:long-running',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: null,
+        date: mockDate,
+      },
+      'endowment:rpc': {
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: true,
+              snaps: true,
+            },
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
+          },
+        },
+      },
+    };
 
-  //   const expectedDate = 'Approved on May 24 at 5:35 pm';
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
+    );
+    const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
 
-  //   expect(permissionCellDates[0].props.children).toBe(expectedDate);
-  //   expect(permissionCellDates[1].props.children).toBe(expectedDate);
-  // });
+    const expectedDate1 = 'Approved on May 24 at 5:35 pm';
+    const expectedDate2 = 'Approved on Jun 6 at 4:02 pm';
+
+    expect(permissionCellDates[0].props.children).toBe(expectedDate1);
+    expect(permissionCellDates[1].props.children).toBe(expectedDate2);
+  });
 
   // it('renders correct permissions cells for endowment:rpc when both dapps and snaps are permitted', () => {
   //   const permissions: SnapPermissionsType = {

--- a/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermission.test.tsx
@@ -7,9 +7,20 @@ import {
   SNAP_PERMISSION_CELL,
 } from '../../../../../../constants/test-ids';
 import { SnapPermissions as SnapPermissionsType } from '@metamask/snaps-utils';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import {
+  SubjectPermissions,
+  PermissionConstraint,
+} from '@metamask/permission-controller';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
 
 describe('SnapPermissions', () => {
+  const mockSnapId = '@metamask/mock-snap';
   const mockDate = 1684964145490;
+  const mockDate2 = 1686081721987;
   const longRunningTitle = 'Run indefinitely';
   const networkAccessTitle = 'Access the internet';
   const transactionInsightTitle = 'Display transaction insights';
@@ -119,604 +130,768 @@ describe('SnapPermissions', () => {
   });
 
   it('renders permissions correctly', () => {
-    const mockPermissions: SnapPermissionsType = {
-      'endowment:long-running': {},
-      'endowment:network-access': {},
+    const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+      'endowment:long-running': {
+        id: 'Bjj3InYtb6U4ak-uja0f_',
+        parentCapability: 'endowment:long-running',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: null,
+        date: mockDate,
+      },
+      'endowment:network-access': {
+        id: 'Bjj3InYtb6U4ak-uja0f_',
+        parentCapability: 'endowment:network-access',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: null,
+        date: mockDate,
+      },
       'endowment:transaction-insight': {
-        allowTransactionOrigin: true,
+        id: '_6zTUtmw1BQAF-Iospl_m',
+        parentCapability: 'endowment:transaction-insight',
+        invoker: 'npm:@metamask/test-snap-insights',
+        caveats: null,
+        date: mockDate,
       },
       'endowment:cronjob': {
-        jobs: [
+        id: '_6zTUtmw1BQAF-Iospl_m',
+        parentCapability: 'endowment:cronjob',
+        invoker: 'npm:@metamask/test-snap-insights',
+        caveats: [
           {
-            expression: '* * * * *',
-            request: {
-              method: 'GET',
-              params: {},
-              id: '1',
-              jsonrpc: '2.0',
+            type: 'jobs',
+            value: {
+              jobs: [
+                {
+                  expression: '* * * * *',
+                  request: {
+                    method: 'GET',
+                    params: {},
+                    id: '1',
+                    jsonrpc: '2.0',
+                  },
+                },
+              ],
             },
           },
         ],
+        date: mockDate,
       },
       'endowment:rpc': {
-        dapps: true,
-        snaps: true,
+        id: 'Zma-vejrSvLtHmLrbSBAX',
+        parentCapability: 'endowment:rpc',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: true,
+              snaps: true,
+            },
+          },
+        ],
+        date: mockDate2,
       },
-      snap_confirm: {},
-      snap_manageState: {},
-      snap_notify: {},
-      snap_getBip32Entropy: [
-        {
-          path: ['m', "44'", "0'"],
-          curve: 'secp256k1',
-        },
-      ],
-      snap_getBip32PublicKey: [
-        {
-          path: ['m', "44'", "0'"],
-          curve: 'secp256k1',
-        },
-      ],
-      snap_getBip44Entropy: [
-        {
-          coinType: 1,
-        },
-      ],
-      snap_getEntropy: {},
-      'endowment:keyring': {
-        namespaces: {
-          mockNamespace: {
-            chains: [
+      snap_confirm: {
+        id: 'tVtSEUjc48Ab-gF6UI7X3',
+        parentCapability: 'snap_confirm',
+        invoker: 'npm:@chainsafe/filsnap',
+        caveats: null,
+        date: mockDate2,
+      },
+      snap_manageState: {
+        id: 'BKbg3uDSHHu0D1fCUTOmS',
+        parentCapability: 'snap_manageState',
+        invoker: 'npm:@metamask/test-snap-managestate',
+        caveats: null,
+        date: mockDate2,
+      },
+      snap_notify: {
+        id: '2JfZ78WEwQT3qvB20EyJR',
+        parentCapability: 'snap_notify',
+        invoker: 'npm:@metamask/test-snap-notification',
+        caveats: null,
+        date: mockDate2,
+      },
+      snap_getBip32Entropy: {
+        id: 'j8TJuxqEtJZbIqjd2bqsq',
+        parentCapability: 'snap_getBip32Entropy',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: [
               {
-                name: 'Mock Chain',
-                id: 'mock-chain-id',
+                path: ['m', "44'", "0'"],
+                curve: 'secp256k1',
               },
             ],
-            methods: ['mockMethod1', 'mockMethod2'],
-            events: ['mockEvent1', 'mockEvent2'],
+          },
+        ],
+        date: mockDate2,
+      },
+      snap_getBip32PublicKey: {
+        id: 'BmILTjG7zK4YKzjq-JMYM',
+        parentCapability: 'snap_getBip32PublicKey',
+        invoker: 'npm:@metamask/test-snap-bip32',
+        caveats: [
+          {
+            type: 'permittedDerivationPaths',
+            value: [
+              {
+                path: ['m', "44'", "0'"],
+                curve: 'secp256k1',
+              },
+            ],
+          },
+        ],
+        date: mockDate2,
+      },
+      snap_getBip44Entropy: {
+        id: 'MuqnOW-7BRg94sRDmVnDK',
+        parentCapability: 'snap_getBip44Entropy',
+        invoker: 'npm:@metamask/test-snap-bip44',
+        caveats: [
+          {
+            type: 'permittedCoinTypes',
+            value: [
+              {
+                coinType: 0,
+              },
+            ],
+          },
+        ],
+        date: mockDate2,
+      },
+      snap_getEntropy: {
+        id: 'MuqnOW-7BRg94sRDmVnDK',
+        parentCapability: 'snap_getEntropy',
+        invoker: 'npm:@metamask/test-snap-bip44',
+        caveats: null,
+        date: mockDate2,
+      },
+      'endowment:keyring': {
+        id: 'MuqnOW-7BRg94sRDmVnDK',
+        parentCapability: 'snap_getEntropy',
+        invoker: 'npm:@metamask/test-snap-bip44',
+        caveats: [
+          {
+            type: 'mockNamespace',
+            value: [
+              {
+                mockNamespace: {
+                  chains: [
+                    {
+                      name: 'Mock Chain',
+                      id: 'mock-chain-id',
+                    },
+                  ],
+                  methods: ['mockMethod1', 'mockMethod2'],
+                  events: ['mockEvent1', 'mockEvent2'],
+                },
+              },
+            ],
+          },
+        ],
+        date: mockDate2,
+      },
+    };
+
+    const engineState = {
+      engine: {
+        backgroundState: {
+          PermissionController: {
+            subjects: {
+              '@metamask/mock-snap': {
+                permissions: mockPermissions,
+              },
+            },
           },
         },
       },
     };
 
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
+    const { getAllByTestId } = renderWithProvider(
+      <SnapPermissions snapId={mockSnapId} />,
+      { state: engineState },
     );
     const permissionCells = getAllByTestId(SNAP_PERMISSION_CELL);
     const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+    const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
 
     expect(permissionCells.length).toBe(14);
     expect(permissionCellTitles[0].props.children).toBe(longRunningTitle);
+    expect(permissionCellDates[0].props.children).toBe(
+      'Approved on May 24 at 5:35 pm',
+    );
     expect(permissionCellTitles[1].props.children).toBe(networkAccessTitle);
+    expect(permissionCellDates[1].props.children).toBe(
+      'Approved on May 24 at 5:35 pm',
+    );
     expect(permissionCellTitles[2].props.children).toBe(
       transactionInsightTitle,
     );
+    expect(permissionCellDates[2].props.children).toBe(
+      'Approved on May 24 at 5:35 pm',
+    );
     expect(permissionCellTitles[3].props.children).toBe(cronjobTitle);
+    expect(permissionCellDates[3].props.children).toBe(
+      'Approved on May 24 at 5:35 pm',
+    );
     expect(permissionCellTitles[4].props.children).toBe(rpcDappsTitle);
+    expect(permissionCellDates[4].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[5].props.children).toBe(rpcSnapsTitle);
+    expect(permissionCellDates[5].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[6].props.children).toBe(snapConfirmTitle);
+    expect(permissionCellDates[6].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[7].props.children).toBe(snapManageStateTitle);
+    expect(permissionCellDates[7].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[8].props.children).toBe(snapNotifyTitle);
+    expect(permissionCellDates[8].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[9].props.children).toBe(
       snapGetBip32EntropyTitle('Bitcoin Legacy'),
+    );
+    expect(permissionCellDates[9].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
     );
     expect(permissionCellTitles[10].props.children).toBe(
       snapGetBip32PublicKeyTitle('Bitcoin Legacy'),
     );
+    expect(permissionCellDates[10].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[11].props.children).toBe(
       snapGetBip44EntropyTitle('Bitcoin'),
+    );
+    expect(permissionCellDates[11].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
     );
     expect(permissionCellTitles[12].props.children).toBe(snapGetEntropyTitle);
+    expect(permissionCellDates[12].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
+    );
     expect(permissionCellTitles[13].props.children).toBe(endowmentKeyringTitle);
-  });
-
-  it('renders correct installed date', () => {
-    const permissions: SnapPermissionsType = {
-      'endowment:network-access': {},
-      'endowment:rpc': {
-        dapps: true,
-        snaps: true,
-      },
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
-
-    const expectedDate = 'Approved on May 24 at 5:35 pm';
-
-    expect(permissionCellDates[0].props.children).toBe(expectedDate);
-    expect(permissionCellDates[1].props.children).toBe(expectedDate);
-  });
-
-  it('renders correct permissions cells for endowment:rpc when both dapps and snaps are permitted', () => {
-    const permissions: SnapPermissionsType = {
-      'endowment:rpc': {
-        dapps: true,
-        snaps: true,
-      },
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
-
-    expect(permissionCells.length).toBe(2);
-    expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
-    expect(permissionCells[1].props.children).toBe(rpcSnapsTitle);
-  });
-
-  it('only renders snap rpc permission when only snaps are permitted', () => {
-    const permissions: SnapPermissionsType = {
-      'endowment:rpc': {
-        dapps: false,
-        snaps: true,
-      },
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
-
-    expect(permissionCells.length).toBe(1);
-    expect(permissionCells[0].props.children).toBe(rpcSnapsTitle);
-  });
-
-  it('only renders dapps rpc permission when only dapps are permitted', () => {
-    const permissions: SnapPermissionsType = {
-      'endowment:rpc': {
-        dapps: true,
-        snaps: false,
-      },
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
-
-    expect(permissionCells.length).toBe(1);
-    expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
-  });
-
-  it('does not render rpc permissions when both snaps and dapps are false', () => {
-    const permissions: SnapPermissionsType = {
-      'endowment:rpc': {
-        dapps: false,
-        snaps: false,
-      },
-    };
-    const { queryAllByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    const permissionCells = queryAllByTestId(SNAP_PERMISSIONS_TITLE);
-
-    expect(permissionCells.length).toBe(0);
-  });
-
-  it('renders the correct permissions snap_getBip44Entropy with specified protocols', () => {
-    const mockPermissions: SnapPermissionsType = {
-      snap_getBip44Entropy: [
-        { coinType: 0 }, // Bitcoin
-        { coinType: 1 }, // Testnet (all coins)
-        { coinType: 2 }, // Litecoin
-        { coinType: 3 }, // Dogecoin
-        { coinType: 4 }, // Reddcoin
-        { coinType: 5 }, // Dash
-        { coinType: 6 }, // Peercoin
-        { coinType: 7 }, // Namecoin
-        { coinType: 8 }, // Feathercoin
-        { coinType: 9 }, // Counterparty
-        { coinType: 10 }, // 0x8000000a	BLK	Blackcoin
-        { coinType: 11 }, //	0x8000000b	NSR	NuShares
-        { coinType: 12 }, // 0x8000000c	NBT	NuBits
-        { coinType: 13 }, // 0x8000000d	MZC	Mazacoin
-        { coinType: 14 }, // 0x8000000e	VIA	Viacoin
-        { coinType: 15 }, //	0x8000000f	XCH	ClearingHouse
-        { coinType: 16 }, //	0x80000010	RBY	Rubycoin
-        { coinType: 17 }, //	0x80000011	GRS	Groestlcoin
-        { coinType: 18 }, //	0x80000012	DGC	Digitalcoin
-        { coinType: 19 }, // 0x80000013	CCN	Cannacoin
-        { coinType: 20 }, //	0x80000014	DGB	DigiByte
-        { coinType: 21 }, //	0x80000015		Open Assets
-        { coinType: 22 }, //	0x80000016	MONA	Monacoin
-        { coinType: 23 }, //	0x80000017	CLAM	Clams
-        { coinType: 24 }, //	0x80000018	XPM	Primecoin
-        { coinType: 25 }, //	0x80000019	NEOS	Neoscoin
-        { coinType: 26 }, //	0x8000001a	JBS	Jumbucks
-        { coinType: 27 }, //	0x8000001b	ZRC	ziftrCOIN
-        { coinType: 28 }, //	0x8000001c	VTC	Vertcoin
-        { coinType: 29 }, //0x8000001d	NXT	NXT
-        { coinType: 30 }, //	0x8000001e	BURST	Burst
-        { coinType: 31 }, //	0x8000001f	MUE	MonetaryUnit
-        { coinType: 32 }, //	0x80000020	ZOOM	Zoom
-        { coinType: 33 }, //	0x80000021	VASH	Virtual Cash
-        { coinType: 34 }, //	0x80000022	CDN	Canada eCoin
-        { coinType: 35 }, //	0x80000023	SDC	ShadowCash
-        { coinType: 36 }, //	0x80000024	PKB	ParkByte
-        { coinType: 37 }, //	0x80000025	PND	Pandacoin
-        { coinType: 38 }, //	0x80000026	START	StartCOIN
-        { coinType: 39 }, //	0x80000027	MOIN	MOIN
-        { coinType: 40 }, //	0x80000028	EXP	Expanse
-        { coinType: 41 }, //	0x80000029	EMC2	Einsteinium
-        { coinType: 42 }, //	0x8000002a	DCR	Decred
-        { coinType: 43 }, //	0x8000002b	XEM	NEM
-        { coinType: 44 }, //	0x8000002c	PART	Particl
-        { coinType: 45 }, // 0x8000002d	ARG	Argentum (dead)
-        { coinType: 46 }, //	0x8000002e		Libertas
-        { coinType: 47 }, //	0x8000002f		Posw coin
-        { coinType: 48 }, //	0x80000030	SHR	Shreeji
-        { coinType: 49 }, //	0x80000031	GCR	Global Currency Reserve (GCRcoin)
-      ],
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-    );
-    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
-
-    expect(permissionCellTitles.length).toBe(50);
-    expect(permissionCellTitles[0].props.children).toBe(
-      snapGetBip44EntropyTitle('Bitcoin'),
-    );
-    expect(permissionCellTitles[1].props.children).toBe(
-      snapGetBip44EntropyTitle('Test Networks'),
-    );
-    expect(permissionCellTitles[2].props.children).toBe(
-      snapGetBip44EntropyTitle('Litecoin'),
-    );
-    expect(permissionCellTitles[3].props.children).toBe(
-      snapGetBip44EntropyTitle('Dogecoin'),
-    );
-    expect(permissionCellTitles[4].props.children).toBe(
-      snapGetBip44EntropyTitle('Reddcoin'),
-    );
-    expect(permissionCellTitles[5].props.children).toBe(
-      snapGetBip44EntropyTitle('Dash'),
-    );
-    expect(permissionCellTitles[6].props.children).toBe(
-      snapGetBip44EntropyTitle('Peercoin'),
-    );
-    expect(permissionCellTitles[7].props.children).toBe(
-      snapGetBip44EntropyTitle('Namecoin'),
-    );
-    expect(permissionCellTitles[8].props.children).toBe(
-      snapGetBip44EntropyTitle('Feathercoin'),
-    );
-    expect(permissionCellTitles[9].props.children).toBe(
-      snapGetBip44EntropyTitle('Counterparty'),
-    );
-    expect(permissionCellTitles[10].props.children).toBe(
-      snapGetBip44EntropyTitle('Blackcoin'),
-    );
-    expect(permissionCellTitles[11].props.children).toBe(
-      snapGetBip44EntropyTitle('NuShares'),
-    );
-    expect(permissionCellTitles[12].props.children).toBe(
-      snapGetBip44EntropyTitle('NuBits'),
-    );
-    expect(permissionCellTitles[13].props.children).toBe(
-      snapGetBip44EntropyTitle('Mazacoin'),
-    );
-    expect(permissionCellTitles[14].props.children).toBe(
-      snapGetBip44EntropyTitle('Viacoin'),
-    );
-    expect(permissionCellTitles[15].props.children).toBe(
-      snapGetBip44EntropyTitle('ClearingHouse'),
-    );
-    expect(permissionCellTitles[16].props.children).toBe(
-      snapGetBip44EntropyTitle('Rubycoin'),
-    );
-    expect(permissionCellTitles[17].props.children).toBe(
-      snapGetBip44EntropyTitle('Groestlcoin'),
-    );
-    expect(permissionCellTitles[18].props.children).toBe(
-      snapGetBip44EntropyTitle('Digitalcoin'),
-    );
-    expect(permissionCellTitles[19].props.children).toBe(
-      snapGetBip44EntropyTitle('Cannacoin'),
-    );
-    expect(permissionCellTitles[20].props.children).toBe(
-      snapGetBip44EntropyTitle('DigiByte'),
-    );
-    expect(permissionCellTitles[21].props.children).toBe(
-      snapGetBip44EntropyTitle('Open Assets'),
-    );
-    expect(permissionCellTitles[22].props.children).toBe(
-      snapGetBip44EntropyTitle('Monacoin'),
-    );
-    expect(permissionCellTitles[23].props.children).toBe(
-      snapGetBip44EntropyTitle('Clams'),
-    );
-    expect(permissionCellTitles[24].props.children).toBe(
-      snapGetBip44EntropyTitle('Primecoin'),
-    );
-    expect(permissionCellTitles[25].props.children).toBe(
-      snapGetBip44EntropyTitle('Neoscoin'),
-    );
-    expect(permissionCellTitles[26].props.children).toBe(
-      snapGetBip44EntropyTitle('Jumbucks'),
-    );
-    expect(permissionCellTitles[27].props.children).toBe(
-      snapGetBip44EntropyTitle('ziftrCOIN'),
-    );
-    expect(permissionCellTitles[28].props.children).toBe(
-      snapGetBip44EntropyTitle('Vertcoin'),
-    );
-    expect(permissionCellTitles[29].props.children).toBe(
-      snapGetBip44EntropyTitle('NXT'),
-    );
-    expect(permissionCellTitles[30].props.children).toBe(
-      snapGetBip44EntropyTitle('Burst'),
-    );
-    expect(permissionCellTitles[31].props.children).toBe(
-      snapGetBip44EntropyTitle('MonetaryUnit'),
-    );
-    expect(permissionCellTitles[32].props.children).toBe(
-      snapGetBip44EntropyTitle('Zoom'),
-    );
-    expect(permissionCellTitles[33].props.children).toBe(
-      snapGetBip44EntropyTitle('Virtual Cash'),
-    );
-    expect(permissionCellTitles[34].props.children).toBe(
-      snapGetBip44EntropyTitle('Canada eCoin'),
-    );
-    expect(permissionCellTitles[35].props.children).toBe(
-      snapGetBip44EntropyTitle('ShadowCash'),
-    );
-    expect(permissionCellTitles[36].props.children).toBe(
-      snapGetBip44EntropyTitle('ParkByte'),
-    );
-    expect(permissionCellTitles[37].props.children).toBe(
-      snapGetBip44EntropyTitle('Pandacoin'),
-    );
-    expect(permissionCellTitles[38].props.children).toBe(
-      snapGetBip44EntropyTitle('StartCOIN'),
-    );
-    expect(permissionCellTitles[39].props.children).toBe(
-      snapGetBip44EntropyTitle('MOIN'),
-    );
-    expect(permissionCellTitles[40].props.children).toBe(
-      snapGetBip44EntropyTitle('Expanse'),
-    );
-    expect(permissionCellTitles[41].props.children).toBe(
-      snapGetBip44EntropyTitle('Einsteinium'),
-    );
-    expect(permissionCellTitles[42].props.children).toBe(
-      snapGetBip44EntropyTitle('Decred'),
-    );
-    expect(permissionCellTitles[43].props.children).toBe(
-      snapGetBip44EntropyTitle('NEM'),
-    );
-    expect(permissionCellTitles[44].props.children).toBe(
-      snapGetBip44EntropyTitle('Particl'),
-    );
-    expect(permissionCellTitles[45].props.children).toBe(
-      snapGetBip44EntropyTitle('Argentum (dead)'),
-    );
-    expect(permissionCellTitles[46].props.children).toBe(
-      snapGetBip44EntropyTitle('Libertas'),
-    );
-    expect(permissionCellTitles[47].props.children).toBe(
-      snapGetBip44EntropyTitle('Posw coin'),
-    );
-    expect(permissionCellTitles[48].props.children).toBe(
-      snapGetBip44EntropyTitle('Shreeji'),
-    );
-    expect(permissionCellTitles[49].props.children).toBe(
-      snapGetBip44EntropyTitle('Global Currency Reserve (GCRcoin)'),
+    expect(permissionCellDates[13].props.children).toBe(
+      'Approved on Jun 6 at 4:02 pm',
     );
   });
 
-  it('renders the correct permissions titles for snap_getBip32Entropy with specified protocols', () => {
-    const mockPermissions: SnapPermissionsType = {
-      snap_getBip32Entropy: mockCurves,
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-    );
-    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  // it('renders correct installed date', () => {
+  //   const permissions: SnapPermissionsType = {
+  //     'endowment:network-access': {},
+  //     'endowment:rpc': {
+  //       dapps: true,
+  //       snaps: true,
+  //     },
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCellDates = getAllByTestId(SNAP_PERMISSIONS_DATE);
 
-    expect(permissionCellTitles.length).toBe(20);
-    expect(permissionCellTitles[0].props.children).toBe(
-      snapGetBip32EntropyTitle('Test BIP-32 Path (ed25519)'),
-    );
-    expect(permissionCellTitles[1].props.children).toBe(
-      snapGetBip32EntropyTitle('Test BIP-32 Path (secp256k1)'),
-    );
-    expect(permissionCellTitles[2].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Legacy'),
-    );
-    expect(permissionCellTitles[3].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Nested SegWit'),
-    );
-    expect(permissionCellTitles[4].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Testnet Nested SegWit'),
-    );
-    expect(permissionCellTitles[5].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Native SegWit'),
-    );
-    expect(permissionCellTitles[6].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Testnet Native SegWit'),
-    );
-    expect(permissionCellTitles[7].props.children).toBe(
-      snapGetBip32EntropyTitle('Solana'),
-    );
-    expect(permissionCellTitles[8].props.children).toBe(
-      snapGetBip32EntropyTitle('Litecoin'),
-    );
-    expect(permissionCellTitles[9].props.children).toBe(
-      snapGetBip32EntropyTitle('Dogecoin'),
-    );
-    expect(permissionCellTitles[10].props.children).toBe(
-      snapGetBip32EntropyTitle('Ethereum'),
-    );
-    expect(permissionCellTitles[11].props.children).toBe(
-      snapGetBip32EntropyTitle('Atom'),
-    );
-    expect(permissionCellTitles[12].props.children).toBe(
-      snapGetBip32EntropyTitle('Bitcoin Cash'),
-    );
-    expect(permissionCellTitles[13].props.children).toBe(
-      snapGetBip32EntropyTitle('Binance (BNB)'),
-    );
-    expect(permissionCellTitles[14].props.children).toBe(
-      snapGetBip32EntropyTitle('THORChain (RUNE)'),
-    );
-    expect(permissionCellTitles[15].props.children).toBe(
-      snapGetBip32EntropyTitle('Terra (LUNA)'),
-    );
-    expect(permissionCellTitles[16].props.children).toBe(
-      snapGetBip32EntropyTitle('Kava'),
-    );
-    expect(permissionCellTitles[17].props.children).toBe(
-      snapGetBip32EntropyTitle('Secret Network'),
-    );
-    expect(permissionCellTitles[18].props.children).toBe(
-      snapGetBip32EntropyTitle('NEAR Protocol'),
-    );
-    expect(permissionCellTitles[19].props.children).toBe(
-      snapGetBip32EntropyTitle('NEAR Protocol Testnet'),
-    );
-  });
+  //   const expectedDate = 'Approved on May 24 at 5:35 pm';
 
-  it('renders the correct default text for snap_getBip32Entropy with invalid curves', () => {
-    const invalidMockPermissions: SnapPermissionsType = {
-      snap_getBip32Entropy: [
-        {
-          path: ['m', "44'", "0'", '0'],
-          curve: 'secp256k1',
-        },
-        {
-          path: ['m', "44'", "0'", '3'],
-          curve: 'ed25519',
-        },
-      ],
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions
-        permissions={invalidMockPermissions}
-        installedAt={mockDate}
-      />,
-    );
-    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  //   expect(permissionCellDates[0].props.children).toBe(expectedDate);
+  //   expect(permissionCellDates[1].props.children).toBe(expectedDate);
+  // });
 
-    expect(permissionCellTitles.length).toBe(2);
-    expect(permissionCellTitles[0].props.children).toBe(
-      snapGetBip32EntropyTitle("m/44'/0'/0 (secp256k1)"),
-    );
+  // it('renders correct permissions cells for endowment:rpc when both dapps and snaps are permitted', () => {
+  //   const permissions: SnapPermissionsType = {
+  //     'endowment:rpc': {
+  //       dapps: true,
+  //       snaps: true,
+  //     },
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-    expect(permissionCellTitles[1].props.children).toBe(
-      snapGetBip32EntropyTitle("m/44'/0'/3 (ed25519)"),
-    );
-  });
+  //   expect(permissionCells.length).toBe(2);
+  //   expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
+  //   expect(permissionCells[1].props.children).toBe(rpcSnapsTitle);
+  // });
 
-  it('renders the correct default text for snap_getBip32PublicKey with invalid curves', () => {
-    const invalidMockPermissions: SnapPermissionsType = {
-      snap_getBip32PublicKey: [
-        {
-          path: ['m', "44'", "0'", '0'],
-          curve: 'secp256k1',
-        },
-        {
-          path: ['m', "44'", "0'", '3'],
-          curve: 'ed25519',
-        },
-      ],
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions
-        permissions={invalidMockPermissions}
-        installedAt={mockDate}
-      />,
-    );
-    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  // it('only renders snap rpc permission when only snaps are permitted', () => {
+  //   const permissions: SnapPermissionsType = {
+  //     'endowment:rpc': {
+  //       dapps: false,
+  //       snaps: true,
+  //     },
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-    expect(permissionCellTitles.length).toBe(2);
-    expect(permissionCellTitles[0].props.children).toBe(
-      snapGetBip32PublicKeyTitle("m/44'/0'/0 (secp256k1)"),
-    );
+  //   expect(permissionCells.length).toBe(1);
+  //   expect(permissionCells[0].props.children).toBe(rpcSnapsTitle);
+  // });
 
-    expect(permissionCellTitles[1].props.children).toBe(
-      snapGetBip32PublicKeyTitle("m/44'/0'/3 (ed25519)"),
-    );
-  });
+  // it('only renders dapps rpc permission when only dapps are permitted', () => {
+  //   const permissions: SnapPermissionsType = {
+  //     'endowment:rpc': {
+  //       dapps: true,
+  //       snaps: false,
+  //     },
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCells = getAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  it('renders the correct permissions titles for snap_getBip32PublicKey with specified protocols', () => {
-    const mockPermissions: SnapPermissionsType = {
-      snap_getBip32PublicKey: mockCurves,
-    };
-    const { getAllByTestId } = render(
-      <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
-    );
-    const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+  //   expect(permissionCells.length).toBe(1);
+  //   expect(permissionCells[0].props.children).toBe(rpcDappsTitle);
+  // });
 
-    expect(permissionCellTitles.length).toBe(20);
-    expect(permissionCellTitles[0].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Test BIP-32 Path (ed25519)'),
-    );
-    expect(permissionCellTitles[1].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Test BIP-32 Path (secp256k1)'),
-    );
-    expect(permissionCellTitles[2].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Legacy'),
-    );
-    expect(permissionCellTitles[3].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Nested SegWit'),
-    );
-    expect(permissionCellTitles[4].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Testnet Nested SegWit'),
-    );
-    expect(permissionCellTitles[5].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Native SegWit'),
-    );
-    expect(permissionCellTitles[6].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Testnet Native SegWit'),
-    );
-    expect(permissionCellTitles[7].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Solana'),
-    );
-    expect(permissionCellTitles[8].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Litecoin'),
-    );
-    expect(permissionCellTitles[9].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Dogecoin'),
-    );
-    expect(permissionCellTitles[10].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Ethereum'),
-    );
-    expect(permissionCellTitles[11].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Atom'),
-    );
-    expect(permissionCellTitles[12].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Bitcoin Cash'),
-    );
-    expect(permissionCellTitles[13].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Binance (BNB)'),
-    );
-    expect(permissionCellTitles[14].props.children).toBe(
-      snapGetBip32PublicKeyTitle('THORChain (RUNE)'),
-    );
-    expect(permissionCellTitles[15].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Terra (LUNA)'),
-    );
-    expect(permissionCellTitles[16].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Kava'),
-    );
-    expect(permissionCellTitles[17].props.children).toBe(
-      snapGetBip32PublicKeyTitle('Secret Network'),
-    );
-    expect(permissionCellTitles[18].props.children).toBe(
-      snapGetBip32PublicKeyTitle('NEAR Protocol'),
-    );
-    expect(permissionCellTitles[19].props.children).toBe(
-      snapGetBip32PublicKeyTitle('NEAR Protocol Testnet'),
-    );
-  });
+  // it('does not render rpc permissions when both snaps and dapps are false', () => {
+  //   const permissions: SnapPermissionsType = {
+  //     'endowment:rpc': {
+  //       dapps: false,
+  //       snaps: false,
+  //     },
+  //   };
+  //   const { queryAllByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCells = queryAllByTestId(SNAP_PERMISSIONS_TITLE);
 
-  it('renders correctly with no permissions', () => {
-    const permissions = {};
-    const { queryByTestId } = render(
-      <SnapPermissions permissions={permissions} installedAt={mockDate} />,
-    );
-    expect(queryByTestId(SNAP_PERMISSION_CELL)).toBeNull();
-  });
+  //   expect(permissionCells.length).toBe(0);
+  // });
+
+  // it('renders the correct permissions snap_getBip44Entropy with specified protocols', () => {
+  //   const mockPermissions: SnapPermissionsType = {
+  //     snap_getBip44Entropy: [
+  //       { coinType: 0 }, // Bitcoin
+  //       { coinType: 1 }, // Testnet (all coins)
+  //       { coinType: 2 }, // Litecoin
+  //       { coinType: 3 }, // Dogecoin
+  //       { coinType: 4 }, // Reddcoin
+  //       { coinType: 5 }, // Dash
+  //       { coinType: 6 }, // Peercoin
+  //       { coinType: 7 }, // Namecoin
+  //       { coinType: 8 }, // Feathercoin
+  //       { coinType: 9 }, // Counterparty
+  //       { coinType: 10 }, // 0x8000000a	BLK	Blackcoin
+  //       { coinType: 11 }, //	0x8000000b	NSR	NuShares
+  //       { coinType: 12 }, // 0x8000000c	NBT	NuBits
+  //       { coinType: 13 }, // 0x8000000d	MZC	Mazacoin
+  //       { coinType: 14 }, // 0x8000000e	VIA	Viacoin
+  //       { coinType: 15 }, //	0x8000000f	XCH	ClearingHouse
+  //       { coinType: 16 }, //	0x80000010	RBY	Rubycoin
+  //       { coinType: 17 }, //	0x80000011	GRS	Groestlcoin
+  //       { coinType: 18 }, //	0x80000012	DGC	Digitalcoin
+  //       { coinType: 19 }, // 0x80000013	CCN	Cannacoin
+  //       { coinType: 20 }, //	0x80000014	DGB	DigiByte
+  //       { coinType: 21 }, //	0x80000015		Open Assets
+  //       { coinType: 22 }, //	0x80000016	MONA	Monacoin
+  //       { coinType: 23 }, //	0x80000017	CLAM	Clams
+  //       { coinType: 24 }, //	0x80000018	XPM	Primecoin
+  //       { coinType: 25 }, //	0x80000019	NEOS	Neoscoin
+  //       { coinType: 26 }, //	0x8000001a	JBS	Jumbucks
+  //       { coinType: 27 }, //	0x8000001b	ZRC	ziftrCOIN
+  //       { coinType: 28 }, //	0x8000001c	VTC	Vertcoin
+  //       { coinType: 29 }, //0x8000001d	NXT	NXT
+  //       { coinType: 30 }, //	0x8000001e	BURST	Burst
+  //       { coinType: 31 }, //	0x8000001f	MUE	MonetaryUnit
+  //       { coinType: 32 }, //	0x80000020	ZOOM	Zoom
+  //       { coinType: 33 }, //	0x80000021	VASH	Virtual Cash
+  //       { coinType: 34 }, //	0x80000022	CDN	Canada eCoin
+  //       { coinType: 35 }, //	0x80000023	SDC	ShadowCash
+  //       { coinType: 36 }, //	0x80000024	PKB	ParkByte
+  //       { coinType: 37 }, //	0x80000025	PND	Pandacoin
+  //       { coinType: 38 }, //	0x80000026	START	StartCOIN
+  //       { coinType: 39 }, //	0x80000027	MOIN	MOIN
+  //       { coinType: 40 }, //	0x80000028	EXP	Expanse
+  //       { coinType: 41 }, //	0x80000029	EMC2	Einsteinium
+  //       { coinType: 42 }, //	0x8000002a	DCR	Decred
+  //       { coinType: 43 }, //	0x8000002b	XEM	NEM
+  //       { coinType: 44 }, //	0x8000002c	PART	Particl
+  //       { coinType: 45 }, // 0x8000002d	ARG	Argentum (dead)
+  //       { coinType: 46 }, //	0x8000002e		Libertas
+  //       { coinType: 47 }, //	0x8000002f		Posw coin
+  //       { coinType: 48 }, //	0x80000030	SHR	Shreeji
+  //       { coinType: 49 }, //	0x80000031	GCR	Global Currency Reserve (GCRcoin)
+  //     ],
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+  //   expect(permissionCellTitles.length).toBe(50);
+  //   expect(permissionCellTitles[0].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Bitcoin'),
+  //   );
+  //   expect(permissionCellTitles[1].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Test Networks'),
+  //   );
+  //   expect(permissionCellTitles[2].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Litecoin'),
+  //   );
+  //   expect(permissionCellTitles[3].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Dogecoin'),
+  //   );
+  //   expect(permissionCellTitles[4].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Reddcoin'),
+  //   );
+  //   expect(permissionCellTitles[5].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Dash'),
+  //   );
+  //   expect(permissionCellTitles[6].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Peercoin'),
+  //   );
+  //   expect(permissionCellTitles[7].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Namecoin'),
+  //   );
+  //   expect(permissionCellTitles[8].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Feathercoin'),
+  //   );
+  //   expect(permissionCellTitles[9].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Counterparty'),
+  //   );
+  //   expect(permissionCellTitles[10].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Blackcoin'),
+  //   );
+  //   expect(permissionCellTitles[11].props.children).toBe(
+  //     snapGetBip44EntropyTitle('NuShares'),
+  //   );
+  //   expect(permissionCellTitles[12].props.children).toBe(
+  //     snapGetBip44EntropyTitle('NuBits'),
+  //   );
+  //   expect(permissionCellTitles[13].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Mazacoin'),
+  //   );
+  //   expect(permissionCellTitles[14].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Viacoin'),
+  //   );
+  //   expect(permissionCellTitles[15].props.children).toBe(
+  //     snapGetBip44EntropyTitle('ClearingHouse'),
+  //   );
+  //   expect(permissionCellTitles[16].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Rubycoin'),
+  //   );
+  //   expect(permissionCellTitles[17].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Groestlcoin'),
+  //   );
+  //   expect(permissionCellTitles[18].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Digitalcoin'),
+  //   );
+  //   expect(permissionCellTitles[19].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Cannacoin'),
+  //   );
+  //   expect(permissionCellTitles[20].props.children).toBe(
+  //     snapGetBip44EntropyTitle('DigiByte'),
+  //   );
+  //   expect(permissionCellTitles[21].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Open Assets'),
+  //   );
+  //   expect(permissionCellTitles[22].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Monacoin'),
+  //   );
+  //   expect(permissionCellTitles[23].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Clams'),
+  //   );
+  //   expect(permissionCellTitles[24].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Primecoin'),
+  //   );
+  //   expect(permissionCellTitles[25].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Neoscoin'),
+  //   );
+  //   expect(permissionCellTitles[26].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Jumbucks'),
+  //   );
+  //   expect(permissionCellTitles[27].props.children).toBe(
+  //     snapGetBip44EntropyTitle('ziftrCOIN'),
+  //   );
+  //   expect(permissionCellTitles[28].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Vertcoin'),
+  //   );
+  //   expect(permissionCellTitles[29].props.children).toBe(
+  //     snapGetBip44EntropyTitle('NXT'),
+  //   );
+  //   expect(permissionCellTitles[30].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Burst'),
+  //   );
+  //   expect(permissionCellTitles[31].props.children).toBe(
+  //     snapGetBip44EntropyTitle('MonetaryUnit'),
+  //   );
+  //   expect(permissionCellTitles[32].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Zoom'),
+  //   );
+  //   expect(permissionCellTitles[33].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Virtual Cash'),
+  //   );
+  //   expect(permissionCellTitles[34].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Canada eCoin'),
+  //   );
+  //   expect(permissionCellTitles[35].props.children).toBe(
+  //     snapGetBip44EntropyTitle('ShadowCash'),
+  //   );
+  //   expect(permissionCellTitles[36].props.children).toBe(
+  //     snapGetBip44EntropyTitle('ParkByte'),
+  //   );
+  //   expect(permissionCellTitles[37].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Pandacoin'),
+  //   );
+  //   expect(permissionCellTitles[38].props.children).toBe(
+  //     snapGetBip44EntropyTitle('StartCOIN'),
+  //   );
+  //   expect(permissionCellTitles[39].props.children).toBe(
+  //     snapGetBip44EntropyTitle('MOIN'),
+  //   );
+  //   expect(permissionCellTitles[40].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Expanse'),
+  //   );
+  //   expect(permissionCellTitles[41].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Einsteinium'),
+  //   );
+  //   expect(permissionCellTitles[42].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Decred'),
+  //   );
+  //   expect(permissionCellTitles[43].props.children).toBe(
+  //     snapGetBip44EntropyTitle('NEM'),
+  //   );
+  //   expect(permissionCellTitles[44].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Particl'),
+  //   );
+  //   expect(permissionCellTitles[45].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Argentum (dead)'),
+  //   );
+  //   expect(permissionCellTitles[46].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Libertas'),
+  //   );
+  //   expect(permissionCellTitles[47].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Posw coin'),
+  //   );
+  //   expect(permissionCellTitles[48].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Shreeji'),
+  //   );
+  //   expect(permissionCellTitles[49].props.children).toBe(
+  //     snapGetBip44EntropyTitle('Global Currency Reserve (GCRcoin)'),
+  //   );
+  // });
+
+  // it('renders the correct permissions titles for snap_getBip32Entropy with specified protocols', () => {
+  //   const mockPermissions: SnapPermissionsType = {
+  //     snap_getBip32Entropy: mockCurves,
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+  //   expect(permissionCellTitles.length).toBe(20);
+  //   expect(permissionCellTitles[0].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Test BIP-32 Path (ed25519)'),
+  //   );
+  //   expect(permissionCellTitles[1].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Test BIP-32 Path (secp256k1)'),
+  //   );
+  //   expect(permissionCellTitles[2].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Legacy'),
+  //   );
+  //   expect(permissionCellTitles[3].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Nested SegWit'),
+  //   );
+  //   expect(permissionCellTitles[4].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Testnet Nested SegWit'),
+  //   );
+  //   expect(permissionCellTitles[5].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Native SegWit'),
+  //   );
+  //   expect(permissionCellTitles[6].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Testnet Native SegWit'),
+  //   );
+  //   expect(permissionCellTitles[7].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Solana'),
+  //   );
+  //   expect(permissionCellTitles[8].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Litecoin'),
+  //   );
+  //   expect(permissionCellTitles[9].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Dogecoin'),
+  //   );
+  //   expect(permissionCellTitles[10].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Ethereum'),
+  //   );
+  //   expect(permissionCellTitles[11].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Atom'),
+  //   );
+  //   expect(permissionCellTitles[12].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Bitcoin Cash'),
+  //   );
+  //   expect(permissionCellTitles[13].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Binance (BNB)'),
+  //   );
+  //   expect(permissionCellTitles[14].props.children).toBe(
+  //     snapGetBip32EntropyTitle('THORChain (RUNE)'),
+  //   );
+  //   expect(permissionCellTitles[15].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Terra (LUNA)'),
+  //   );
+  //   expect(permissionCellTitles[16].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Kava'),
+  //   );
+  //   expect(permissionCellTitles[17].props.children).toBe(
+  //     snapGetBip32EntropyTitle('Secret Network'),
+  //   );
+  //   expect(permissionCellTitles[18].props.children).toBe(
+  //     snapGetBip32EntropyTitle('NEAR Protocol'),
+  //   );
+  //   expect(permissionCellTitles[19].props.children).toBe(
+  //     snapGetBip32EntropyTitle('NEAR Protocol Testnet'),
+  //   );
+  // });
+
+  // it('renders the correct default text for snap_getBip32Entropy with invalid curves', () => {
+  //   const invalidMockPermissions: SnapPermissionsType = {
+  //     snap_getBip32Entropy: [
+  //       {
+  //         path: ['m', "44'", "0'", '0'],
+  //         curve: 'secp256k1',
+  //       },
+  //       {
+  //         path: ['m', "44'", "0'", '3'],
+  //         curve: 'ed25519',
+  //       },
+  //     ],
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions
+  //       permissions={invalidMockPermissions}
+  //       installedAt={mockDate}
+  //     />,
+  //   );
+  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+  //   expect(permissionCellTitles.length).toBe(2);
+  //   expect(permissionCellTitles[0].props.children).toBe(
+  //     snapGetBip32EntropyTitle("m/44'/0'/0 (secp256k1)"),
+  //   );
+
+  //   expect(permissionCellTitles[1].props.children).toBe(
+  //     snapGetBip32EntropyTitle("m/44'/0'/3 (ed25519)"),
+  //   );
+  // });
+
+  // it('renders the correct default text for snap_getBip32PublicKey with invalid curves', () => {
+  //   const invalidMockPermissions: SnapPermissionsType = {
+  //     snap_getBip32PublicKey: [
+  //       {
+  //         path: ['m', "44'", "0'", '0'],
+  //         curve: 'secp256k1',
+  //       },
+  //       {
+  //         path: ['m', "44'", "0'", '3'],
+  //         curve: 'ed25519',
+  //       },
+  //     ],
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions
+  //       permissions={invalidMockPermissions}
+  //       installedAt={mockDate}
+  //     />,
+  //   );
+  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+  //   expect(permissionCellTitles.length).toBe(2);
+  //   expect(permissionCellTitles[0].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle("m/44'/0'/0 (secp256k1)"),
+  //   );
+
+  //   expect(permissionCellTitles[1].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle("m/44'/0'/3 (ed25519)"),
+  //   );
+  // });
+
+  // it('renders the correct permissions titles for snap_getBip32PublicKey with specified protocols', () => {
+  //   const mockPermissions: SnapPermissionsType = {
+  //     snap_getBip32PublicKey: mockCurves,
+  //   };
+  //   const { getAllByTestId } = render(
+  //     <SnapPermissions permissions={mockPermissions} installedAt={mockDate} />,
+  //   );
+  //   const permissionCellTitles = getAllByTestId(SNAP_PERMISSIONS_TITLE);
+
+  //   expect(permissionCellTitles.length).toBe(20);
+  //   expect(permissionCellTitles[0].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Test BIP-32 Path (ed25519)'),
+  //   );
+  //   expect(permissionCellTitles[1].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Test BIP-32 Path (secp256k1)'),
+  //   );
+  //   expect(permissionCellTitles[2].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Legacy'),
+  //   );
+  //   expect(permissionCellTitles[3].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Nested SegWit'),
+  //   );
+  //   expect(permissionCellTitles[4].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Testnet Nested SegWit'),
+  //   );
+  //   expect(permissionCellTitles[5].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Native SegWit'),
+  //   );
+  //   expect(permissionCellTitles[6].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Testnet Native SegWit'),
+  //   );
+  //   expect(permissionCellTitles[7].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Solana'),
+  //   );
+  //   expect(permissionCellTitles[8].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Litecoin'),
+  //   );
+  //   expect(permissionCellTitles[9].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Dogecoin'),
+  //   );
+  //   expect(permissionCellTitles[10].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Ethereum'),
+  //   );
+  //   expect(permissionCellTitles[11].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Atom'),
+  //   );
+  //   expect(permissionCellTitles[12].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Bitcoin Cash'),
+  //   );
+  //   expect(permissionCellTitles[13].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Binance (BNB)'),
+  //   );
+  //   expect(permissionCellTitles[14].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('THORChain (RUNE)'),
+  //   );
+  //   expect(permissionCellTitles[15].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Terra (LUNA)'),
+  //   );
+  //   expect(permissionCellTitles[16].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Kava'),
+  //   );
+  //   expect(permissionCellTitles[17].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('Secret Network'),
+  //   );
+  //   expect(permissionCellTitles[18].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('NEAR Protocol'),
+  //   );
+  //   expect(permissionCellTitles[19].props.children).toBe(
+  //     snapGetBip32PublicKeyTitle('NEAR Protocol Testnet'),
+  //   );
+  // });
+
+  // it('renders correctly with no permissions', () => {
+  //   const permissions = {};
+  //   const { queryByTestId } = render(
+  //     <SnapPermissions permissions={permissions} installedAt={mockDate} />,
+  //   );
+  //   expect(queryByTestId(SNAP_PERMISSION_CELL)).toBeNull();
+  // });
 });

--- a/app/core/Permissions/constants.ts
+++ b/app/core/Permissions/constants.ts
@@ -12,5 +12,5 @@ export const RestrictedMethods = Object.freeze({
   snap_getBip32Entropy: 'snap_getBip32Entropy',
   snap_getBip44Entropy: 'snap_getBip44Entropy',
   snap_getEntropy: 'snap_getEntropy',
-  'wallet_snap_*': 'wallet_snap_*',
+  wallet_snap: 'wallet_snap',
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -770,7 +770,8 @@
           "snap_getBip32PublicKey": "View your public key for {{protocol}}",
           "snap_getBip44Entropy": "Control your {{protocol}} accounts and assets",
           "snap_getEntropy": "Derive arbitrary keys unique to this snap",
-          "endowment:keyring": "endowment:keyring"
+          "endowment:keyring": "endowment:keyring",
+          "wallet_snap": "Connect to {{otherSnapName}}"
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_
- the permission controller should be the source of truth for all snaps permissions. This will become essential when dynamic permissions are enabled.

_2. What is the improvement/solution?_
- instead of passing in the raw manifest to the SnapPermissions component, this screen queries the global state for the permissions of a certain snap.
    - [Here](https://github.com/MetaMask/metamask-extension/blob/84cb4a7b629209a5f10ce0d4de8f1a4dca41425c/ui/pages/settings/snaps/view-snap/view-snap.js#L75-L77) is a reference to how extension is achieving the same result
- we then parse this in a similar way we did previously (deriving the protocol names and paths)
- moved the view logic of rendering a sap permission cell into its own separate component 
- updated the test cases

**Screenshots/Recordings**
![Simulator Screen Shot - iPhone 14 Pro - 2023-06-07 at 00 38 12](https://github.com/MetaMask/metamask-mobile/assets/22918444/c63c7b6e-c9d7-4ebb-b302-14a27c5e4759)

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/1003

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
