### PR TITLE
fix: sign v3 and v4 expecting chain id on hexadecimal format

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -40,6 +40,7 @@ import {
   renderFromTokenMinimalUnit,
   balanceToFiatNumber,
   weiToFiatNumber,
+  toHexadecimal,
 } from '../util/number';
 import NotificationManager from './NotificationManager';
 import Logger from '../util/Logger';
@@ -442,7 +443,7 @@ class Engine {
             ),
           getAllState: () => store.getState(),
           getCurrentChainId: () =>
-            networkController.state.providerConfig.chainId,
+            toHexadecimal(networkController.state.providerConfig.chainId),
           keyringController: {
             signMessage: keyringController.signMessage.bind(keyringController),
             signPersonalMessage:


### PR DESCRIPTION
**Description**
Sign v3 and v4 were expecting a hexadecimal format, for example, the error was  `Provided chainId "137" must match the active chainId "311"`, if we try to convert 137 to a decimal, it will be 311

**Screenshots/Recordings**
https://recordit.co/3IypvoupbT


**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
