### PR TITLE
fix: update cookie-tough dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "detox/**/moment": "^2.29.4",
     "oss-attribution-generator/**/debug": "^2.6.9",
     "d3-color": "3.1.0",
-    "**/fast-xml-parser": "4.2.4"
+    "**/fast-xml-parser": "4.2.4",
+    "tough-cookie": "4.1.3"
   },
   "dependencies": {
     "@consensys/on-ramp-sdk": "1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22581,11 +22581,6 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
 psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -26176,18 +26171,10 @@ toposort@^2.0.2:
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
   integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
-tough-cookie@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
-  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+tough-cookie@4.1.3, tough-cookie@^2.3.3, tough-cookie@^4.0.0, tough-cookie@~2.5.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"


### PR DESCRIPTION
**Description**
This PR aims to solve vulnerabilities found

Vulnerability Found:
Severity: MODERATE
Modules: @metamask/network-controller>web3-provider-engine>request>tough-cookie, @metamask/assets-controllers>@metamask/network-controller>web3-provider-engine>request>tough-cookie
URL: https://github.com/advisories/GHSA-72xf-g2v4-qvf3
Vulnerability Found:
Severity: MODERATE
Modules: @metamask/network-controller>web3-provider-engine>request>tough-cookie, @metamask/assets-controllers>@metamask/network-controller>web3-provider-engine>request>tough-cookie
URL: https://github.com/advisories/GHSA-72xf-g2v4-qvf3

**Screenshots/Recordings**

Wallet with zero balance changing networks:
https://recordit.co/ZuOnh6Z14H
Imported account -> imported tokens, imported nfts (automatically and manually)
https://recordit.co/f09WdFAkW6 (import nft manually)
https://recordit.co/9TWRuGY56I
Transactions (e2e test dapp, send flow and almost swap on uniswap)
https://recordit.co/Hx921Okotm


E2E QA: 
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/d5caec38-1f19-4536-b180-3541cf4cda40

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
