### PR TITLE
refactor: Use selectors for nft controller state access

### DIFF
--- a/app/reducers/collectibles/index.js
+++ b/app/reducers/collectibles/index.js
@@ -1,35 +1,33 @@
 import { createSelector } from 'reselect';
 import { selectChainId } from '../../selectors/networkController';
+import {
+  selectAllNftContracts,
+  selectAllNfts,
+} from '../../selectors/nftController';
 import { compareTokenIds } from '../../util/tokens';
 
 const addressSelector = (state) =>
   state.engine.backgroundState.PreferencesController.selectedAddress;
-const chainIdSelector = (state) => selectChainId(state);
 const favoritesSelector = (state) => state.collectibles.favorites;
-
-const allNftContractsSelector = (state) =>
-  state.engine.backgroundState.NftController.allNftContracts;
-const allNftsSelector = (state) =>
-  state.engine.backgroundState.NftController.allNfts;
 
 export const collectibleContractsSelector = createSelector(
   addressSelector,
-  chainIdSelector,
-  allNftContractsSelector,
+  selectChainId,
+  selectAllNftContracts,
   (address, chainId, allNftContracts) =>
     allNftContracts[address]?.[chainId] || [],
 );
 
 export const collectiblesSelector = createSelector(
   addressSelector,
-  chainIdSelector,
-  allNftsSelector,
+  selectChainId,
+  selectAllNfts,
   (address, chainId, allNfts) => allNfts[address]?.[chainId] || [],
 );
 
 export const favoritesCollectiblesSelector = createSelector(
   addressSelector,
-  chainIdSelector,
+  selectChainId,
   favoritesSelector,
   (address, chainId, favorites) => favorites[address]?.[chainId] || [],
 );

--- a/app/selectors/nftController.ts
+++ b/app/selectors/nftController.ts
@@ -1,0 +1,16 @@
+import { createSelector } from 'reselect';
+import { NftState } from '@metamask/assets-controllers';
+import { EngineState } from './types';
+
+const selectNftControllerState = (state: EngineState) =>
+  state.engine.backgroundState.NftController;
+
+export const selectAllNftContracts = createSelector(
+  selectNftControllerState,
+  (nftControllerState: NftState) => nftControllerState.allNftContracts,
+);
+
+export const selectAllNfts = createSelector(
+  selectNftControllerState,
+  (nftControllerState: NftState) => nftControllerState.allNfts,
+);


### PR DESCRIPTION
**Description**

Nft controller Redux state is now accessed excusively through selectors. This makes future state changes easier to manage.

Most of these changes consist of replacing the direct access to NftController State, by selectors.

**Issue**


Relates to https://github.com/MetaMask/mobile-planning/issues/1062

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
