### PR TITLE
fix(test): Appium: remove whats new step

### DIFF
--- a/wdio/features/Accounts/AccountActions.feature
+++ b/wdio/features/Accounts/AccountActions.feature
@@ -8,7 +8,6 @@ Feature: Displaying account actions
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I open the account actions
     And I press show private key
     Then The Reveal Private key screen should be displayed

--- a/wdio/features/Accounts/CreatingWalletAccount.feature
+++ b/wdio/features/Accounts/CreatingWalletAccount.feature
@@ -8,7 +8,6 @@ Feature: Create Account
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario: Creating a new wallet account
     Given I am on the wallet view

--- a/wdio/features/Accounts/ImportingAccount.feature
+++ b/wdio/features/Accounts/ImportingAccount.feature
@@ -8,7 +8,7 @@ Feature: Import Aaccount
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
+    
 
   Scenario Outline: Import an account using an invalid private key
     Given I am on the wallet view

--- a/wdio/features/BrowserFlow/AddFavorite.feature
+++ b/wdio/features/BrowserFlow/AddFavorite.feature
@@ -10,7 +10,6 @@ Feature: Browser Add Favorite
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     And I have 1 browser tab displayed
     And I am on Home MetaMask website

--- a/wdio/features/BrowserFlow/AddressBar.feature
+++ b/wdio/features/BrowserFlow/AddressBar.feature
@@ -9,7 +9,6 @@ Feature: Browser Address Bar
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     And I have 1 browser tab displayed
     When I tap on address bar

--- a/wdio/features/BrowserFlow/ENSWebsite.feature
+++ b/wdio/features/BrowserFlow/ENSWebsite.feature
@@ -10,7 +10,6 @@ Feature: Browser ENS Website
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     And I am on Home MetaMask website
     When I navigate to "https://brunobarbieri.eth.link"

--- a/wdio/features/BrowserFlow/InvalidURL.feature
+++ b/wdio/features/BrowserFlow/InvalidURL.feature
@@ -8,7 +8,6 @@ Feature: Browser Invalid URL
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     When I navigate to "https://quackquakc.easq"
     Then I should see "Something went wrong" error title

--- a/wdio/features/BrowserFlow/NavigationControls.feature
+++ b/wdio/features/BrowserFlow/NavigationControls.feature
@@ -10,7 +10,6 @@ Feature: Browser Control Options
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     And I have 1 browser tab displayed
     And I am on Home MetaMask website

--- a/wdio/features/BrowserFlow/OptionMenu.feature
+++ b/wdio/features/BrowserFlow/OptionMenu.feature
@@ -8,7 +8,6 @@ Feature: Browser Options Menu
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario: The user navigates to the Browser screen
     When I navigate to the browser

--- a/wdio/features/BrowserFlow/PhishingDetection.feature
+++ b/wdio/features/BrowserFlow/PhishingDetection.feature
@@ -8,7 +8,6 @@ Feature: Browser Phishing Detection
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I navigate to the browser
     And I have 1 browser tab displayed
     And I am on Home MetaMask website

--- a/wdio/features/BrowserFlow/RemovingImportedAccountAfterConnectingToDapp.feature
+++ b/wdio/features/BrowserFlow/RemovingImportedAccountAfterConnectingToDapp.feature
@@ -8,7 +8,6 @@ Feature: Browser Import, Revoke, Remove Account
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario: User grants permission to a sushiswap to access one of their accounts
     When I navigate to the browser

--- a/wdio/features/BrowserFlow/RevokingSingleAccount.feature
+++ b/wdio/features/BrowserFlow/RevokingSingleAccount.feature
@@ -8,7 +8,6 @@ Feature: Browser Revoke Account dApp Permissions
         And I have imported my wallet
         And I tap No Thanks on the Enable security check screen
         And I tap No thanks on the onboarding welcome tutorial
-        And I close the Whats New modal
 
     Scenario: User grants permission to a dapp to access one of their accounts
         When I navigate to the browser

--- a/wdio/features/Confirmations/DappSendERC20.feature
+++ b/wdio/features/Confirmations/DappSendERC20.feature
@@ -3,7 +3,7 @@
 @regression
 
 Feature: Sending an ERC20 token from a dapp
-  A user should be able to send an ERC20 token from a dapp.
+  User should be able to send an ERC20 token from a dapp.
 
   Scenario: Import wallet
     Given the app displayed the splash animation
@@ -13,7 +13,6 @@ Feature: Sending an ERC20 token from a dapp
   
   Scenario: Send ERC20 token from a dapp
     Given Ganache server is started
-    And I close the Whats New modal
     And Ganache network is selected
     And ERC20 token contract is deployed
     When I navigate to the browser

--- a/wdio/features/Confirmations/SendEthEOA.feature
+++ b/wdio/features/Confirmations/SendEthEOA.feature
@@ -3,7 +3,7 @@
 @regression
 
 Feature: Sending ETH to an EOA
-  A user should be able to send ETH to another EOA address.
+  User should be able to send ETH to another EOA address.
 
   Scenario: Import wallet
     Given the app displayed the splash animation
@@ -13,7 +13,6 @@ Feature: Sending ETH to an EOA
                                                       
   Scenario Outline: Sending ETH to an EOA from inside MetaMask wallet
     Given Ganache server is started
