### PR TITLE
test: Remove obsolete test fixture state

### DIFF
--- a/app/components/UI/AccountInfoCard/index.test.tsx
+++ b/app/components/UI/AccountInfoCard/index.test.tsx
@@ -48,9 +48,6 @@ const initialState = {
           type: 'sepolia',
           nickname: 'Sepolia',
         },
-        provider: {
-          ticker: 'eth',
-        },
       },
       TokenBalancesController: {
         contractBalances: {},

--- a/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.test.tsx
+++ b/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.test.tsx
@@ -82,9 +82,6 @@ const initialState = {
           type: 'sepolia',
           nickname: 'Sepolia',
         },
-        provider: {
-          ticker: 'eth',
-        },
       },
       AddressBookController: {
         addressBook: {},

--- a/app/components/hooks/useExistingAddress.test.ts
+++ b/app/components/hooks/useExistingAddress.test.ts
@@ -18,9 +18,6 @@ jest.mock('react-redux', () => ({
           },
           NetworkController: {
             network: 1,
-            provider: {
-              ticker: 'eth',
-            },
           },
           AddressBookController: {
             addressBook: {
@@ -52,9 +49,6 @@ const initialState = {
       },
       NetworkController: {
         network: 1,
-        provider: {
-          ticker: 'eth',
-        },
       },
       AddressBookController: {
         addressBook: {


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `NetworkController` state property `provider` was still referenced in a few unit tests, despite the fact that it no longer exists. All such obsolete state references have been removed.

**Issue**

This change was done to simplify PR #6872, which is part of https://github.com/MetaMask/mobile-planning/issues/798

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
