### PR TITLE
Fix: deeplink intrinsic gas issue

### DIFF
--- a/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
+++ b/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
@@ -84,7 +84,11 @@ const TransactionReviewEIP1559Update = ({
       updateTransactionState(gasTransaction);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gasEstimationReady, updateTransactionState]);
+  }, [
+    gasEstimationReady,
+    updateTransactionState,
+    gasTransaction.suggestedGasLimit,
+  ]);
 
   const openLinkAboutGas = useCallback(
     () => Linking.openURL(AppConstants.URLS.WHY_TRANSACTION_TAKE_TIME),

--- a/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
+++ b/app/components/UI/TransactionReview/TransactionReviewEIP1559Update/index.tsx
@@ -77,6 +77,7 @@ const TransactionReviewEIP1559Update = ({
     transactionFeeFiat,
     transactionTotalAmount,
     transactionTotalAmountFiat,
+    suggestedGasLimit,
   } = gasTransaction;
 
   useEffect(() => {
@@ -84,11 +85,7 @@ const TransactionReviewEIP1559Update = ({
       updateTransactionState(gasTransaction);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    gasEstimationReady,
-    updateTransactionState,
-    gasTransaction.suggestedGasLimit,
-  ]);
+  }, [gasEstimationReady, updateTransactionState, suggestedGasLimit]);
 
   const openLinkAboutGas = useCallback(
     () => Linking.openURL(AppConstants.URLS.WHY_TRANSACTION_TAKE_TIME),

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -379,7 +379,7 @@ class Send extends PureComponent {
         newTxMeta.gasPrice = toBN(gas);
       }
 
-      // if gas or gasPrice is not defined in the deeplink, we should define them
+      // if gas and gasPrice is not defined in the deeplink, we should define them
       if (!gas && !gasPrice) {
         const { gas, gasPrice } =
           await Engine.context.TransactionController.estimateGas(

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -176,11 +176,11 @@ class Send extends PureComponent {
   /**
    * Check if view is called with txMeta object for a deeplink
    */
-  checkForDeeplinks() {
+  async checkForDeeplinks() {
     const { route } = this.props;
     const txMeta = route.params?.txMeta;
     if (txMeta) {
-      this.handleNewTxMeta(txMeta);
+      await this.handleNewTxMeta(txMeta);
     } else {
       this.mounted && this.setState({ ready: true });
     }
@@ -217,7 +217,7 @@ class Send extends PureComponent {
     dappTransactionModalVisible && toggleDappTransactionModal();
     this.mounted = true;
     await this.reset();
-    this.checkForDeeplinks();
+    await this.checkForDeeplinks();
   }
 
   /**
@@ -377,6 +377,19 @@ class Send extends PureComponent {
       }
       if (gasPrice) {
         newTxMeta.gasPrice = toBN(gas);
+      }
+
+      // if gas or gasPrice is not defined in the deeplink, we should define them
+      if (!gas && !gasPrice) {
+        const { gas, gasPrice } =
+          await Engine.context.TransactionController.estimateGas(
+            this.props.transaction,
+          );
+        newTxMeta = {
+          ...newTxMeta,
+          gas,
+          gasPrice,
+        };
       }
       // TODO: We should add here support for sending tokens
       // or calling smart contract functions


### PR DESCRIPTION
**Description**

**Describe the bug**
Previously, when opening an ERC20 transfer deeplink the gas limit would be estimated, allowing users to "just click" send.  Now, when a user opens an ERC20 transfer, the gas limit is set to the default of 21000, which is far too low.  Thus, when clicking send, they get an "intrinsic gas too low" error, as metamask knows the tx would fail so does not send it (Thanks there :D ).  What should be happening is the gas is set to something like 75k depending on the complexity of a contract's transfer function.

I'm pretty familiar with the EIP-681 standard, so I took a stab at using the query params "gasLimit" and "gas" in the deeplink to at least fix this for my users temporarily.  Luckily for me, "gas" is accepted in the deeplink and QR scanning formats (though gasLimit is not, and per the 681 standard, should be).  But with this solution, users have to pay more gas than they need to up front since I had to set it to a high default.

The desired UX is that gas estimation is always done if gas or gasLimit is not specified in the link.  This currently works when you click send on a token, so the functionality exists already within the app.

**Screenshots**
Before

![image](https://user-images.githubusercontent.com/93164809/184445352-bc2c286b-627d-48d7-90e3-3c1b5e5aaa04.png)

After

![image](https://github.com/MetaMask/metamask-mobile/assets/44811/33ad4633-709d-4cd9-8be1-97d8529ce9e0)

**Issue**
Fixes #4853
Progresses/Fixes

- #6505 
- #6490 

**NOTE**
The issue is basically that the gas fees are not being calculated properly. This solution makes sure the gas fees are properly calculated. 

When the suggested gas fee is 21000, the transaction will fail with intrinsic gas too low. But when the gas is properly calculated, it's usually above 21000.

But even after this solution, on the confirm screen there's usually a brief moment (during my testing like 1 to 3 seconds) where the Send button is active while the gas fee is 21000. 

I'm not sure how to fix this short of hardcoding suggestedGas * 2 when suggestedGas <= 21000.

**To Reproduce**
_Steps to reproduce the behavior_
1. Create a deeplink for an ERC20 transfer https://metamask.github.io/metamask-deeplinks/#
2. Open it using a mobile device
3. Try to send the transaction without editing gas parameters
4. See it fail


**Checklist**

* [x ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
