### PR TITLE
fix: Support Decimal Comma for Token Custom Spend Cap (#6637)

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -9,7 +9,9 @@ import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
 import {
-    CUSTOM_SPEND_CAP_INPUT_INPUT_ID, CUSTOM_SPEND_CAP_INPUT_TEST_ID, CUSTOM_SPEND_CAP_MAX_TEST_ID
+  CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
+  CUSTOM_SPEND_CAP_INPUT_TEST_ID,
+  CUSTOM_SPEND_CAP_MAX_TEST_ID,
 } from './CustomInput.constants';
 import stylesheet from './CustomInput.styles';
 // Internal dependencies.

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -9,9 +9,7 @@ import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';
 import {
-  CUSTOM_SPEND_CAP_INPUT_INPUT_ID,
-  CUSTOM_SPEND_CAP_INPUT_TEST_ID,
-  CUSTOM_SPEND_CAP_MAX_TEST_ID,
+    CUSTOM_SPEND_CAP_INPUT_INPUT_ID, CUSTOM_SPEND_CAP_INPUT_TEST_ID, CUSTOM_SPEND_CAP_MAX_TEST_ID
 } from './CustomInput.constants';
 import stylesheet from './CustomInput.styles';
 // Internal dependencies.

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -664,6 +664,14 @@ class ApproveTransactionReview extends PureComponent {
     });
   };
 
+  handleCustomSpendOnInputChange = (value) => {
+    if (isNumber(value)) {
+      this.setState({
+        tokenSpendValue: value.replace(/[^0-9.]/g, ''),
+      });
+    }
+  };
+
   renderDetails = () => {
     const {
       originalApproveAmount,
@@ -872,13 +880,7 @@ class ApproveTransactionReview extends PureComponent {
                           toggleLearnMoreWebPage={this.toggleLearnMoreWebPage}
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}
-                          onInputChanged={(value) => {
-                            if (isNumber(value)) {
-                              this.setState({
-                                tokenSpendValue: value.replace(/[^0-9.]/g, ''),
-                              });
-                            }
-                          }}
+                          onInputChanged={this.handleCustomSpendOnInputChange}
                           isInputValid={this.handleSetIsCustomSpendInputValid}
                         />
                       )


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Approving ERC20 token doesn't support decimal comma numbers. Context: [Decimal Separators](https://www.smartick.com/blog/other-contents/curiosities/decimal-separators/)

**Screenshots/Recordings**
Before: 

https://github.com/MetaMask/metamask-mobile/assets/29962968/0ab63c2d-a26b-4d9a-ada5-4a0980c5c60a

After:

https://github.com/MetaMask/metamask-mobile/assets/29962968/37d648a3-74dc-4ee7-817e-0c5a2130a5a3

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
