### PR TITLE
refactor: Use selectors for preferences controller state access

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -86,6 +86,7 @@ import EditAccountName from '../../Views/EditAccountName/EditAccountName';
 import WC2Manager, {
   isWC2Enabled,
 } from '../../../../app/core/WalletConnect/WalletConnectV2';
+import { selectFrequentRpcList } from '../../../selectors/preferencesController';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -231,10 +232,7 @@ const App = ({ userLoggedIn }) => {
       dispatch(setCurrentBottomNavRoute(route));
     }
   };
-  const frequentRpcList = useSelector(
-    (state) =>
-      state?.engine?.backgroundState?.PreferencesController?.frequentRpcList,
-  );
+  const frequentRpcList = useSelector(selectFrequentRpcList);
 
   useEffect(() => {
     if (prevNavigator.current || !navigator) return;

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -59,6 +59,7 @@ import {
 import { selectTokenList } from '../../../selectors/tokenListController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import { createAccountConnectNavDetails } from '../../Views/AccountConnect';
 import { ApprovalResult } from '../../UI/Approval/ApprovalResult';
 import { ApprovalResultType } from '../../UI/Approval/ApprovalResult/ApprovalResult';
@@ -953,8 +954,7 @@ RootRPCMethodsUI.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   chainId: selectChainId(state),
   tokens: selectTokens(state),
   swapsTransactions:

--- a/app/components/UI/AccountApproval/index.js
+++ b/app/components/UI/AccountApproval/index.js
@@ -31,6 +31,7 @@ import {
 } from '../../../selectors/networkController';
 import { selectTokensLength } from '../../../selectors/tokensController';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import AppConstants from '../../../../app/core/AppConstants';
 import { shuffle } from 'lodash';
 import SDKConnect from '../../../core/SDKConnect/SDKConnect';
@@ -462,9 +463,8 @@ class AccountApproval extends PureComponent {
 
 const mapStateToProps = (state) => ({
   accountsLength: selectAccountsLength(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   tokensLength: selectTokensLength(state),
+  selectedAddress: selectSelectedAddress(state),
   networkType: selectProviderType(state),
   chainId: selectChainId(state),
 });

--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
@@ -9,6 +9,7 @@ import {
   selectNetwork,
   selectTicker,
 } from '../../../selectors/networkController';
+import { selectIdentities } from '../../../selectors/preferencesController';
 import { collectConfusables } from '../../../util/confusables';
 import { decodeTransferData } from '../../../util/transactions';
 import { doENSReverseLookup } from '../../../util/ENSUtils';
@@ -172,7 +173,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
 };
 
 const mapStateToProps = (state: any) => ({
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  identities: selectIdentities(state),
   network: selectNetwork(state),
   ticker: selectTicker(state),
 });

--- a/app/components/UI/AccountInfoCard/index.js
+++ b/app/components/UI/AccountInfoCard/index.js
@@ -26,6 +26,7 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectIdentities } from '../../../selectors/preferencesController';
 import ApproveTransactionHeader from '../ApproveTransactionHeader';
 
 const createStyles = (colors) =>
@@ -240,7 +241,7 @@ class AccountInfoCard extends PureComponent {
 
 const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  identities: selectIdentities(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   ticker: selectTicker(state),

--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -40,6 +40,10 @@ import AppConstants from '../../../core/AppConstants';
 import Engine from '../../../core/Engine';
 import { selectNetwork } from '../../../selectors/networkController';
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 
 const createStyles = (colors) =>
@@ -251,11 +255,10 @@ class AccountOverview extends PureComponent {
 
   setAccountLabel = () => {
     const { PreferencesController } = Engine.context;
-    const { selectedAddress } = this.props;
+    const { selectedAddress, identities } = this.props;
     const { accountLabel } = this.state;
 
-    const lastAccountLabel =
-      PreferencesController.state.identities[selectedAddress].name;
+    const lastAccountLabel = identities[selectedAddress].name;
 
     PreferencesController.setAccountLabel(
       selectedAddress,
@@ -452,9 +455,8 @@ class AccountOverview extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
   currentCurrency: selectCurrentCurrency(state),
   network: String(selectNetwork(state)),
   browserTabs: state.browser.tabs,

--- a/app/components/UI/AddCustomCollectible/index.tsx
+++ b/app/components/UI/AddCustomCollectible/index.tsx
@@ -28,6 +28,7 @@ import {
   NFT_IDENTIFIER_INPUT_BOX_ID,
 } from '../../../../wdio/screen-objects/testIDs/Screens/NFTImportScreen.testIds';
 import { selectChainId } from '../../../selectors/networkController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -81,10 +82,7 @@ const AddCustomCollectible = ({
   const { colors, themeAppearance } = useTheme();
   const styles = createStyles(colors);
 
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
   const chainId = useSelector(selectChainId);
 
   useEffect(() => {

--- a/app/components/UI/AddressCopy/AddressCopy.tsx
+++ b/app/components/UI/AddressCopy/AddressCopy.tsx
@@ -26,6 +26,10 @@ import generateTestId from '../../../../wdio/utils/generateTestId';
 // Internal dependencies
 import styleSheet from './AddressCopy.styles';
 import { AddressCopyProps } from './AddressCopy.types';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const AddressCopy = ({ formatAddressType = 'full' }: AddressCopyProps) => {
   const { styles } = useStyles(styleSheet, {});
@@ -45,23 +49,18 @@ const AddressCopy = ({ formatAddressType = 'full' }: AddressCopyProps) => {
   /**
    * A string that represents the selected address
    */
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
 
   /**
    * An object containing each identity in the format address => account
    */
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
 
   const account = {
     address: selectedAddress,
     ...identities[selectedAddress],
   };
+
   const copyAccountToClipboard = async () => {
     await ClipboardManager.setString(selectedAddress);
     handleShowAlert({

--- a/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
+++ b/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
@@ -11,6 +11,7 @@ import TagUrl from '../../../component-library/components/Tags/TagUrl';
 import { useStyles } from '../../../component-library/hooks';
 import { selectProviderConfig } from '../../../selectors/networkController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectIdentities } from '../../../selectors/preferencesController';
 import { renderAccountName, renderShortAddress } from '../../../util/address';
 import {
   getHost,
@@ -49,10 +50,7 @@ const ApproveTransactionHeader = ({
 
   const accounts = useSelector(selectAccounts);
 
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
   const activeAddress = toChecksumAddress(from);
 
   const networkProvider = useSelector(selectProviderConfig);

--- a/app/components/UI/ApproveTransactionReview/AddNickname/index.tsx
+++ b/app/components/UI/ApproveTransactionReview/AddNickname/index.tsx
@@ -37,6 +37,10 @@ import {
   selectProviderType,
   selectRpcTarget,
 } from '../../../../selectors/networkController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+} from '../../../../selectors/preferencesController';
 
 const getAnalyticsParams = () => ({});
 
@@ -263,9 +267,8 @@ const mapStateToProps = (state: any) => ({
   providerChainId: selectChainId(state),
   providerNetwork: selectNetwork(state),
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
-  identities: state.engine.backgroundState.PreferencesController.identities,
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  identities: selectIdentities(state),
+  frequentRpcList: selectFrequentRpcList(state),
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -80,6 +80,7 @@ import {
 import { selectTokenList } from '../../../selectors/tokenListController';
 import { selectTokensLength } from '../../../selectors/tokensController';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import { selectFrequentRpcList } from '../../../selectors/preferencesController';
 import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
@@ -1178,8 +1179,7 @@ class ApproveTransactionReview extends PureComponent {
 
 const mapStateToProps = (state) => ({
   ticker: selectTicker(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   transaction: getNormalizedTxState(state),
   tokensLength: selectTokensLength(state),
   accountsLength: selectAccountsLength(state),

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -27,6 +27,7 @@ import {
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import Logger from '../../../util/Logger';
 import { safeToChecksumAddress } from '../../../util/address';
 import {
@@ -68,10 +69,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   const primaryCurrency = useSelector(
     (state: RootStateOrAny) => state.settings.primaryCurrency,
   );
-  const selectedAddress = useSelector(
-    (state: RootStateOrAny) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
   const tokenExchangeRates = useSelector(selectContractExchangeRates);
   const tokenBalances = useSelector(selectContractBalances);
   const chainId = useSelector((state: RootStateOrAny) => selectChainId(state));

--- a/app/components/UI/CollectibleContractElement/index.js
+++ b/app/components/UI/CollectibleContractElement/index.js
@@ -15,6 +15,7 @@ import { removeFavoriteCollectible } from '../../../actions/collectibles';
 import { collectibleContractsSelector } from '../../../reducers/collectibles';
 import { useTheme } from '../../../util/theme';
 import { selectChainId } from '../../../selectors/networkController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const DEVICE_WIDTH = Device.getDeviceWidth();
 const COLLECTIBLE_WIDTH = (DEVICE_WIDTH - 30 - 16) / 3;
@@ -296,8 +297,7 @@ CollectibleContractElement.propTypes = {
 const mapStateToProps = (state) => ({
   collectibleContracts: collectibleContractsSelector(state),
   chainId: selectChainId(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -37,9 +37,14 @@ import {
   selectProviderType,
 } from '../../../selectors/networkController';
 import {
+  selectSelectedAddress,
+  selectUseNftDetection,
+} from '../../../selectors/preferencesController';
+import {
   IMPORT_NFT_BUTTON_ID,
   NFT_TAB_CONTAINER_ID,
 } from '../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
+
 const createStyles = (colors) =>
   StyleSheet.create({
     wrapper: {
@@ -361,10 +366,8 @@ CollectibleContracts.propTypes = {
 const mapStateToProps = (state) => ({
   networkType: selectProviderType(state),
   chainId: selectChainId(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
-  useNftDetection:
-    state.engine.backgroundState.PreferencesController.useNftDetection,
+  selectedAddress: selectSelectedAddress(state),
+  useNftDetection: selectUseNftDetection(state),
   nftDetectionDismissed: state.user.nftDetectionDismissed,
   collectibleContracts: collectibleContractsSelector(state),
   collectibles: collectiblesSelector(state),

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -45,6 +45,7 @@ import {
 import AppConstants from '../../../core/AppConstants';
 import { useTheme } from '../../../util/theme';
 import { selectChainId } from '../../../selectors/networkController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const ANIMATION_VELOCITY = 250;
 const HAS_NOTCH = Device.hasNotch();
@@ -521,8 +522,7 @@ CollectibleOverview.propTypes = {
 
 const mapStateToProps = (state, props) => ({
   chainId: selectChainId(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   isInFavorites: isCollectibleInFavoritesSelector(state, props.collectible),
 });
 

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -81,6 +81,11 @@ import { selectCurrentCurrency } from '../../../selectors/currencyRateController
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 import NetworkInfo from '../NetworkInfo';
@@ -1242,12 +1247,10 @@ class DrawerView extends PureComponent {
 
 const mapStateToProps = (state) => ({
   providerConfig: selectProviderConfig(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   accounts: selectAccounts(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
+  frequentRpcList: selectFrequentRpcList(state),
   currentCurrency: selectCurrentCurrency(state),
   keyrings: state.engine.backgroundState.KeyringController.keyrings,
   networkModalVisible: state.modals.networkModalVisible,

--- a/app/components/UI/NavbarLeftButton/index.js
+++ b/app/components/UI/NavbarLeftButton/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { TouchableOpacity, StyleSheet } from 'react-native';
 import Identicon from '../Identicon';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const styles = StyleSheet.create({
   leftButton: {
@@ -43,6 +44,6 @@ class NavbarLeftButton extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  address: state.engine.backgroundState.PreferencesController.selectedAddress,
+  address: selectSelectedAddress(state),
 });
 export default connect(mapStateToProps)(NavbarLeftButton);

--- a/app/components/UI/NetworkInfo/index.tsx
+++ b/app/components/UI/NetworkInfo/index.tsx
@@ -15,6 +15,7 @@ import { fontStyles } from '../../../styles/common';
 import { isTokenDetectionSupportedForNetwork } from '@metamask/assets-controllers/dist/assetsUtil';
 import { NETWORK_EDUCATION_MODAL_CLOSE_BUTTON } from '../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids.js';
 import { selectProviderConfig } from '../../../selectors/networkController';
+import { selectUseTokenDetection } from '../../../selectors/preferencesController';
 import {
   getNetworkImageSource,
   getNetworkNameFromProvider,
@@ -231,8 +232,7 @@ const NetworkInfo = (props: NetworkInfoProps) => {
 };
 
 const mapStateToProps = (state: any) => ({
-  isTokenDetectionEnabled:
-    state.engine.backgroundState.PreferencesController.useTokenDetection,
+  isTokenDetectionEnabled: selectUseTokenDetection(state),
 });
 
 export default connect(mapStateToProps)(NetworkInfo);

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -34,6 +34,7 @@ import {
 import { selectTokensByAddress } from '../../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../../selectors/preferencesController';
 
 const WINDOW_WIDTH = Dimensions.get('window').width;
 const ACTION_CANCEL = 'cancel';
@@ -420,8 +421,7 @@ TransactionNotification.propTypes = {
 
 const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
   ticker: selectTicker(state),
   chainId: selectChainId(state),

--- a/app/components/UI/OnboardingWizard/Step3/index.js
+++ b/app/components/UI/OnboardingWizard/Step3/index.js
@@ -16,6 +16,10 @@ import generateTestId from '../../../../../wdio/utils/generateTestId';
 import { ONBOARDING_WIZARD_THIRD_STEP_CONTENT_ID } from '../../../../../wdio/screen-objects/testIDs/Components/OnboardingWizard.testIds';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 
 const styles = StyleSheet.create({
   main: {
@@ -131,9 +135,8 @@ Step3.propTypes = {
 const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   currentCurrency: selectCurrentCurrency(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/UI/PaymentRequest/index.js
+++ b/app/components/UI/PaymentRequest/index.js
@@ -59,6 +59,7 @@ import {
 import { selectTokenListArray } from '../../../selectors/tokenListController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import {
   REQUEST_AMOUNT_INPUT,
@@ -888,9 +889,8 @@ const mapStateToProps = (state) => ({
   currentCurrency: selectCurrentCurrency(state),
   contractExchangeRates: selectContractExchangeRates(state),
   searchEngine: state.settings.searchEngine,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   tokens: selectTokens(state),
+  selectedAddress: selectSelectedAddress(state),
   primaryCurrency: state.settings.primaryCurrency,
   ticker: selectTicker(state),
   chainId: selectChainId(state),

--- a/app/components/UI/Ramp/Views/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails.tsx
@@ -21,6 +21,7 @@ import {
 import { useTheme } from '../../../../util/theme';
 import Logger from '../../../../util/Logger';
 import { selectProviderConfig } from '../../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 
 interface OrderDetailsParams {
   orderId?: string;
@@ -34,10 +35,7 @@ export const createOrderDetailsNavDetails =
 const OrderDetails = () => {
   const trackEvent = useAnalytics();
   const providerConfig = useSelector(selectProviderConfig);
-  const frequentRpcList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const frequentRpcList = useSelector(selectFrequentRpcList);
   const params = useParams<OrderDetailsParams>();
   const order = useSelector((state) => getOrderById(state, params.orderId));
   const { colors } = useTheme();

--- a/app/components/UI/Ramp/components/Account.tsx
+++ b/app/components/UI/Ramp/components/Account.tsx
@@ -7,6 +7,11 @@ import { View, StyleSheet } from 'react-native';
 import { useTheme } from '../../../../util/theme';
 import { Colors } from '../../../../util/theme/models';
 import { colors as importedColors } from '../../../../styles/common';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
+
 // TODO: Convert into typescript and correctly type
 const Identicon = JSIdenticon as any;
 
@@ -43,14 +48,8 @@ const Account = ({
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
+  const identities = useSelector(selectIdentities);
   return (
     <View
       style={[styles.container, transparent && styles.transparentContainer]}

--- a/app/components/UI/Ramp/components/AccountSelector.tsx
+++ b/app/components/UI/Ramp/components/AccountSelector.tsx
@@ -9,6 +9,10 @@ import Text from '../../../Base/Text';
 import JSSelectorButton from '../../../Base/SelectorButton';
 import { useNavigation } from '@react-navigation/native';
 import { createAccountSelectorNavDetails } from '../../../Views/AccountSelector';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 
 // TODO: Convert into typescript and correctly type
 const SelectorButton = JSSelectorButton as any;
@@ -27,15 +31,9 @@ const styles = StyleSheet.create({
 
 const AccountSelector = () => {
   const navigation = useNavigation();
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
 
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
 
   const openAccountSelector = () =>
     navigation.navigate(...createAccountSelectorNavDetails());

--- a/app/components/UI/ReceiveRequest/index.js
+++ b/app/components/UI/ReceiveRequest/index.js
@@ -43,6 +43,7 @@ import {
   selectTicker,
 } from '../../../selectors/networkController';
 import { isNetworkBuySupported } from '../Ramp/utils';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import { getRampNetworks } from '../../../reducers/fiatOrders';
 
 const createStyles = (colors) =>
@@ -360,8 +361,7 @@ const mapStateToProps = (state) => ({
   chainId: selectChainId(state),
   network: selectNetwork(state),
   ticker: selectTicker(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   receiveAsset: state.modals.receiveAsset,
   seedphraseBackedUp: state.user.seedphraseBackedUp,
   isNetworkBuySupported: isNetworkBuySupported(

--- a/app/components/UI/SearchTokenAutocomplete/index.tsx
+++ b/app/components/UI/SearchTokenAutocomplete/index.tsx
@@ -21,6 +21,7 @@ import { FORMATTED_NETWORK_NAMES } from '../../../constants/on-ramp';
 import NotificationManager from '../../../core/NotificationManager';
 import { useTheme } from '../../../util/theme';
 import { selectChainId } from '../../../selectors/networkController';
+import { selectUseTokenDetection } from '../../../selectors/preferencesController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -60,10 +61,7 @@ const SearchTokenAutocomplete = ({ navigation }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
-  const isTokenDetectionEnabled = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.useTokenDetection,
-  );
+  const isTokenDetectionEnabled = useSelector(selectUseTokenDetection);
   const chainId = useSelector(selectChainId);
 
   const setFocusState = useCallback(

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -88,6 +88,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import { resetTransaction, setRecipient } from '../../../actions/transaction';
 
 const POLLING_INTERVAL = 30000;
@@ -2348,9 +2349,8 @@ const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   chainId: selectChainId(state),
   ticker: selectTicker(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   balances: selectContractBalances(state),
+  selectedAddress: selectSelectedAddress(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   isInPolling: state.engine.backgroundState.SwapsController.isInPolling,

--- a/app/components/UI/Swaps/components/TokenSelectModal.js
+++ b/app/components/UI/Swaps/components/TokenSelectModal.js
@@ -53,6 +53,10 @@ import {
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
+import {
+  selectFrequentRpcList,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 
 import Analytics from '../../../../core/Analytics/Analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -565,14 +569,12 @@ const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   tokenExchangeRates: selectContractExchangeRates(state),
   balances: selectContractBalances(state),
   chainId: selectChainId(state),
   providerConfig: selectProviderConfig(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
 });
 
 export default connect(mapStateToProps)(TokenSelectModal);

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -80,6 +80,10 @@ import {
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import {
+  selectFrequentRpcList,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 import AccountSelector from '../Ramp/components/AccountSelector';
 
 const createStyles = (colors) =>
@@ -1001,15 +1005,13 @@ const mapStateToProps = (state) => ({
   swapsTokens: swapsTokensSelector(state),
   swapsControllerTokens: swapsControllerTokens(state),
   accounts: selectAccounts(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   balances: selectContractBalances(state),
+  selectedAddress: selectSelectedAddress(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   tokenExchangeRates: selectContractExchangeRates(state),
   providerConfig: selectProviderConfig(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   chainId: selectChainId(state),
   tokensWithBalance: swapsTokensWithBalanceSelector(state),
   tokensTopAssets: swapsTopAssetsSelector(state),

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -89,6 +89,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectDetectedTokens } from '../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
+import { selectUseTokenDetection } from '../../../selectors/preferencesController';
 
 const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const { colors, themeAppearance } = useTheme();
@@ -118,10 +119,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
     (state: any) => state.settings.hideZeroBalanceTokens,
   );
   const detectedTokens = useSelector(selectDetectedTokens);
-  const isTokenDetectionEnabled = useSelector(
-    (state: EngineState) =>
-      state.engine.backgroundState.PreferencesController.useTokenDetection,
-  );
+  const isTokenDetectionEnabled = useSelector(selectUseTokenDetection);
   const browserTabs = useSelector((state: any) => state.browser.tabs);
 
   const renderEmpty = () => (

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -49,6 +49,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -882,8 +883,7 @@ const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   contractBalances: selectContractBalances(state),
   networkType: selectProviderType(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   ticker: selectTicker(state),
   transaction: getNormalizedTxState(state),
   activeTabUrl: getActiveTabUrl(state),

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -37,6 +37,10 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { selectTokensByAddress } from '../../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
+import {
+  selectFrequentRpcList,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -411,10 +415,8 @@ class TransactionDetails extends PureComponent {
 const mapStateToProps = (state) => ({
   providerConfig: selectProviderConfig(state),
   chainId: selectChainId(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  frequentRpcList: selectFrequentRpcList(state),
+  selectedAddress: selectSelectedAddress(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
   ticker: selectTicker(state),
   tokens: selectTokensByAddress(state),

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -32,6 +32,10 @@ import {
   selectChainId,
   selectTicker,
 } from '../../../selectors/networkController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const createStyles = (colors, typography) =>
   StyleSheet.create({
@@ -573,10 +577,9 @@ class TransactionElement extends PureComponent {
 const mapStateToProps = (state) => ({
   ticker: selectTicker(state),
   chainId: selectChainId(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  identities: selectIdentities(state),
   primaryCurrency: state.settings.primaryCurrency,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   swapsTransactions:
     state.engine.backgroundState.TransactionController.swapsTransactions || {},
   swapsTokens: state.engine.backgroundState.SwapsController.tokens,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -58,6 +58,10 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import {
+  selectFrequentRpcList,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const createStyles = (colors, typography) =>
   StyleSheet.create({
@@ -775,11 +779,9 @@ const mapStateToProps = (state) => ({
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   nativeCurrency: selectNativeCurrency(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   providerConfig: selectProviderConfig(state),
   gasFeeEstimates:
     state.engine.backgroundState.GasFeeController.gasFeeEstimates,

--- a/app/components/UI/UpdateEIP1559Tx/index.tsx
+++ b/app/components/UI/UpdateEIP1559Tx/index.tsx
@@ -20,6 +20,7 @@ import {
   selectTicker,
 } from '../../../selectors/networkController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const UpdateEIP1559Tx = ({
   gas,
@@ -251,8 +252,7 @@ const UpdateEIP1559Tx = ({
 
 const mapStateToProps = (state: any) => ({
   accounts: selectAccounts(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   ticker: selectTicker(state),
   gasFeeEstimates:
     state.engine.backgroundState.GasFeeController.gasFeeEstimates,

--- a/app/components/UI/WalletAccount/WalletAccount.tsx
+++ b/app/components/UI/WalletAccount/WalletAccount.tsx
@@ -23,6 +23,10 @@ import {
   isDefaultAccountName,
 } from '../../../util/ENSUtils';
 import { selectChainId } from '../../../selectors/networkController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon/ButtonIcon';
 import { ButtonIconSizes } from '../../../component-library/components/Buttons/ButtonIcon';
 import Routes from '../../../constants/navigation/Routes';
@@ -51,18 +55,12 @@ const WalletAccount = ({ style }: WalletAccountProps, ref: React.Ref<any>) => {
   /**
    * A string that represents the selected address
    */
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
 
   /**
    * An object containing each identity in the format address => account
    */
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
 
   const chainId = useSelector(selectChainId);
 

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -23,6 +23,10 @@ import {
 import { Analytics, MetaMetricsEvents } from '../../../core/Analytics';
 import { RPC } from '../../../constants/network';
 import { selectProviderConfig } from '../../../selectors/networkController';
+import {
+  selectFrequentRpcList,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 import { strings } from '../../../../locales/i18n';
 
 // Internal dependencies
@@ -47,14 +51,8 @@ const AccountActions = () => {
 
   const providerConfig = useSelector(selectProviderConfig);
 
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
-  const frequentRpcList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
+  const frequentRpcList = useSelector(selectFrequentRpcList);
 
   const blockExplorer = useMemo(() => {
     if (providerConfig?.rpcTarget && providerConfig.type === RPC) {

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -37,6 +37,10 @@ import { AvatarAccountType } from '../../../component-library/components/Avatars
 import { safeToChecksumAddress } from '../../../util/address';
 import USER_INTENT from '../../../constants/permissions';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 // Internal dependencies.
 import {
@@ -52,10 +56,7 @@ const AccountConnect = (props: AccountConnectProps) => {
   const { hostInfo, permissionRequestId } = props.route.params;
   const [isLoading, setIsLoading] = useState(false);
   const navigation = useNavigation();
-  const selectedWalletAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedWalletAddress = useSelector(selectSelectedAddress);
   const [selectedAddresses, setSelectedAddresses] = useState<string[]>([
     selectedWalletAddress,
   ]);
@@ -67,10 +68,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     isLoading,
   });
   const previousIdentitiesListSize = useRef<number>();
-  const identitiesMap = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identitiesMap = useSelector(selectIdentities);
 
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
 

--- a/app/components/Views/AccountPermissions/AccountPermissions.tsx
+++ b/app/components/Views/AccountPermissions/AccountPermissions.tsx
@@ -38,6 +38,10 @@ import { getActiveTabUrl } from '../../../util/transactions';
 import { strings } from '../../../../locales/i18n';
 import { AvatarAccountType } from '../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+} from '../../../selectors/preferencesController';
 
 // Internal dependencies.
 import {
@@ -65,9 +69,7 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
   const accountsLength = useSelector(selectAccountsLength);
 
   const nonTestnetNetworks = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList
-        .length + 1,
+    (state: any) => selectFrequentRpcList(state).length + 1,
   );
 
   const origin: string = useSelector(getActiveTabUrl, isEqual);
@@ -108,10 +110,7 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
   });
   const previousPermittedAccounts = useRef<string[]>();
   const previousIdentitiesListSize = useRef<number>();
-  const identitiesMap = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identitiesMap = useSelector(selectIdentities);
   const activeAddress: string = permittedAccountsByHostname[0];
 
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);

--- a/app/components/Views/AccountPermissions/AccountPermissionsRevoke/AccountPermissionsRevoke.tsx
+++ b/app/components/Views/AccountPermissions/AccountPermissionsRevoke/AccountPermissionsRevoke.tsx
@@ -27,6 +27,7 @@ import getAccountNameWithENS from '../../../../util/accounts';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import AnalyticsV2 from '../../../../util/analyticsV2';
 import { selectAccountsLength } from '../../../../selectors/accountTrackerController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 
 // Internal dependencies.
 import { AccountPermissionsRevokeProps } from './AccountPermissionsRevoke.types';
@@ -61,9 +62,7 @@ const AccountPermissionsRevoke = ({
   const accountsLength = useSelector(selectAccountsLength);
 
   const nonTestnetNetworks = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList
-        .length + 1,
+    (state: any) => selectFrequentRpcList(state).length + 1,
   );
 
   const revokeAllAccounts = useCallback(

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -15,6 +15,7 @@ import Routes from '../../../constants/navigation/Routes';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -25,10 +26,7 @@ const styles = StyleSheet.create({
 const ActivityView = () => {
   const { colors } = useTheme();
   const navigation = useNavigation();
-  const selectedAddress = useSelector(
-    (state) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
   const hasOrders = useSelector((state) => getHasOrders(state) || false);
   const accounts = useSelector(selectAccounts);
 

--- a/app/components/Views/AddAsset/index.js
+++ b/app/components/Views/AddAsset/index.js
@@ -18,6 +18,7 @@ import {
   selectChainId,
   selectProviderType,
 } from '../../../selectors/networkController';
+import { selectUseNftDetection } from '../../../selectors/preferencesController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -189,8 +190,7 @@ AddAsset.contextType = ThemeContext;
 const mapStateToProps = (state) => ({
   networkType: selectProviderType(state),
   chainId: selectChainId(state),
-  useNftDetection:
-    state.engine.backgroundState.PreferencesController.useNftDetection,
+  useNftDetection: selectUseNftDetection(state),
 });
 
 export default connect(mapStateToProps)(AddAsset);

--- a/app/components/Views/AddressQRCode/index.js
+++ b/app/components/Views/AddressQRCode/index.js
@@ -18,6 +18,7 @@ import GlobalAlert from '../../UI/GlobalAlert';
 import { protectWalletModalVisible } from '../../../actions/user';
 import ClipboardManager from '../../../core/ClipboardManager';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const WIDTH = Dimensions.get('window').width - 88;
 
@@ -176,8 +177,7 @@ class AddressQRCode extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   seedphraseBackedUp: state.user.seedphraseBackedUp,
 });
 

--- a/app/components/Views/Approval/index.js
+++ b/app/components/Views/Approval/index.js
@@ -40,6 +40,7 @@ import {
   selectChainId,
   selectProviderType,
 } from '../../../selectors/networkController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import { ethErrors } from 'eth-rpc-errors';
 
 const REVIEW = 'review';
@@ -536,8 +537,7 @@ class Approval extends PureComponent {
 const mapStateToProps = (state) => ({
   transaction: getNormalizedTxState(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   networkType: selectProviderType(state),
   showCustomNonce: state.settings.showCustomNonce,
   chainId: selectChainId(state),

--- a/app/components/Views/ApproveView/Approve/index.js
+++ b/app/components/Views/ApproveView/Approve/index.js
@@ -61,6 +61,7 @@ import {
   selectAccounts,
   selectAccountsLength,
 } from '../../../../selectors/accountTrackerController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 import ShowBlockExplorer from '../../../UI/ApproveTransactionReview/ShowBlockExplorer';
 import createStyles from './styles';
 import { ethErrors } from 'eth-rpc-errors';
@@ -845,8 +846,7 @@ const mapStateToProps = (state) => ({
   network: selectNetwork(state),
   providerType: selectProviderType(state),
   providerRpcTarget: selectRpcTarget(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -55,6 +55,11 @@ import {
   selectConversionRate,
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -565,16 +570,14 @@ const mapStateToProps = (state) => ({
     state.engine.backgroundState.TransactionController.swapsTransactions || {},
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
   chainId: selectChainId(state),
   tokens: selectTokens(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
   rpcTarget: selectRpcTarget(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   isNetworkBuyNativeTokenSupported: isNetworkBuyNativeTokenSupported(
     selectChainId(state),
     getRampNetworks(state),

--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -10,6 +10,7 @@ import Icon, {
 } from '../../../component-library/components/Icons/Icon';
 import useBlockExplorer from '../../../components/UI/Swaps/utils/useBlockExplorer';
 import { selectProviderConfig } from '../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../selectors/preferencesController';
 import ReusableModal, { ReusableModalRef } from '../../UI/ReusableModal';
 import styleSheet from './AssetOptions.styles';
 
@@ -35,10 +36,7 @@ const AssetOptions = (props: Props) => {
   const navigation = useNavigation();
   const modalRef = useRef<ReusableModalRef>(null);
   const providerConfig = useSelector(selectProviderConfig);
-  const frequentRpcList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const frequentRpcList = useSelector(selectFrequentRpcList);
   const explorer = useBlockExplorer(providerConfig, frequentRpcList);
 
   const goToBrowserUrl = (url: string, title: string) => {

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -35,6 +35,7 @@ import { AvatarAccountType } from '../../../component-library/components/Avatars
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import { BROWSER_SCREEN_ID } from '../../../../wdio/screen-objects/testIDs/BrowserScreen/BrowserScreen.testIds';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
+import { selectFrequentRpcList } from '../../../selectors/preferencesController';
 
 import URL from 'url-parse';
 import { isEqual } from 'lodash';
@@ -374,8 +375,7 @@ const Browser = (props) => {
 
 const mapStateToProps = (state) => ({
   accountsLength: selectAccountsLength(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   tabs: state.browser.tabs,
   activeTab: state.browser.activeTab,
 });

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -83,6 +83,10 @@ import {
   RELOAD_OPTION,
   SHARE_OPTION,
 } from '../../../../wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds';
+import {
+  selectIpfsGateway,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const { HOMEPAGE_URL, NOTIFICATION_NAMES } = AppConstants;
 const HOMEPAGE_HOST = new URL(HOMEPAGE_URL)?.hostname;
@@ -1509,9 +1513,8 @@ BrowserTab.defaultProps = {
 
 const mapStateToProps = (state) => ({
   bookmarks: state.bookmarks,
-  ipfsGateway: state.engine.backgroundState.PreferencesController.ipfsGateway,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress?.toLowerCase(),
+  ipfsGateway: selectIpfsGateway(state),
+  selectedAddress: selectSelectedAddress(state)?.toLowerCase(),
   searchEngine: state.settings.searchEngine,
   whitelist: state.browser.whitelist,
   wizardStep: state.wizard.step,

--- a/app/components/Views/ConnectQRHardware/SelectQRAccounts/index.tsx
+++ b/app/components/Views/ConnectQRHardware/SelectQRAccounts/index.tsx
@@ -21,6 +21,7 @@ import { useTheme } from '../../../../util/theme';
 import AccountDetails from '../AccountDetails';
 import StyledButton from '../../../UI/StyledButton';
 import { selectProviderConfig } from '../../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 
 interface ISelectQRAccountsProps {
   canUnlock: boolean;
@@ -101,10 +102,7 @@ const SelectQRAccounts = (props: ISelectQRAccountsProps) => {
   const styles = createStyle(colors);
   const navigation = useNavigation();
   const providerConfig = useSelector(selectProviderConfig);
-  const frequentRpcList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const frequentRpcList = useSelector(selectFrequentRpcList);
 
   const toBlockExplorer = useCallback(
     (address: string) => {

--- a/app/components/Views/EditAccountName/EditAccountName.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.tsx
@@ -26,6 +26,10 @@ import Analytics from '../../../core/Analytics/Analytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { selectChainId } from '../../../selectors/networkController';
 import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
+import {
   doENSReverseLookup,
   isDefaultAccountName,
 } from '../../../util/ENSUtils';
@@ -41,14 +45,8 @@ const EditAccountName = () => {
   const [accountName, setAccountName] = useState<string>();
   const [ens, setEns] = useState<string>();
 
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
+  const identities = useSelector(selectIdentities);
 
   const chainId = useSelector(selectChainId);
 

--- a/app/components/Views/LockScreen/index.js
+++ b/app/components/Views/LockScreen/index.js
@@ -21,6 +21,7 @@ import {
   ThemeContext,
 } from '../../../util/theme';
 import Routes from '../../../constants/navigation/Routes';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const LOGO_SIZE = 175;
 const createStyles = (colors) =>
@@ -246,8 +247,7 @@ class LockScreen extends PureComponent {
 
 const mapStateToProps = (state) => ({
   passwordSet: state.user.passwordSet,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   appTheme: state.user.appTheme,
 });
 

--- a/app/components/Views/Login/index.js
+++ b/app/components/Views/Login/index.js
@@ -65,6 +65,7 @@ import { parseVaultValue } from '../../../util/validators';
 import { getVaultFromBackup } from '../../../core/BackupVault';
 import { containsErrorMessage } from '../../../util/errorHandling';
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const deviceHeight = Device.getDeviceHeight();
 const breakPoint = deviceHeight < 700;
@@ -617,8 +618,7 @@ class Login extends PureComponent {
 Login.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   userLoggedIn: state.user.userLoggedIn,
 });
 

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -19,6 +19,10 @@ import SheetBottom, {
 } from '../../../component-library/components/Sheet/SheetBottom';
 import { useSelector } from 'react-redux';
 import { selectProviderConfig } from '../../../selectors/networkController';
+import {
+  selectFrequentRpcList,
+  selectShowTestNetworks,
+} from '../../../selectors/preferencesController';
 import Networks, {
   compareRpcUrls,
   getAllNetworks,
@@ -26,7 +30,6 @@ import Networks, {
   isTestNet,
   shouldShowLineaMainnetNetwork,
 } from '../../../util/networks';
-import { EngineState } from 'app/selectors/types';
 import { LINEA_MAINNET, MAINNET } from '../../../constants/network';
 import Button from '../../../component-library/components/Buttons/Button/Button';
 import {
@@ -59,20 +62,14 @@ const NetworkSelector = () => {
   const { navigate } = useNavigation();
   const { colors } = useAppTheme();
   const sheetRef = useRef<SheetBottomRef>(null);
-  const showTestNetworks = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.showTestNetworks,
-  );
+  const showTestNetworks = useSelector(selectShowTestNetworks);
   const thirdPartyApiMode = useSelector(
     (state: any) => state.privacy.thirdPartyApiMode,
   );
   const [lineaMainnetReleased, setLineaMainnetReleased] = useState(false);
 
   const providerConfig: ProviderConfig = useSelector(selectProviderConfig);
-  const frequentRpcList: FrequentRpc[] = useSelector(
-    (state: EngineState) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const frequentRpcList: FrequentRpc[] = useSelector(selectFrequentRpcList);
 
   useEffect(() => {
     const shouldShowLineaMainnet = shouldShowLineaMainnetNetwork();

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -66,6 +66,7 @@ import { LoginOptionsSwitch } from '../../UI/LoginOptionsSwitch';
 import { recreateVaultWithNewPassword } from '../../../core/Vault';
 import generateTestId from '../../../../wdio/utils/generateTestId';
 import Logger from '../../../util/Logger';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -831,8 +832,7 @@ class ResetPassword extends PureComponent {
 ResetPassword.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/RestoreWallet/WalletRestored.tsx
+++ b/app/components/Views/RestoreWallet/WalletRestored.tsx
@@ -25,6 +25,7 @@ import { trackEventV2 as trackEvent } from '../../../util/analyticsV2';
 import generateDeviceAnalyticsMetaData from '../../../util/metrics';
 import { SRP_GUIDE_URL } from '../../../constants/urls';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 export const createWalletRestoredNavDetails = createNavigationDetails(
   Routes.VAULT_RECOVERY.WALLET_RESTORED,
@@ -35,10 +36,7 @@ const WalletRestored = () => {
   const { colors } = useAppThemeFromContext();
   const styles = createStyles(colors);
   const navigation = useNavigation<StackNavigationProp<any>>();
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
 
   const deviceMetaData = useMemo(() => generateDeviceAnalyticsMetaData(), []);
 

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -56,6 +56,7 @@ import {
   SECRET_RECOVERY_PHRASE_NEXT_BUTTON_ID,
   SECRET_RECOVERY_PHRASE_TEXT,
 } from '../../../../wdio/screen-objects/testIDs/Screens/RevelSecretRecoveryPhrase.testIds';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const PRIVATE_KEY = 'private_key';
 
@@ -85,10 +86,7 @@ const RevealPrivateCredential = ({
   const [clipboardEnabled, setClipboardEnabled] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
   const passwordSet = useSelector((state: any) => state.user.passwordSet);
 
   const dispatch = useDispatch();

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -54,6 +54,11 @@ import { selectTokenList } from '../../../selectors/tokenListController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 import { ethErrors } from 'eth-rpc-errors';
 
 const REVIEW = 'review';
@@ -762,16 +767,14 @@ class Send extends PureComponent {
 const mapStateToProps = (state) => ({
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
   accounts: selectAccounts(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
   contractBalances: selectContractBalances(state),
+  frequentRpcList: selectFrequentRpcList(state),
   transaction: state.transaction,
   networkType: selectProviderType(state),
   tokens: selectTokens(state),
   network: selectNetwork(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  identities: selectIdentities(state),
+  selectedAddress: selectSelectedAddress(state),
   dappTransactionModalVisible: state.modals.dappTransactionModalVisible,
   tokenList: selectTokenList(state),
 });

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -13,6 +13,10 @@ import {
   selectTicker,
 } from '../../../../selectors/networkController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 import { doENSReverseLookup } from '../../../../util/ENSUtils';
 import { renderFromWei, hexToBN } from '../../../../util/number';
 import { getEther, getTicker } from '../../../../util/transactions';
@@ -23,20 +27,14 @@ const SendFlowAddressFrom = ({
   fromAccountBalanceState,
 }: SFAddressFromProps) => {
   const navigation = useNavigation();
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
 
   const accounts = useSelector(selectAccounts);
 
   const network = useSelector((state: any) => selectNetwork(state));
   const ticker = useSelector(selectTicker);
 
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
 
   const [accountAddress, setAccountAddress] = useState(selectedAddress);
   const [accountName, setAccountName] = useState(

--- a/app/components/Views/SendFlow/AddressList/AddressList.tsx
+++ b/app/components/Views/SendFlow/AddressList/AddressList.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '../../../../util/theme';
 import Text from '../../../../component-library/components/Texts/Text/Text';
 import { TextVariant } from '../../../../component-library/components/Texts/Text';
 import { selectNetwork } from '../../../../selectors/networkController';
+import { selectIdentities } from '../../../../selectors/preferencesController';
 
 // Internal dependencies
 import { AddressListProps, Contact } from './AddressList.types';
@@ -44,10 +45,7 @@ const AddressList: React.FC<AddressListProps> = ({
   const [contactElements, setContactElements] = useState<Contact[]>([]);
   const [fuse, setFuse] = useState<any>(undefined);
   const network = useSelector(selectNetwork);
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
   const addressBook = useSelector(
     (state: any) =>
       state.engine.backgroundState.AddressBookController.addressBook,

--- a/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
+++ b/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
@@ -10,6 +10,7 @@ import { NetworkSwitchErrorType } from '../../../../constants/error';
 import Routes from '../../../../constants/navigation/Routes';
 import Engine from '../../../../core/Engine';
 import { selectNetwork } from '../../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 import { handleNetworkSwitch } from '../../../../util/networks';
 import { AddressTo } from '../../../UI/AddressInputs';
 import { createQRScannerNavDetails } from '../../QRScanner';
@@ -33,10 +34,7 @@ const SendFlowAddressTo = ({
 
   const network = useSelector(selectNetwork);
 
-  const frequentRpcList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const frequentRpcList = useSelector(selectFrequentRpcList);
 
   const showAlertAction = (config: any) => dispatch(showAlert(config));
 

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -100,6 +100,7 @@ import {
 import { selectTokens } from '../../../../selectors/tokensController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
+import { selectSelectedAddress } from '../../../../selectors/preferencesController';
 import { PREFIX_HEX_STRING } from '../../../../constants/transaction';
 import Routes from '../../../../constants/navigation/Routes';
 
@@ -1423,8 +1424,7 @@ const mapStateToProps = (state, ownProps) => ({
   currentCurrency: selectCurrentCurrency(state),
   providerType: selectProviderType(state),
   primaryCurrency: state.settings.primaryCurrency,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   ticker: selectTicker(state),
   tokens: selectTokens(state),
   transactionState: ownProps.transaction || state.transaction,

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -65,6 +65,11 @@ import {
   selectProviderType,
   selectTicker,
 } from '../../../../selectors/networkController';
+import {
+  selectFrequentRpcList,
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../selectors/preferencesController';
 import AddToAddressBookWrapper from '../../../UI/AddToAddressBookWrapper';
 import { isNetworkBuyNativeTokenSupported } from '../../../UI/Ramp/utils';
 import { getRampNetworks } from '../../../../reducers/fiatOrders';
@@ -630,16 +635,14 @@ SendFlow.contextType = ThemeContext;
 const mapStateToProps = (state) => ({
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
   chainId: selectChainId(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   selectedAsset: state.transaction.selectedAsset,
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  identities: selectIdentities(state),
   ticker: selectTicker(state),
   network: selectNetwork(state),
   providerType: selectProviderType(state),
   isPaymentRequest: state.transaction.paymentRequest,
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   isNativeTokenBuySupported: isNetworkBuyNativeTokenSupported(
     selectChainId(state),
     getRampNetworks(state),

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -46,6 +46,11 @@ import { generateStateLogs } from '../../../../util/logs';
 import Device from '../../../../util/device';
 import { mockTheme, ThemeContext } from '../../../../util/theme';
 import { selectChainId } from '../../../../selectors/networkController';
+import {
+  selectDisabledRpcMethodPreferences,
+  selectIpfsGateway,
+  selectUseTokenDetection,
+} from '../../../../selectors/preferencesController';
 import Routes from '../../../../constants/navigation/Routes';
 import Icon, {
   IconColor,
@@ -583,15 +588,12 @@ class AdvancedSettings extends PureComponent {
 AdvancedSettings.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
-  ipfsGateway: state.engine.backgroundState.PreferencesController.ipfsGateway,
+  ipfsGateway: selectIpfsGateway(state),
   showHexData: state.settings.showHexData,
   showCustomNonce: state.settings.showCustomNonce,
-  enableEthSign:
-    state.engine.backgroundState.PreferencesController
-      .disabledRpcMethodPreferences.eth_sign,
+  enableEthSign: selectDisabledRpcMethodPreferences(state).eth_sign,
   fullState: state,
-  isTokenDetectionEnabled:
-    state.engine.backgroundState.PreferencesController.useTokenDetection,
+  isTokenDetectionEnabled: selectUseTokenDetection(state),
   chainId: selectChainId(state),
 });
 

--- a/app/components/Views/Settings/Contacts/ContactForm/index.js
+++ b/app/components/Views/Settings/Contacts/ContactForm/index.js
@@ -36,6 +36,7 @@ import {
   selectChainId,
   selectNetwork,
 } from '../../../../../selectors/networkController';
+import { selectIdentities } from '../../../../../selectors/preferencesController';
 import {
   ADD_CONTACT_ADD_BUTTON,
   ADD_CONTACT_ADDRESS_INPUT,
@@ -514,7 +515,7 @@ ContactForm.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
   addressBook: state.engine.backgroundState.AddressBookController.addressBook,
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  identities: selectIdentities(state),
   network: selectNetwork(state),
   chainId: selectChainId(state),
 });

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -35,6 +35,7 @@ import { toDataUrl } from '../../../../util/blockies.js';
 import Jazzicon from 'react-native-jazzicon';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
+import { selectSelectedAddress } from '../../../../selectors/preferencesController';
 // import { AppThemeKey } from '../../../../util/theme/models';
 // import StyledButton from '../../../UI/StyledButton';
 
@@ -472,8 +473,7 @@ const mapStateToProps = (state) => ({
   searchEngine: state.settings.searchEngine,
   primaryCurrency: state.settings.primaryCurrency,
   useBlockieIcon: state.settings.useBlockieIcon,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
+  selectedAddress: selectSelectedAddress(state),
   hideZeroBalanceTokens: state.settings.hideZeroBalanceTokens,
   // appTheme: state.user.appTheme,
 });

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../../../../../../util/theme';
 import PopularList from '../../../../../../util/networks/customNetworks';
 import createStyles from '../styles';
 import { CustomNetworkProps, Network } from './CustomNetwork.types';
+import { selectFrequentRpcList } from '../../../../../../selectors/preferencesController';
 
 const CustomNetwork = ({
   isNetworkModalVisible,
@@ -22,10 +23,7 @@ const CustomNetwork = ({
   switchTab,
   shouldNetworkSwitchPopToWallet,
 }: CustomNetworkProps) => {
-  const savedNetworkList = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.frequentRpcList,
-  );
+  const savedNetworkList = useSelector(selectFrequentRpcList);
 
   const supportedNetworkList = PopularList.map((network: Network) => {
     const isAdded = savedNetworkList.some(

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -77,6 +77,7 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { selectProviderConfig } from '../../../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../../../selectors/preferencesController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -1126,8 +1127,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const mapStateToProps = (state) => ({
   providerConfig: selectProviderConfig(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   networkOnboardedState: state.networkOnboarded.networkOnboardedState,
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
 });

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -35,6 +35,7 @@ import {
 } from '../../../../../wdio/screen-objects/testIDs/Screens/NetworksScreen.testids';
 import { compareSanitizedUrl } from '../../../../util/sanitizeUrl';
 import { selectProviderConfig } from '../../../../selectors/networkController';
+import { selectFrequentRpcList } from '../../../../selectors/preferencesController';
 import {
   AvatarSize,
   AvatarVariants,
@@ -487,8 +488,7 @@ NetworksSettings.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
   providerConfig: selectProviderConfig(state),
-  frequentRpcList:
-    state.engine.backgroundState.PreferencesController.frequentRpcList,
+  frequentRpcList: selectFrequentRpcList(state),
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
 });
 

--- a/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/RevealPrivateKey/RevealPrivateKey.tsx
@@ -13,6 +13,10 @@ import { strings } from '../../../../../../../locales/i18n';
 import { createStyles } from './styles';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { selectAccounts } from '../../../../../../selectors/accountTrackerController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../../../../selectors/preferencesController';
 
 const testIds = {
   section: 'reveal-private-key-section',
@@ -24,17 +28,10 @@ const RevealPrivateKey = () => {
   const navigation = useNavigation();
 
   const accounts = useSelector(selectAccounts);
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const identities = useSelector(selectIdentities);
+  const selectedAddress = useSelector(selectSelectedAddress);
 
   const account = {
-    address: selectedAddress,
     ...identities[selectedAddress],
     ...accounts[selectedAddress],
   };

--- a/app/components/Views/Settings/SecuritySettings/index.js
+++ b/app/components/Views/Settings/SecuritySettings/index.js
@@ -63,6 +63,13 @@ import Routes from '../../../../constants/navigation/Routes';
 import { selectProviderType } from '../../../../selectors/networkController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
 import {
+  selectIdentities,
+  selectIsMultiAccountBalancesEnabled,
+  selectOpenSeaEnabled,
+  selectSelectedAddress,
+  selectUseNftDetection,
+} from '../../../../selectors/preferencesController';
+import {
   SECURITY_PRIVACY_MULTI_ACCOUNT_BALANCES_TOGGLE_ID,
   SECURITY_PRIVACY_VIEW_ID,
 } from '../../../../../wdio/screen-objects/testIDs/Screens/SecurityPrivacy.testIds';
@@ -781,21 +788,16 @@ const mapStateToProps = (state) => ({
   browserHistory: state.browser.history,
   lockTime: state.settings.lockTime,
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   accounts: selectAccounts(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
   keyrings: state.engine.backgroundState.KeyringController.keyrings,
-  openSeaEnabled:
-    state.engine.backgroundState.PreferencesController.openSeaEnabled,
-  useNftDetection:
-    state.engine.backgroundState.PreferencesController.useNftDetection,
+  openSeaEnabled: selectOpenSeaEnabled(state),
+  useNftDetection: selectUseNftDetection(state),
   passwordHasBeenSet: state.user.passwordSet,
   seedphraseBackedUp: state.user.seedphraseBackedUp,
   type: selectProviderType(state),
-  isMultiAccountBalancesEnabled:
-    state.engine.backgroundState.PreferencesController
-      .isMultiAccountBalancesEnabled,
+  isMultiAccountBalancesEnabled: selectIsMultiAccountBalancesEnabled(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -29,6 +29,10 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectTokens } from '../../../selectors/tokensController';
+import {
+  selectIdentities,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -214,10 +218,9 @@ TransactionsView.propTypes = {
 const mapStateToProps = (state) => ({
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
-  selectedAddress:
-    state.engine.backgroundState.PreferencesController.selectedAddress,
   tokens: selectTokens(state),
-  identities: state.engine.backgroundState.PreferencesController.identities,
+  selectedAddress: selectSelectedAddress(state),
+  identities: selectIdentities(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
   networkType: selectProviderType(state),
   chainId: selectChainId(state),

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -44,6 +44,7 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
@@ -99,10 +100,7 @@ const Wallet = ({ navigation }: any) => {
   /**
    * A string that represents the selected address
    */
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
+  const selectedAddress = useSelector(selectSelectedAddress);
   /**
    * An array that represents the user tokens
    */

--- a/app/components/hooks/useAccounts/useAccounts.ts
+++ b/app/components/hooks/useAccounts/useAccounts.ts
@@ -27,6 +27,11 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import {
+  selectIdentities,
+  selectIsMultiAccountBalancesEnabled,
+  selectSelectedAddress,
+} from '../../../selectors/preferencesController';
 
 /**
  * Hook that returns both wallet accounts and ens name information.
@@ -43,24 +48,16 @@ const useAccounts = ({
   const [ensByAccountAddress, setENSByAccountAddress] =
     useState<EnsByAccountAddress>({});
 
-  const identities = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.identities,
-  );
+  const identities = useSelector(selectIdentities);
   const network = useSelector(selectNetwork);
-  const selectedAddress = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.selectedAddress,
-  );
   const accountInfoByAddress = useSelector(selectAccounts, isEqual);
+  const selectedAddress = useSelector(selectSelectedAddress);
   const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const ticker = useSelector(selectTicker);
 
   const isMultiAccountBalancesEnabled = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController
-        .isMultiAccountBalancesEnabled,
+    selectIsMultiAccountBalancesEnabled,
   );
 
   const fetchENSNames = useCallback(

--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -12,6 +12,7 @@ import { safeToChecksumAddress } from '../../../util/address';
 import { selectTicker } from '../../../selectors/networkController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
+import { selectSelectedAddress } from '../../../selectors/preferencesController';
 import { Asset } from './useAddressBalance.types';
 
 const useAddressBalance = (asset: Asset, address?: string) => {
@@ -21,8 +22,7 @@ const useAddressBalance = (asset: Asset, address?: string) => {
     (state: any) => ({
       accounts: selectAccounts(state),
       contractBalances: selectContractBalances(state),
-      selectedAddress:
-        state.engine.backgroundState.PreferencesController.selectedAddress,
+      selectedAddress: selectSelectedAddress(state),
     }),
   );
   const ticker = useSelector(selectTicker);

--- a/app/components/hooks/useExistingAddress.ts
+++ b/app/components/hooks/useExistingAddress.ts
@@ -2,6 +2,7 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { useSelector } from 'react-redux';
 
 import { selectNetwork } from '../../selectors/networkController';
+import { selectIdentities } from '../../selectors/preferencesController';
 
 export interface Address {
   address: string;
@@ -16,7 +17,7 @@ const useExistingAddress = (address?: string): Address | undefined => {
   const network = useSelector(selectNetwork);
   const { addressBook, identities } = useSelector((state: any) => ({
     addressBook: state.engine.backgroundState.AddressBookController.addressBook,
-    identities: state.engine.backgroundState.PreferencesController.identities,
+    identities: selectIdentities(state),
   }));
 
   if (!address) return;

--- a/app/components/hooks/useIpfsGateway.ts
+++ b/app/components/hooks/useIpfsGateway.ts
@@ -1,13 +1,11 @@
 import { useSelector } from 'react-redux';
 import AppConstants from '../../core/AppConstants';
+import { selectIpfsGateway } from '../../selectors/preferencesController';
 
 const IPFS_DEFAULT_GATEWAY_URL = AppConstants.IPFS_DEFAULT_GATEWAY_URL;
 
 function useIpfsGateway(): string {
-  const selectedIpfsGateway = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.PreferencesController.ipfsGateway,
-  );
+  const selectedIpfsGateway = useSelector(selectIpfsGateway);
 
   return selectedIpfsGateway || IPFS_DEFAULT_GATEWAY_URL;
 }

--- a/app/reducers/collectibles/index.js
+++ b/app/reducers/collectibles/index.js
@@ -4,14 +4,13 @@ import {
   selectAllNftContracts,
   selectAllNfts,
 } from '../../selectors/nftController';
+import { selectSelectedAddress } from '../../selectors/preferencesController';
 import { compareTokenIds } from '../../util/tokens';
 
-const addressSelector = (state) =>
-  state.engine.backgroundState.PreferencesController.selectedAddress;
 const favoritesSelector = (state) => state.collectibles.favorites;
 
 export const collectibleContractsSelector = createSelector(
-  addressSelector,
+  selectSelectedAddress,
   selectChainId,
   selectAllNftContracts,
   (address, chainId, allNftContracts) =>
@@ -19,14 +18,14 @@ export const collectibleContractsSelector = createSelector(
 );
 
 export const collectiblesSelector = createSelector(
-  addressSelector,
+  selectSelectedAddress,
   selectChainId,
   selectAllNfts,
   (address, chainId, allNfts) => allNfts[address]?.[chainId] || [],
 );
 
 export const favoritesCollectiblesSelector = createSelector(
-  addressSelector,
+  selectSelectedAddress,
   selectChainId,
   favoritesSelector,
   (address, chainId, favorites) => favorites[address]?.[chainId] || [],

--- a/app/reducers/fiatOrders/index.ts
+++ b/app/reducers/fiatOrders/index.ts
@@ -2,6 +2,7 @@ import { Order } from '@consensys/on-ramp-sdk';
 import { createSelector } from 'reselect';
 import { Region } from '../../components/UI/Ramp/types';
 import { selectChainId } from '../../selectors/networkController';
+import { selectSelectedAddress } from '../../selectors/preferencesController';
 import {
   FIAT_ORDER_PROVIDERS,
   FIAT_ORDER_STATES,
@@ -131,7 +132,7 @@ export const chainIdSelector: (state: RootState) => string = (
 
 export const selectedAddressSelector: (state: RootState) => string = (
   state: RootState,
-) => state.engine.backgroundState.PreferencesController.selectedAddress;
+) => selectSelectedAddress(state);
 export const fiatOrdersRegionSelectorAgg: (
   state: RootState,
 ) => FiatOrdersState['selectedRegionAgg'] = (state: RootState) =>

--- a/app/selectors/preferencesController.ts
+++ b/app/selectors/preferencesController.ts
@@ -1,0 +1,76 @@
+import { createSelector } from 'reselect';
+import { PreferencesState } from '@metamask/preferences-controller';
+import { EngineState } from './types';
+
+const selectPreferencesControllerState = (state: EngineState) =>
+  state.engine.backgroundState.PreferencesController;
+
+export const selectIdentities = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.identities,
+);
+
+export const selectIpfsGateway = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.ipfsGateway,
+);
+
+export const selectSelectedAddress = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.selectedAddress,
+);
+
+export const selectFrequentRpcList = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.frequentRpcList,
+);
+
+export const selectUseNftDetection = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.useNftDetection,
+);
+
+export const selectUseTokenDetection = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.useTokenDetection,
+);
+
+export const selectOpenSeaEnabled = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.openSeaEnabled,
+);
+
+export const selectDisabledRpcMethodPreferences = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.disabledRpcMethodPreferences,
+);
+
+// isMultiAccountBalancesEnabled is a patched property - ref patches/@metamask+preferences-controller+2.1.0.patch
+export const selectIsMultiAccountBalancesEnabled = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    (
+      preferencesControllerState as PreferencesState & {
+        isMultiAccountBalancesEnabled: boolean;
+      }
+    ).isMultiAccountBalancesEnabled,
+);
+
+// showTestNetworks is a patched property - ref patches/@metamask+preferences-controller+2.1.0.patch
+export const selectShowTestNetworks = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    (
+      preferencesControllerState as PreferencesState & {
+        showTestNetworks: boolean;
+      }
+    ).showTestNetworks,
+);


### PR DESCRIPTION
**Description**

Preferences controller Redux state is now accessed excusively through selectors. This makes future state changes easier to manage.

Most of these changes consist of replacing the direct access to PreferencesController State, by selectors.

**Issue**


Relates to https://github.com/MetaMask/mobile-planning/issues/1017

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