-    And I close the Whats New modal
     And Ganache network is selected
     When On the Main Wallet view I tap "ETHER"
     And On the Main Wallet view I tap "Send"

--- a/wdio/features/Confirmations/SendEthMultisig.feature
+++ b/wdio/features/Confirmations/SendEthMultisig.feature
@@ -3,7 +3,7 @@
 @regression
 
 Feature: Sending ETH to a Multisig
-  A user should be able to send ETH to a Multisig address.
+  User should be able to send ETH to a Multisig address.
 
   Scenario: Import wallet
     Given the app displayed the splash animation
@@ -13,7 +13,6 @@ Feature: Sending ETH to a Multisig
   
   Scenario Outline: Sending ETH to a Multisig address from inside MetaMask wallet
     Given Ganache server is started
-    And I close the Whats New modal
     And Ganache network is selected
     And Multisig contract is deployed
     When On the Main Wallet view I tap "ETHER"

--- a/wdio/features/Networks/NetworkFlow.feature
+++ b/wdio/features/Networks/NetworkFlow.feature
@@ -10,7 +10,6 @@ User should also have the ability to a add custom network via the custom network
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     When I tap on the navbar network title button
     And I tap on the Add a Network button
     Then "POPULAR" tab is displayed on networks screen

--- a/wdio/features/Performance/AppLaunchTime.feature
+++ b/wdio/features/Performance/AppLaunchTime.feature
@@ -15,7 +15,6 @@ Feature: App Cold Start Launch Times
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I am on the wallet view
     When I kill the app
     And I relaunch the app

--- a/wdio/features/SecurityAndPrivacy/DeleteWallet.feature
+++ b/wdio/features/SecurityAndPrivacy/DeleteWallet.feature
@@ -8,7 +8,6 @@ Feature: Security & Privacy Delete Wallet
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario: Delete wallet from Settings
     When I tap burger icon

--- a/wdio/features/SecurityAndPrivacy/RememberMe.feature
+++ b/wdio/features/SecurityAndPrivacy/RememberMe.feature
@@ -8,7 +8,6 @@ Feature: Security & Privacy Remember Me
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     When I tap burger icon
     And I tap on "Settings" in the menu
     And In settings I tap on "Security & Privacy"

--- a/wdio/features/Settings/ChangePassword.feature
+++ b/wdio/features/Settings/ChangePassword.feature
@@ -8,7 +8,6 @@ Feature: Settings Change Password
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario: Navigate to Change Password in Settings
     When I tap burger icon

--- a/wdio/features/Wallet/AddressFlow.feature
+++ b/wdio/features/Wallet/AddressFlow.feature
@@ -11,7 +11,6 @@ Feature: Add Contacts
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And On the Main Wallet view I tap on the Send Action
 
   Scenario Outline: Validate invalid and valid wallet address <Case>

--- a/wdio/features/Wallet/ExploringWizard.feature
+++ b/wdio/features/Wallet/ExploringWizard.feature
@@ -31,7 +31,7 @@ Feature: Exploring wizard
     And there should be an explanation of the what the purpose of the search input box.
     When On the onboarding wizard I tap on "Got it" button
     Then the onboarding wizard is no longer visible
-    And I close the Whats New modal
+    
 
 # Scenario: A user should be able to tap the Skip button
 #   Given the app displayed the splash animation
@@ -47,4 +47,4 @@ Feature: Exploring wizard
 # When On the onboarding wizard I tap on "Skip" button
 # Then the onboarding wizard is no longer visible
 # And the "Skip" button is no longer visible
-# And I close the Whats New modal
+# 

--- a/wdio/features/Wallet/ImportCustomToken.feature
+++ b/wdio/features/Wallet/ImportCustomToken.feature
@@ -7,7 +7,6 @@ Feature: Import Custom Token
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario Outline: Adding AVAX testnet to my networks list
     When I tap on the navbar network title button

--- a/wdio/features/Wallet/LockResetWallet.feature
+++ b/wdio/features/Wallet/LockResetWallet.feature
@@ -8,7 +8,6 @@ Feature: Lock and Reset Wallet
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
 
   Scenario Outline: Lock Wallet
     When I tap burger icon

--- a/wdio/features/Wallet/RequestTokenFlow.feature
+++ b/wdio/features/Wallet/RequestTokenFlow.feature
@@ -10,7 +10,6 @@ This feature goes through the request token flow
     And Select "Skip" on remind secure modal
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     And I tap the remind me later button on the Protect Your Wallet Modal
     Then I am on the main wallet view
     When I tap on the navbar network title button

--- a/wdio/features/Wallet/SendToken.feature
+++ b/wdio/features/Wallet/SendToken.feature
@@ -8,7 +8,6 @@ Feature: Sending Native and ERC Tokens
     And I have imported my wallet
     And I tap No Thanks on the Enable security check screen
     And I tap No thanks on the onboarding welcome tutorial
-    And I close the Whats New modal
     Then I am on the wallet view
 
   Scenario Outline: Import ChainLink Token


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Removed steps to close what's new modal from feature files since the modal has been removed in 7.0.1.  Will keep the step in the step file to be reused when What's new is utilized again.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
