### PR TITLE
feat: Add security alerts settings to experimental tab

### DIFF
--- a/app/actions/experimental/index.ts
+++ b/app/actions/experimental/index.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/prefer-default-export */
+import type { Action } from 'redux';
+
+export enum ActionType {
+  SET_SECURITY_ALERTS_ENABLED = 'SET_SECURITY_ALERTS_ENABLED',
+}
+
+export interface SetSecurityAlertsEnabled
+  extends Action<ActionType.SET_SECURITY_ALERTS_ENABLED> {
+  securityAlertsEnabled: boolean;
+}
+
+export const setSecurityAlertsEnabled = (
+  securityAlertsEnabled: boolean,
+): SetSecurityAlertsEnabled => ({
+  type: ActionType.SET_SECURITY_ALERTS_ENABLED,
+  securityAlertsEnabled,
+});

--- a/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExperimentalSettings should render blockaid togggle button 1`] = `
+exports[`ExperimentalSettings should render blockaid toggle button 1`] = `
 Array [
   <RCTScrollView
     style={

--- a/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
@@ -1,40 +1,487 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExperimentalSettings should render correctly 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "store": Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "subscription": Subscription {
-        "handleChangeWrapper": [Function],
-        "listeners": Object {
-          "notify": [Function],
-        },
-        "onStateChange": [Function],
-        "parentSub": undefined,
-        "store": Object {
-          "clearActions": [Function],
-          "dispatch": [Function],
-          "getActions": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-        },
-        "unsubscribe": null,
-      },
+exports[`ExperimentalSettings should render blockaid togggle button 1`] = `
+Array [
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "flex": 1,
+        "padding": 24,
+        "paddingBottom": 48,
+      }
     }
