### PR TITLE
fix: Approving an ERC20 token with an amount with more decimals than expected crashes approving

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.constants.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.constants.ts
@@ -1,3 +1,3 @@
-const CUSTOM_INPUT_TEST_ID = 'custom-input-test-id';
-
-export default CUSTOM_INPUT_TEST_ID;
+export const CUSTOM_INPUT_TEST_ID = 'custom-input-test-id';
+export const CUSTOM_INPUT_MAX_TEXT_ID = 'custom-input-max-text-id';
+export const CUSTOM_INPUT_INPUT_ID = 'custom-input-input-id';

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.constants.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.constants.ts
@@ -1,3 +1,4 @@
-export const CUSTOM_INPUT_TEST_ID = 'custom-input-test-id';
-export const CUSTOM_INPUT_MAX_TEXT_ID = 'custom-input-max-text-id';
-export const CUSTOM_INPUT_INPUT_ID = 'custom-input-input-id';
+export const CUSTOM_SPEND_CAP_INPUT_TEST_ID = 'custom-spend-cap-input-test-id';
+export const CUSTOM_SPEND_CAP_MAX_TEST_ID = 'custom-spend-cap-max-test-id';
+export const CUSTOM_SPEND_CAP_INPUT_INPUT_ID =
+  'custom-spend-cap-input-input-id';

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.test.tsx
@@ -6,6 +6,10 @@ import React from 'react';
 import { TICKER } from '../CustomSpendCap.constants';
 // Internal dependencies.
 import CustomInput from './CustomInput';
+import {
+  CUSTOM_INPUT_INPUT_ID,
+  CUSTOM_INPUT_MAX_TEXT_ID,
+} from './CustomInput.constants';
 import { CustomInputProps } from './CustomInput.types';
 
 describe('CustomInput', () => {
@@ -19,6 +23,7 @@ describe('CustomInput', () => {
       isEditDisabled: false,
       setMaxSelected: jest.fn(),
       setValue: jest.fn(),
+      tokenDecimal: 4,
     };
   });
 
@@ -27,5 +32,29 @@ describe('CustomInput', () => {
   it('should render correctly', () => {
     const component = renderComponent();
     expect(component).toMatchSnapshot();
+  });
+
+  it('should call setMaxSelected when max button is pressed', () => {
+    const component = renderComponent();
+    component
+      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_MAX_TEXT_ID)
+      .simulate('press');
+    expect(props.setMaxSelected).toHaveBeenCalled();
+  });
+
+  it('should update value if input is decimal and decimal points are less than or equal to tokenDecimal', () => {
+    const component = renderComponent();
+    component
+      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_INPUT_ID)
+      .simulate('changeText', '123.1234');
+    expect(props.setValue).toHaveBeenCalledWith('123.1234');
+  });
+
+  it('should not update value if input is decimal and decimal points are greater than tokenDecimal', () => {
+    const component = renderComponent();
+    component
+      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_INPUT_ID)
+      .simulate('changeText', '123.1234567');
+    expect(props.setValue).not.toHaveBeenCalled();
   });
 });

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.test.tsx
@@ -7,8 +7,8 @@ import { TICKER } from '../CustomSpendCap.constants';
 // Internal dependencies.
 import CustomInput from './CustomInput';
 import {
-  CUSTOM_INPUT_INPUT_ID,
-  CUSTOM_INPUT_MAX_TEXT_ID,
+  CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+  CUSTOM_SPEND_CAP_MAX_TEST_ID,
 } from './CustomInput.constants';
 import { CustomInputProps } from './CustomInput.types';
 
