### PR TITLE
fix: sign v3 and v4 expecting chain id on hexadecimal format

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -40,6 +40,7 @@ import {
   renderFromTokenMinimalUnit,
   balanceToFiatNumber,
   weiToFiatNumber,
+  toHexadecimal,
 } from '../util/number';
 import NotificationManager from './NotificationManager';
 import Logger from '../util/Logger';
@@ -446,7 +447,7 @@ class Engine {
             ),
           getAllState: () => store.getState(),
           getCurrentChainId: () =>
-            networkController.state.providerConfig.chainId,
+            toHexadecimal(networkController.state.providerConfig.chainId),
           keyringController: {
             signMessage: keyringController.signMessage.bind(keyringController),
             signPersonalMessage:

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -124,8 +124,6 @@ export const checkActiveAccountAndChainId = async ({
     }
 
     if (activeChainId !== chainIdRequest) {
-      console.log('ENTER HEREEEEEEEEEE');
-
       Alert.alert(
         `Active chainId is ${activeChainId} but received ${chainIdRequest}`,
       );
@@ -551,7 +549,6 @@ export const getRpcMethodMiddleware = ({
 
         const data = JSON.parse(req.params[1]);
         const chainId = data.domain.chainId;
-        console.log('ENTER CHZAIN ID', chainId);
 
         const pageMeta = {
           meta: {
@@ -573,9 +570,6 @@ export const getRpcMethodMiddleware = ({
           checkSelectedAddress: isMMSDK || isWalletConnect,
         });
 
-        console.log('ENTER HEREEE d', req.params[0]);
-        console.log('ENTER HEREEE d1', req.params[1]);
-
         const rawSig = await SignatureController.newUnsignedTypedMessage(
           {
             data: req.params[1],
@@ -586,8 +580,6 @@ export const getRpcMethodMiddleware = ({
           req,
           'V4',
         );
-
-        console.log('ENTER Hereee raw sig', rawSig);
 
         res.result = rawSig;
       },

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -124,6 +124,8 @@ export const checkActiveAccountAndChainId = async ({
     }
 
     if (activeChainId !== chainIdRequest) {
+      console.log('ENTER HEREEEEEEEEEE');
+
       Alert.alert(
         `Active chainId is ${activeChainId} but received ${chainIdRequest}`,
       );
@@ -549,6 +551,7 @@ export const getRpcMethodMiddleware = ({
 
         const data = JSON.parse(req.params[1]);
         const chainId = data.domain.chainId;
+        console.log('ENTER CHZAIN ID', chainId);
 
         const pageMeta = {
           meta: {
@@ -570,6 +573,9 @@ export const getRpcMethodMiddleware = ({
           checkSelectedAddress: isMMSDK || isWalletConnect,
         });
 
+        console.log('ENTER HEREEE d', req.params[0]);
+        console.log('ENTER HEREEE d1', req.params[1]);
+
         const rawSig = await SignatureController.newUnsignedTypedMessage(
           {
             data: req.params[1],
@@ -580,6 +586,8 @@ export const getRpcMethodMiddleware = ({
           req,
           'V4',
         );
+
+        console.log('ENTER Hereee raw sig', rawSig);
 
         res.result = rawSig;
       },


### PR DESCRIPTION
**Description**
Sign v3 and v4 were expecting a hexadecimal format, for example, the error was  `Provided chainId "137" must match the active chainId "311"`, if we try to convert 137 to a decimal, it will be 311

**Screenshots/Recordings**
https://recordit.co/3IypvoupbT


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
