### PR TITLE
refactor: Use Redux network controller state

### DIFF
--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -85,6 +85,10 @@ export default class AddCustomToken extends PureComponent {
 
   static propTypes = {
     /**
+     * The chain ID for the current selected network
+     */
+    chainId: PropTypes.string,
+    /**
     /* navigation object required to push new views
     */
     navigation: PropTypes.object,
@@ -96,8 +100,7 @@ export default class AddCustomToken extends PureComponent {
 
   getAnalyticsParams = () => {
     try {
-      const { NetworkController } = Engine.context;
-      const { chainId } = NetworkController?.state?.providerConfig || {};
+      const { chainId } = this.props;
       const { address, symbol } = this.state;
       return {
         token_address: address,
@@ -184,8 +187,7 @@ export default class AddCustomToken extends PureComponent {
     let validated = true;
     const address = this.state.address;
     const isValidTokenAddress = isValidAddress(address);
-    const { NetworkController } = Engine.context;
-    const { chainId } = NetworkController?.state?.providerConfig || {};
+    const { chainId } = this.props;
     const toSmartContract =
       isValidTokenAddress && (await isSmartContractAddress(address, chainId));
     const addressWithoutSpaces = address.replace(/\s/g, '');

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -507,14 +507,13 @@ class ApproveTransactionReview extends PureComponent {
 
   getAnalyticsParams = () => {
     try {
-      const { activeTabUrl, transaction, onSetAnalyticsParams } = this.props;
+      const { activeTabUrl, chainId, transaction, onSetAnalyticsParams } =
+        this.props;
       const {
         token: { tokenSymbol },
         originalApproveAmount,
         encodedHexAmount,
       } = this.state;
-      const { NetworkController } = Engine.context;
-      const { chainId } = NetworkController?.state?.providerConfig || {};
       const isDapp = !Object.values(AppConstants.DEEPLINKS).includes(
         transaction?.origin,
       );

--- a/app/components/UI/WatchAssetRequest/index.js
+++ b/app/components/UI/WatchAssetRequest/index.js
@@ -2,19 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, View, Text, InteractionManager } from 'react-native';
 import URL from 'url-parse';
+import { useSelector } from 'react-redux';
 import { fontStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import ActionView from '../ActionView';
 import { renderFromTokenMinimalUnit } from '../../../util/number';
 import TokenImage from '../../UI/TokenImage';
 import Device from '../../../util/device';
-import Engine from '../../../core/Engine';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import AnalyticsV2 from '../../../util/analyticsV2';
 
 import useTokenBalance from '../../hooks/useTokenBalance';
 import { useTheme } from '../../../util/theme';
 import NotificationManager from '../../../core/NotificationManager';
+import { selectChainId } from '../../../selectors/networkController';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -97,14 +98,13 @@ const WatchAssetRequest = ({
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const [balance, , error] = useTokenBalance(asset.address, interactingAddress);
+  const chainId = useSelector(selectChainId);
   const balanceWithSymbol = error
     ? strings('transaction.failed')
     : `${renderFromTokenMinimalUnit(balance, asset.decimals)} ${asset.symbol}`;
 
   const getAnalyticsParams = () => {
     try {
-      const { NetworkController } = Engine.context;
-      const { chainId } = NetworkController?.state?.providerConfig || {};
       const url = new URL(currentPageInformation?.url);
 
       return {

--- a/app/components/Views/AddAsset/index.js
+++ b/app/components/Views/AddAsset/index.js
@@ -167,6 +167,7 @@ class AddAsset extends PureComponent {
               />
             )}
             <AddCustomToken
+              chainId={chainId}
               navigation={navigation}
               tabLabel={strings('add_asset.custom_token')}
               testID={'tab-add-custom-token'}

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -31,6 +31,7 @@ import {
 } from '../../../reducers/swaps';
 import {
   selectChainId,
+  selectNetwork,
   selectRpcTarget,
 } from '../../../selectors/networkController';
 import { selectTokens } from '../../../selectors/tokensController';
@@ -143,7 +144,11 @@ class Asset extends PureComponent {
      */
     selectedAddress: PropTypes.string,
     /**
-     * A string representing the network name
+     * The network ID for the current selected network
+     */
+    networkId: PropTypes.string,
+    /**
+     * The chain ID for the current selected network
      */
     chainId: PropTypes.string,
     /**
@@ -267,18 +272,17 @@ class Asset extends PureComponent {
     this.txsPending.length !== newTxsPending.length;
 
   ethFilter = (tx) => {
-    const { selectedAddress, chainId } = this.props;
+    const { selectedAddress, chainId, networkId } = this.props;
     const {
       transaction: { from, to },
       isTransfer,
       transferInformation,
     } = tx;
 
-    const network = Engine.context.NetworkController.state.network;
     if (
       (safeToChecksumAddress(from) === selectedAddress ||
         safeToChecksumAddress(to) === selectedAddress) &&
-      (chainId === tx.chainId || (!tx.chainId && network === tx.networkID)) &&
+      (chainId === tx.chainId || (!tx.chainId && networkId === tx.networkID)) &&
       tx.status !== 'unapproved'
     ) {
       if (isTransfer)
@@ -291,17 +295,17 @@ class Asset extends PureComponent {
   };
 
   noEthFilter = (tx) => {
-    const { chainId, swapsTransactions, selectedAddress } = this.props;
+    const { chainId, networkId, swapsTransactions, selectedAddress } =
+      this.props;
     const {
       transaction: { to, from },
       isTransfer,
       transferInformation,
     } = tx;
-    const network = Engine.context.NetworkController.state.network;
     if (
       (safeToChecksumAddress(from) === selectedAddress ||
         safeToChecksumAddress(to) === selectedAddress) &&
-      (chainId === tx.chainId || (!tx.chainId && network === tx.networkID)) &&
+      (chainId === tx.chainId || (!tx.chainId && networkId === tx.networkID)) &&
       tx.status !== 'unapproved'
     ) {
       if (to?.toLowerCase() === this.navAddress) return true;
@@ -574,6 +578,7 @@ const mapStateToProps = (state) => ({
   identities: selectIdentities(state),
   chainId: selectChainId(state),
   tokens: selectTokens(state),
+  networkId: selectNetwork(state),
   transactions: state.engine.backgroundState.TransactionController.transactions,
   thirdPartyApiMode: state.privacy.thirdPartyApiMode,
   rpcTarget: selectRpcTarget(state),

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -32,7 +32,10 @@ import { useTheme } from '../../../util/theme';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import Routes from '../../../constants/navigation/Routes';
-import { selectProviderConfig } from '../../../selectors/networkController';
+import {
+  selectChainId,
+  selectProviderConfig,
+} from '../../../selectors/networkController';
 import {
   selectConversionRate,
   selectCurrentCurrency,
@@ -108,6 +111,7 @@ const AssetDetails = (props: Props) => {
   const tokens = useSelector(selectTokens);
   const conversionRate = useSelector(selectConversionRate);
   const currentCurrency = useSelector(selectCurrentCurrency);
+  const chainId = useSelector(selectChainId);
   const primaryCurrency = useSelector(
     (state: any) => state.settings.primaryCurrency,
   );
@@ -157,7 +161,7 @@ const AssetDetails = (props: Props) => {
   };
 
   const triggerHideToken = () => {
-    const { TokensController, NetworkController } = Engine.context as any;
+    const { TokensController } = Engine.context as any;
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: 'AssetHideConfirmation',
       params: {
@@ -179,9 +183,7 @@ const AssetDetails = (props: Props) => {
                 token_standard: 'ERC20',
                 asset_type: 'token',
                 tokens: [`${symbol} - ${address}`],
-                chain_id: getDecimalChainId(
-                  NetworkController?.state?.providerConfig?.chainId,
-                ),
+                chain_id: getDecimalChainId(chainId),
               });
             } catch (err) {
               Logger.log(err, 'AssetDetails: Failed to hide token!');

--- a/app/components/Views/DetectedTokens/index.tsx
+++ b/app/components/Views/DetectedTokens/index.tsx
@@ -22,6 +22,7 @@ import SheetBottom, {
   SheetBottomRef,
 } from '../../../component-library/components/Sheet/SheetBottom';
 import { selectDetectedTokens } from '../../../selectors/tokensController';
+import { selectChainId } from '../../../selectors/networkController';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -67,6 +68,7 @@ const DetectedTokens = () => {
   const navigation = useNavigation();
   const sheetRef = useRef<SheetBottomRef>(null);
   const detectedTokens = useSelector(selectDetectedTokens);
+  const chainId = useSelector(selectChainId);
   const [ignoredTokens, setIgnoredTokens] = useState<IgnoredTokensByAddress>(
     {},
   );
@@ -114,8 +116,6 @@ const DetectedTokens = () => {
       }
 
       sheetRef.current?.hide(async () => {
-        const { NetworkController } = Engine.context as any;
-
         try {
           tokensToIgnore.length > 0 &&
             (await TokensController.ignoreTokens(tokensToIgnore));
@@ -126,9 +126,7 @@ const DetectedTokens = () => {
                 AnalyticsV2.trackEvent(MetaMetricsEvents.TOKEN_ADDED, {
                   token_address: address,
                   token_symbol: symbol,
-                  chain_id: getDecimalChainId(
-                    NetworkController?.state?.providerConfig?.chainId,
-                  ),
+                  chain_id: getDecimalChainId(chainId),
                   source: 'detected',
                 }),
               ),
@@ -145,12 +143,10 @@ const DetectedTokens = () => {
         }
       });
     },
-    [detectedTokens, ignoredTokens],
+    [chainId, detectedTokens, ignoredTokens],
   );
 
   const triggerIgnoreAllTokens = () => {
-    const { NetworkController } = Engine.context as any;
-
     navigation.navigate('DetectedTokensConfirmation', {
       onConfirm: () => dismissModalAndTriggerAction(true),
       isHidingAll: true,
@@ -161,9 +157,7 @@ const DetectedTokens = () => {
         token_standard: 'ERC20',
         asset_type: 'token',
         tokens: detectedTokensForAnalytics,
-        chain_id: getDecimalChainId(
-          NetworkController?.state?.providerConfig?.chainId,
-        ),
+        chain_id: getDecimalChainId(chainId),
       }),
     );
   };
@@ -252,16 +246,13 @@ const DetectedTokens = () => {
   };
 
   const trackCancelWithoutAction = (hasPendingAction: boolean) => {
-    const { NetworkController } = Engine.context as any;
     if (hasPendingAction) {
       return;
     }
     AnalyticsV2.trackEvent(MetaMetricsEvents.TOKEN_IMPORT_CANCELED, {
       source: 'detected',
       tokens: detectedTokensForAnalytics,
-      chain_id: getDecimalChainId(
-        NetworkController?.state?.providerConfig?.chainId,
-      ),
+      chain_id: getDecimalChainId(chainId),
     });
   };
 


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://docs.google.com/document/d/1VJLwTRsUw_5EDq_o8d6sSbXUAYENLurkRitYO45eY5o/edit?usp=sharing)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

Various UI components have been updated to use Redux network controller state (via selectors) rather than directly accessing the controller state using the `Engine` global.

**Issue**


Relates to MetaMask/mobile-planning#1016

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
