### PR TITLE
fix: [7.4.0] - from account address send flow

### DIFF
--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -20,6 +20,7 @@ import { SFAddressFromProps } from './AddressFrom.types';
 
 const SendFlowAddressFrom = ({
   fromAccountBalanceState,
+  setFromAddress,
 }: SFAddressFromProps) => {
   const navigation = useNavigation();
   const identities = useSelector(
@@ -110,6 +111,7 @@ const SendFlowAddressFrom = ({
     setAccountName(accName);
     setAccountBalance(balance);
     fromAccountBalanceState(balanceIsZero);
+    setFromAddress(address);
   };
 
   const openAccountSelector = () => {

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.types.ts
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.types.ts
@@ -1,3 +1,4 @@
 export interface SFAddressFromProps {
   fromAccountBalanceState: (value: boolean) => void;
+  setFromAddress: (address: string) => void;
 }

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -370,6 +370,10 @@ class SendFlow extends PureComponent {
     this.setState({ balanceIsZero: value });
   };
 
+  setFromAddress = (address) => {
+    this.setState({ fromSelectedAddress: address });
+  };
+
   getAddressNameFromBookOrIdentities = (toAccount) => {
     const { addressBook, identities, network } = this.props;
     if (!toAccount) return;
@@ -490,6 +494,7 @@ class SendFlow extends PureComponent {
         <View style={styles.imputWrapper}>
           <SendFlowAddressFrom
             fromAccountBalanceState={this.fromAccountBalanceState}
+            setFromAddress={this.setFromAddress}
           />
           <SendFlowAddressTo
             inputRef={this.addressToInputRef}


### PR DESCRIPTION
**Description**
From address is not changing when changed on the send flow.
This PR aims to address it by changing the from address on the transaction object.

**Screenshots/Recordings**
<img width="250" src="https://github.com/MetaMask/metamask-mobile/assets/46944231/eba9ba26-12ac-48ee-a4d1-537945b5d3a1" />

Send flow recording of success and canceling on confirm screen:
http://recordit.co/KZKHskSKQ5

**Issue**

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
