### PR TITLE
feat: add missing `wallet_requestPermissions` and `wallet_getPermissions` to the mobile API.

### DIFF
--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -87,7 +87,7 @@ export const getCaveatSpecifications = ({ getIdentities }) => ({
 export const getPermissionSpecifications = ({ getAllAccounts }) => ({
   [PermissionKeys.eth_accounts]: {
     permissionType: PermissionType.RestrictedMethod,
-    targetKey: PermissionKeys.eth_accounts,
+    targetName: PermissionKeys.eth_accounts,
     allowedCaveats: [CaveatTypes.restrictReturnedAccounts],
 
     factory: (permissionOptions, requestData) => {

--- a/app/core/Permissions/specifications.test.js
+++ b/app/core/Permissions/specifications.test.js
@@ -132,7 +132,7 @@ describe('PermissionController specifications', () => {
       const permissionSpecifications = getPermissionSpecifications({});
       expect(Object.keys(permissionSpecifications)).toHaveLength(1);
       expect(
-        permissionSpecifications[RestrictedMethods.eth_accounts].targetKey,
+        permissionSpecifications[RestrictedMethods.eth_accounts].targetName,
       ).toStrictEqual(RestrictedMethods.eth_accounts);
     });
 

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -15,6 +15,7 @@ import { getPermittedAccounts } from '../Permissions';
 import { RPC } from '../../constants/network';
 import { getRpcMethodMiddleware } from './RPCMethodMiddleware';
 import AppConstants from '../AppConstants';
+import { PermissionConstraint } from '@metamask/permission-controller';
 
 jest.mock('../Engine', () => ({
   context: {
@@ -32,6 +33,10 @@ jest.mock('../Engine', () => ({
       newUnsignedPersonalMessage: jest.fn(),
       newUnsignedTypedMessage: jest.fn(),
     },
+    PermissionController: {
+      requestPermissions: jest.fn(),
+      getPermissions: jest.fn(),
+    },
   },
 }));
 const MockEngine = Engine as Omit<typeof Engine, 'context'> & {
@@ -39,6 +44,7 @@ const MockEngine = Engine as Omit<typeof Engine, 'context'> & {
     NetworkController: Record<string, any>;
     PreferencesController: Record<string, any>;
     TransactionController: Record<string, any>;
+    PermissionController: Record<string, any>;
   };
 };
 
@@ -415,6 +421,66 @@ describe('getRpcMethodMiddleware', () => {
       });
     });
   }
+
+  describe('wallet_requestPermissions', () => {
+    it('can requestPermissions for eth_accounts', async () => {
+      MockEngine.context.PermissionController.requestPermissions.mockImplementation(
+        async () => [
+          {
+            eth_accounts: {
+              parentCapability: 'eth_accounts',
+              caveats: [],
+            },
+          },
+        ],
+      );
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'wallet_requestPermissions',
+        params: [
+          {
+            eth_accounts: {},
+          },
+        ],
+      };
+      const response = await callMiddleware({ middleware, request });
+      expect(
+        (response as JsonRpcSuccess<PermissionConstraint[]>).result,
+      ).toEqual([{ parentCapability: 'eth_accounts', caveats: [] }]);
+    });
+  });
+
+  describe('wallet_getPermissions', () => {
+    it('can getPermissions', async () => {
+      MockEngine.context.PermissionController.getPermissions.mockImplementation(
+        () => ({
+          eth_accounts: {
+            parentCapability: 'eth_accounts',
+            caveats: [],
+          },
+        }),
+      );
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+      });
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'wallet_getPermissions',
+        params: [],
+      };
+      const response = await callMiddleware({ middleware, request });
+      expect(
+        (response as JsonRpcSuccess<PermissionConstraint[]>).result,
+      ).toEqual([{ parentCapability: 'eth_accounts', caveats: [] }]);
+    });
+  });
 
   describe('eth_sendTransaction', () => {
     describe('browser', () => {

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -14,7 +14,7 @@ import { recoverPersonalSignature } from '@metamask/eth-sig-util';
 import RPCMethods from './index.js';
 import { RPC } from '../../constants/network';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
-import { permissionRpcMethods } from '@metamask/permission-controller';
+import { PermissionConstraint, permissionRpcMethods, PermittedHandlerExport, RequestedPermissions } from '@metamask/permission-controller';
 import Networks, {
   blockTagParamIndex,
   getAllNetworks,
@@ -31,6 +31,8 @@ import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants.js';
 import { isSmartContractAddress } from '../../util/transactions';
 import { TOKEN_NOT_SUPPORTED_FOR_NETWORK } from '../../constants/error';
+import { GetPermissionsHooks } from '@metamask/permission-controller/dist/rpc-methods/getPermissions.js';
+import { RequestPermissionsHooks } from '@metamask/permission-controller/dist/rpc-methods/requestPermissions.js';
 const Engine = ImportedEngine as any;
 
 let appVersion = '';
@@ -252,8 +254,18 @@ export const getRpcMethodMiddleware = ({
       return responseData;
     };
 
-    const [requestPermissionsHandler, getPermissionsHandler] =
-      permissionRpcMethods.handlers;
+    const requestPermissionsHandler = permissionRpcMethods
+      .handlers[0] as PermittedHandlerExport<
+      RequestPermissionsHooks,
+      [RequestedPermissions],
+      PermissionConstraint[]
+    >;
+    const getPermissionsHandler = permissionRpcMethods
+      .handlers[1] as PermittedHandlerExport<
+      GetPermissionsHooks,
+      undefined,
+      PermissionConstraint[]
+    >;
     const rpcMethods: any = {
       wallet_getPermissions: async () =>
         new Promise<any>((resolve) => {
@@ -265,11 +277,6 @@ export const getRpcMethodMiddleware = ({
               resolve(undefined);
             },
             {
-              requestPermissionsForOrigin:
-                Engine.context.PermissionController.requestPermissions.bind(
-                  Engine.context.PermissionController,
-                  { origin: hostname },
-                ),
               getPermissionsForOrigin:
                 Engine.context.PermissionController.getPermissions.bind(
                   Engine.context.PermissionController,
@@ -296,11 +303,6 @@ export const getRpcMethodMiddleware = ({
                   Engine.context.PermissionController.requestPermissions.bind(
                     Engine.context.PermissionController,
                     { origin: hostname },
-                  ),
-                getPermissionsForOrigin:
-                  Engine.context.PermissionController.getPermissions.bind(
-                    Engine.context.PermissionController,
-                    hostname,
                   ),
               },
             )

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -14,7 +14,7 @@ import { recoverPersonalSignature } from '@metamask/eth-sig-util';
 import RPCMethods from './index.js';
 import { RPC } from '../../constants/network';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
-import { PermissionConstraint, permissionRpcMethods, PermittedHandlerExport, RequestedPermissions } from '@metamask/permission-controller';
+import { permissionRpcMethods } from '@metamask/permission-controller';
 import Networks, {
   blockTagParamIndex,
   getAllNetworks,
@@ -31,8 +31,6 @@ import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants.js';
 import { isSmartContractAddress } from '../../util/transactions';
 import { TOKEN_NOT_SUPPORTED_FOR_NETWORK } from '../../constants/error';
-import { GetPermissionsHooks } from '@metamask/permission-controller/dist/rpc-methods/getPermissions.js';
-import { RequestPermissionsHooks } from '@metamask/permission-controller/dist/rpc-methods/requestPermissions.js';
 const Engine = ImportedEngine as any;
 
 let appVersion = '';

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -254,18 +254,9 @@ export const getRpcMethodMiddleware = ({
       return responseData;
     };
 
-    const requestPermissionsHandler = permissionRpcMethods
-      .handlers[0] as PermittedHandlerExport<
-      RequestPermissionsHooks,
-      [RequestedPermissions],
-      PermissionConstraint[]
-    >;
-    const getPermissionsHandler = permissionRpcMethods
-      .handlers[1] as PermittedHandlerExport<
-      GetPermissionsHooks,
-      undefined,
-      PermissionConstraint[]
-    >;
+    const [requestPermissionsHandler, getPermissionsHandler] =
+      permissionRpcMethods.handlers;
+
     const rpcMethods: any = {
       wallet_getPermissions: async () =>
         new Promise<any>((resolve) => {

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -1,6 +1,9 @@
 import { Alert } from 'react-native';
 import { getVersion } from 'react-native-device-info';
-import { createAsyncMiddleware } from 'json-rpc-engine';
+import {
+  createAsyncMiddleware,
+  JsonRpcEngineCallbackError,
+} from 'json-rpc-engine';
 import { ethErrors } from 'eth-json-rpc-errors';
 import {
   EndFlowOptions,
@@ -11,6 +14,7 @@ import { recoverPersonalSignature } from '@metamask/eth-sig-util';
 import RPCMethods from './index.js';
 import { RPC } from '../../constants/network';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { permissionRpcMethods } from '@metamask/permission-controller';
 import Networks, {
   blockTagParamIndex,
   getAllNetworks,
@@ -248,7 +252,61 @@ export const getRpcMethodMiddleware = ({
       return responseData;
     };
 
+    const [requestPermissionsHandler, getPermissionsHandler] =
+      permissionRpcMethods.handlers;
     const rpcMethods: any = {
+      wallet_getPermissions: async () =>
+        new Promise<any>((resolve) => {
+          getPermissionsHandler.implementation(
+            req,
+            res,
+            next,
+            () => {
+              resolve(undefined);
+            },
+            {
+              requestPermissionsForOrigin:
+                Engine.context.PermissionController.requestPermissions.bind(
+                  Engine.context.PermissionController,
+                  { origin: hostname },
+                ),
+              getPermissionsForOrigin:
+                Engine.context.PermissionController.getPermissions.bind(
+                  Engine.context.PermissionController,
+                  hostname,
+                ),
+            },
+          );
+        }),
+      wallet_requestPermissions: async () =>
+        new Promise<any>((resolve, reject) => {
+          requestPermissionsHandler
+            .implementation(
+              req,
+              res,
+              next,
+              (err: JsonRpcEngineCallbackError | undefined) => {
+                if (err) {
+                  return reject(err);
+                }
+                resolve(undefined);
+              },
+              {
+                requestPermissionsForOrigin:
+                  Engine.context.PermissionController.requestPermissions.bind(
+                    Engine.context.PermissionController,
+                    { origin: hostname },
+                  ),
+                getPermissionsForOrigin:
+                  Engine.context.PermissionController.getPermissions.bind(
+                    Engine.context.PermissionController,
+                    hostname,
+                  ),
+              },
+            )
+            ?.then(resolve)
+            .catch(reject);
+        }),
       eth_getTransactionByHash: async () => {
         res.result = await polyfillGasPrice('getTransactionByHash', req.params);
       },

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@metamask/gas-fee-controller": "4.0.0",
     "@metamask/keyring-controller": "^1.0.1",
     "@metamask/network-controller": "^5.0.0",
-    "@metamask/permission-controller": "~3.0.0",
+    "@metamask/permission-controller": "^4.0.1",
     "@metamask/phishing-controller": "^3.0.0",
     "@metamask/preferences-controller": "^2.1.0",
     "@metamask/sdk-communication-layer": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,7 +5110,7 @@
     "@metamask/base-controller" "^2.0.0"
     "@metamask/controller-utils" "^3.0.0"
 
-"@metamask/approval-controller@3.4.0", "@metamask/approval-controller@^2.0.0", "@metamask/approval-controller@^2.1.1", "@metamask/approval-controller@^3.4.0":
+"@metamask/approval-controller@3.4.0", "@metamask/approval-controller@^2.1.1", "@metamask/approval-controller@^3.3.0", "@metamask/approval-controller@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@metamask/approval-controller/-/approval-controller-3.4.0.tgz#282900361d42f785578728b45014ff8cb5e557ea"
   integrity sha512-DjqrhiX9+W/Fh6Crr7FPJ87Y/uhPWzBvfXGtekv1LHZNmEtUxkrA7aelddUM0fpTdURIGT4aNGBoQudFidc+Lw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,7 +5195,7 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-2.2.0.tgz#277764d0d56e37180ae7644a9d11eb96295b36fc"
   integrity sha512-SM6A4C7vXNbVpgMTX67kfW8QWvu3eSXxMZlY5PqZBTkvri1s9zgQ0uwRkK5r2VXNEoVmXCDnnEX/tX5EzzgNUQ==
 
-"@metamask/controller-utils@^1.0.0", "@metamask/controller-utils@^3.0.0", "@metamask/controller-utils@^3.4.0", "@metamask/controller-utils@~3.0.0":
+"@metamask/controller-utils@^1.0.0", "@metamask/controller-utils@^3.0.0", "@metamask/controller-utils@^3.4.0", "@metamask/controller-utils@^4.0.1", "@metamask/controller-utils@~3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/controller-utils/-/controller-utils-3.0.0.tgz#e0984cdab14280409297671b5858891527c5e4ee"
   integrity sha512-JjFWBZnnh5DSX2tRsw5xtXxaqVkTzaW7mkSZ+lL3LoCAw47Cf8zGP1kGR6VKxcceKi+MpEFvZr7gf1OFnOoEjw==
@@ -5378,18 +5378,18 @@
     "@metamask/safe-event-emitter" "^2.0.0"
     through2 "^2.0.3"
 
-"@metamask/permission-controller@~3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/permission-controller/-/permission-controller-3.0.0.tgz#2c58f749c4fc192743fd2e5fad5ffa503ba1c068"
-  integrity sha512-902jw48yetCsNo6DGrXKHDWWz/QzdmC90O6Am5WgUmwUlboU9Mr0uS8Fp8b7qPQiDZRXz8PvckodyEX2XNW+tQ==
+"@metamask/permission-controller@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/permission-controller/-/permission-controller-4.0.1.tgz#b3eee18b49cd9be9e7241e1038fd0df30d546867"
+  integrity sha512-LMhD2+3QHmrYQzs81/ZUf473or+B+HmKLpVwpC0L1FfAeSrEpcDrfxWbGtYwiMo9wqNqwN2UAH7ifNy5rudtsA==
   dependencies:
-    "@metamask/approval-controller" "^2.0.0"
-    "@metamask/base-controller" "^2.0.0"
-    "@metamask/controller-utils" "^3.0.0"
-    "@metamask/types" "^1.1.0"
+    "@metamask/approval-controller" "^3.3.0"
+    "@metamask/base-controller" "^3.0.0"
+    "@metamask/controller-utils" "^4.0.1"
+    "@metamask/utils" "^5.0.2"
     "@types/deep-freeze-strict" "^1.1.0"
     deep-freeze-strict "^1.1.1"
-    eth-rpc-errors "^4.0.0"
+    eth-rpc-errors "^4.0.2"
     immer "^9.0.6"
     json-rpc-engine "^6.1.0"
     nanoid "^3.1.31"


### PR DESCRIPTION
**Description**
Added missing methods `wallet_requestPermissions` and `wallet_getPermissions` to the mobile API.

This brings it in line with the extension API so that dapps that build against requestPermissions don't have to have extra logic to do `requestAccounts` instead.

fixes https://github.com/MetaMask/MetaMask-planning/issues/861


**Screenshots/Recordings**

some screenshots of it working in the new api playground:

### `wallet_requestPermissions`
![image](https://github.com/MetaMask/metamask-mobile/assets/364566/012da830-6cf5-460a-b95d-6d20aa8dc293)
![image](https://github.com/MetaMask/metamask-mobile/assets/364566/e2c8721c-a84b-4c42-b050-6305bcae23fe)
#### error case:
![image](https://github.com/MetaMask/metamask-mobile/assets/364566/32609af2-ae4a-4ee9-9c80-576906f7aea5)


### `wallet_getPermissions`

![image](https://github.com/MetaMask/metamask-mobile/assets/364566/dfee682f-d147-44cc-83d6-5dbf4e1d20e3)

