### PR TITLE
e2e: [MC 0.75] Appium and detox test scripts updated for test network toggle

### DIFF
--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -40,7 +40,10 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import Routes from '../../../constants/navigation/Routes';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { ADD_NETWORK_BUTTON } from '../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
-import { NETWORK_SCROLL_ID } from '../../../../wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds';
+import {
+  NETWORK_SCROLL_ID,
+  NETWORK_TEST_SWITCH_ID,
+} from '../../../../wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds';
 import { colors as importedColors } from '../../../styles/common';
 import { useAppTheme } from '../../../util/theme';
 import Text from '../../../component-library/components/Texts/Text/Text';
@@ -246,7 +249,7 @@ const NetworkSelector = () => {
         }}
         thumbColor={importedColors.white}
         ios_backgroundColor={colors.border.muted}
-        testID="test-network-switch-id"
+        {...generateTestId(Platform, NETWORK_TEST_SWITCH_ID)}
         disabled={isTestNet(providerConfig.chainId)}
       />
     </View>

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -36,10 +36,6 @@ export default class TestHelpers {
     return element(by.id(elementId)).tap(point);
   }
 
-  static async tapAtCoordinates(point) {
-    await device.tap(point);
-  }
-
   static tapItemAtIndex(elementID, index) {
     return element(by.id(elementID))
       .atIndex(index || 0)
@@ -73,7 +69,7 @@ export default class TestHelpers {
   }
 
   static async tapAndLongPressAtIndex(elementId, index) {
-    return element(by.id(elementId, index))
+    return element(by.id(elementId))
       .atIndex(index || 0)
       .longPress(2000);
   }
@@ -106,8 +102,8 @@ export default class TestHelpers {
     await element(by.text(text)).swipe(direction, speed, percentage);
   }
 
-  static async scrollTo(scrollviewId, edge) {
-    await element(by.id(scrollviewId)).scrollTo(edge);
+  static async scrollTo(scrollViewId, edge) {
+    await element(by.id(scrollViewId)).scrollTo(edge);
   }
 
   static async scrollUpTo(elementId, distance, direction) {
@@ -130,12 +126,12 @@ export default class TestHelpers {
 
   static checkIfNotVisible(elementId) {
     return waitFor(element(by.id(elementId)))
-      .toBeNotVisible()
+      .not.toBeVisible()
       .withTimeout(10000);
   }
 
   static checkIfElementWithTextIsNotVisible(text) {
-    return expect(element(by.text(text)).atIndex(0)).toBeNotVisible();
+    return expect(element(by.text(text)).atIndex(0)).not.toBeVisible();
   }
 
   static checkIfExists(elementId) {

--- a/e2e/pages/WalletView.js
+++ b/e2e/pages/WalletView.js
@@ -5,6 +5,7 @@ import {
   IMPORT_NFT_BUTTON_ID,
   IMPORT_TOKEN_BUTTON_ID,
   NAVBAR_NETWORK_BUTTON,
+  NAVBAR_NETWORK_TEXT,
   NFT_TAB_CONTAINER_ID,
   SEND_BUTTON_ID,
   WALLET_ACCOUNT_ICON,
@@ -36,6 +37,10 @@ export default class WalletView {
 
   static async tapNetworksButtonOnNavBar() {
     await TestHelpers.waitAndTap(NAVBAR_NETWORK_BUTTON);
+  }
+
+  static async isConnectedNetwork(value) {
+    await TestHelpers.checkIfHasText(NAVBAR_NETWORK_TEXT, value);
   }
 
   static async tapNftTab() {

--- a/e2e/pages/modals/NetworkListModal.js
+++ b/e2e/pages/modals/NetworkListModal.js
@@ -37,4 +37,12 @@ export default class NetworkListModal {
   static async tapTestNetworkSwitch() {
     await TestHelpers.waitAndTap(NETWORK_TEST_SWITCH_ID);
   }
+
+  static async isTestNetworkToggleOn() {
+    await TestHelpers.checkIfToggleIsOn(NETWORK_TEST_SWITCH_ID);
+  }
+
+  static async isTestNetworkToggleOff() {
+    await TestHelpers.checkIfToggleIsOff(NETWORK_TEST_SWITCH_ID);
+  }
 }

--- a/e2e/pages/modals/NetworkListModal.js
+++ b/e2e/pages/modals/NetworkListModal.js
@@ -1,6 +1,7 @@
 import TestHelpers from '../../helpers';
 import {
   NETWORK_SCROLL_ID,
+  NETWORK_TEST_SWITCH_ID,
   OTHER_NETWORK_LIST_ID,
 } from '../../../wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds';
 
@@ -31,5 +32,9 @@ export default class NetworkListModal {
       OTHER_NETWORK_LIST_ID,
       networkName,
     );
+  }
+
+  static async tapTestNetworkSwitch() {
+    await TestHelpers.waitAndTap(NETWORK_TEST_SWITCH_ID);
   }
 }

--- a/e2e/pages/modals/NetworkListModal.js
+++ b/e2e/pages/modals/NetworkListModal.js
@@ -45,4 +45,8 @@ export default class NetworkListModal {
   static async isTestNetworkToggleOff() {
     await TestHelpers.checkIfToggleIsOff(NETWORK_TEST_SWITCH_ID);
   }
+
+  static async isTestNetworkDisplayed(network) {
+    await TestHelpers.checkIfElementWithTextIsNotVisible(network);
+  }
 }

--- a/e2e/specs/add-custom-rpc.spec.js
+++ b/e2e/specs/add-custom-rpc.spec.js
@@ -145,6 +145,8 @@ describe(Regression('Custom RPC Tests'), () => {
     await NetworkListModal.isNetworkNameVisibleInListOfNetworks('xDai');
   });
   it('should switch to Goreli then dismiss the network education modal', async () => {
+    await NetworkListModal.isVisible();
+    await NetworkListModal.tapTestNetworkSwitch();
     await NetworkListModal.changeNetwork(GORELI);
 
     await NetworkEducationModal.isVisible();

--- a/e2e/specs/add-custom-rpc.spec.js
+++ b/e2e/specs/add-custom-rpc.spec.js
@@ -144,9 +144,11 @@ describe(Regression('Custom RPC Tests'), () => {
     await NetworkListModal.isVisible();
     await NetworkListModal.isNetworkNameVisibleInListOfNetworks('xDai');
   });
+
   it('should switch to Goreli then dismiss the network education modal', async () => {
     await NetworkListModal.isVisible();
     await NetworkListModal.tapTestNetworkSwitch();
+    await NetworkListModal.isTestNetworkToggleOn();
     await NetworkListModal.changeNetwork(GORELI);
 
     await NetworkEducationModal.isVisible();

--- a/e2e/specs/connect-test-network.spec.js
+++ b/e2e/specs/connect-test-network.spec.js
@@ -1,0 +1,58 @@
+import { Regression } from '../tags';
+import { importWalletWithRecoveryPhrase } from '../viewHelper';
+import WalletView from '../pages/WalletView';
+import NetworkListModal from '../pages/modals/NetworkListModal';
+import NetworkEducationModal from '../pages/modals/NetworkEducationModal';
+
+const GORELI = 'Goerli Test Network';
+const ETHEREUM = 'Ethereum Main Network';
+
+describe(Regression('Connect to a Test Network'), () => {
+  beforeEach(() => {
+    jest.setTimeout(150000);
+  });
+
+  it('should import wallet and go to the wallet view', async () => {
+    await importWalletWithRecoveryPhrase();
+  });
+
+  it('should switch to test Network then dismiss the network education modal', async () => {
+    // Tap to prompt network list
+    await WalletView.tapNetworksButtonOnNavBar();
+    await NetworkListModal.isVisible();
+    await NetworkListModal.tapTestNetworkSwitch();
+    await NetworkListModal.isTestNetworkToggleOn();
+    await NetworkListModal.changeNetwork(GORELI);
+
+    await NetworkEducationModal.isVisible();
+    await NetworkEducationModal.isNetworkNameCorrect(GORELI);
+    await NetworkEducationModal.tapGotItButton();
+    await NetworkEducationModal.isNotVisible();
+    await WalletView.isVisible();
+    await WalletView.isConnectedNetwork(GORELI);
+  });
+
+  it('should not toggle off the Test Network switch while connected to test network', async () => {
+    await WalletView.tapNetworksButtonOnNavBar();
+    await NetworkListModal.isVisible();
+    await NetworkListModal.tapTestNetworkSwitch();
+    await NetworkListModal.isTestNetworkToggleOn();
+  });
+
+  it('should disconnect to Test Network', async () => {
+    await NetworkListModal.changeNetwork(ETHEREUM);
+    await NetworkEducationModal.isVisible();
+    await NetworkEducationModal.isNetworkNameCorrect(ETHEREUM);
+    await NetworkEducationModal.tapGotItButton();
+    await NetworkEducationModal.isNotVisible();
+    await WalletView.isVisible();
+    await WalletView.isConnectedNetwork(ETHEREUM);
+  });
+
+  it('should toggle off the Test Network switch', async () => {
+    await WalletView.tapNetworksButtonOnNavBar();
+    await NetworkListModal.isVisible();
+    await NetworkListModal.tapTestNetworkSwitch();
+    await NetworkListModal.isTestNetworkToggleOff();
+  });
+});

--- a/e2e/specs/connect-test-network.spec.js
+++ b/e2e/specs/connect-test-network.spec.js
@@ -54,5 +54,6 @@ describe(Regression('Connect to a Test Network'), () => {
     await NetworkListModal.isVisible();
     await NetworkListModal.tapTestNetworkSwitch();
     await NetworkListModal.isTestNetworkToggleOff();
+    await NetworkListModal.isTestNetworkDisplayed(GORELI);
   });
 });

--- a/e2e/specs/permission-system-removing-imported-account.spec.js
+++ b/e2e/specs/permission-system-removing-imported-account.spec.js
@@ -77,6 +77,8 @@ describe.skip(
     it('should switch to Sepolia', async () => {
       await Browser.tapNetworkAvatarButtonOnBrowser();
       await ConnectedAccountsModal.tapNetworksPicker();
+      await NetworkListModal.isVisible();
+      await NetworkListModal.tapTestNetworkSwitch();
       await NetworkListModal.changeNetwork(SEPOLIA);
     });
 

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -87,6 +87,7 @@ describe(Smoke('Wallet Tests'), () => {
     await WalletView.tapNetworksButtonOnNavBar();
     await NetworkListModal.isVisible();
     await NetworkListModal.tapTestNetworkSwitch();
+    await NetworkListModal.isTestNetworkToggleOn();
     await NetworkListModal.changeNetwork(GOERLI);
     await WalletView.isNetworkNameVisible(GOERLI);
   });

--- a/e2e/specs/wallet-tests.spec.js
+++ b/e2e/specs/wallet-tests.spec.js
@@ -86,6 +86,7 @@ describe(Smoke('Wallet Tests'), () => {
   it('should switch to Goerli network', async () => {
     await WalletView.tapNetworksButtonOnNavBar();
     await NetworkListModal.isVisible();
+    await NetworkListModal.tapTestNetworkSwitch();
     await NetworkListModal.changeNetwork(GOERLI);
     await WalletView.isNetworkNameVisible(GOERLI);
   });

--- a/e2e/viewHelper.js
+++ b/e2e/viewHelper.js
@@ -106,6 +106,7 @@ export const addLocalhostNetwork = async () => {
 export const switchToGoreliNetwork = async () => {
   await WalletView.tapNetworksButtonOnNavBar();
   await NetworkListModal.tapTestNetworkSwitch();
+  await NetworkListModal.isTestNetworkToggleOn();
   await NetworkListModal.changeNetwork(GOERLI);
   await WalletView.isNetworkNameVisible(GOERLI);
   await NetworkEducationModal.tapGotItButton();

--- a/e2e/viewHelper.js
+++ b/e2e/viewHelper.js
@@ -105,6 +105,7 @@ export const addLocalhostNetwork = async () => {
 
 export const switchToGoreliNetwork = async () => {
   await WalletView.tapNetworksButtonOnNavBar();
+  await NetworkListModal.tapTestNetworkSwitch();
   await NetworkListModal.changeNetwork(GOERLI);
   await WalletView.isNetworkNameVisible(GOERLI);
   await NetworkEducationModal.tapGotItButton();

--- a/wdio/features/Networks/ConnectTestNetwork.feature
+++ b/wdio/features/Networks/ConnectTestNetwork.feature
@@ -1,0 +1,34 @@
+@androidApp
+@networks
+Feature: ConnectTestNetwork
+
+  Scenario: Import wallet
+    Given the app displayed the splash animation
+    And I have imported my wallet
+    And I tap No Thanks on the Enable security check screen
+    And I tap No thanks on the onboarding welcome tutorial
+
+  Scenario: Connect to a test network using the Test Network Toggle
+    Given I tap on the navbar network title button
+    And the Network List Modal is Displayed
+    When I tap the Test Network toggle
+    Then the Test Network toggle value should be "ON"
+    When I tap on the "Goerli Test Network" button
+    Then "Goerli Test Network" should be displayed in network educational modal
+    And I should see the added network name "Goerli Test Network" in the top navigation bar
+
+  Scenario: Change to the Test Network Toggle to OFF while connected to Test network
+    Given I tap on the navbar network title button
+    And the Network List Modal is Displayed
+    When I tap the Test Network toggle
+    Then the Test Network toggle value should be "ON"
+
+  Scenario: Change to the Test Network Toggle to OFF
+    Given I tap on the "Ethereum Main Network" button
+    And "Ethereum Main Network" should be displayed in network educational modal
+    And I should see the added network name "Ethereum Main Network" in the top navigation bar
+    And I tap on the navbar network title button
+    And the Network List Modal is Displayed
+    When I tap the Test Network toggle
+    Then the Test Network toggle value should be "OFF"
+    And Ethereum Main Network should be the only Network displayed

--- a/wdio/screen-objects/BrowserObject/AddressBarScreen.js
+++ b/wdio/screen-objects/BrowserObject/AddressBarScreen.js
@@ -44,7 +44,7 @@ class AddressBarScreen {
   }
 
   async isUrlValueContains(text) {
-    await expect(this.urlModalInput).toHaveText(text);
+    await expect(this.urlModalInput).toHaveTextContaining(text);
   }
 
   async isUrlInputEmpty() {

--- a/wdio/screen-objects/Modals/NetworkListModal.js
+++ b/wdio/screen-objects/Modals/NetworkListModal.js
@@ -1,7 +1,10 @@
 import Selectors from '../../helpers/Selectors';
 import Gestures from '../../helpers/Gestures';
 
-import { NETWORK_SCROLL_ID } from '../testIDs/Components/NetworkListModal.TestIds';
+import {
+  NETWORK_SCROLL_ID,
+  NETWORK_TEST_SWITCH_ID,
+} from '../testIDs/Components/NetworkListModal.TestIds';
 import { ADD_NETWORK_BUTTON } from '../testIDs/Screens/NetworksScreen.testids';
 
 class NetworkListModal {
@@ -11,6 +14,10 @@ class NetworkListModal {
 
   get addNetworkButton() {
     return Selectors.getElementByPlatform(ADD_NETWORK_BUTTON);
+  }
+
+  get testNetworkSwitch() {
+    return Selectors.getElementByPlatform(NETWORK_TEST_SWITCH_ID);
   }
 
   async changeNetwork(networkName) {
@@ -29,6 +36,10 @@ class NetworkListModal {
 
   async tapAddNetworkButton() {
     await Gestures.waitAndTap(this.addNetworkButton);
+  }
+
+  async tapTestNetworkSwitch() {
+    await Gestures.waitAndTap(this.testNetworkSwitch);
   }
 }
 

--- a/wdio/screen-objects/Modals/NetworkListModal.js
+++ b/wdio/screen-objects/Modals/NetworkListModal.js
@@ -6,6 +6,7 @@ import {
   NETWORK_TEST_SWITCH_ID,
 } from '../testIDs/Components/NetworkListModal.TestIds';
 import { ADD_NETWORK_BUTTON } from '../testIDs/Screens/NetworksScreen.testids';
+import { CELL_SELECT_TEST_ID } from '../../../app/constants/test-ids';
 
 class NetworkListModal {
   get scroll() {
@@ -18,6 +19,10 @@ class NetworkListModal {
 
   get testNetworkSwitch() {
     return Selectors.getElementByPlatform(NETWORK_TEST_SWITCH_ID);
+  }
+
+  get networksButton() {
+    return Selectors.getXpathByContentDesc(CELL_SELECT_TEST_ID);
   }
 
   async changeNetwork(networkName) {
@@ -40,6 +45,14 @@ class NetworkListModal {
 
   async tapTestNetworkSwitch() {
     await Gestures.waitAndTap(this.testNetworkSwitch);
+  }
+
+  async isTestNetworkToggle(value) {
+    await expect(this.testNetworkSwitch).toHaveTextContaining(value);
+  }
+
+  async isNetworksDisplayed(value) {
+    await expect(this.networksButton).toBeElementsArrayOfSize(value);
   }
 }
 

--- a/wdio/screen-objects/WalletMainScreen.js
+++ b/wdio/screen-objects/WalletMainScreen.js
@@ -1,10 +1,7 @@
 import Selectors from '../helpers/Selectors';
 import Gestures from '../helpers/Gestures.js';
 import { WALLET_CONTAINER_ID } from './testIDs/Screens/WalletScreen-testIds.js';
-import {
-  ONBOARDING_WIZARD_STEP_1_CONTAINER_ID,
-  ONBOARDING_WIZARD_STEP_1_NO_THANKS_ID,
-} from './testIDs/Components/OnboardingWizard.testIds';
+import { ONBOARDING_WIZARD_STEP_1_NO_THANKS_ID } from './testIDs/Components/OnboardingWizard.testIds';
 
 import {
   IMPORT_NFT_BUTTON_ID,
@@ -26,12 +23,6 @@ import { TAB_BAR_WALLET_BUTTON } from './testIDs/Components/TabBar.testIds';
 import { BACK_BUTTON_SIMPLE_WEBVIEW } from './testIDs/Components/SimpleWebView.testIds';
 
 class WalletMainScreen {
-  get wizardContainer() {
-    return Selectors.getElementByPlatform(
-      ONBOARDING_WIZARD_STEP_1_CONTAINER_ID,
-    );
-  }
-
   get noThanks() {
     return Selectors.getElementByPlatform(
       ONBOARDING_WIZARD_STEP_1_NO_THANKS_ID,
@@ -173,10 +164,6 @@ class WalletMainScreen {
     await tokenText.waitForExist({ reverse: true });
   }
 
-  async isOnboardingWizardVisible() {
-    await expect(this.wizardContainer).toBeDisplayed();
-  }
-
   async isMainWalletViewVisible() {
     const element = await this.mainWalletView;
     await element.waitForDisplayed({ timeout: 100000 });
@@ -198,8 +185,7 @@ class WalletMainScreen {
   }
 
   async isNetworkNavbarTitle(text) {
-    const element = await this.networkNavbarTitle;
-    await expect(await element.getText()).toContain(text);
+    await expect(this.networkNavbarTitle).toHaveText(text);
   }
 
   async tapAccountActions() {

--- a/wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds.js
+++ b/wdio/screen-objects/testIDs/Components/NetworkListModal.TestIds.js
@@ -1,2 +1,3 @@
 export const OTHER_NETWORK_LIST_ID = 'other-network-name';
 export const NETWORK_SCROLL_ID = 'other-networks-scroll';
+export const NETWORK_TEST_SWITCH_ID = 'test-network-switch-id';

--- a/wdio/step-definitions/browser-steps.js
+++ b/wdio/step-definitions/browser-steps.js
@@ -71,12 +71,16 @@ Then(/^select account component is displayed$/, async () => {
 
 When(/^I navigate to "([^"]*)"$/, async function (text) {
   await BrowserScreen.tapUrlBar();
-  switch(text) {
+  switch (text) {
     case 'test-dapp-erc20':
-      await AddressBarScreen.editUrlInput(`${TEST_DAPP}?contract=${this.erc20}`);
+      await AddressBarScreen.editUrlInput(
+        `${TEST_DAPP}?contract=${this.erc20}`,
+      );
       break;
     case 'test-dapp-erc721':
-      await AddressBarScreen.editUrlInput(`${TEST_DAPP}?contract=${this.erc721}`);
+      await AddressBarScreen.editUrlInput(
+        `${TEST_DAPP}?contract=${this.erc721}`,
+      );
       break;
     default:
       await AddressBarScreen.editUrlInput(text);
@@ -378,6 +382,7 @@ Then(
 
 When(/^I select "([^"]*)" network option$/, async (network) => {
   await NetworkListModal.waitForDisplayed();
+  await NetworkListModal.tapTestNetworkSwitch();
   await CommonScreen.tapOnText(network);
 });
 

--- a/wdio/step-definitions/connect-test-network.step.js
+++ b/wdio/step-definitions/connect-test-network.step.js
@@ -1,0 +1,20 @@
+import { Given, When, Then } from '@wdio/cucumber-framework';
+import NetworkListModal from '../screen-objects/Modals/NetworkListModal';
+
+When(/^I tap the Test Network toggle$/, async () => {
+  await NetworkListModal.tapTestNetworkSwitch();
+});
+Given(/^the Network List Modal is Displayed$/, async () => {
+  await NetworkListModal.waitForDisplayed();
+});
+
+Then(/^the Test Network toggle value should be "([^"]*)"$/, async (value) => {
+  await NetworkListModal.isTestNetworkToggle(value);
+});
+
+Then(
+  /^Ethereum Main Network should be the only Network displayed$/,
+  async () => {
+    await NetworkListModal.isNetworksDisplayed(1);
+  },
+);


### PR DESCRIPTION
**Description**
Update for the Appium and detox test scripts to follow the implementation of test network toggle on Network Selector component.

**Screenshots/Recordings**

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
