### PR TITLE
feat(action): remove labels after issue closed

### DIFF
--- a/.github/workflows/remove_labels_after_pr_closed.yml
+++ b/.github/workflows/remove_labels_after_pr_closed.yml
@@ -1,6 +1,8 @@
-name: Remove labels after PR closed
+name: Remove labels after issue (or PR) closed
 
 on:
+  issues:
+    types: [closed]
   pull_request:
     types: [closed]
 
@@ -12,7 +14,7 @@ jobs:
     - name: Remove labels
       env:
         REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       run: |
@@ -35,5 +37,5 @@ jobs:
           -X DELETE \
           -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/$LABEL"
+          "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/labels/$LABEL"
         done

--- a/.github/workflows/remove_labels_after_pr_closed.yml
+++ b/.github/workflows/remove_labels_after_pr_closed.yml
@@ -1,0 +1,39 @@
+name: Remove labels after PR closed
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Remove labels
+      env:
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      run: |
+        LABELS=(
+          "product-backlog"
+          "needs-design"
+          "design-in-progress"
+          "ready-for-dev"
+          "sprint-backlog"
+          "in-progress"
+          "blocked"
+          "needs-dev-review"
+          "needs-qa"
+          "issues-found"
+          "ready-for-release"
+        )
+
+        for LABEL in "${LABELS[@]}"; do
+          curl \
+          -X DELETE \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/$LABEL"
+        done


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

An existing [automation](https://github.com/MetaMask/metamask-zaps/tree/main/zaps/github-labels-automation) adds labels on Github issues when they move to a different column on Zenhub.
However these labels are not being removed when the issue is closed.

We need a Github action that removes the following labels from issue once it is closed:
- product-backlog
- needs-design
- design-in-progress
- ready-for-dev
- sprint-backlog
- in-progress
- blocked
- needs-dev-review
- needs-qa
- issues-found
- ready-for-release

**Screenshots/Recordings**

https://recordit.co/PZtLcn6Q5s

**Issue**

Closes https://github.com/MetaMask/mobile-planning/issues/1010

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
