### PR TITLE
fix: onPress prop added to SelectItem component

### DIFF
--- a/app/component-library/components/Select/Select/SelectItem/SelectItem.tsx
+++ b/app/component-library/components/Select/Select/SelectItem/SelectItem.tsx
@@ -21,12 +21,17 @@ const SelectItem: React.FC<SelectItemProps> = ({
   isSelected = false,
   isDisabled = false,
   children,
+  onPress,
   ...props
 }) => {
   const { styles } = useStyles(styleSheet, { style, isDisabled });
 
   return (
-    <TouchableOpacity style={styles.base} disabled={isDisabled}>
+    <TouchableOpacity
+      style={styles.base}
+      disabled={isDisabled}
+      onPress={onPress}
+    >
       <ListItem
         padding={DEFAULT_SELECTITEM_PADDING}
         borderRadius={DEFAULT_SELECTITEM_BORDERRADIUS}

--- a/app/components/UI/AccountSelectorList/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/UI/AccountSelectorList/__snapshots__/AccountSelector.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`AccountSelectorList should render all accounts but only the balance for
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -221,6 +222,7 @@ exports[`AccountSelectorList should render all accounts but only the balance for
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -382,6 +384,7 @@ exports[`AccountSelectorList should render all accounts with balances 1`] = `
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -641,6 +644,7 @@ exports[`AccountSelectorList should render all accounts with balances 1`] = `
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -929,6 +933,7 @@ exports[`AccountSelectorList should render all accounts with right acessory 1`] 
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -1141,6 +1146,7 @@ exports[`AccountSelectorList should render all accounts with right acessory 1`] 
     >
       <TouchableOpacity
         disabled={false}
+        onPress={[Function]}
         style={
           Object {
             "opacity": 1,

--- a/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
@@ -437,6 +437,7 @@ exports[`Network Selector renders correctly 1`] = `
                           <View>
                             <TouchableOpacity
                               disabled={false}
+                              onPress={[Function]}
                               style={
                                 Object {
                                   "alignItems": "center",
@@ -553,6 +554,7 @@ exports[`Network Selector renders correctly 1`] = `
                             </TouchableOpacity>
                             <TouchableOpacity
                               disabled={false}
+                              onPress={[Function]}
                               style={
                                 Object {
                                   "alignItems": "center",
@@ -644,6 +646,7 @@ exports[`Network Selector renders correctly 1`] = `
                             </TouchableOpacity>
                             <TouchableOpacity
                               disabled={false}
+                              onPress={[Function]}
                               style={
                                 Object {
                                   "alignItems": "center",
@@ -735,6 +738,7 @@ exports[`Network Selector renders correctly 1`] = `
                             </TouchableOpacity>
                             <TouchableOpacity
                               disabled={false}
+                              onPress={[Function]}
                               style={
                                 Object {
                                   "alignItems": "center",
@@ -826,6 +830,7 @@ exports[`Network Selector renders correctly 1`] = `
                             </TouchableOpacity>
                             <TouchableOpacity
                               disabled={false}
+                              onPress={[Function]}
                               style={
                                 Object {
                                   "alignItems": "center",


### PR DESCRIPTION
**Description**
The SelectItem component didn't have the onPress property.

Added the onPress property to the TouchableOpacity component of SelectItem component

**Screenshots/Recordings**
https://recordit.co/hzOkc1TxGL

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
