### PR TITLE
fix(test): detox: change view ID back to Security & Privacy view to scroll down to bottom

### DIFF
--- a/e2e/pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.js
+++ b/e2e/pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.js
@@ -39,7 +39,7 @@ export default class SecurityAndPrivacy {
       await TestHelpers.swipe(SECURITY_SETTINGS_SCROLL_ID, 'up', 'fast');
       await TestHelpers.delay(1000);
     } else {
-      await TestHelpers.swipe(CHANGE_PASSWORD_TITLE_ID, 'up', 'fast', 0.9);
+      await TestHelpers.swipe(SECURITY_SETTINGS_SCROLL_ID, 'up', 'fast', 0.9);
     }
     //await TestHelpers.swipe(PRIVACY_MODE_SECTION_ID, 'up', 'fast');
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
detox test `e2e/specs/onboarding-wizard-opt-in.spec.js` was failing because wrong testID was used on Security & Privacy view to swipe down to the bottom of the view.

Working with changes:
![image](https://github.com/MetaMask/metamask-mobile/assets/6626407/4f9253b8-c096-4388-8fba-d34e8bff0f81)


**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
