### PR TITLE
fix: added contact alias to destination address on send flow

### DIFF
--- a/app/components/UI/AddToAddressBookWrapper/AddToAddressBookWrapper.tsx
+++ b/app/components/UI/AddToAddressBookWrapper/AddToAddressBookWrapper.tsx
@@ -26,12 +26,14 @@ export const ADD_TO_ADDRESS_BOOK_BUTTON_ID = 'add-address-button';
 interface AddToAddressBookWrapperProps {
   address: string;
   children: ReactElement;
+  setToAddressName?: (name: string) => void;
   defaultNull?: boolean;
 }
 
 export const AddToAddressBookWrapper = ({
   address,
   children,
+  setToAddressName,
   defaultNull = false,
 }: AddToAddressBookWrapperProps) => {
   const network = useSelector(selectNetwork);
@@ -52,6 +54,7 @@ export const AddToAddressBookWrapper = ({
   const onSaveToAddressBook = () => {
     const { AddressBookController } = Engine.context;
     AddressBookController.set(address, alias, network);
+    !!alias && setToAddressName?.(alias);
     setAlias(undefined);
   };
 

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -569,6 +569,9 @@ class SendFlow extends PureComponent {
                 </View>
               )}
               <AddToAddressBookWrapper
+                setToAddressName={(toSelectedAddressName) =>
+                  this.setState({ toSelectedAddressName })
+                }
                 address={toEnsAddressResolved || toAccount}
                 defaultNull
               >


### PR DESCRIPTION
**Description**
When added a contact, it needed to be added to the to address field as well.

**Screenshots/Recordings**
http://recordit.co/KnLtvesBCT

Transaction review (This one it's to make sure nothing changed because it uses the same component modified):
https://recordit.co/ntPuquhNh5


Just a copy of this [PR](https://github.com/MetaMask/metamask-mobile/pull/6657)

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
