### PR TITLE
refactor: Use selectors for token balances controller state access

### DIFF
--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
@@ -22,7 +22,6 @@ import { AccountFromToInfoCardProps } from './AccountFromToInfoCard.types';
 
 const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
   const {
-    contractBalances,
     identities,
     network,
     onPressFromAddressIcon,
@@ -120,7 +119,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
     if (toAddr) {
       setToAddress(toAddr);
     }
-  }, [contractBalances, data, fromAddress, selectedAsset, ticker, to]);
+  }, [data, fromAddress, selectedAsset, ticker, to]);
 
   const addressTo = (
     <AddressTo
@@ -173,8 +172,6 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
 };
 
 const mapStateToProps = (state: any) => ({
-  contractBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
   identities: state.engine.backgroundState.PreferencesController.identities,
   network: selectNetwork(state),
   ticker: selectTicker(state),

--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.types.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.types.tsx
@@ -26,7 +26,6 @@ export interface Transaction {
 }
 
 export interface AccountFromToInfoCardProps {
-  contractBalances: Record<string, number>;
   identities: Identities;
   network: string;
   onPressFromAddressIcon?: () => void;

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import Logger from '../../../util/Logger';
 import { safeToChecksumAddress } from '../../../util/address';
 import {
@@ -71,11 +72,8 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
     (state: RootStateOrAny) =>
       state.engine.backgroundState.PreferencesController.selectedAddress,
   );
-  const tokenBalances = useSelector(
-    (state: RootStateOrAny) =>
-      state.engine.backgroundState.TokenBalancesController.contractBalances,
-  );
   const tokenExchangeRates = useSelector(selectContractExchangeRates);
+  const tokenBalances = useSelector(selectContractBalances);
   const chainId = useSelector((state: RootStateOrAny) => selectChainId(state));
   const ticker = useSelector((state: RootStateOrAny) => selectTicker(state));
 

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -80,6 +80,7 @@ import {
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 import NetworkInfo from '../NetworkInfo';
@@ -1256,8 +1257,7 @@ const mapStateToProps = (state) => ({
   wizard: state.wizard,
   ticker: selectTicker(state),
   tokens: selectTokens(state),
-  tokenBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
+  tokenBalances: selectContractBalances(state),
   collectibles: collectiblesSelector(state),
   seedphraseBackedUp: state.user.seedphraseBackedUp,
   currentRoute: getCurrentRoute(state),

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -87,6 +87,7 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import { resetTransaction, setRecipient } from '../../../actions/transaction';
 
 const POLLING_INTERVAL = 30000;
@@ -2349,8 +2350,7 @@ const mapStateToProps = (state) => ({
   ticker: selectTicker(state),
   selectedAddress:
     state.engine.backgroundState.PreferencesController.selectedAddress,
-  balances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
+  balances: selectContractBalances(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   isInPolling: state.engine.backgroundState.SwapsController.isInPolling,

--- a/app/components/UI/Swaps/components/TokenSelectModal.js
+++ b/app/components/UI/Swaps/components/TokenSelectModal.js
@@ -52,6 +52,7 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
 
 import Analytics from '../../../../core/Analytics/Analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -566,9 +567,8 @@ const mapStateToProps = (state) => ({
   currentCurrency: selectCurrentCurrency(state),
   selectedAddress:
     state.engine.backgroundState.PreferencesController.selectedAddress,
-  balances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
   tokenExchangeRates: selectContractExchangeRates(state),
+  balances: selectContractBalances(state),
   chainId: selectChainId(state),
   providerConfig: selectProviderConfig(state),
   frequentRpcList:

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -79,6 +79,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import AccountSelector from '../FiatOnRampAggregator/components/AccountSelector';
 
 const createStyles = (colors) =>
@@ -1002,8 +1003,7 @@ const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   selectedAddress:
     state.engine.backgroundState.PreferencesController.selectedAddress,
-  balances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
+  balances: selectContractBalances(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   tokenExchangeRates: selectContractExchangeRates(state),

--- a/app/components/UI/TransactionEditor/index.js
+++ b/app/components/UI/TransactionEditor/index.js
@@ -48,6 +48,7 @@ import {
   selectNativeCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 
 const EDIT = 'edit';
 const REVIEW = 'review';
@@ -879,8 +880,7 @@ class TransactionEditor extends PureComponent {
 
 const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
-  contractBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
+  contractBalances: selectContractBalances(state),
   networkType: selectProviderType(state),
   selectedAddress:
     state.engine.backgroundState.PreferencesController.selectedAddress,

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../../selectors/currencyRateController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -110,11 +111,8 @@ const AssetDetails = (props: Props) => {
   const primaryCurrency = useSelector(
     (state: any) => state.settings.primaryCurrency,
   );
-  const tokenBalances = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.TokenBalancesController.contractBalances,
-  );
   const tokenExchangeRates = useSelector(selectContractExchangeRates);
+  const tokenBalances = useSelector(selectContractBalances);
   const token = useMemo(
     () => tokens.find((rawToken) => rawToken.address === address),
     [tokens, address],

--- a/app/components/Views/DetectedTokens/components/Token.tsx
+++ b/app/components/Views/DetectedTokens/components/Token.tsx
@@ -20,6 +20,7 @@ import {
   selectCurrentCurrency,
 } from '../../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
+import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -93,10 +94,7 @@ const Token = ({ token, selected, toggleSelected }: Props) => {
   const styles = createStyles(colors);
   const [expandTokenList, setExpandTokenList] = useState(false);
   const tokenExchangeRates = useSelector(selectContractExchangeRates);
-  const tokenBalances = useSelector(
-    (state: any) =>
-      state.engine.backgroundState.TokenBalancesController.contractBalances,
-  );
+  const tokenBalances = useSelector(selectContractBalances);
   const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const exchangeRate = tokenExchangeRates[address];

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -53,6 +53,7 @@ import {
 import { selectTokenList } from '../../../selectors/tokenListController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import { ethErrors } from 'eth-rpc-errors';
 
 const REVIEW = 'review';
@@ -763,8 +764,7 @@ const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
   frequentRpcList:
     state.engine.backgroundState.PreferencesController.frequentRpcList,
-  contractBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
+  contractBalances: selectContractBalances(state),
   transaction: state.transaction,
   networkType: selectProviderType(state),
   tokens: selectTokens(state),

--- a/app/components/Views/SendFlow/Amount/index.js
+++ b/app/components/Views/SendFlow/Amount/index.js
@@ -99,6 +99,7 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { selectTokens } from '../../../../selectors/tokensController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
 import { PREFIX_HEX_STRING } from '../../../../constants/transaction';
 import Routes from '../../../../constants/navigation/Routes';
 
@@ -1414,9 +1415,8 @@ Amount.contextType = ThemeContext;
 
 const mapStateToProps = (state, ownProps) => ({
   accounts: selectAccounts(state),
-  contractBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
   contractExchangeRates: selectContractExchangeRates(state),
+  contractBalances: selectContractBalances(state),
   collectibles: collectiblesSelector(state),
   collectibleContracts: collectibleContractsSelector(state),
   conversionRate: selectConversionRate(state),

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -100,6 +100,7 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../../selectors/tokenBalancesController';
 import generateTestId from '../../../../../wdio/utils/generateTestId';
 import { COMFIRM_TXN_AMOUNT } from '../../../../../wdio/screen-objects/testIDs/Screens/TransactionConfirm.testIds';
 import { isNetworkBuyNativeTokenSupported } from '../../../UI/FiatOnRampAggregator/utils';
@@ -1307,9 +1308,8 @@ Confirm.contextType = ThemeContext;
 
 const mapStateToProps = (state) => ({
   accounts: selectAccounts(state),
-  contractBalances:
-    state.engine.backgroundState.TokenBalancesController.contractBalances,
   contractExchangeRates: selectContractExchangeRates(state),
+  contractBalances: selectContractBalances(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   network: selectNetwork(state),

--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -11,6 +11,7 @@ import {
 import { safeToChecksumAddress } from '../../../util/address';
 import { selectTicker } from '../../../selectors/networkController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import { Asset } from './useAddressBalance.types';
 
 const useAddressBalance = (asset: Asset, address?: string) => {
@@ -19,8 +20,7 @@ const useAddressBalance = (asset: Asset, address?: string) => {
   const { accounts, contractBalances, selectedAddress } = useSelector(
     (state: any) => ({
       accounts: selectAccounts(state),
-      contractBalances:
-        state.engine.backgroundState.TokenBalancesController.contractBalances,
+      contractBalances: selectContractBalances(state),
       selectedAddress:
         state.engine.backgroundState.PreferencesController.selectedAddress,
     }),

--- a/app/components/hooks/useTokenBalancesController/useTokenBalancesController.test.tsx
+++ b/app/components/hooks/useTokenBalancesController/useTokenBalancesController.test.tsx
@@ -23,9 +23,22 @@ const initialState = {
 // test reducer for the test store
 const testBalancesReducer = (state: any, action: any) => {
   if (action.type === 'add-balances') {
-    state.engine.backgroundState.TokenBalancesController.contractBalances = {
-      ...state.engine.backgroundState.TokenBalancesController.contractBalances,
-      ...action.value,
+    return {
+      ...state,
+      engine: {
+        ...state.engine,
+        backgroundState: {
+          ...state.engine.backgroundState,
+          TokenBalancesController: {
+            ...state.engine.backgroundState.TokenBalancesController,
+            contractBalances: {
+              ...state.engine.backgroundState.TokenBalancesController
+                .contractBalances,
+              ...action.value,
+            },
+          },
+        },
+      },
     };
   }
   return state;

--- a/app/components/hooks/useTokenBalancesController/useTokenBalancesController.ts
+++ b/app/components/hooks/useTokenBalancesController/useTokenBalancesController.ts
@@ -1,19 +1,15 @@
 import { useSelector } from 'react-redux';
-import { EngineState } from '../../../selectors/types';
 import { isEqual } from 'lodash';
 import { ControllerHookType } from '../controllerHook.types';
 import { BN } from 'ethereumjs-util';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 
 interface TokenBalances {
   [address: string]: BN;
 }
 
 const useTokenBalancesController = (): ControllerHookType<TokenBalances> => {
-  const tokenBalances = useSelector(
-    (state: EngineState) =>
-      state.engine.backgroundState?.TokenBalancesController?.contractBalances,
-    isEqual,
-  );
+  const tokenBalances = useSelector(selectContractBalances, isEqual);
 
   return { data: tokenBalances };
 };

--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -19,6 +19,7 @@ import {
 } from '../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../selectors/tokenRatesController';
 import { selectAccounts } from '../../selectors/accountTrackerController';
+import { selectContractBalances } from '../../selectors/tokenBalancesController';
 
 /**
  *
@@ -64,7 +65,7 @@ export const useDataStore = () => {
       selectCurrentCurrency(state),
       selectNativeCurrency(state),
       selectAccounts(state),
-      state.engine.backgroundState.TokenBalancesController.contractBalances,
+      selectContractBalances(state),
       selectTicker(state),
       state.transaction,
       state.transaction.selectedAsset,

--- a/app/reducers/swaps/index.js
+++ b/app/reducers/swaps/index.js
@@ -6,6 +6,7 @@ import Engine from '../../core/Engine';
 import { lte } from '../../util/lodash';
 import { selectChainId } from '../../selectors/networkController';
 import { selectTokens } from '../../selectors/tokensController';
+import { selectContractBalances } from '../../selectors/tokenBalancesController';
 
 // * Constants
 export const SWAPS_SET_LIVENESS = 'SWAPS_SET_LIVENESS';
@@ -126,20 +127,13 @@ export const swapsTokensObjectSelector = createSelector(
 );
 
 /**
- * Balances
- */
-
-const balances = (state) =>
-  state.engine.backgroundState.TokenBalancesController.contractBalances;
-
-/**
  * Returns an array of tokens to display by default on the selector modal
  * based on the current account's balances.
  */
 export const swapsTokensWithBalanceSelector = createSelector(
   chainIdSelector,
   swapsControllerAndUserTokens,
-  balances,
+  selectContractBalances,
   (chainId, tokens, balances) => {
     if (!tokens) {
       return [];

--- a/app/selectors/tokenBalancesController.ts
+++ b/app/selectors/tokenBalancesController.ts
@@ -4,10 +4,10 @@ import { TokenBalancesState } from '@metamask/assets-controllers';
 import { EngineState } from './types';
 
 const selectTokenBalancesControllerState = (state: EngineState) =>
-  state?.engine?.backgroundState?.TokenBalancesController;
+  state.engine.backgroundState.TokenBalancesController;
 
 export const selectContractBalances = createSelector(
   selectTokenBalancesControllerState,
   (tokenBalancesControllerState: TokenBalancesState) =>
-    tokenBalancesControllerState?.contractBalances,
+    tokenBalancesControllerState.contractBalances,
 );

--- a/app/selectors/tokenBalancesController.ts
+++ b/app/selectors/tokenBalancesController.ts
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+import { createSelector } from 'reselect';
+import { TokenBalancesState } from '@metamask/assets-controllers';
+import { EngineState } from './types';
+
+const selectTokenBalancesControllerState = (state: EngineState) =>
+  state?.engine?.backgroundState?.TokenBalancesController;
+
+export const selectContractBalances = createSelector(
+  selectTokenBalancesControllerState,
+  (tokenBalancesControllerState: TokenBalancesState) =>
+    tokenBalancesControllerState?.contractBalances,
+);


### PR DESCRIPTION
**Description**

Token balances controller Redux state is now accessed excusively through selectors. This makes future state changes easier to manage.

Most of these changes consist of replacing the direct access to TokenBalancesController State, by selectors.

**Issue**


Relates to https://github.com/MetaMask/mobile-planning/issues/1064

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
