### PR TITLE
fix: Fix header artifact when transitioning to Import screens

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -136,7 +136,7 @@ const metamask_fox = require('../../../images/fox.png'); // eslint-disable-line
 export function getTransactionsNavbarOptions(
   title,
   themeColors,
-  navigation,
+  _,
   selectedAddress,
   handleRightButtonPress,
 ) {
@@ -1027,10 +1027,9 @@ export function getNetworkNavbarOptions(
 ) {
   const innerStyles = StyleSheet.create({
     headerStyle: {
-      backgroundColor: contentOffset
-        ? themeColors.background.default
-        : themeColors.background.primary,
-      height: 105,
+      backgroundColor: themeColors.background.default,
+      shadowColor: importedColors.transparent,
+      elevation: 0,
     },
     headerShadow: {
       elevation: 2,
@@ -1584,6 +1583,7 @@ export const getSettingsNavigationOptions = (title, themeColors) => {
     },
   });
   return {
+    headerLeft: null,
     headerTitle: <Text>{title}</Text>,
     ...innerStyles,
   };


### PR DESCRIPTION
**Description**

This fix addresses an artifact that shows when navigating to both Import tokens and Import NFT screens. This same header is used when navigating to the Asset screen as well, which is responsible for the header gradient animation.

**Screenshots/Recordings**

This video shows a smooth transition to both the Import screen and Asset screen. It also shows that the gradient animation still works while scrolling on the Asset screen.

https://github.com/MetaMask/metamask-mobile/assets/10508597/6dc4acbb-e3d5-46ce-ba47-7a199a937d52


