### PR TITLE
refactor: Update `@metamask/assets-controllers` patch

### DIFF
--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -117,7 +117,7 @@ export default class AddCustomToken extends PureComponent {
     if (!(await this.validateCustomToken())) return;
     const { TokensController } = Engine.context;
     const { address, symbol, decimals, name } = this.state;
-    await TokensController.addToken(address, symbol, decimals, null, name);
+    await TokensController.addToken(address, symbol, decimals, { name });
 
     AnalyticsV2.trackEvent(
       MetaMetricsEvents.TOKEN_ADDED,

--- a/app/components/UI/Ramp/hooks/useHandleSuccessfulOrder.ts
+++ b/app/components/UI/Ramp/hooks/useHandleSuccessfulOrder.ts
@@ -45,7 +45,7 @@ function useHandleSuccessfulOrder() {
           toLowerCaseEquals(t.address, address),
         )
       ) {
-        await TokensController.addToken(address, symbol, decimals, null, name);
+        await TokensController.addToken(address, symbol, decimals, { name });
       }
     },
     [selectedChainId],

--- a/app/components/UI/SearchTokenAutocomplete/index.tsx
+++ b/app/components/UI/SearchTokenAutocomplete/index.tsx
@@ -106,7 +106,10 @@ const SearchTokenAutocomplete = ({ navigation }: Props) => {
 
   const addToken = useCallback(async () => {
     const { TokensController } = Engine.context as any;
-    await TokensController.addToken(address, symbol, decimals, iconUrl, name);
+    await TokensController.addToken(address, symbol, decimals, {
+      image: iconUrl,
+      name,
+    });
 
     AnalyticsV2.trackEvent(MetaMetricsEvents.TOKEN_ADDED, getAnalyticsParams());
 

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -348,7 +348,7 @@ async function addTokenToAssetsController(newToken) {
     )
   ) {
     const { address, symbol, decimals, name } = newToken;
-    await TokensController.addToken(address, symbol, decimals, null, name);
+    await TokensController.addToken(address, symbol, decimals, { name });
   }
 }
 

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -526,7 +526,7 @@ function SwapsAmountView({
     ) {
       const { TokensController } = Engine.context;
       const { address, symbol, decimals, name } = sourceToken;
-      await TokensController.addToken(address, symbol, decimals, null, name);
+      await TokensController.addToken(address, symbol, decimals, { name });
     }
     return navigation.navigate(
       'SwapsQuotesView',

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -526,7 +526,10 @@ class Confirm extends PureComponent {
       const { TokensController } = Engine.context;
 
       if (!contractBalances[address]) {
-        await TokensController.addToken(address, symbol, decimals, image, name);
+        await TokensController.addToken(address, symbol, decimals, {
+          image,
+          name,
+        });
       }
 
       const [, , rawAmount] = decodeTransferData('transfer', data);

--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -42,13 +42,10 @@ const useAddressBalance = (asset: Asset, address?: string) => {
         return;
       }
       if (!contractBalances[contractAddress]) {
-        TokensController.addToken(
-          contractAddress,
-          symbol,
-          decimals,
+        TokensController.addToken(contractAddress, symbol, decimals, {
           image,
           name,
-        );
+        });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/patches/@metamask+assets-controllers+5.0.1.patch
+++ b/patches/@metamask+assets-controllers+5.0.1.patch
@@ -111,7 +111,7 @@ index 332c87d..b634fde 100644
       * Enumerate assets assigned to an owner.
       *
 diff --git a/node_modules/@metamask/assets-controllers/dist/NftController.js b/node_modules/@metamask/assets-controllers/dist/NftController.js
-index 6a14075..0c7fd4d 100644
+index 6a14075..0b77b80 100644
 --- a/node_modules/@metamask/assets-controllers/dist/NftController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/NftController.js
 @@ -127,21 +127,7 @@ class NftController extends base_controller_1.BaseController {
@@ -133,7 +133,7 @@ index 6a14075..0c7fd4d 100644
 -                    errorCodesToCatch: [403],
 -                });
 -            }
-+        
++
              // if we were still unable to fetch the data we return out the default/null of `NftMetadata`
              if (!nftInformation) {
                  return {
@@ -162,7 +162,7 @@ index 1f234ca..ef2b7e7 100644
                      return nfts;
                  }
 diff --git a/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js b/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
-index 9ddbc28..c973f68 100644
+index 9ddbc28..b9f309a 100644
 --- a/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
 +++ b/node_modules/@metamask/assets-controllers/dist/Standards/ERC20Standard.js
 @@ -14,6 +14,7 @@ const contracts_1 = require("@ethersproject/contracts");
@@ -212,7 +212,7 @@ index 9ddbc28..c973f68 100644
              }
              catch (_b) {
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js b/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js
-index 4ed4990..da18116 100644
+index 4ed4990..df0524b 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/TokenDetectionController.js
 @@ -34,7 +34,7 @@ class TokenDetectionController extends base_controller_1.BaseController {
@@ -236,12 +236,12 @@ index 4ed4990..da18116 100644
                  return;
              }
              const { tokens } = this.getTokensState();
-+            
++
              const { selectedAddress, chainId } = this.config;
              const tokensAddresses = tokens.map(
              /* istanbul ignore next*/ (token) => token.address.toLowerCase());
              const { tokenList } = this.getTokenListState();
-+         
++
 +            if (tokens.length && !tokens[0].name) {
 +                this.updateTokensName(tokenList);
 +            }
@@ -275,7 +275,7 @@ index 4ed4990..da18116 100644
                          }
                      }
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
-index e3f81e9..c3a13ac 100644
+index e3f81e9..c7b0a33 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
 @@ -77,6 +77,7 @@ class TokenRatesController extends base_controller_1.BaseController {
@@ -351,7 +351,7 @@ index e3f81e9..c3a13ac 100644
                  let tokenExchangeRates;
                  let vsCurrencyToNativeCurrencyConversionRate = 0;
 -                try {
-+                
++
                      [
                          tokenExchangeRates,
                          { conversionRate: vsCurrencyToNativeCurrencyConversionRate },
@@ -392,7 +392,7 @@ index e3f81e9..c3a13ac 100644
          });
      }
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokensController.js b/node_modules/@metamask/assets-controllers/dist/TokensController.js
-index dc59d68..c6ac7d5 100644
+index dc59d68..26ad7d1 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokensController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/TokensController.js
 @@ -44,8 +44,10 @@ class TokensController extends base_controller_1.BaseController {
@@ -427,16 +427,37 @@ index dc59d68..c6ac7d5 100644
      /**
       * Fetch metadata for a token.
       *
-@@ -125,7 +125,7 @@ class TokensController extends base_controller_1.BaseController {
-      * @param image - Image of the token.
+@@ -122,16 +122,25 @@ class TokensController extends base_controller_1.BaseController {
+      * @param address - Hex address of the token contract.
+      * @param symbol - Symbol of the token.
+      * @param decimals - Number of decimals the token uses.
+-     * @param image - Image of the token.
++     * @param options - Object containing name and image of the token
++     * @param options.name - Name of the token
++     * @param options.image - Image of the token
++     * @param options.interactingAddress - The address of the account to add a token to.
       * @returns Current token list.
       */
 -    addToken(address, symbol, decimals, image) {
-+    addToken(address, symbol, decimals, image, name) {
++    addToken(address, symbol, decimals, { image, name, interactingAddress } = {}) {
++        var _a, _b, _c;
          return __awaiter(this, void 0, void 0, function* () {
-             const currentChainId = this.config.chainId;
+-            const currentChainId = this.config.chainId;
++            const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
++            const { chainId: currentChainId, selectedAddress } = this.config;
++            const accountAddress = interactingAddress || selectedAddress;
++            const isInteractingWithWalletAccount = accountAddress === selectedAddress;
              const releaseLock = yield this.mutex.acquire();
-@@ -151,6 +151,7 @@ class TokensController extends base_controller_1.BaseController {
+             try {
+                 address = (0, controller_utils_1.toChecksumHexAddress)(address);
+-                const { tokens, ignoredTokens, detectedTokens } = this.state;
++                const tokens = ((_a = allTokens[currentChainId]) === null || _a === void 0 ? void 0 : _a[accountAddress]) || [];
++                const ignoredTokens = ((_b = allIgnoredTokens[currentChainId]) === null || _b === void 0 ? void 0 : _b[accountAddress]) || [];
++                const detectedTokens = ((_c = allDetectedTokens[currentChainId]) === null || _c === void 0 ? void 0 : _c[accountAddress]) || [];
+                 const newTokens = [...tokens];
+                 const [isERC721, tokenMetadata] = yield Promise.all([
+                     this._detectIsERC721(address),
+@@ -151,6 +160,7 @@ class TokensController extends base_controller_1.BaseController {
                          }),
                      isERC721,
                      aggregators: (0, assetsUtil_1.formatAggregatorNames)((tokenMetadata === null || tokenMetadata === void 0 ? void 0 : tokenMetadata.aggregators) || []),
@@ -444,87 +465,31 @@ index dc59d68..c6ac7d5 100644
                  };
                  const previousEntry = newTokens.find((token) => token.address.toLowerCase() === address.toLowerCase());
                  if (previousEntry) {
-@@ -182,6 +183,79 @@ class TokensController extends base_controller_1.BaseController {
+@@ -166,15 +176,18 @@ class TokensController extends base_controller_1.BaseController {
+                     newTokens,
+                     newIgnoredTokens,
+                     newDetectedTokens,
++                    interactingAddress: accountAddress,
+                 });
+-                this.update({
+-                    tokens: newTokens,
+-                    ignoredTokens: newIgnoredTokens,
+-                    detectedTokens: newDetectedTokens,
++                let newState = {
+                     allTokens: newAllTokens,
+                     allIgnoredTokens: newAllIgnoredTokens,
+                     allDetectedTokens: newAllDetectedTokens,
+-                });
++                };
++                // Only update active tokens if user is interacting with their active wallet account.
++                if (isInteractingWithWalletAccount) {
++                  newState = Object.assign(Object.assign({}, newState), { tokens: newTokens, ignoredTokens: newIgnoredTokens, detectedTokens: newDetectedTokens });
++                }
++                this.update(newState);
+                 return newTokens;
              }
-         });
-     }
-+
-+
-+     /**
-+     * Adds a token to the stored token list for a specific wallet.
-+     * TODO - Should consolidate this with addToken method since much of the logic is similar.
-+     *
-+     * @param params - Params used for adding token to an account address.
-+     * @param params.accountAddress - Account address to add the token to.
-+     * @param params.token - Token to add.
-+     * @param params.token.address - Hex address of the token contract.
-+     * @param params.token.symbol - Symbol of the token.
-+     * @param params.token.decimals - Number of decimals the token uses.
-+     * @param params.token.image - Image of the token.
-+     * @returns Current token list.
-+     */
-+    addTokenToAccount({ accountAddress, token: { address, symbol, decimals, image } }) {
-+            return __awaiter(this, void 0, void 0, function* () {
-+                const currentChainId = this.config.chainId;
-+                const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
-+                const releaseLock = yield this.mutex.acquire();
-+                try {
-+                    address = (0, controller_utils_1.toChecksumHexAddress)(address);
-+                    const tokens = allTokens[currentChainId]?.[accountAddress] || [];
-+                    const ignoredTokens = allIgnoredTokens[currentChainId]?.[accountAddress] || [];
-+                    const detectedTokens = allDetectedTokens[currentChainId]?.[accountAddress] || [];
-+                    const newTokens = [...tokens];
-+                    const [isERC721, tokenMetadata] = yield Promise.all([
-+                        this._detectIsERC721(address),
-+                        this.fetchTokenMetadata(address),
-+                    ]);
-+                    if (currentChainId !== this.config.chainId) {
-+                        throw new Error('TokensController Error: Switched networks while adding token');
-+                    }
-+                    const newEntry = {
-+                        address,
-+                        symbol,
-+                        decimals,
-+                        image: image ||
-+                            (0, assetsUtil_1.formatIconUrlWithProxy)({
-+                                chainId: this.config.chainId,
-+                                tokenAddress: address,
-+                            }),
-+                        isERC721,
-+                        aggregators: (0, assetsUtil_1.formatAggregatorNames)((tokenMetadata === null || tokenMetadata === void 0 ? void 0 : tokenMetadata.aggregators) || []),
-+                    };
-+                    const previousEntry = newTokens.find((token) => token.address.toLowerCase() === address.toLowerCase());
-+                    if (previousEntry) {
-+                        const previousIndex = newTokens.indexOf(previousEntry);
-+                        newTokens[previousIndex] = newEntry;
-+                    }
-+                    else {
-+                        newTokens.push(newEntry);
-+                    }
-+                    const newIgnoredTokens = ignoredTokens.filter((tokenAddress) => tokenAddress.toLowerCase() !== address.toLowerCase());
-+                    const newDetectedTokens = detectedTokens.filter((token) => token.address.toLowerCase() !== address.toLowerCase());
-+                    const { newAllTokens, newAllIgnoredTokens, newAllDetectedTokens } = this._getNewAllTokensState({
-+                        newTokens,
-+                        newIgnoredTokens,
-+                        newDetectedTokens,
-+                        detectionAddress: accountAddress,
-+                    });
-+                    this.update({
-+                        allTokens: newAllTokens,
-+                        allIgnoredTokens: newAllIgnoredTokens,
-+                        allDetectedTokens: newAllDetectedTokens,
-+                    });
-+                    return newTokens;
-+                }
-+                finally {
-+                    releaseLock();
-+                }
-+            });
-+        }
-     /**
-      * Add a batch of tokens.
-      *
-@@ -199,7 +273,7 @@ class TokensController extends base_controller_1.BaseController {
+             finally {
+@@ -199,7 +212,7 @@ class TokensController extends base_controller_1.BaseController {
              }, {});
              try {
                  tokensToImport.forEach((tokenToAdd) => {
@@ -533,7 +498,7 @@ index dc59d68..c6ac7d5 100644
                      const checksumAddress = (0, controller_utils_1.toChecksumHexAddress)(address);
                      const formattedToken = {
                          address: checksumAddress,
-@@ -207,6 +281,7 @@ class TokensController extends base_controller_1.BaseController {
+@@ -207,6 +220,7 @@ class TokensController extends base_controller_1.BaseController {
                          decimals,
                          image,
                          aggregators,
@@ -541,7 +506,7 @@ index dc59d68..c6ac7d5 100644
                      };
                      newTokensMap[address] = formattedToken;
                      importedTokensMap[address.toLowerCase()] = true;
-@@ -282,7 +357,7 @@ class TokensController extends base_controller_1.BaseController {
+@@ -282,7 +296,7 @@ class TokensController extends base_controller_1.BaseController {
              let newDetectedTokens = [...detectedTokens];
              try {
                  incomingDetectedTokens.forEach((tokenToAdd) => {
@@ -550,7 +515,7 @@ index dc59d68..c6ac7d5 100644
                      const checksumAddress = (0, controller_utils_1.toChecksumHexAddress)(address);
                      const newEntry = {
                          address: checksumAddress,
-@@ -291,6 +366,7 @@ class TokensController extends base_controller_1.BaseController {
+@@ -291,6 +305,7 @@ class TokensController extends base_controller_1.BaseController {
                          image,
                          isERC721,
                          aggregators,
@@ -558,7 +523,23 @@ index dc59d68..c6ac7d5 100644
                      };
                      const previousImportedEntry = newTokens.find((token) => token.address.toLowerCase() === checksumAddress.toLowerCase());
                      if (previousImportedEntry) {
-@@ -357,6 +433,22 @@ class TokensController extends base_controller_1.BaseController {
+@@ -313,12 +328,12 @@ class TokensController extends base_controller_1.BaseController {
+                         }
+                     }
+                 });
+-                const { selectedAddress: detectionAddress, chainId: detectionChainId } = detectionDetails || {};
++                const { selectedAddress: interactingAddress, chainId: interactingChainId } = detectionDetails || {};
+                 const { newAllTokens, newAllDetectedTokens } = this._getNewAllTokensState({
+                     newTokens,
+                     newDetectedTokens,
+-                    detectionAddress,
+-                    detectionChainId,
++                    interactingAddress,
++                    interactingChainId,
+                 });
+                 const { chainId, selectedAddress } = this.config;
+                 // if the newly added detectedTokens were detected on (and therefore added to) a different chainId/selectedAddress than the currently configured combo
+@@ -357,6 +372,22 @@ class TokensController extends base_controller_1.BaseController {
              return tokens[tokenIndex];
          });
      }
@@ -581,7 +562,7 @@ index dc59d68..c6ac7d5 100644
      /**
       * Detects whether or not a token is ERC-721 compatible.
       *
-@@ -396,107 +488,46 @@ class TokensController extends base_controller_1.BaseController {
+@@ -396,107 +427,45 @@ class TokensController extends base_controller_1.BaseController {
      _generateRandomId() {
          return (0, uuid_1.v1)();
      }
@@ -604,7 +585,6 @@ index dc59d68..c6ac7d5 100644
 +                throw new Error(`Asset of type ${type} not supported`);
 +            }
 +            const { selectedAddress } = this.config;
-+            const isAddingOnWalletAccount = interactingAddress ? interactingAddress === selectedAddress : true;
              const suggestedAssetMeta = {
                  asset,
                  id: this._generateRandomId(),
@@ -613,7 +593,11 @@ index dc59d68..c6ac7d5 100644
                  type,
 +                interactingAddress: interactingAddress || selectedAddress,
              };
--            try {
++            (0, assetsUtil_1.validateTokenToWatch)(asset);
++            yield this._requestApproval(suggestedAssetMeta);
++
++            let name;
+             try {
 -                switch (type) {
 -                    case 'ERC20':
 -                        (0, assetsUtil_1.validateTokenToWatch)(asset);
@@ -621,24 +605,14 @@ index dc59d68..c6ac7d5 100644
 -                    default:
 -                        throw new Error(`Asset of type ${type} not supported`);
 -                }
-+            (0, assetsUtil_1.validateTokenToWatch)(asset);
-+            yield this._requestApproval(suggestedAssetMeta);
-+            const { address, symbol, decimals, image } = suggestedAssetMeta.asset;
-+            if (isAddingOnWalletAccount) {
-+                let name;
-+                try{
-+                    name = yield this.getERC20TokenName(address);
-+                }catch(error){
-+                    name = null;
-+                              }
-+                yield this.addToken(address, symbol, decimals, image, name);
-+            } else {
-+                yield this.addTokenToAccount({ accountAddress: interactingAddress, token: { address, symbol, decimals, image } });
-             }
+-            }
 -            catch (error) {
 -                this.failSuggestedAsset(suggestedAssetMeta, error);
 -                return Promise.reject(error);
--            }
++                name = yield this.getERC20TokenName(address);
++            } catch(error) {
++                name = null;
+             }
 -            const result = new Promise((resolve, reject) => {
 -                this.hub.once(`${suggestedAssetMeta.id}:finished`, (meta) => {
 -                    switch (meta.status) {
@@ -653,14 +627,18 @@ index dc59d68..c6ac7d5 100644
 -                            return reject(new Error(`Unknown status: ${meta.status}`));
 -                    }
 -                });
--            });
++            yield this.addToken(asset.address, asset.symbol, asset.decimals, {
++              image: asset.image,
++              name,
++              interactingAddress: suggestedAssetMeta.interactingAddress
+             });
 -            const { suggestedAssets } = this.state;
 -            suggestedAssets.push(suggestedAssetMeta);
 -            this.update({ suggestedAssets: [...suggestedAssets] });
 -            this.hub.emit('pendingSuggestedAsset', suggestedAssetMeta);
 -            return { result, suggestedAssetMeta };
--        });
--    }
+         });
+     }
 -    /**
 -     * Accepts to watch an asset and updates it's status and deletes the suggestedAsset from state,
 -     * adding the asset to corresponding asset state. In this case ERC20 tokens.
@@ -690,8 +668,8 @@ index dc59d68..c6ac7d5 100644
 -            }
 -            const newSuggestedAssets = suggestedAssets.filter(({ id }) => id !== suggestedAssetID);
 -            this.update({ suggestedAssets: [...newSuggestedAssets] });
-         });
-     }
+-        });
+-    }
 -    /**
 -     * Rejects a watchAsset request based on its ID by setting its status to "rejected"
 -     * and emitting a `<suggestedAssetMeta.id>:finished` hub event.
@@ -713,7 +691,29 @@ index dc59d68..c6ac7d5 100644
      /**
       * Takes a new tokens and ignoredTokens array for the current network/account combination
       * and returns new allTokens and allIgnoredTokens state to update to.
-@@ -553,6 +584,26 @@ class TokensController extends base_controller_1.BaseController {
+@@ -505,16 +474,16 @@ class TokensController extends base_controller_1.BaseController {
+      * @param params.newTokens - The new tokens to set for the current network and selected account.
+      * @param params.newIgnoredTokens - The new ignored tokens to set for the current network and selected account.
+      * @param params.newDetectedTokens - The new detected tokens to set for the current network and selected account.
+-     * @param params.detectionAddress - The address on which the detected tokens to add were detected.
+-     * @param params.detectionChainId - The chainId on which the detected tokens to add were detected.
++     * @param params.interactingAddress - The address on which the detected tokens to add were detected.
++     * @param params.interactingChainId - The chainId on which the detected tokens to add were detected.
+      * @returns The updated `allTokens` and `allIgnoredTokens` state.
+      */
+     _getNewAllTokensState(params) {
+-        const { newTokens, newIgnoredTokens, newDetectedTokens, detectionAddress, detectionChainId, } = params;
++        const { newTokens, newIgnoredTokens, newDetectedTokens, interactingAddress, interactingChainId, } = params;
+         const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
+         const { chainId, selectedAddress } = this.config;
+-        const userAddressToAddTokens = detectionAddress !== null && detectionAddress !== void 0 ? detectionAddress : selectedAddress;
+-        const chainIdToAddTokens = detectionChainId !== null && detectionChainId !== void 0 ? detectionChainId : chainId;
++        const userAddressToAddTokens = interactingAddress !== null && interactingAddress !== void 0 ? interactingAddress : selectedAddress;
++        const chainIdToAddTokens = interactingChainId !== null && interactingChainId !== void 0 ? interactingChainId : chainId;
+         let newAllTokens = allTokens;
+         if ((newTokens === null || newTokens === void 0 ? void 0 : newTokens.length) ||
+             (newTokens &&
+@@ -553,6 +522,26 @@ class TokensController extends base_controller_1.BaseController {
      clearIgnoredTokens() {
          this.update({ ignoredTokens: [], allIgnoredTokens: {} });
      }
@@ -755,7 +755,7 @@ index a58b709..20667c0 100644
  /**
   * Check if token detection is enabled for certain networks.
 diff --git a/node_modules/@metamask/assets-controllers/dist/assetsUtil.js b/node_modules/@metamask/assets-controllers/dist/assetsUtil.js
-index 4b54e82..aa3ffa1 100644
+index 4b54e82..2322286 100644
 --- a/node_modules/@metamask/assets-controllers/dist/assetsUtil.js
 +++ b/node_modules/@metamask/assets-controllers/dist/assetsUtil.js
 @@ -120,6 +120,7 @@ var SupportedTokenDetectionNetworks;


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

The `@metamask/assets-controllers` patch added as part of the [permission system implementation](https://github.com/MetaMask/metamask-mobile/pull/5062) has been updated to more closely match [how the feature was implemented upstream](https://github.com/MetaMask/core/pull/1124).

This should be functionally equivalent except that the function signature of `addToken` has changed; the `image` and `name` parameters were moved into an "options bag" parameter that also includes `interactingAddress`. All references to this method in the codebase have been updated accordingly.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/877

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
