### PR TITLE
fix: prevent infinite spinner when adding network

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -386,22 +386,28 @@ const RootRPCMethodsUI = (props) => {
     ],
   );
 
-  const renderApprovalFlowModal = () => (
-    <Modal
-      isVisible={showPendingApprovalFlow}
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      style={styles.bottomModal}
-      backdropColor={colors.overlay.default}
-      backdropOpacity={1}
-      animationInTiming={600}
-      animationOutTiming={600}
-      swipeDirection={'down'}
-      propagateSwipe
-    >
-      <ApprovalFlowLoader loadingText={approvalFlowLoadingText} />
-    </Modal>
-  );
+  const renderApprovalFlowModal = () => {
+    if (!showPendingApprovalFlow || showPendingApproval) {
+      return null;
+    }
+
+    return (
+      <Modal
+        isVisible
+        animationIn="slideInUp"
+        animationOut="slideOutDown"
+        style={styles.bottomModal}
+        backdropColor={colors.overlay.default}
+        backdropOpacity={1}
+        animationInTiming={600}
+        animationOutTiming={600}
+        swipeDirection={'down'}
+        propagateSwipe
+      >
+        <ApprovalFlowLoader loadingText={approvalFlowLoadingText} />
+      </Modal>
+    );
+  };
 
   const renderQRSigningModal = () => {
     const { isSigningQRObject, QRState } = props;


### PR DESCRIPTION
**Description**

Ensure the approval flow loader is only visible if there are no pending approvals.

**Issue**

Fixes [#1101](https://github.com/MetaMask/mobile-planning/issues/1101)

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
