### PR TITLE
fix: update multi select snapshot

### DIFF
--- a/app/component-library/components/Select/MultiSelect/MultiSelectItem/__snapshots__/MultiSelectItem.test.tsx.snap
+++ b/app/component-library/components/Select/MultiSelect/MultiSelectItem/__snapshots__/MultiSelectItem.test.tsx.snap
@@ -34,11 +34,11 @@ exports[`MultiSelectItem should render snapshot correctly 1`] = `
           "borderColor": "#BBC0C5",
           "borderRadius": 4,
           "borderWidth": 1.5,
-          "height": 24,
+          "height": 20,
           "justifyContent": "center",
           "marginRight": -8,
           "opacity": 1,
-          "width": 24,
+          "width": 20,
         }
       }
     />


### PR DESCRIPTION
**Description**
Fix the multi select snapshot

The snapshot was wrong after a PR updated the Checkbox component style.

> **Note**
> This wrong snapshot test passed into `main` without failing. We are now investigating the reason why it made it to `main`.

**Screenshots/Recordings**

<img width="902" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/4677568/3e590bab-4602-409e-8771-b1d1121b9e10">

**Issue**

NA

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