-  }
->
-  <ExperimentalSettings
-    navigation={Object {}}
-    route={Object {}}
-  />
-</ContextProvider>
+  >
+    <View>
+      <Text
+        style={
+          Object {
+            "color": "#24272A",
+            "fontFamily": "EuclidCircularB-Regular",
+            "fontSize": 20,
+            "fontWeight": "400",
+            "lineHeight": 20,
+            "marginTop": -4,
+            "paddingTop": 4,
+          }
+        }
+      >
+        WalletConnect Sessions
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#535A61",
+            "fontFamily": "EuclidCircularB-Regular",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "lineHeight": 20,
+            "marginTop": 12,
+          }
+        }
+      >
+        View the list of active WalletConnect sessions
+      </Text>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Array [
+            Array [
+              Object {
+                "borderRadius": 100,
+                "justifyContent": "center",
+                "padding": 15,
+              },
+              Object {
+                "backgroundColor": "#FFFFFF",
+                "borderColor": "#0376C9",
+                "borderWidth": 1,
+              },
+              Object {
+                "marginTop": 18,
+              },
+            ],
+            null,
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#007aff",
+                "fontSize": 17,
+                "fontWeight": "500",
+                "textAlign": "center",
+              },
+              null,
+              Array [
+                Object {
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "textAlign": "center",
+                },
+                Object {
+                  "color": "#0376C9",
+                },
+                undefined,
+              ],
+              null,
+            ]
+          }
+        >
+          VIEW SESSIONS
+        </Text>
+      </TouchableOpacity>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            },
+            Object {
+              "fontSize": 24,
+              "lineHeight": 20,
+              "marginTop": 18,
+            },
+          ]
+        }
+      >
+        Security
+      </Text>
+      <View
+        style={
+          Object {
+            "marginVertical": 18,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          Security alerts
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#535A61",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": 12,
+            }
+          }
+        >
+          This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#24272A",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 20,
+                "fontWeight": "400",
+                "lineHeight": 20,
+                "marginTop": -4,
+                "paddingTop": 4,
+              },
+              Object {
+                "fontFamily": "EuclidCircularB-Bold",
+                "fontWeight": "600",
+                "marginBottom": 18,
+                "marginTop": 18,
+              },
+            ]
+          }
+        >
+          Select providers
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+              },
+              Object {
+                "color": "#24272A",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 20,
+                "fontWeight": "400",
+                "lineHeight": 20,
+                "marginTop": -4,
+                "paddingTop": 4,
+              },
+            ]
+          }
+        >
+          Blockaid
+        </Text>
+        <RCTSwitch
+          accessibilityRole="switch"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          onTintColor="#0376C9"
+          style={
+            Array [
+              Object {
+                "height": 31,
+                "width": 51,
+              },
+              Array [
+                Object {
+                  "alignSelf": "flex-end",
+                },
+                Object {
+                  "backgroundColor": "#D6D9DC",
+                  "borderRadius": 16,
+                },
+              ],
+            ]
+          }
+          testID="security-alerts-toggle"
+          thumbTintColor="#FFFFFF"
+          tintColor="#D6D9DC"
+          value={false}
+        />
+      </View>
+    </View>
+  </RCTScrollView>,
+  ",",
+]
+`;
+
+exports[`ExperimentalSettings should render correctly 1`] = `
+Array [
+  <RCTScrollView
+    style={
+      Object {
+        "backgroundColor": "#FFFFFF",
+        "flex": 1,
+        "padding": 24,
+        "paddingBottom": 48,
+      }
+    }
+  >
+    <View>
+      <Text
+        style={
+          Object {
+            "color": "#24272A",
+            "fontFamily": "EuclidCircularB-Regular",
+            "fontSize": 20,
+            "fontWeight": "400",
+            "lineHeight": 20,
+            "marginTop": -4,
+            "paddingTop": 4,
+          }
+        }
+      >
+        WalletConnect Sessions
+      </Text>
+      <Text
+        style={
+          Object {
+            "color": "#535A61",
+            "fontFamily": "EuclidCircularB-Regular",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "lineHeight": 20,
+            "marginTop": 12,
+          }
+        }
+      >
+        View the list of active WalletConnect sessions
+      </Text>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Array [
+            Array [
+              Object {
+                "borderRadius": 100,
+                "justifyContent": "center",
+                "padding": 15,
+              },
+              Object {
+                "backgroundColor": "#FFFFFF",
+                "borderColor": "#0376C9",
+                "borderWidth": 1,
+              },
+              Object {
+                "marginTop": 18,
+              },
+            ],
+            null,
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#007aff",
+                "fontSize": 17,
+                "fontWeight": "500",
+                "textAlign": "center",
+              },
+              null,
+              Array [
+                Object {
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "textAlign": "center",
+                },
+                Object {
+                  "color": "#0376C9",
+                },
+                undefined,
+              ],
+              null,
+            ]
+          }
+        >
+          VIEW SESSIONS
+        </Text>
+      </TouchableOpacity>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            },
+            Object {
+              "fontSize": 24,
+              "lineHeight": 20,
+              "marginTop": 18,
+            },
+          ]
+        }
+      >
+        Security
+      </Text>
+      <View
+        style={
+          Object {
+            "marginVertical": 18,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            }
+          }
+        >
+          Security alerts
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#535A61",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": 12,
+            }
+          }
+        >
+          This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#24272A",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 20,
+                "fontWeight": "400",
+                "lineHeight": 20,
+                "marginTop": -4,
+                "paddingTop": 4,
+              },
+              Object {
+                "fontFamily": "EuclidCircularB-Bold",
+                "fontWeight": "600",
+                "marginBottom": 18,
+                "marginTop": 18,
+              },
+            ]
+          }
+        >
+          Select providers
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+              },
+              Object {
+                "color": "#24272A",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 20,
+                "fontWeight": "400",
+                "lineHeight": 20,
+                "marginTop": -4,
+                "paddingTop": 4,
+              },
+            ]
+          }
+        >
+          Blockaid
+        </Text>
+        <RCTSwitch
+          accessibilityRole="switch"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          onTintColor="#0376C9"
+          style={
+            Array [
+              Object {
+                "height": 31,
+                "width": 51,
+              },
+              Array [
+                Object {
+                  "alignSelf": "flex-end",
+                },
+                Object {
+                  "backgroundColor": "#D6D9DC",
+                  "borderRadius": 16,
+                },
+              ],
+            ]
+          }
+          testID="security-alerts-toggle"
+          thumbTintColor="#FFFFFF"
+          tintColor="#D6D9DC"
+          value={false}
+        />
+      </View>
+    </View>
+  </RCTScrollView>,
+  ",",
+]
 `;

--- a/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/ExperimentalSettings/__snapshots__/index.test.tsx.snap
@@ -237,6 +237,28 @@ Array [
           value={false}
         />
       </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            },
+            Object {
+              "color": "#BBC0C5",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontWeight": "400",
+            },
+          ]
+        }
+      >
+        More providers coming soon
+      </Text>
     </View>
   </RCTScrollView>,
   ",",
@@ -480,6 +502,28 @@ Array [
           value={false}
         />
       </View>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#24272A",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "lineHeight": 20,
+              "marginTop": -4,
+              "paddingTop": 4,
+            },
+            Object {
+              "color": "#BBC0C5",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontWeight": "400",
+            },
+          ]
+        }
+      >
+        More providers coming soon
+      </Text>
     </View>
   </RCTScrollView>,
   ",",

--- a/app/components/Views/Settings/ExperimentalSettings/constants.ts
+++ b/app/components/Views/Settings/ExperimentalSettings/constants.ts
@@ -1,0 +1,3 @@
+const SECURITY_ALERTS_TOGGLE_TEST_ID = 'security-alerts-toggle';
+
+export default SECURITY_ALERTS_TOGGLE_TEST_ID;

--- a/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
@@ -1,25 +1,72 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import ExperimentalSettings from './';
 import configureMockStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
 import initialBackgroundState from '../../../../util/test/initial-background-state.json';
+import ExperimentalSettings from '.';
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
+import { ThemeContext, mockTheme } from '../../../../util/theme';
 
 const mockStore = configureMockStore();
+
 const initialState = {
+  experimentalSettings: {
+    securityAlertsEnabled: false,
+  },
   engine: {
     backgroundState: initialBackgroundState,
   },
 };
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigation: {},
+  }),
+  createNavigatorFactory: () => ({}),
+}));
+
 const store = mockStore(initialState);
+
+const setOptions = jest.fn();
 
 describe('ExperimentalSettings', () => {
   it('should render correctly', () => {
-    const wrapper = shallow(
+    const wrapper = render(
       <Provider store={store}>
-        <ExperimentalSettings navigation={{}} route={{}} />
+        <ThemeContext.Provider value={mockTheme}>
+          <ExperimentalSettings
+            navigation={{
+              setOptions,
+            }}
+            route={{}}
+          />
+          ,
+        </ThemeContext.Provider>
       </Provider>,
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render blockaid togggle button', async () => {
+    const wrapper = render(
+      <Provider store={store}>
+        <ThemeContext.Provider value={mockTheme}>
+          <ExperimentalSettings
+            navigation={{
+              setOptions,
+            }}
+            route={{}}
+          />
+          ,
+        </ThemeContext.Provider>
+      </Provider>,
+    );
+    expect(wrapper).toMatchSnapshot();
+    expect(await wrapper.findByText('Security alerts')).toBeDefined();
+    expect(await wrapper.findByText('Blockaid')).toBeDefined();
+
+    const toggle = wrapper.getByTestId(SECURITY_ALERTS_TOGGLE_TEST_ID);
+    expect(toggle).toBeDefined();
+    expect(toggle.props.value).toBe(false);
   });
 });

--- a/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { ThemeContext, mockTheme } from '../../../../util/theme';
 import configureMockStore from 'redux-mock-store';
 import initialBackgroundState from '../../../../util/test/initial-background-state.json';
 import ExperimentalSettings from '.';
-import { render } from '@testing-library/react-native';
-import { Provider } from 'react-redux';
 import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
-import { ThemeContext, mockTheme } from '../../../../util/theme';
 
 const mockStore = configureMockStore();
 

--- a/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
-import { ThemeContext, mockTheme } from '../../../../util/theme';
 import configureMockStore from 'redux-mock-store';
+
+import { render } from '@testing-library/react-native';
+
 import initialBackgroundState from '../../../../util/test/initial-background-state.json';
-import ExperimentalSettings from '.';
+import { mockTheme, ThemeContext } from '../../../../util/theme';
+import ExperimentalSettings from './';
 import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
 
 const mockStore = configureMockStore();
@@ -23,6 +25,10 @@ jest.mock('@react-navigation/native', () => ({
     navigation: {},
   }),
   createNavigatorFactory: () => ({}),
+}));
+
+jest.mock('../../../../util/blockaid', () => ({
+  showBlockaidUI: jest.fn().mockReturnValue(true),
 }));
 
 const store = mockStore(initialState);
@@ -47,7 +53,7 @@ describe('ExperimentalSettings', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render blockaid togggle button', async () => {
+  it('should render blockaid toggle button', async () => {
     const wrapper = render(
       <Provider store={store}>
         <ThemeContext.Provider value={mockTheme}>

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -27,7 +27,7 @@ const createStyles = (colors: any) =>
       lineHeight: 20,
       paddingTop: 4,
       marginTop: -4,
-    },    
+    },
     boldTitle: {
       ...(fontStyles.bold as any),
       marginTop: 18,
@@ -189,8 +189,8 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
         />
       </View>
       <Text style={[styles.title, styles.mutedText]}>
-          {strings('experimental_settings.moreProviders')}
-        </Text>        
+        {strings('experimental_settings.moreProviders')}
+      </Text>
     </>
   );
 

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -45,7 +45,7 @@ const createStyles = (colors: any) =>
       lineHeight: 20,
       marginTop: 12,
     },
-    moreProvidersLabel: {
+    mutedText: {
       ...(fontStyles.normal as any),
       color: colors.text.muted,
     },
@@ -188,7 +188,7 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
           testID={SECURITY_ALERTS_TOGGLE_TEST_ID}
         />
       </View>
-      <Text style={[styles.title, styles.moreProvidersLabel]}>
+      <Text style={[styles.title, styles.mutedText]}>
           {strings('experimental_settings.moreProviders')}
         </Text>        
     </>

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -27,7 +27,7 @@ const createStyles = (colors: any) =>
       lineHeight: 20,
       paddingTop: 4,
       marginTop: -4,
-    },
+    },    
     boldTitle: {
       ...(fontStyles.bold as any),
       marginTop: 18,
@@ -44,6 +44,10 @@ const createStyles = (colors: any) =>
       fontSize: 14,
       lineHeight: 20,
       marginTop: 12,
+    },
+    moreProvidersLabel: {
+      ...(fontStyles.normal as any),
+      color: colors.text.muted,
     },
     setting: {
       marginVertical: 18,
@@ -184,6 +188,9 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
           testID={SECURITY_ALERTS_TOGGLE_TEST_ID}
         />
       </View>
+      <Text style={[styles.title, styles.moreProvidersLabel]}>
+          {strings('experimental_settings.moreProviders')}
+        </Text>        
     </>
   );
 

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useEffect, FC } from 'react';
-import { StyleSheet, Text, ScrollView, View, Switch } from 'react-native';
-import StyledButton from '../../../UI/StyledButton';
-import {
-  colors as importedColors,
-  fontStyles,
-} from '../../../../styles/common';
-import { getNavigationOptionsTitle } from '../../../UI/Navbar';
+import React, { FC, useCallback, useEffect } from 'react';
+import { ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import { setSecurityAlertsEnabled } from '../../../../actions/experimental';
+import {
+  fontStyles,
+  colors as importedColors,
+} from '../../../../styles/common';
 import { useTheme } from '../../../../util/theme';
-import { useDispatch, useSelector } from 'react-redux';
+import { getNavigationOptionsTitle } from '../../../UI/Navbar';
+import StyledButton from '../../../UI/StyledButton';
 import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
 
 const createStyles = (colors: any) =>

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -1,16 +1,18 @@
 import React, { FC, useCallback, useEffect } from 'react';
 import { ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
+
 import { strings } from '../../../../../locales/i18n';
 import { setSecurityAlertsEnabled } from '../../../../actions/experimental';
 import {
-  fontStyles,
   colors as importedColors,
+  fontStyles,
 } from '../../../../styles/common';
 import { useTheme } from '../../../../util/theme';
 import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import StyledButton from '../../../UI/StyledButton';
 import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
+import { showBlockaidUI } from '../../../../util/blockaid';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -197,7 +199,7 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
   return (
     <ScrollView style={styles.wrapper}>
       <WalletConnectSettings />
-      <BlockaidSettings />
+      {showBlockaidUI() && <BlockaidSettings />}
     </ScrollView>
   );
 };

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -1,10 +1,16 @@
-import React, { useCallback, useEffect } from 'react';
-import { StyleSheet, Text, ScrollView, View } from 'react-native';
+import React, { useCallback, useEffect, FC } from 'react';
+import { StyleSheet, Text, ScrollView, View, Switch } from 'react-native';
 import StyledButton from '../../../UI/StyledButton';
-import { fontStyles } from '../../../../styles/common';
+import {
+  colors as importedColors,
+  fontStyles,
+} from '../../../../styles/common';
 import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import { strings } from '../../../../../locales/i18n';
+import { setSecurityAlertsEnabled } from '../../../../actions/experimental';
 import { useTheme } from '../../../../util/theme';
+import { useDispatch, useSelector } from 'react-redux';
+import SECURITY_ALERTS_TOGGLE_TEST_ID from './constants';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -22,6 +28,16 @@ const createStyles = (colors: any) =>
       paddingTop: 4,
       marginTop: -4,
     },
+    boldTitle: {
+      ...(fontStyles.bold as any),
+      marginTop: 18,
+      marginBottom: 18,
+    },
+    heading: {
+      marginTop: 18,
+      fontSize: 24,
+      lineHeight: 20,
+    },
     desc: {
       ...(fontStyles.normal as any),
       color: colors.text.alternative,
@@ -36,8 +52,15 @@ const createStyles = (colors: any) =>
       marginTop: 18,
     },
     switchElement: {
-      marginTop: 18,
-      alignItems: 'flex-start',
+      display: 'flex',
+      justifyContent: 'space-between',
+      flexDirection: 'row',
+    },
+    switch: {
+      alignSelf: 'flex-end',
+    },
+    switchLabel: {
+      alignSelf: 'flex-start',
     },
     modalView: {
       alignItems: 'center',
@@ -80,6 +103,16 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
+  const dispatch = useDispatch();
+
+  const securityAlertsEnabled = useSelector(
+    (state: any) => state.experimentalSettings.securityAlertsEnabled,
+  );
+
+  const toggleSecurityAlertsEnabled = () => {
+    dispatch(setSecurityAlertsEnabled(!securityAlertsEnabled));
+  };
+
   useEffect(
     () => {
       navigation.setOptions(
@@ -100,23 +133,64 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
     navigation.navigate('WalletConnectSessionsView');
   }, [navigation]);
 
-  return (
-    <ScrollView style={styles.wrapper}>
+  const WalletConnectSettings: FC = () => (
+    <>
+      <Text style={styles.title}>
+        {strings('experimental_settings.wallet_connect_dapps')}
+      </Text>
+      <Text style={styles.desc}>
+        {strings('experimental_settings.wallet_connect_dapps_desc')}
+      </Text>
+      <StyledButton
+        type="normal"
+        onPress={goToWalletConnectSessions}
+        containerStyle={styles.clearHistoryConfirm}
+      >
+        {strings('experimental_settings.wallet_connect_dapps_cta')}
+      </StyledButton>
+    </>
+  );
+
+  const BlockaidSettings: FC = () => (
+    <>
+      <Text style={[styles.title, styles.heading]}>
+        {strings('app_settings.security_heading')}
+      </Text>
       <View style={styles.setting}>
         <Text style={styles.title}>
-          {strings('experimental_settings.wallet_connect_dapps')}
+          {strings('experimental_settings.security_alerts')}
         </Text>
         <Text style={styles.desc}>
-          {strings('experimental_settings.wallet_connect_dapps_desc')}
+          {strings('experimental_settings.security_alerts_desc')}
         </Text>
-        <StyledButton
-          type="normal"
-          onPress={goToWalletConnectSessions}
-          containerStyle={styles.clearHistoryConfirm}
-        >
-          {strings('experimental_settings.wallet_connect_dapps_cta')}
-        </StyledButton>
+        <Text style={[styles.title, styles.boldTitle]}>
+          {strings('experimental_settings.select_providers')}
+        </Text>
       </View>
+      <View style={styles.switchElement}>
+        <Text style={[styles.switchLabel, styles.title]}>
+          {strings('experimental_settings.blockaid')}
+        </Text>
+        <Switch
+          value={securityAlertsEnabled}
+          onValueChange={toggleSecurityAlertsEnabled}
+          trackColor={{
+            true: colors.primary.default,
+            false: colors.border.muted,
+          }}
+          thumbColor={importedColors.white}
+          style={styles.switch}
+          ios_backgroundColor={colors.border.muted}
+          testID={SECURITY_ALERTS_TOGGLE_TEST_ID}
+        />
+      </View>
+    </>
+  );
+
+  return (
+    <ScrollView style={styles.wrapper}>
+      <WalletConnectSettings />
+      <BlockaidSettings />
     </ScrollView>
   );
 };

--- a/app/reducers/experimentalSettings/index.ts
+++ b/app/reducers/experimentalSettings/index.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/default-param-last */
+
+import {
+  ActionType,
+  SetSecurityAlertsEnabled,
+} from '../../actions/experimental';
+
+const initialState = {
+  securityAlertsEnabled: false,
+};
+
+const experimentalSettingsReducer = (
+  state = initialState,
+  action: SetSecurityAlertsEnabled,
+) => {
+  switch (action.type) {
+    case ActionType.SET_SECURITY_ALERTS_ENABLED:
+      return {
+        ...state,
+        securityAlertsEnabled: action.securityAlertsEnabled,
+      };
+    default:
+      return state;
+  }
+};
+
+export default experimentalSettingsReducer;

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -18,6 +18,7 @@ import navigationReducer from './navigation';
 import networkOnboardReducer from './networkSelector';
 import securityReducer from './security';
 import { combineReducers } from 'redux';
+import experimentalSettingsReducer from './experimentalSettings';
 
 const rootReducer = combineReducers({
   collectibles: collectiblesReducer,
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   navigation: navigationReducer,
   networkOnboarded: networkOnboardReducer,
   security: securityReducer,
+  experimentalSettings: experimentalSettingsReducer,
 });
 
 export default rootReducer;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -828,11 +828,11 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   Branch: 4ac024cb3c29b0ef628048694db3c4cfa679beb0
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: a83ceaa8a8581003a623facdb3c44f6d4f342ac5
   FBReactNativeSpec: 85eee79837cb797ab6176f0243a2b40511c09158
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -845,7 +845,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   JitsiWebRTC: f441eb0e2d67f0588bf24e21c5162e97342714fb
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 016449b5d8be0c3dcbcfa0a9988469999cd04c5d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -828,11 +828,11 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   Branch: 4ac024cb3c29b0ef628048694db3c4cfa679beb0
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: a83ceaa8a8581003a623facdb3c44f6d4f342ac5
   FBReactNativeSpec: 85eee79837cb797ab6176f0243a2b40511c09158
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -845,7 +845,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   JitsiWebRTC: f441eb0e2d67f0588bf24e21c5162e97342714fb
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 016449b5d8be0c3dcbcfa0a9988469999cd04c5d

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1690,6 +1690,10 @@
     "wallet_connect_dapps_desc": "View the list of active WalletConnect sessions",
     "wallet_connect_dapps_cta": "VIEW SESSIONS",
     "network_not_supported": "Current network not supported",
+    "security_alerts": "Security alerts",
+    "security_alerts_desc": "This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.",
+    "select_providers": "Select providers",
+    "blockaid": "Blockaid",
     "switch_network": "Please switch to mainnet or sepolia"
   },
   "walletconnect_sessions": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1694,6 +1694,7 @@
     "security_alerts_desc": "This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.",
     "select_providers": "Select providers",
     "blockaid": "Blockaid",
+    "moreProviders": "More providers coming soon",
     "switch_network": "Please switch to mainnet or sepolia"
   },
   "walletconnect_sessions": {


### PR DESCRIPTION
**Description**

## Explanation

As we introduce the Blockaid security provider feature we should add a toggle under experimental to allow users to turn the feature on and off.

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/527


## Screenshots/Screencaps

<img width="433" alt="Screenshot 2023-07-10 at 21 59 48" src="https://github.com/MetaMask/metamask-mobile/assets/44811/9c984f16-200e-43f2-b615-b6f8f2caa064">


## Manual Testing Steps

1. Open Settings
2. Tab Experimental
3. You should see the screenshot above
4. Toggle button should be off by default
5. Tap on the toggle button it should stay on
6. Restart MetaMask
7. Toggle should remain on
8. Repeat steps 5-7, this time make sure toggle stays off


**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
