### PR TITLE
refactor: Remove dead network controller code

### DIFF
--- a/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
+++ b/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
@@ -55,12 +55,6 @@ const ApproveTransactionHeader = ({
     (state: any) =>
       state.engine.backgroundState.PreferencesController.identities,
   );
-
-  const network = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.NetworkController.providerConfig,
-  );
-
   const activeAddress = toChecksumAddress(from);
 
   const networkProvider = useSelector(selectProviderConfig);
@@ -87,7 +81,7 @@ const ApproveTransactionHeader = ({
     setIsOriginDeepLink(isOriginDeepLinkVal);
     setIsOriginWalletConnect(isOriginWalletConnectVal);
     setIsOriginMMSDKRemoteConn(isOriginMMSDKRemoteConnVal);
-  }, [accounts, identities, activeAddress, network, origin]);
+  }, [accounts, identities, activeAddress, origin]);
 
   const networkImage = getNetworkImageSource({
     networkType: networkProvider.type,

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -1168,7 +1168,6 @@ const mapStateToProps = (state) => ({
   ticker: selectTicker(state),
   frequentRpcList:
     state.engine.backgroundState.PreferencesController.frequentRpcList,
-  provider: state.engine.backgroundState.NetworkController.provider,
   transaction: getNormalizedTxState(state),
   accountsLength: Object.keys(
     state.engine.backgroundState.AccountTrackerController.accounts || {},

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -928,16 +928,6 @@ class DrawerView extends PureComponent {
     this.trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_SHARE_PUBLIC_ADDRESS);
   };
 
-  closeInvalidCustomNetworkAlert = () => {
-    this.setState({ invalidCustomNetwork: null });
-  };
-
-  showInvalidCustomNetworkAlert = (network) => {
-    InteractionManager.runAfterInteractions(() => {
-      this.setState({ invalidCustomNetwork: network });
-    });
-  };
-
   onSecureWalletModalAction = () => {
     this.setState({ showProtectWalletModal: false });
     this.props.navigation.navigate(


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Dead code that references the network controller state has been removed. These lines were having absolutely no functional impact.

**Issue**

Relates to https://github.com/MetaMask/mobile-planning/issues/1016

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
