### PR TITLE
fix: Custom Approve value is reset whenever we see Transaction details or click Edit

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -7,6 +7,7 @@ import CustomSpendCap from './CustomSpendCap';
 import {
   ACCOUNT_BALANCE,
   CUSTOM_SPEND_CAP_TEST_ID,
+  DAPP_PROPOSED_VALUE,
   INPUT_VALUE_CHANGED,
   TICKER,
 } from './CustomSpendCap.constants';
@@ -14,14 +15,15 @@ import {
 import { CustomSpendCapProps } from './CustomSpendCap.types';
 
 function RenderCustomSpendCap(
-  tokenSpendValue: string,
+  tokenSpendValue = '',
   isInputValid: () => boolean = () => true,
+  dappProposedValue: string = DAPP_PROPOSED_VALUE,
 ) {
   return (
     <CustomSpendCap
       ticker={TICKER}
       accountBalance={ACCOUNT_BALANCE}
-      dappProposedValue={tokenSpendValue}
+      dappProposedValue={dappProposedValue}
       onInputChanged={INPUT_VALUE_CHANGED}
       isEditDisabled={false}
       editValue={() => ({})}
@@ -103,5 +105,19 @@ describe('CustomSpendCap', () => {
     renderWithProvider(RenderCustomSpendCap(validNumber, isInputValid));
 
     expect(isInputValid).toHaveBeenCalledWith(true);
+  });
+
+  it('should render token spend value if present', async () => {
+    const inputtedSpendValue = '100';
+
+    const { findByText } = renderWithProvider(
+      RenderCustomSpendCap(
+        inputtedSpendValue,
+        isInputValid,
+        DAPP_PROPOSED_VALUE,
+      ),
+    );
+
+    expect(await findByText(`${inputtedSpendValue} ${TICKER}`)).toBeDefined();
   });
 });

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -71,8 +71,7 @@ const CustomSpendCap = ({
   };
 
   const handlePress = () => {
-    if (isEditDisabled) editValue();
-    handleDefaultValue();
+    isEditDisabled ? editValue() : handleDefaultValue();
   };
 
   useEffect(() => {

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -60,10 +60,9 @@ const CustomSpendCap = ({
   }, [inputHasError, isInputValid]);
 
   useEffect(() => {
-    if (dappProposedValue) {
-      setValue(dappProposedValue);
-    }
-  }, [dappProposedValue]);
+    const spendValue = tokenSpendValue || dappProposedValue;
+    setValue(spendValue);
+  }, [dappProposedValue, tokenSpendValue]);
 
   const handleDefaultValue = () => {
     setMaxSelected(false);

--- a/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
@@ -57,9 +57,9 @@ exports[`CustomSpendCap should match snapshot 1`] = `
         onStartShouldSetResponder={[Function]}
       >
         <SvgMock
-          color="#BBC0C5"
+          color="#D73847"
           height={16}
-          name="Question"
+          name="Danger"
           style={
             Object {
               "height": 16,
@@ -137,11 +137,13 @@ exports[`CustomSpendCap should match snapshot 1`] = `
                 "paddingBottom": 0,
                 "paddingTop": 0,
               },
-              false,
+              Object {
+                "color": "#D73847",
+              },
             ]
           }
           testID="custom-spend-cap-input-input-id"
-          value=""
+          value="115792089237316195423570985008687907853269984665640564039457.584007913129639936"
         />
       </View>
       <Text
@@ -181,7 +183,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
         }
       }
     >
-      Only enter a number that you're comfortable with the third party spending now or in the future. You can always increase the spending cap later.
+      This allows the third party to spend all your token balance until it reaches the cap or you revoke the spending cap. If this is not intended, consider setting a lower spending cap.
        
       <Text
         onPress={[Function]}

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -664,6 +664,14 @@ class ApproveTransactionReview extends PureComponent {
     });
   };
 
+  handleCustomSpendOnInputChange = (value) => {
+    if (isNumber(value)) {
+      this.setState({
+        tokenSpendValue: value.replace(/[^0-9.]/g, ''),
+      });
+    }
+  };
+
   renderDetails = () => {
     const {
       originalApproveAmount,
@@ -872,13 +880,7 @@ class ApproveTransactionReview extends PureComponent {
                           toggleLearnMoreWebPage={this.toggleLearnMoreWebPage}
                           isEditDisabled={Boolean(isReadyToApprove)}
                           editValue={this.goToSpendCap}
-                          onInputChanged={(value) => {
-                            if (isNumber(value)) {
-                              this.setState({
-                                tokenSpendValue: value.replace(/[^0-9.]/g, ''),
-                              });
-                            }
-                          }}
+                          onInputChanged={this.handleCustomSpendOnInputChange}
                           isInputValid={this.handleSetIsCustomSpendInputValid}
                         />
                       )


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**
Whenever the user sets a custom value, if clicks View transaction details the value is changed back to the default dapp value. This same behaviour also happens if you click Edit - you will see that the value is again the default by the dapp instead of the one the user filled.

**Screenshots/Recordings**
Before:

https://github.com/MetaMask/metamask-mobile/assets/29962968/0141acdc-71f5-4cea-803b-89f3e32f0a30

After:

https://github.com/MetaMask/metamask-mobile/assets/29962968/2f6db05e-eeb7-4e34-8483-509fef1df791


_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #6674 

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
