### PR TITLE
refactor: Simplify `isMainnet` utility function

### DIFF
--- a/app/components/UI/CollectibleContractInformation/index.js
+++ b/app/components/UI/CollectibleContractInformation/index.js
@@ -157,7 +157,7 @@ class CollectibleContractInformation extends PureComponent {
     } = this.props;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
-    const is_main_net = isMainNet(network);
+    const is_main_net = isMainNet(network.providerConfig.chainId);
 
     return (
       <SafeAreaView style={styles.wrapper}>

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -121,8 +121,13 @@ export const getAllNetworks = () =>
  */
 export const isDefaultMainnet = (networkType) => networkType === MAINNET;
 
-export const isMainNet = (network) =>
-  isDefaultMainnet(network?.providerConfig?.type) || network === String(1);
+/**
+ * Check whether the given chain ID is Ethereum Mainnet.
+ *
+ * @param {string} chainId - The chain ID to check.
+ * @returns True if the chain ID is Ethereum Mainnet, false otherwise.
+ */
+export const isMainNet = (chainId) => chainId === String(1);
 
 export const isLineaMainnet = (networkType) => networkType === LINEA_MAINNET;
 

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -53,27 +53,11 @@ describe('NetworkUtils::getAllNetworks', () => {
 });
 
 describe('NetworkUtils::isMainNet', () => {
-  it(`should return true if the selected network is ${MAINNET}`, () => {
+  it(`should return true if the given chain ID is Ethereum Mainnet`, () => {
     expect(isMainNet('1')).toEqual(true);
-    expect(
-      isMainNet({
-        providerConfig: {
-          type: MAINNET,
-        },
-      }),
-    ).toEqual(true);
   });
-  it(`should return false if the selected network is not ${MAINNET}`, () => {
+  it(`should return false if the selected network is not Ethereum Mainnet`, () => {
     expect(isMainNet('42')).toEqual(false);
-    expect(
-      isMainNet({
-        network: {
-          providerConfig: {
-            type: SEPOLIA,
-          },
-        },
-      }),
-    ).toEqual(false);
   });
 });
 


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `isMainnet` utility function used to accept either a network controller state object or a chain ID. Now it only accepts a chain ID. The one place where the network controller state was passed in has been updated to pass in a chain ID instead.

A JSDoc comment has been added for this utility function as well.

**Issue**

Relates to https://github.com/MetaMask/mobile-planning/issues/1016

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
