### PR TITLE
fix: Hold to reveal Spanish copy

### DIFF
--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -807,7 +807,7 @@
     "seed_warning": "Esta es la frase de 12 palabras de su cartera. Esta frase se puede usar para controlar todas sus cuentas actuales y futuras, incluida la capacidad de transferir sus fondos. Guarde esta frase en un lugar seguro y NO la comparta con nadie.",
     "text": "TEXTO",
     "qr_code": "CÓDIGO QR",
-    "hold_to_reveal_credential": "No revele su {{credentialName}}",
+    "hold_to_reveal_credential": "Mantén presionado para revelar su {{credentialName}}",
     "keep_credential_safe": "Proteja su {{credentialName}}",
     "srp_abbreviation_text": "SRP",
     "srp_text": "Frase secreta de recuperación",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions,_
_1. What is the reason for the change?_

Bug on the Spanish copy for the "Reveal SRP" screen.

_2. What is the improvement/solution?_

Fix the copy. Change `No revele...` to `Mantén presionado...`

**Screenshots/Recordings**

<img src='https://github.com/MetaMask/metamask-mobile/assets/17601467/a1c1b812-d388-4d35-a4e4-5847e5b6b5cc' width='350' />

<img src='https://github.com/MetaMask/metamask-mobile/assets/17601467/fd8f4b31-6e9b-4219-a802-021fb7cba65f' width='350' />


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
