### PR TITLE
fix: Custom Nonce Issues

### DIFF
--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -331,7 +331,14 @@ class Approval extends PureComponent {
     const { nonce } = transaction;
     const { transactionConfirmed } = this.state;
     if (transactionConfirmed) return;
-    if (showCustomNonce && nonce) transaction.nonce = BNToHex(nonce);
+
+    if (showCustomNonce && nonce) {
+      transaction.nonce = BNToHex(nonce);
+    } else {
+      // If nonce is not set in transaction, TransactionController will set it to the next nonce
+      transaction.nonce = undefined;
+    }
+
     this.setState({ transactionConfirmed: true });
     try {
       if (assetType === 'ETH') {


### PR DESCRIPTION
Whenever we are performing a tx from a dapp, we get the error  `undefined is not an object (evaluating transactionMeta.transaction)` and cannot send the transaction if we have `Customize Tx Nonce` setting enabled and then we disabled it.


**Screenshots**




https://github.com/MetaMask/metamask-mobile/assets/54408225/8ee5395b-9187-49cc-a31f-f6989196e0f5








**To Reproduce**
_Steps to reproduce the behavior_
1. Enable Customize tx Nonce from settings
2. Go to test-dapp
3. Connect MM
4. Deploy an ERC20 token
5. Click Send token
6. Confirm
7.  Now change disable Customize tx nonce
8. Click again Send token
9. Confirm
10. See error

**Expected behavior**
No error should appear, tx should succeed.

**Issue**

Fixes #6604

**Checklist**

* [x ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x ] Any added code is fully documented