@@ -37,15 +37,27 @@ describe('CustomInput', () => {
   it('should call setMaxSelected when max button is pressed', () => {
     const component = renderComponent();
     component
-      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_MAX_TEXT_ID)
+      .findWhere((node) => node.prop('testID') === CUSTOM_SPEND_CAP_MAX_TEST_ID)
       .simulate('press');
     expect(props.setMaxSelected).toHaveBeenCalled();
+  });
+
+  it('should update value if input is integer', () => {
+    const component = renderComponent();
+    component
+      .findWhere(
+        (node) => node.prop('testID') === CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+      )
+      .simulate('changeText', '123');
+    expect(props.setValue).toHaveBeenCalledWith('123');
   });
 
   it('should update value if input is decimal and decimal points are less than or equal to tokenDecimal', () => {
     const component = renderComponent();
     component
-      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_INPUT_ID)
+      .findWhere(
+        (node) => node.prop('testID') === CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+      )
       .simulate('changeText', '123.1234');
     expect(props.setValue).toHaveBeenCalledWith('123.1234');
   });
@@ -53,7 +65,9 @@ describe('CustomInput', () => {
   it('should not update value if input is decimal and decimal points are greater than tokenDecimal', () => {
     const component = renderComponent();
     component
-      .findWhere((node) => node.prop('testID') === CUSTOM_INPUT_INPUT_ID)
+      .findWhere(
+        (node) => node.prop('testID') === CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+      )
       .simulate('changeText', '123.1234567');
     expect(props.setValue).not.toHaveBeenCalled();
   });

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -9,7 +9,9 @@ import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
 import {
-    CUSTOM_SPEND_CAP_INPUT_INPUT_ID, CUSTOM_SPEND_CAP_INPUT_TEST_ID, CUSTOM_SPEND_CAP_MAX_TEST_ID
+  CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+  CUSTOM_SPEND_CAP_INPUT_TEST_ID,
+  CUSTOM_SPEND_CAP_MAX_TEST_ID,
 } from './CustomInput.constants';
 import stylesheet from './CustomInput.styles';
 // Internal dependencies.

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -9,7 +9,7 @@ import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
 import {
-    CUSTOM_INPUT_INPUT_ID, CUSTOM_INPUT_MAX_TEXT_ID, CUSTOM_INPUT_TEST_ID
+    CUSTOM_SPEND_CAP_INPUT_INPUT_ID, CUSTOM_SPEND_CAP_INPUT_TEST_ID, CUSTOM_SPEND_CAP_MAX_TEST_ID
 } from './CustomInput.constants';
 import stylesheet from './CustomInput.styles';
 // Internal dependencies.
@@ -59,12 +59,12 @@ const CustomInput = ({
           backgroundColor: colors.background.alternative,
         },
       ]}
-      testID={CUSTOM_INPUT_TEST_ID}
+      testID={CUSTOM_SPEND_CAP_INPUT_TEST_ID}
     >
       <View style={styles.body}>
         {!isEditDisabled ? (
           <TextInput
-            testID={CUSTOM_INPUT_INPUT_ID}
+            testID={CUSTOM_SPEND_CAP_INPUT_INPUT_ID}
             multiline
             onChangeText={onChangeValueText}
             value={value}
@@ -85,7 +85,7 @@ const CustomInput = ({
       </View>
       {!isEditDisabled && (
         <Text
-          testID={CUSTOM_INPUT_MAX_TEXT_ID}
+          testID={CUSTOM_SPEND_CAP_MAX_TEST_ID}
           variant={TextVariant.BodySM}
           style={styles.maxValueText}
           onPress={handleMaxPress}

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -4,6 +4,7 @@ import { TextInput, View } from 'react-native';
 
 import { strings } from '../../../../../locales/i18n';
 import formatNumber from '../../../../util/formatNumber';
+import { dotAndCommaDecimalFormatter } from '../../../../util/number';
 import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
@@ -21,7 +22,7 @@ const CustomInput = ({
   isEditDisabled,
 }: CustomInputProps) => {
   const handleUpdate = (text: string) => {
-    setValue(text);
+    setValue(dotAndCommaDecimalFormatter(text));
   };
 
   const handleMaxPress = () => {

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -8,7 +8,9 @@ import { dotAndCommaDecimalFormatter } from '../../../../util/number';
 import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
-import CUSTOM_INPUT_TEST_ID from './CustomInput.constants';
+import {
+    CUSTOM_INPUT_INPUT_ID, CUSTOM_INPUT_MAX_TEXT_ID, CUSTOM_INPUT_TEST_ID
+} from './CustomInput.constants';
 import stylesheet from './CustomInput.styles';
 // Internal dependencies.
 import { CustomInputProps } from './CustomInput.types';
@@ -20,8 +22,16 @@ const CustomInput = ({
   isInputGreaterThanBalance,
   setValue,
   isEditDisabled,
+  tokenDecimal,
 }: CustomInputProps) => {
   const handleUpdate = (text: string) => {
+    const decimalIndex = text.indexOf('.');
+    const decimalPoints = text.substring(decimalIndex + 1).length;
+
+    if (decimalIndex !== -1 && decimalPoints > Number(tokenDecimal)) {
+      return;
+    }
+
     setValue(dotAndCommaDecimalFormatter(text));
   };
 
@@ -54,6 +64,7 @@ const CustomInput = ({
       <View style={styles.body}>
         {!isEditDisabled ? (
           <TextInput
+            testID={CUSTOM_INPUT_INPUT_ID}
             multiline
             onChangeText={onChangeValueText}
             value={value}
@@ -74,6 +85,7 @@ const CustomInput = ({
       </View>
       {!isEditDisabled && (
         <Text
+          testID={CUSTOM_INPUT_MAX_TEXT_ID}
           variant={TextVariant.BodySM}
           style={styles.maxValueText}
           onPress={handleMaxPress}

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -26,9 +26,9 @@ const CustomInput = ({
 }: CustomInputProps) => {
   const handleUpdate = (text: string) => {
     const decimalIndex = text.indexOf('.');
-    const decimalPoints = text.substring(decimalIndex + 1).length;
+    const fractionalLength = text.substring(decimalIndex + 1).length;
 
-    if (decimalIndex !== -1 && decimalPoints > Number(tokenDecimal)) {
+    if (decimalIndex !== -1 && fractionalLength > Number(tokenDecimal)) {
       return;
     }
 

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.types.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.types.ts
@@ -25,4 +25,5 @@ export interface CustomInputProps {
    * Boolean to disable edit
    */
   isEditDisabled: boolean;
+  tokenDecimal?: number;
 }

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/__snapshots__/CustomInput.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/__snapshots__/CustomInput.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`CustomInput should render correctly 1`] = `
       false,
     ]
   }
-  testID="custom-input-test-id"
+  testID="custom-spend-cap-input-test-id"
 >
   <View
     style={
@@ -47,7 +47,7 @@ exports[`CustomInput should render correctly 1`] = `
           false,
         ]
       }
-      testID="custom-input-input-id"
+      testID="custom-spend-cap-input-input-id"
       value="123"
     />
   </View>
@@ -58,7 +58,7 @@ exports[`CustomInput should render correctly 1`] = `
         "color": "#535A61",
       }
     }
-    testID="custom-input-max-text-id"
+    testID="custom-spend-cap-max-test-id"
     variant="sBodySM"
   >
     Max

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/__snapshots__/CustomInput.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/__snapshots__/CustomInput.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`CustomInput should render correctly 1`] = `
           false,
         ]
       }
+      testID="custom-input-input-id"
       value="123"
     />
   </View>
@@ -57,6 +58,7 @@ exports[`CustomInput should render correctly 1`] = `
         "color": "#535A61",
       }
     }
+    testID="custom-input-max-text-id"
     variant="sBodySM"
   >
     Max

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -5,12 +5,8 @@ import React from 'react';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import CustomSpendCap from './CustomSpendCap';
 import {
-  ACCOUNT_BALANCE,
-  CUSTOM_SPEND_CAP_TEST_ID,
-  DAPP_DOMAIN,
-  DAPP_PROPOSED_VALUE,
-  INPUT_VALUE_CHANGED,
-  TICKER,
+    ACCOUNT_BALANCE, CUSTOM_SPEND_CAP_TEST_ID, DAPP_DOMAIN, DAPP_PROPOSED_VALUE,
+    INPUT_VALUE_CHANGED, TICKER
 } from './CustomSpendCap.constants';
 // Internal dependencies.
 import { CustomSpendCapProps } from './CustomSpendCap.types';
@@ -30,6 +26,7 @@ function RenderCustomSpendCap(
       editValue={() => ({})}
       tokenSpendValue={tokenSpendValue}
       isInputValid={isInputValid}
+      tokenDecimal={18}
     />
   );
 }

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -5,8 +5,12 @@ import React from 'react';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import CustomSpendCap from './CustomSpendCap';
 import {
-    ACCOUNT_BALANCE, CUSTOM_SPEND_CAP_TEST_ID, DAPP_DOMAIN, DAPP_PROPOSED_VALUE,
-    INPUT_VALUE_CHANGED, TICKER
+  ACCOUNT_BALANCE,
+  CUSTOM_SPEND_CAP_TEST_ID,
+  DAPP_DOMAIN,
+  DAPP_PROPOSED_VALUE,
+  INPUT_VALUE_CHANGED,
+  TICKER,
 } from './CustomSpendCap.constants';
 // Internal dependencies.
 import { CustomSpendCapProps } from './CustomSpendCap.types';

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -28,6 +28,7 @@ const CustomSpendCap = ({
   editValue,
   tokenSpendValue,
   isInputValid,
+  tokenDecimal,
 }: CustomSpendCapProps) => {
   const {
     styles,
@@ -218,6 +219,7 @@ const CustomSpendCap = ({
           setMaxSelected={setMaxSelected}
           value={value}
           isEditDisabled={isEditDisabled}
+          tokenDecimal={tokenDecimal}
         />
       </View>
       {value.length > 0 && inputHasError && (

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
@@ -24,7 +24,7 @@ export interface CustomSpendCapProps {
    * isInputValid - function to check if input is valid and has no errors
    */
   isInputValid: (value: boolean) => boolean;
-    /**
+  /**
    * tokenDecimal - token decimal number
    */
   tokenDecimal?: number;

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
@@ -24,4 +24,8 @@ export interface CustomSpendCapProps {
    * isInputValid - function to check if input is valid and has no errors
    */
   isInputValid: (value: boolean) => boolean;
+    /**
+   * tokenDecimal - token decimal number
+   */
+  tokenDecimal?: number;
 }

--- a/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
               false,
             ]
           }
+          testID="custom-input-input-id"
           value=""
         />
       </View>
@@ -155,6 +156,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
             "lineHeight": 20,
           }
         }
+        testID="custom-input-max-text-id"
       >
         Max
       </Text>

--- a/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
           false,
         ]
       }
-      testID="custom-input-test-id"
+      testID="custom-spend-cap-input-test-id"
     >
       <View
         style={
@@ -140,7 +140,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
               false,
             ]
           }
-          testID="custom-input-input-id"
+          testID="custom-spend-cap-input-input-id"
           value=""
         />
       </View>
@@ -156,7 +156,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
             "lineHeight": 20,
           }
         }
-        testID="custom-input-max-text-id"
+        testID="custom-spend-cap-max-test-id"
       >
         Max
       </Text>

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -24,6 +24,7 @@ import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { hexToBN } from '@metamask/controller-utils';
 import {
   fromTokenMinimalUnit,
+  isNumber,
   renderFromTokenMinimalUnit,
 } from '../../../util/number';
 import {
@@ -867,11 +868,13 @@ class ApproveTransactionReview extends PureComponent {
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}
                           isInputValid={this.customSpendInputValid}
-                          onInputChanged={(value) =>
-                            this.setState({
-                              tokenSpendValue: value.replace(/[^0-9.]/g, ''),
-                            })
-                          }
+                          onInputChanged={(value) => {
+                            if (isNumber(value)) {
+                              this.setState({
+                                tokenSpendValue: value.replace(/[^0-9.]/g, ''),
+                              });
+                            }
+                          }}
                         />
                       )
                     )}

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -864,6 +864,7 @@ class ApproveTransactionReview extends PureComponent {
                           dappProposedValue={originalApproveAmount}
                           tokenSpendValue={tokenSpendValue}
                           accountBalance={tokenBalance}
+                          tokenDecimal={tokenDecimals}
                           domain={host}
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -361,6 +361,14 @@ export function isNumber(str) {
   return /^(\d+(\.\d+)?)$/.test(str);
 }
 
+export const dotAndCommaDecimalFormatter = (value) => {
+  const valueStr = String(value);
+
+  const formattedValue = valueStr.replace(',', '.');
+
+  return formattedValue;
+};
+
 /**
  * Determines whether the given number is going to be
  * displalyed in scientific notation after being converted to a string.

--- a/app/util/number/index.test.ts
+++ b/app/util/number/index.test.ts
@@ -1,36 +1,38 @@
 import { BN } from 'ethereumjs-util';
+
 import {
+  addCurrencySymbol,
+  balanceToFiat,
+  balanceToFiatNumber,
   BNToHex,
-  fromWei,
+  calcTokenValueToSend,
+  calculateEthFeeForMultiLayer,
+  dotAndCommaDecimalFormatter,
+  fastSplit,
+  fiatNumberToTokenMinimalUnit,
+  fiatNumberToWei,
   fromTokenMinimalUnit,
   fromTokenMinimalUnitString,
-  toTokenMinimalUnit,
-  renderFromTokenMinimalUnit,
-  renderFromWei,
-  calcTokenValueToSend,
+  fromWei,
+  handleWeiNumber,
   hexToBN,
   isBN,
   isDecimal,
+  isNumber,
+  isNumberScientificNotationWhenString,
+  isZeroValue,
+  limitToMaximumDecimalPlaces,
+  renderFiat,
+  renderFromTokenMinimalUnit,
+  renderFromWei,
+  safeNumberToBN,
+  toBN,
+  toHexadecimal,
+  toTokenMinimalUnit,
   toWei,
   weiToFiat,
   weiToFiatNumber,
-  fiatNumberToWei,
-  fiatNumberToTokenMinimalUnit,
-  balanceToFiat,
-  balanceToFiatNumber,
-  renderFiat,
-  handleWeiNumber,
-  toHexadecimal,
-  safeNumberToBN,
-  fastSplit,
-  isNumber,
-  isNumberScientificNotationWhenString,
-  calculateEthFeeForMultiLayer,
-  limitToMaximumDecimalPlaces,
-  isZeroValue,
-  toBN,
-  addCurrencySymbol,
-} from '.';
+} from './';
 
 describe('Number utils :: BNToHex', () => {
   it('BNToHex', () => {
@@ -725,6 +727,18 @@ describe('Number utils :: isNumber', () => {
     expect(isNumber('.01')).toBe(false);
     expect(isNumber(undefined)).toBe(false);
     expect(isNumber(null)).toBe(false);
+  });
+});
+
+describe('Number utils :: dotAndCommaDecimalFormatter', () => {
+  it('should return the number if it does not contain a dot or comma', () => {
+    expect(dotAndCommaDecimalFormatter('1650')).toBe('1650');
+  });
+  it('should return the number if it contains a dot', () => {
+    expect(dotAndCommaDecimalFormatter('1650.7')).toBe('1650.7');
+  });
+  it('should replace the comma with a decimal with a comma if it contains a dot', () => {
+    expect(dotAndCommaDecimalFormatter('1650,7')).toBe('1650.7');
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
The fix for [[Bug] Approving an ERC20 token with an amount with more decimals than expected, results in nothing](https://github.com/MetaMask/metamask-mobile/issues/6408) in the updated flow is to prevent accepting decimal values more than the token decimal. Also mirroring the extension [here](https://github.com/MetaMask/metamask-mobile/issues/6408#issuecomment-1551458905)

**Screenshots/Recordings**
Before:

https://github.com/MetaMask/metamask-mobile/assets/29962968/82dc18f6-d03d-4a67-8d37-0c861fa32abe


Before with Token Spend Cap:

https://github.com/MetaMask/metamask-mobile/assets/29962968/f7b889e3-1452-4bab-ad1a-708683d2230b


After:

https://github.com/MetaMask/metamask-mobile/assets/29962968/26d55fca-298f-49ef-a019-a8cef1cba2f8

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6408 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
