### PR TITLE
fix: wallet connect v1 is fully deprecated

### DIFF
--- a/app/util/walletconnect.js
+++ b/app/util/walletconnect.js
@@ -3,9 +3,7 @@ export const CLIENT_OPTIONS = {
     // Required
     description: 'MetaMask Mobile app',
     url: 'https://metamask.io',
-    icons: [
-      'https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg',
-    ],
+    icons: [],
     name: 'MetaMask',
     ssl: true,
   },


### PR DESCRIPTION
**Description**
This PR aims to start removing code of the wallet connect v1, that it's fully deprecated




**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
