### PR TITLE
fix: Disable next button if input is invalid for token approval

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -15,7 +15,10 @@ import {
 // Internal dependencies.
 import { CustomSpendCapProps } from './CustomSpendCap.types';
 
-function RenderCustomSpendCap(tokenSpendValue: string) {
+function RenderCustomSpendCap(
+  tokenSpendValue: string,
+  isInputValid: () => boolean = () => true,
+) {
   return (
     <CustomSpendCap
       ticker={TICKER}
@@ -26,9 +29,12 @@ function RenderCustomSpendCap(tokenSpendValue: string) {
       isEditDisabled={false}
       editValue={() => ({})}
       tokenSpendValue={tokenSpendValue}
+      isInputValid={isInputValid}
     />
   );
 }
+
+const isInputValid = jest.fn();
 
 describe('CustomSpendCap', () => {
   it('should render CustomSpendCap', () => {
@@ -82,5 +88,19 @@ describe('CustomSpendCap', () => {
     );
 
     expect(JSON.stringify(toJSON())).toMatch(`${valueDifference} ${TICKER}`);
+  });
+
+  it('should call isInputValid with false if value is not a number', async () => {
+    const notANumber = 'abc';
+    renderWithProvider(RenderCustomSpendCap(notANumber, isInputValid));
+
+    expect(isInputValid).toHaveBeenCalledWith(false);
+  });
+
+  it('should call isInputValid with true if value is a number', async () => {
+    const validNumber = '100';
+    renderWithProvider(RenderCustomSpendCap(validNumber, isInputValid));
+
+    expect(isInputValid).toHaveBeenCalledWith(true);
   });
 });

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -27,6 +27,7 @@ const CustomSpendCap = ({
   isEditDisabled,
   editValue,
   tokenSpendValue,
+  isInputValid,
 }: CustomSpendCapProps) => {
   const {
     styles,
@@ -52,6 +53,10 @@ const CustomSpendCap = ({
 
     onInputChanged(value);
   }, [value, onInputChanged]);
+
+  useEffect(() => {
+    isInputValid(!inputHasError);
+  }, [inputHasError, isInputValid]);
 
   const handleDefaultValue = () => {
     setMaxSelected(false);

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
@@ -20,4 +20,8 @@ export interface CustomSpendCapProps {
    * token spend value - The value of the input field
    */
   tokenSpendValue: string;
+  /**
+   * isInputValid - function to check if input is valid and has no errors
+   */
+  isInputValid: (value: boolean) => boolean;
 }

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -285,6 +285,7 @@ class ApproveTransactionReview extends PureComponent {
     fetchingUpdateDone: false,
     showBlockExplorerModal: false,
     address: '',
+    isCustomSpendInputValid: false,
   };
 
   customSpendLimitInput = React.createRef();
@@ -651,6 +652,10 @@ class ApproveTransactionReview extends PureComponent {
 
   goToSpendCap = () => this.setState({ isReadyToApprove: false });
 
+  customSpendInputValid = (value) => {
+    this.setState({ isCustomSpendInputValid: value });
+  };
+
   renderDetails = () => {
     const {
       originalApproveAmount,
@@ -668,6 +673,7 @@ class ApproveTransactionReview extends PureComponent {
       tokenSpendValue,
       fetchingUpdateDone,
       isReadyToApprove,
+      isCustomSpendInputValid,
     } = this.state;
 
     const {
@@ -730,6 +736,7 @@ class ApproveTransactionReview extends PureComponent {
       isFirstScreenERC20 ||
       Boolean(gasError) ||
       transactionConfirmed ||
+      !isCustomSpendInputValid ||
       (isFinalScreenNonERC20 && !isGasEstimateStatusIn);
 
     const confirmText =
@@ -859,6 +866,7 @@ class ApproveTransactionReview extends PureComponent {
                           domain={host}
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}
+                          isInputValid={this.customSpendInputValid}
                           onInputChanged={(value) =>
                             this.setState({
                               tokenSpendValue: value.replace(/[^0-9.]/g, ''),


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
When approving an erc20 token, if input has an error, disable next button. Ideally, this might not happen for most devices as the keyboard is set to numeric, however some android devices might still display alphabets.

**Screenshots/Recordings**
Before:

https://github.com/MetaMask/metamask-mobile/assets/29962968/2af363ff-b56b-4bd7-b3ed-1af70c78e865

After

https://github.com/MetaMask/metamask-mobile/assets/29962968/9996565f-bc82-41b0-9337-cb56cac9a284


_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6635 

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
