### PR TITLE
refactor: Use selectors for network state access

### DIFF
--- a/app/components/UI/CollectibleContractInformation/index.js
+++ b/app/components/UI/CollectibleContractInformation/index.js
@@ -16,6 +16,7 @@ import Device from '../../../util/device';
 import { connect } from 'react-redux';
 import { isMainNet } from '../../../util/networks';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import { selectChainId } from '../../../selectors/networkController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -127,9 +128,9 @@ class CollectibleContractInformation extends PureComponent {
      */
     collectibleContract: PropTypes.object,
     /**
-     * Object representing the selected network
+     * The chain ID for the current selected network
      */
-    network: PropTypes.object.isRequired,
+    chainId: PropTypes.string.isRequired,
   };
 
   closeModal = () => {
@@ -153,11 +154,11 @@ class CollectibleContractInformation extends PureComponent {
   render = () => {
     const {
       collectibleContract: { name, description, totalSupply, address },
-      network,
+      chainId,
     } = this.props;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
-    const is_main_net = isMainNet(network.providerConfig.chainId);
+    const is_main_net = isMainNet(chainId);
 
     return (
       <SafeAreaView style={styles.wrapper}>
@@ -220,7 +221,7 @@ class CollectibleContractInformation extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  network: state.engine.backgroundState.NetworkController,
+  chainId: selectChainId(state),
 });
 
 CollectibleContractInformation.contextType = ThemeContext;

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -73,7 +73,10 @@ import Routes from '../../../constants/navigation/Routes';
 import { scale } from 'react-native-size-matters';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { DRAWER_VIEW_LOCK_TEXT_ID } from '../../../../wdio/screen-objects/testIDs/Screens/DrawerView.testIds';
-import { selectTicker } from '../../../selectors/networkController';
+import {
+  selectProviderConfig,
+  selectTicker,
+} from '../../../selectors/networkController';
 
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 import NetworkInfo from '../NetworkInfo';
@@ -327,9 +330,9 @@ class DrawerView extends PureComponent {
     */
     navigation: PropTypes.object,
     /**
-     * Object representing the selected the selected network
+     * Object representing the configuration of the current selected network
      */
-    network: PropTypes.object.isRequired,
+    providerConfig: PropTypes.object.isRequired,
     /**
      * Selected address as string
      */
@@ -447,7 +450,7 @@ class DrawerView extends PureComponent {
       ens: undefined,
       name: undefined,
       address: undefined,
-      currentNetwork: undefined,
+      currentChainId: undefined,
     },
     networkType: undefined,
     showModal: false,
@@ -580,23 +583,23 @@ class DrawerView extends PureComponent {
   }
 
   updateAccountInfo = async () => {
-    const { identities, network, selectedAddress } = this.props;
-    const { currentNetwork, address, name } = this.state.account;
+    const { identities, providerConfig, selectedAddress } = this.props;
+    const { currentChainId, address, name } = this.state.account;
     const accountName = identities[selectedAddress]?.name;
     if (
-      currentNetwork !== network ||
+      currentChainId !== providerConfig.chainId ||
       address !== selectedAddress ||
       name !== accountName
     ) {
       const ens = await doENSReverseLookup(
         selectedAddress,
-        network.providerConfig.chainId,
+        providerConfig.chainId,
       );
       this.setState((state) => ({
         account: {
           ens,
           name: accountName,
-          currentNetwork: network,
+          currentChainId: providerConfig.chainId,
           address: selectedAddress,
         },
       }));
@@ -632,10 +635,10 @@ class DrawerView extends PureComponent {
 
   // NOTE: do we need this event?
   trackOpenBrowserEvent = () => {
-    const { network } = this.props;
+    const { providerConfig } = this.props;
     AnalyticsV2.trackEvent(MetaMetricsEvents.BROWSER_OPENED, {
       source: 'In-app Navigation',
-      chain_id: network,
+      chain_id: providerConfig.chainId,
     });
   };
 
@@ -700,27 +703,21 @@ class DrawerView extends PureComponent {
   };
 
   viewInEtherscan = () => {
-    const {
-      selectedAddress,
-      network,
-      network: {
-        providerConfig: { rpcTarget },
-      },
-      frequentRpcList,
-    } = this.props;
-    if (network.providerConfig.type === RPC) {
-      const blockExplorer = findBlockExplorerForRpc(rpcTarget, frequentRpcList);
+    const { selectedAddress, providerConfig, frequentRpcList } = this.props;
+    if (providerConfig.type === RPC) {
+      const blockExplorer = findBlockExplorerForRpc(
+        providerConfig.rpcTarget,
+        frequentRpcList,
+      );
       const url = `${blockExplorer}/address/${selectedAddress}`;
       const title = new URL(blockExplorer).hostname;
       this.goToBrowserUrl(url, title);
     } else {
-      const url = getEtherscanAddressUrl(
-        network.providerConfig.type,
-        selectedAddress,
+      const url = getEtherscanAddressUrl(providerConfig.type, selectedAddress);
+      const etherscan_url = getEtherscanBaseUrl(providerConfig.type).replace(
+        'https://',
+        '',
       );
-      const etherscan_url = getEtherscanBaseUrl(
-        network.providerConfig.type,
-      ).replace('https://', '');
       this.goToBrowserUrl(url, etherscan_url);
     }
     this.trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_VIEW_ETHERSCAN);
@@ -765,9 +762,7 @@ class DrawerView extends PureComponent {
     const { frequentRpcList } = this.props;
     if (providerType === RPC) {
       const {
-        network: {
-          providerConfig: { rpcTarget },
-        },
+        providerConfig: { rpcTarget },
       } = this.props;
       const blockExplorer = findBlockExplorerForRpc(rpcTarget, frequentRpcList);
       if (blockExplorer) {
@@ -852,9 +847,7 @@ class DrawerView extends PureComponent {
 
   getSections = () => {
     const {
-      network: {
-        providerConfig: { type, rpcTarget },
-      },
+      providerConfig: { type, rpcTarget },
       frequentRpcList,
     } = this.props;
     let blockExplorer, blockExplorerName;
@@ -947,7 +940,7 @@ class DrawerView extends PureComponent {
 
   onInfoNetworksModalClose = () => {
     const {
-      network: { providerConfig },
+      providerConfig,
       onboardNetworkAction,
       networkSwitched,
       toggleInfoNetworkModal,
@@ -1003,7 +996,7 @@ class DrawerView extends PureComponent {
 
   render() {
     const {
-      network,
+      providerConfig,
       accounts,
       identities,
       selectedAddress,
@@ -1145,7 +1138,7 @@ class DrawerView extends PureComponent {
                           name &&
                           name.toLowerCase().indexOf('etherscan') !== -1
                         ) {
-                          const type = network.providerConfig?.type;
+                          const type = providerConfig?.type;
                           return (
                             (type && this.hasBlockExplorer(type)) || undefined
                           );
@@ -1215,8 +1208,8 @@ class DrawerView extends PureComponent {
         >
           <NetworkInfo
             onClose={this.onInfoNetworksModalClose}
-            type={network.providerConfig.type}
-            ticker={network.providerConfig.ticker}
+            type={providerConfig.type}
+            ticker={providerConfig.ticker}
           />
         </Modal>
 
@@ -1244,7 +1237,7 @@ class DrawerView extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  network: state.engine.backgroundState.NetworkController,
+  providerConfig: selectProviderConfig(state),
   selectedAddress:
     state.engine.backgroundState.PreferencesController.selectedAddress,
   accounts: state.engine.backgroundState.AccountTrackerController.accounts,

--- a/app/components/UI/NavbarBrowserTitle/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NavbarBrowserTitle/__snapshots__/index.test.tsx.snap
@@ -35,13 +35,6 @@ exports[`NavbarBrowserTitle should render correctly 1`] = `
   <Component
     hostname="faucet.metamask.io"
     https={true}
-    network={
-      Object {
-        "provider": Object {
-          "type": "mainnet",
-        },
-      }
-    }
   />
 </ContextProvider>
 `;

--- a/app/components/UI/NavbarBrowserTitle/index.js
+++ b/app/components/UI/NavbarBrowserTitle/index.js
@@ -7,6 +7,7 @@ import Networks from '../../../util/networks';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import Device from '../../../util/device';
 import { mockTheme, ThemeContext } from '../../../util/theme';
+import { selectProviderConfig } from '../../../selectors/networkController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -66,9 +67,9 @@ const createStyles = (colors) =>
 class NavbarBrowserTitle extends PureComponent {
   static propTypes = {
     /**
-     * Object representing the selected the selected network
+     * Object representing the configuration for the selected network
      */
-    network: PropTypes.object.isRequired,
+    providerConfig: PropTypes.object.isRequired,
     /**
      * hostname of the current webview
      */
@@ -95,14 +96,14 @@ class NavbarBrowserTitle extends PureComponent {
     this.props.route.params?.showUrlModal?.();
   };
 
-  getNetworkName(network) {
+  getNetworkName(providerConfig) {
     let name = { ...Networks.rpc, color: null }.name;
 
-    if (network && network.providerConfig) {
-      if (network.providerConfig.nickname) {
-        name = network.providerConfig.nickname;
-      } else if (network.providerConfig.type) {
-        const currentNetwork = Networks[network.providerConfig.type];
+    if (providerConfig) {
+      if (providerConfig.nickname) {
+        name = providerConfig.nickname;
+      } else if (providerConfig.type) {
+        const currentNetwork = Networks[providerConfig.type];
         if (currentNetwork && currentNetwork.name) {
           name = currentNetwork.name;
         }
@@ -113,14 +114,13 @@ class NavbarBrowserTitle extends PureComponent {
   }
 
   render = () => {
-    const { https, network, hostname, error, icon } = this.props;
+    const { https, providerConfig, hostname, error, icon } = this.props;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
     const color =
-      (Networks[network.providerConfig.type] &&
-        Networks[network.providerConfig.type].color) ||
+      (Networks[providerConfig.type] && Networks[providerConfig.type].color) ||
       null;
-    const name = this.getNetworkName(network);
+    const name = this.getNetworkName(providerConfig);
 
     return (
       <TouchableOpacity onPress={this.onTitlePress} style={styles.wrapper}>
@@ -163,7 +163,7 @@ class NavbarBrowserTitle extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  network: state.engine.backgroundState.NetworkController,
+  providerConfig: selectProviderConfig(state),
 });
 
 NavbarBrowserTitle.contextType = ThemeContext;

--- a/app/components/UI/NavbarBrowserTitle/index.test.tsx
+++ b/app/components/UI/NavbarBrowserTitle/index.test.tsx
@@ -9,18 +9,9 @@ const store = mockStore({});
 
 describe('NavbarBrowserTitle', () => {
   it('should render correctly', () => {
-    const network = {
-      provider: {
-        type: 'mainnet',
-      },
-    };
     const wrapper = shallow(
       <Provider store={store}>
-        <NavbarBrowserTitle
-          network={network}
-          hostname={'faucet.metamask.io'}
-          https
-        />
+        <NavbarBrowserTitle hostname={'faucet.metamask.io'} https />
       </Provider>,
     );
     expect(wrapper).toMatchSnapshot();

--- a/app/components/UI/NavbarTitle/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NavbarTitle/__snapshots__/index.test.tsx.snap
@@ -33,13 +33,6 @@ exports[`NavbarTitle should render correctly 1`] = `
   }
 >
   <withNavigation(Connect(NavbarTitle))
-    network={
-      Object {
-        "provider": Object {
-          "type": "mainnet",
-        },
-      }
-    }
     title="Test"
   />
 </ContextProvider>

--- a/app/components/UI/NavbarTitle/index.js
+++ b/app/components/UI/NavbarTitle/index.js
@@ -20,6 +20,7 @@ import Routes from '../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import Analytics from '../../../core/Analytics/Analytics';
 import { withNavigation } from '@react-navigation/compat';
+import { selectProviderConfig } from '../../../selectors/networkController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -62,9 +63,9 @@ const createStyles = (colors) =>
 class NavbarTitle extends PureComponent {
   static propTypes = {
     /**
-     * Object representing the selected the selected network
+     * Object representing the configuration of the current selected network
      */
-    network: PropTypes.object.isRequired,
+    providerConfig: PropTypes.object.isRequired,
     /**
      * Name of the current view
      */
@@ -100,7 +101,7 @@ class NavbarTitle extends PureComponent {
         Analytics.trackEventWithParameters(
           MetaMetricsEvents.NETWORK_SELECTOR_PRESSED,
           {
-            chain_id: this.props.network.providerConfig.chainId,
+            chain_id: this.props.providerConfig.chainId,
           },
         );
         setTimeout(() => {
@@ -111,21 +112,19 @@ class NavbarTitle extends PureComponent {
   };
 
   render = () => {
-    const { network, title, translate } = this.props;
+    const { providerConfig, title, translate } = this.props;
     let name = null;
     const color =
-      (Networks[network.providerConfig.type] &&
-        Networks[network.providerConfig.type].color) ||
+      (Networks[providerConfig.type] && Networks[providerConfig.type].color) ||
       null;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
 
-    if (network.providerConfig.nickname) {
-      name = network.providerConfig.nickname;
+    if (providerConfig.nickname) {
+      name = providerConfig.nickname;
     } else {
       name =
-        (Networks[network.providerConfig.type] &&
-          Networks[network.providerConfig.type].name) ||
+        (Networks[providerConfig.type] && Networks[providerConfig.type].name) ||
         { ...Networks.rpc, color: null }.name;
     }
 
@@ -166,7 +165,7 @@ class NavbarTitle extends PureComponent {
 NavbarTitle.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
-  network: state.engine.backgroundState.NetworkController,
+  providerConfig: selectProviderConfig(state),
 });
 
 export default withNavigation(connect(mapStateToProps)(NavbarTitle));

--- a/app/components/UI/NavbarTitle/index.test.tsx
+++ b/app/components/UI/NavbarTitle/index.test.tsx
@@ -10,14 +10,9 @@ const store = mockStore({});
 describe('NavbarTitle', () => {
   it('should render correctly', () => {
     const title = 'Test';
-    const network = {
-      provider: {
-        type: 'mainnet',
-      },
-    };
     const wrapper = shallow(
       <Provider store={store}>
-        <NavbarTitle title={title} network={network} />
+        <NavbarTitle title={title} />
       </Provider>,
     );
     expect(wrapper).toMatchSnapshot();

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -28,6 +28,7 @@ import Engine from '../../../../core/Engine';
 import decodeTransaction from '../../TransactionElement/utils';
 import {
   selectChainId,
+  selectProviderConfig,
   selectTicker,
 } from '../../../../selectors/networkController';
 
@@ -79,9 +80,9 @@ class TransactionDetails extends PureComponent {
      */
     chainId: PropTypes.string,
     /**
-     * Object representing the selected the selected network
+     * Object representing the configuration of the current selected network
      */
-    network: PropTypes.object,
+    providerConfig: PropTypes.object,
     /**
      * Object corresponding to a transaction, containing transaction object, networkId and transaction hash string
      */
@@ -191,9 +192,7 @@ class TransactionDetails extends PureComponent {
 
   componentDidMount = () => {
     const {
-      network: {
-        providerConfig: { rpcTarget, type },
-      },
+      providerConfig: { rpcTarget, type },
       frequentRpcList,
     } = this.props;
     let blockExplorer;
@@ -211,9 +210,7 @@ class TransactionDetails extends PureComponent {
       navigation,
       transactionObject: { networkID },
       transactionDetails: { transactionHash },
-      network: {
-        providerConfig: { type },
-      },
+      providerConfig: { type },
       close,
     } = this.props;
     const { rpcBlockExplorer } = this.state;
@@ -406,7 +403,7 @@ class TransactionDetails extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  network: state.engine.backgroundState.NetworkController,
+  providerConfig: selectProviderConfig(state),
   chainId: selectChainId(state),
   frequentRpcList:
     state.engine.backgroundState.PreferencesController.frequentRpcList,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -25,6 +25,7 @@ import NotificationManager from '../../../core/NotificationManager';
 import { collectibleContractsSelector } from '../../../reducers/collectibles';
 import {
   selectChainId,
+  selectProviderConfig,
   selectProviderType,
 } from '../../../selectors/networkController';
 import { baseStyles, fontStyles } from '../../../styles/common';
@@ -120,9 +121,9 @@ class Transactions extends PureComponent {
     */
     navigation: PropTypes.object,
     /**
-     * Object representing the selected network
+     * Object representing the configuration of the current selected network
      */
-    network: PropTypes.object,
+    providerConfig: PropTypes.object,
     /**
      * An array that represents the user collectible contracts
      */
@@ -230,9 +231,7 @@ class Transactions extends PureComponent {
 
   updateBlockExplorer = () => {
     const {
-      network: {
-        providerConfig: { type, rpcTarget },
-      },
+      providerConfig: { type, rpcTarget },
       frequentRpcList,
     } = this.props;
     let blockExplorer;
@@ -331,10 +330,7 @@ class Transactions extends PureComponent {
   viewOnBlockExplore = () => {
     const {
       navigation,
-      network: {
-        network,
-        providerConfig: { type },
-      },
+      providerConfig: { type },
       selectedAddress,
       close,
     } = this.props;
@@ -356,7 +352,7 @@ class Transactions extends PureComponent {
     } catch (e) {
       Logger.error(e, {
         message: `can't get a block explorer link for network `,
-        network,
+        type,
       });
     }
   };
@@ -367,9 +363,7 @@ class Transactions extends PureComponent {
 
     const {
       chainId,
-      network: {
-        providerConfig: { type },
-      },
+      providerConfig: { type },
     } = this.props;
     const blockExplorerText = () => {
       if (isMainnetByChainId(chainId) || type !== RPC) {
@@ -779,7 +773,7 @@ const mapStateToProps = (state) => ({
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
   frequentRpcList:
     state.engine.backgroundState.PreferencesController.frequentRpcList,
-  network: state.engine.backgroundState.NetworkController,
+  providerConfig: selectProviderConfig(state),
   gasFeeEstimates:
     state.engine.backgroundState.GasFeeController.gasFeeEstimates,
   primaryCurrency: state.settings.primaryCurrency,

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -32,6 +32,7 @@ import { useTheme } from '../../../util/theme';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import Routes from '../../../constants/navigation/Routes';
+import { selectProviderConfig } from '../../../selectors/networkController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -96,9 +97,7 @@ const AssetDetails = (props: Props) => {
   const styles = createStyles(colors);
   const navigation = useNavigation();
   const dispatch = useDispatch();
-  const network = useSelector(
-    (state: any) => state.engine.backgroundState.NetworkController,
-  );
+  const providerConfig = useSelector(selectProviderConfig);
   const tokens = useSelector(
     (state: any) =>
       state.engine.backgroundState.TokensController.tokens as TokenType[],
@@ -130,11 +129,11 @@ const AssetDetails = (props: Props) => {
 
   const getNetworkName = () => {
     let name = '';
-    if (network.providerConfig.nickname) {
-      name = network.providerConfig.nickname;
+    if (providerConfig.nickname) {
+      name = providerConfig.nickname;
     } else {
       name =
-        (Networks as any)[network.providerConfig.type]?.name ||
+        (Networks as any)[providerConfig.type]?.name ||
         { ...Networks.rpc, color: null }.name;
     }
     return name;


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Network controller Redux state is now accessed excusively through selectors. This makes future state changes easier to manage.

Most of these changes consist of replacing the `network` prop with `providerConfig`. `network` was the full network controller state, but in practice these components were only using the provider config.

**Issue**


Relates to https://github.com/MetaMask/mobile-planning/issues/1016

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
