### PR TITLE
feat: Added network badge to the nfts

### DIFF
--- a/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.styles.ts
+++ b/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.styles.ts
@@ -24,7 +24,13 @@ const styleSheet = (params: {
   vars: BadgeWrapperStyleSheetVars;
 }) => {
   const { vars } = params;
-  const { style, anchorElementShape, badgePosition, containerSize } = vars;
+  const {
+    style,
+    anchorElementShape,
+    badgePosition,
+    containerSize,
+    customAnchoringOffset,
+  } = vars;
   let anchoringOffset, positionObj, xOffset, yOffset;
   const elementHeight = containerSize?.height || 0;
 
@@ -43,32 +49,32 @@ const styleSheet = (params: {
   switch (badgePosition) {
     case BadgePosition.TopRight:
       positionObj = {
-        top: anchoringOffset,
-        right: anchoringOffset,
+        top: customAnchoringOffset ?? anchoringOffset,
+        right: customAnchoringOffset ?? anchoringOffset,
       };
       xOffset = elementHeight / 2;
       yOffset = elementHeight / -2;
       break;
     case BadgePosition.BottomRight:
       positionObj = {
-        bottom: anchoringOffset,
-        right: anchoringOffset,
+        bottom: customAnchoringOffset ?? anchoringOffset,
+        right: customAnchoringOffset ?? anchoringOffset,
       };
       xOffset = elementHeight / 2;
       yOffset = elementHeight / 2;
       break;
     case BadgePosition.BottomLeft:
       positionObj = {
-        bottom: anchoringOffset,
-        left: anchoringOffset,
+        bottom: customAnchoringOffset ?? anchoringOffset,
+        left: customAnchoringOffset ?? anchoringOffset,
       };
       xOffset = elementHeight / -2;
       yOffset = elementHeight / 2;
       break;
     case BadgePosition.TopLeft:
       positionObj = {
-        top: anchoringOffset,
-        left: anchoringOffset,
+        top: customAnchoringOffset ?? anchoringOffset,
+        left: customAnchoringOffset ?? anchoringOffset,
       };
       xOffset = elementHeight / -2;
       yOffset = elementHeight / -2;

--- a/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
+++ b/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
@@ -21,6 +21,7 @@ const BadgeWrapper: React.FC<BadgeWrapperProps> = ({
   children,
   badgeElement,
   style,
+  customAnchoringOffset,
 }) => {
   const { size: containerSize, onLayout: onLayoutContainerSize } =
     useComponentSize();
@@ -30,6 +31,7 @@ const BadgeWrapper: React.FC<BadgeWrapperProps> = ({
     anchorElementShape,
     badgePosition,
     containerSize,
+    customAnchoringOffset,
   });
 
   return (

--- a/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.types.ts
+++ b/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.types.ts
@@ -52,6 +52,10 @@ export interface BadgeWrapperProps extends ViewProps {
    * Any element that will be placed in the position of the badge.
    */
   badgeElement: React.ReactNode;
+  /**
+   *  Absolute position of the badge
+   */
+  customAnchoringOffset?: number;
 }
 
 /**
@@ -61,4 +65,5 @@ export type BadgeWrapperStyleSheetVars = Pick<BadgeWrapperProps, 'style'> & {
   anchorElementShape: BadgeAnchorElementShape;
   badgePosition: BadgePosition | BadgePositionCustom;
   containerSize: { width: number; height: number } | null;
+  customAnchoringOffset?: number;
 };

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -34,6 +34,7 @@ import {
   getTestNetImageByChainId,
   isLineaMainnetByChainId,
   isMainnetByChainId,
+  isOptimism,
   isTestNet,
 } from '../../../util/networks';
 import generateTestId from '../../../../wdio/utils/generateTestId';
@@ -252,12 +253,14 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
     const isMainnet = isMainnetByChainId(chainId);
     const isLineaMainnet = isLineaMainnetByChainId(chainId);
 
-    const NetworkBadgeSource = () => {
+    const networkBadgeSource = () => {
       if (isTestNet(chainId)) return getTestNetImageByChainId(chainId);
 
       if (isMainnet) return images.ETHEREUM;
 
       if (isLineaMainnet) return images['LINEA-MAINNET'];
+
+      if (isOptimism(chainId)) return images.OPTIMISM;
 
       return images[ticker];
     };
@@ -274,7 +277,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
           badgeElement={
             <Badge
               variant={BadgeVariant.Network}
-              imageSource={NetworkBadgeSource()}
+              imageSource={networkBadgeSource()}
               name={networkName}
             />
           }

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -144,6 +144,9 @@ export const isMainnetByChainId = (chainId) =>
 export const isLineaMainnetByChainId = (chainId) =>
   getDecimalChainId(String(chainId)) === String(59144);
 
+export const isOptimism = (chainId) =>
+  getDecimalChainId(String(chainId)) === String(10);
+
 export const isMultiLayerFeeNetwork = (chainId) =>
   chainId === NETWORKS_CHAIN_ID.OPTIMISM;
 


### PR DESCRIPTION
**Description**
This PR aims to attach the network badge to the NFTs tab.

**Screenshots/Recordings**
- Scenario: NFT should show Mainnet badge
- Scenario: NFT should show BSC badge after switching to BSC network
- Scenario: Network badges should be unchanged on the tokens tab. 
- Scenario: Tokens should show network badge
* https://recordit.co/M0tIfMmSrH

- Scenario: Network badge is still visible when the device is set to dark mode and on a custom network
* https://recordit.co/3gy3MZVQaQ

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
