### PR TITLE
ci: Fix pipelines to reflect running tests on android detox

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ pipelines:
   #Run E2E test suite for Android only
   run_e2e_android_pipeline:
     stages:
-      - android_e2e_test: {} #runs android detox tests
+      - run_e2e_android_stage: {} #runs android detox E2E
       - notify: {}
   #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
   release_e2e_pipeline:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,7 @@ pipelines:
   #Run E2E test suite for Android only
   run_e2e_android_pipeline:
     stages:
-      - create_build_qa_android: {} #builds app and kicks off separate E2E build
+      - android_e2e_test: {} #runs android detox tests
       - notify: {}
   #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
   release_e2e_pipeline:
@@ -96,10 +96,10 @@ stages:
   run_e2e_ios_android_stage:
     workflows:
       - ios_e2e_test: {}
-      - build_android_qa: {}
+      - android_e2e_test: {}
   run_e2e_android_stage:
     workflows:
-      - build_android_qa: {} #Build QA -> Browserstack -> wdio_ (can be a smaller machine)
+      - android_e2e_test: {} 
   notify:
     workflows:
       - notify_success_on_slack: {}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `run_e2e_android_pipeline` and `release_e2e_pipeline` are running tests against the incorrect test framework. This PR ensures that both these pipelines trigger the android detox tests. 

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
