### PR TITLE
fix: Update button constants structure to prevent require cycle

### DIFF
--- a/app/component-library/components/Buttons/Button/Button.constants.ts
+++ b/app/component-library/components/Buttons/Button/Button.constants.ts
@@ -4,16 +4,7 @@
 import { SAMPLE_BUTTONSECONDARY_PROPS } from './variants/ButtonSecondary/ButtonSecondary.constants';
 
 // Internal dependencies.
-import {
-  ButtonSize,
-  ButtonWidthTypes,
-  ButtonProps,
-  ButtonVariants,
-} from './Button.types';
-
-// Defaults
-export const DEFAULT_BUTTON_SIZE = ButtonSize.Md;
-export const DEFAULT_BUTTON_WIDTH = ButtonWidthTypes.Auto;
+import { ButtonProps, ButtonVariants } from './Button.types';
 
 // Samples
 export const SAMPLE_BUTTON_PROPS: ButtonProps = {

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.constants.ts
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.constants.ts
@@ -1,17 +1,13 @@
 /* eslint-disable no-console */
 /* eslint-disable import/prefer-default-export */
 // External dependencies.
-import {
-  DEFAULT_BUTTON_SIZE,
-  DEFAULT_BUTTON_WIDTH,
-} from '../../Button.constants';
 import { ButtonBaseProps } from './ButtonBase.types';
 import { IconName, IconSize } from '../../../../Icons/Icon';
 import { ButtonSize, ButtonWidthTypes } from '../../Button.types';
 
 // Defaults
-export const DEFAULT_BUTTONBASE_SIZE = DEFAULT_BUTTON_SIZE;
-export const DEFAULT_BUTTONBASE_WIDTH = DEFAULT_BUTTON_WIDTH;
+export const DEFAULT_BUTTONBASE_SIZE = ButtonSize.Md;
+export const DEFAULT_BUTTONBASE_WIDTH = ButtonWidthTypes.Auto;
 export const DEFAULT_BUTTONBASE_ICON_SIZE = IconSize.Sm;
 
 // Samples


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

- Updated `ButtonBase.constants` to not require `Button.constants` to break the unnecessary require cycle

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
