### PR TITLE
fix: Support Decimal Comma for Token Custom Spend Cap

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -4,6 +4,7 @@ import { TextInput, View } from 'react-native';
 
 import { strings } from '../../../../../locales/i18n';
 import formatNumber from '../../../../util/formatNumber';
+import { dotAndCommaDecimalFormatter } from '../../../../util/number';
 import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
@@ -21,7 +22,7 @@ const CustomInput = ({
   isEditDisabled,
 }: CustomInputProps) => {
   const handleUpdate = (text: string) => {
-    setValue(text);
+    setValue(dotAndCommaDecimalFormatter(text));
   };
 
   const handleMaxPress = () => {

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -24,6 +24,7 @@ import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { hexToBN } from '@metamask/controller-utils';
 import {
   fromTokenMinimalUnit,
+  isNumber,
   renderFromTokenMinimalUnit,
 } from '../../../util/number';
 import {
@@ -867,11 +868,13 @@ class ApproveTransactionReview extends PureComponent {
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}
                           isInputValid={this.customSpendInputValid}
-                          onInputChanged={(value) =>
-                            this.setState({
-                              tokenSpendValue: value.replace(/[^0-9.]/g, ''),
-                            })
-                          }
+                          onInputChanged={(value) => {
+                            if (isNumber(value)) {
+                              this.setState({
+                                tokenSpendValue: value.replace(/[^0-9.]/g, ''),
+                              });
+                            }
+                          }}
                         />
                       )
                     )}

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -361,6 +361,14 @@ export function isNumber(str) {
   return /^(\d+(\.\d+)?)$/.test(str);
 }
 
+export const dotAndCommaDecimalFormatter = (value) => {
+  const valueStr = String(value);
+
+  const formattedValue = valueStr.replace(',', '.');
+
+  return formattedValue;
+};
+
 /**
  * Determines whether the given number is going to be
  * displalyed in scientific notation after being converted to a string.

--- a/app/util/number/index.test.ts
+++ b/app/util/number/index.test.ts
@@ -1,36 +1,38 @@
 import { BN } from 'ethereumjs-util';
+
 import {
+  addCurrencySymbol,
+  balanceToFiat,
+  balanceToFiatNumber,
   BNToHex,
-  fromWei,
+  calcTokenValueToSend,
+  calculateEthFeeForMultiLayer,
+  dotAndCommaDecimalFormatter,
+  fastSplit,
+  fiatNumberToTokenMinimalUnit,
+  fiatNumberToWei,
   fromTokenMinimalUnit,
   fromTokenMinimalUnitString,
-  toTokenMinimalUnit,
-  renderFromTokenMinimalUnit,
-  renderFromWei,
-  calcTokenValueToSend,
+  fromWei,
+  handleWeiNumber,
   hexToBN,
   isBN,
   isDecimal,
+  isNumber,
+  isNumberScientificNotationWhenString,
+  isZeroValue,
+  limitToMaximumDecimalPlaces,
+  renderFiat,
+  renderFromTokenMinimalUnit,
+  renderFromWei,
+  safeNumberToBN,
+  toBN,
+  toHexadecimal,
+  toTokenMinimalUnit,
   toWei,
   weiToFiat,
   weiToFiatNumber,
-  fiatNumberToWei,
-  fiatNumberToTokenMinimalUnit,
-  balanceToFiat,
-  balanceToFiatNumber,
-  renderFiat,
-  handleWeiNumber,
-  toHexadecimal,
-  safeNumberToBN,
-  fastSplit,
-  isNumber,
-  isNumberScientificNotationWhenString,
-  calculateEthFeeForMultiLayer,
-  limitToMaximumDecimalPlaces,
-  isZeroValue,
-  toBN,
-  addCurrencySymbol,
-} from '.';
+} from './';
 
 describe('Number utils :: BNToHex', () => {
   it('BNToHex', () => {
@@ -725,6 +727,18 @@ describe('Number utils :: isNumber', () => {
     expect(isNumber('.01')).toBe(false);
     expect(isNumber(undefined)).toBe(false);
     expect(isNumber(null)).toBe(false);
+  });
+});
+
+describe('Number utils :: dotAndCommaDecimalFormatter', () => {
+  it('should return the number if it does not contain a dot or comma', () => {
+    expect(dotAndCommaDecimalFormatter('1650')).toBe('1650');
+  });
+  it('should return the number if it contains a dot', () => {
+    expect(dotAndCommaDecimalFormatter('1650.7')).toBe('1650.7');
+  });
+  it('should replace the comma with a decimal with a comma if it contains a dot', () => {
+    expect(dotAndCommaDecimalFormatter('1650,7')).toBe('1650.7');
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Approving ERC20 token doesn't support decimal comma numbers. Context: [Decimal Separators](https://www.smartick.com/blog/other-contents/curiosities/decimal-separators/)

**Screenshots/Recordings**
Before: 

https://github.com/MetaMask/metamask-mobile/assets/29962968/0ab63c2d-a26b-4d9a-ada5-4a0980c5c60a

After:

https://github.com/MetaMask/metamask-mobile/assets/29962968/37d648a3-74dc-4ee7-817e-0c5a2130a5a3

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
