### PR TITLE
Use `openURL` by default to open external links after user's consent

### DIFF
--- a/app/util/browser/index.ts
+++ b/app/util/browser/index.ts
@@ -125,22 +125,11 @@ export const getAlertMessage = (
 };
 
 /**
- * Promps the Operating System for its ability
- * to open an URI outside the Webview
- * Executes it when a positive response is received.
+ * Will try to open a URL with an external application
  *
  * @param url - String containing url
  * @returns Promise<any>
  */
 export const allowLinkOpen = (url: string) =>
-  Linking.canOpenURL(url)
-    .then((supported) => {
-      if (supported) {
-        return Linking.openURL(url);
-      }
-      console.warn(`Can't open url: ${url}`);
-      return null;
-    })
-    .catch((e) => {
-      console.warn(`Error opening URL: ${e}`);
-    });
+  Linking.openURL(url)
+    .catch((e) => console.warn(`Error opening URL: ${e}`));

--- a/app/util/browser/index.ts
+++ b/app/util/browser/index.ts
@@ -125,11 +125,17 @@ export const getAlertMessage = (
 };
 
 /**
- * Will try to open a URL with an external application
+ * Will try to open a URL with an external application.
+ * The new implementation of this function will not use canOpenURL()
+ * due to https://github.com/facebook/react-native/issues/25722
+ *
+ * This function is called after the user gave consent to opening an external URL.
  *
  * @param url - String containing url
- * @returns Promise<any>
+ * @returns Promise<undefined>
  */
 export const allowLinkOpen = (url: string) =>
   Linking.openURL(url)
     .catch((e) => console.warn(`Error opening URL: ${e}`));
+
+


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
**1. What is the reason for the change?**

External applications will not open because canOpenURL will throw if application scheme is not listed in LSApplicationQueriesSchemes. We are developing a product and noticed that external URLs are not being opened at all. However, this important for our use case.

- https://github.com/facebook/react-native/issues/25722

**2. What is the improvement/solution?**

After the user gave his consent, just try to open the external protocol and catch potential errors. No need to check if a scheme is supported anyway.

**Issue**
A few minutes ago, I have added this issue: https://github.com/MetaMask/metamask-mobile/issues/6563

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented

I have read the CLA Document and I hereby sign the CLA
