### PR TITLE
fix: Nonce too low error on Approve ERC20 and ERC721 transactions

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -420,6 +420,8 @@ class ApproveTransactionReview extends PureComponent {
           : '0',
     });
 
+    delete transaction.proposedNonce;
+    delete transaction.nonce;
     setTransactionObject({
       transaction: {
         ...transaction,

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -321,8 +321,7 @@ class ApproveTransactionReview extends PureComponent {
   componentDidMount = async () => {
     const { chainId } = this.props;
     const {
-      transaction: { origin, to, data, from },
-      transaction,
+      transaction: { origin, to, data, from, transaction },
       setTransactionObject,
       tokenList,
       tokenAllowanceState,
@@ -420,8 +419,6 @@ class ApproveTransactionReview extends PureComponent {
           : '0',
     });
 
-    delete transaction.proposedNonce;
-    delete transaction.nonce;
     setTransactionObject({
       transaction: {
         ...transaction,

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -502,7 +502,7 @@ export function addAccountTimeFlagFilter(
 
 export function getNormalizedTxState(state) {
   return state.transaction
-    ? { ...state.transaction.transaction, ...state.transaction }
+    ? { ...state.transaction, ...state.transaction.transaction }
     : undefined;
 }
 

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -502,7 +502,7 @@ export function addAccountTimeFlagFilter(
 
 export function getNormalizedTxState(state) {
   return state.transaction
-    ? { ...state.transaction, ...state.transaction.transaction }
+    ? { ...state.transaction.transaction, ...state.transaction }
     : undefined;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Approve Nonce issue was previously fixed in [Nonce Too Low for Approve Transaction](https://github.com/MetaMask/metamask-mobile/pull/5718/), but [Custom Spend Allowance](https://github.com/MetaMask/metamask-mobile/pull/5591) reintroduced the similar bug by repopulating the transaction proposed nonce (already used nonce value) when component mounts.  

**Screenshots/Recordings**

https://github.com/MetaMask/metamask-mobile/assets/29962968/8a862f59-7967-455b-bfa4-07fee3c9e169


_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6537 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
