### PR TITLE
fix: Fix crash when switching to Linea

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-native-level-fs/**/bl": "^1.2.3",
     "react-native-level-fs/**/semver": "^4.3.2",
     "@metamask/contract-metadata": "^2.1.0",
+    "@metamask/controller-utils": "^3.4.0",
     "@metamask/approval-controller": "3.4.0",
     "@exodus/react-native-payments/validator": "^13.7.0",
     "react-devtools-core": "4.22.1",

--- a/patches/@metamask+controller-utils+3.4.0.patch
+++ b/patches/@metamask+controller-utils+3.4.0.patch
@@ -1,16 +1,30 @@
 diff --git a/node_modules/@metamask/controller-utils/dist/constants.d.ts b/node_modules/@metamask/controller-utils/dist/constants.d.ts
-index c8e8769..a78401d 100644
+index c8e8769..00e617f 100644
 --- a/node_modules/@metamask/controller-utils/dist/constants.d.ts
 +++ b/node_modules/@metamask/controller-utils/dist/constants.d.ts
-@@ -27,6 +27,7 @@ export declare const ASSET_TYPES: {
+@@ -1,4 +1,7 @@
+ import { NetworkType, NetworksTicker, NetworksChainId, NetworkId } from './types';
++// PATCH: Restore `MAINNET` constant, which was removed in v3.1.0
++// We need this patch until there are no remaining dependencies on <v3.1.0
++export declare const MAINNET = 'mainnet';
+ export declare const RPC = "rpc";
+ export declare const FALL_BACK_VS_CURRENCY = "ETH";
+ export declare const IPFS_DEFAULT_GATEWAY_URL = "https://cloudflare-ipfs.com/ipfs/";
+@@ -27,6 +30,13 @@ export declare const ASSET_TYPES: {
  export declare const TESTNET_TICKER_SYMBOLS: {
      GOERLI: string;
      SEPOLIA: string;
 +    LINEA_GOERLI: string;
++};
++// PATCH: Restore `TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL` constant, which was removed in v3.1.0
++// We need this patch until there are no remaining dependencies on <v3.1.0
++export declare const TESTNET_TICKER_SYMBOLS: {
++  GOERLI: string;
++  SEPOLIA: string;
  };
  /**
   * Map of all build-in Infura networks to their network, ticker and chain IDs.
-@@ -53,6 +54,20 @@ export declare const BUILT_IN_NETWORKS: {
+@@ -53,6 +63,20 @@ export declare const BUILT_IN_NETWORKS: {
              readonly blockExplorerUrl: "https://etherscan.io";
          };
      };
@@ -32,18 +46,37 @@ index c8e8769..a78401d 100644
          readonly chainId: NetworksChainId.localhost;
          readonly blockExplorerUrl: undefined;
 diff --git a/node_modules/@metamask/controller-utils/dist/constants.js b/node_modules/@metamask/controller-utils/dist/constants.js
-index 7bef0e7..07e2249 100644
+index 7bef0e7..92c4143 100644
 --- a/node_modules/@metamask/controller-utils/dist/constants.js
 +++ b/node_modules/@metamask/controller-utils/dist/constants.js
-@@ -36,6 +36,7 @@ exports.ASSET_TYPES = {
+@@ -2,6 +2,9 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP = exports.ApprovalType = exports.ORIGIN_METAMASK = exports.OPENSEA_TEST_API_URL = exports.OPENSEA_API_URL = exports.OPENSEA_PROXY_URL = exports.BUILT_IN_NETWORKS = exports.TESTNET_TICKER_SYMBOLS = exports.ASSET_TYPES = exports.GWEI = exports.ERC1155_TOKEN_RECEIVER_INTERFACE_ID = exports.ERC1155_METADATA_URI_INTERFACE_ID = exports.ERC1155_INTERFACE_ID = exports.ERC721_ENUMERABLE_INTERFACE_ID = exports.ERC721_METADATA_INTERFACE_ID = exports.ERC721_INTERFACE_ID = exports.ERC20 = exports.ERC1155 = exports.ERC721 = exports.MAX_SAFE_CHAIN_ID = exports.GANACHE_CHAIN_ID = exports.IPFS_DEFAULT_GATEWAY_URL = exports.FALL_BACK_VS_CURRENCY = exports.RPC = void 0;
+ const types_1 = require("./types");
++// PATCH: Restore `MAINNET` constant, which was removed in v3.1.0
++// We need this patch until there are no remaining dependencies on <v3.1.0
++exports.MAINNET = 'mainnet';
+ exports.RPC = 'rpc';
+ exports.FALL_BACK_VS_CURRENCY = 'ETH';
+ exports.IPFS_DEFAULT_GATEWAY_URL = 'https://cloudflare-ipfs.com/ipfs/';
+@@ -36,6 +39,16 @@ exports.ASSET_TYPES = {
  exports.TESTNET_TICKER_SYMBOLS = {
      GOERLI: 'GoerliETH',
      SEPOLIA: 'SepoliaETH',
 +    LINEA_GOERLI: 'LineaETH'
++};
++// PATCH: Restore `TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL` constant, which was removed in v3.1.0
++// We need this patch until there are no remaining dependencies on <v3.1.0
++exports.TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL = {
++  goerli: 'GoerliETH',
++  sepolia: 'SepoliaETH',
++  mainnet: '',
++  rpc: '',
++  localhost: '',
  };
  /**
   * Map of all build-in Infura networks to their network, ticker and chain IDs.
-@@ -62,6 +63,20 @@ exports.BUILT_IN_NETWORKS = {
+@@ -62,6 +75,20 @@ exports.BUILT_IN_NETWORKS = {
              blockExplorerUrl: 'https://etherscan.io',
          },
      },
@@ -64,7 +97,7 @@ index 7bef0e7..07e2249 100644
      [types_1.NetworkType.localhost]: {
          chainId: types_1.NetworksChainId.localhost,
          blockExplorerUrl: undefined,
-@@ -107,5 +122,7 @@ exports.NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP = {
+@@ -107,5 +134,7 @@ exports.NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP = {
      [types_1.NetworkId.goerli]: types_1.NetworkType.goerli,
      [types_1.NetworkId.sepolia]: types_1.NetworkType.sepolia,
      [types_1.NetworkId.mainnet]: types_1.NetworkType.mainnet,
@@ -73,7 +106,7 @@ index 7bef0e7..07e2249 100644
  };
  //# sourceMappingURL=constants.js.map
 diff --git a/node_modules/@metamask/controller-utils/dist/types.d.ts b/node_modules/@metamask/controller-utils/dist/types.d.ts
-index 014dbb9..1d6189b 100644
+index 014dbb9..e7f7934 100644
 --- a/node_modules/@metamask/controller-utils/dist/types.d.ts
 +++ b/node_modules/@metamask/controller-utils/dist/types.d.ts
 @@ -6,6 +6,8 @@ export declare enum NetworkType {
@@ -112,7 +145,7 @@ index 014dbb9..1d6189b 100644
      rpc = ""
  }
 diff --git a/node_modules/@metamask/controller-utils/dist/types.js b/node_modules/@metamask/controller-utils/dist/types.js
-index 398c77b..604bda1 100644
+index 398c77b..accac2c 100644
 --- a/node_modules/@metamask/controller-utils/dist/types.js
 +++ b/node_modules/@metamask/controller-utils/dist/types.js
 @@ -10,6 +10,8 @@ var NetworkType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5170,30 +5170,7 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-2.2.0.tgz#277764d0d56e37180ae7644a9d11eb96295b36fc"
   integrity sha512-SM6A4C7vXNbVpgMTX67kfW8QWvu3eSXxMZlY5PqZBTkvri1s9zgQ0uwRkK5r2VXNEoVmXCDnnEX/tX5EzzgNUQ==
 
-"@metamask/controller-utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controller-utils/-/controller-utils-1.0.0.tgz#2e2261b65c3f38ba0c5b893743fca8cce764339c"
-  integrity sha512-LXIpnmF/C5/vCBX0u2DiUWA55utZy54guUV+A8qUYmz8PvZrXfK7mdq1zlk8z0aq+aO0rHHfSVbTNacEE3TlAQ==
-  dependencies:
-    eth-ens-namehash "^2.0.8"
-    eth-rpc-errors "^4.0.0"
-    ethereumjs-util "^7.0.10"
-    ethjs-unit "^0.1.6"
-    fast-deep-equal "^3.1.3"
-    isomorphic-fetch "^3.0.0"
-
-"@metamask/controller-utils@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controller-utils/-/controller-utils-3.0.0.tgz#e0984cdab14280409297671b5858891527c5e4ee"
-  integrity sha512-JjFWBZnnh5DSX2tRsw5xtXxaqVkTzaW7mkSZ+lL3LoCAw47Cf8zGP1kGR6VKxcceKi+MpEFvZr7gf1OFnOoEjw==
-  dependencies:
-    eth-ens-namehash "^2.0.8"
-    eth-rpc-errors "^4.0.0"
-    ethereumjs-util "^7.0.10"
-    ethjs-unit "^0.1.6"
-    fast-deep-equal "^3.1.3"
-
-"@metamask/controller-utils@^3.4.0":
+"@metamask/controller-utils@^1.0.0", "@metamask/controller-utils@^3.0.0", "@metamask/controller-utils@^3.4.0", "@metamask/controller-utils@^4.0.0", "@metamask/controller-utils@^4.0.1":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@metamask/controller-utils/-/controller-utils-3.4.0.tgz#3714799a3e2648cd758272612578238749e3e11b"
   integrity sha512-/++y7qXUd9+aRzOklypfzmehO87QVKndlJXsbLRk36W5L5DJo4lrR2pd/IBbwbWEhFJWHhlfbMD+T+gEBvIftw==
@@ -5201,20 +5178,6 @@
     "@metamask/utils" "^5.0.1"
     "@spruceid/siwe-parser" "1.1.3"
     eth-ens-namehash "^2.0.8"
-    eth-rpc-errors "^4.0.2"
-    ethereumjs-util "^7.0.10"
-    ethjs-unit "^0.1.6"
-    fast-deep-equal "^3.1.3"
-
-"@metamask/controller-utils@^4.0.0", "@metamask/controller-utils@^4.0.1":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controller-utils/-/controller-utils-4.3.0.tgz#63d6fef8ddbdf42ed0b94a0cf929d1898832004c"
-  integrity sha512-WVbapIpjEJtKxZz/1w5DctnZ0h7V3OWu0X46MHEmV8Brna/nN8x6UZ4zySLD9tZGFaO7p3vxJpl7/EK8nSvf9A==
-  dependencies:
-    "@metamask/utils" "^6.2.0"
-    "@spruceid/siwe-parser" "1.1.3"
-    eth-ens-namehash "^2.0.8"
-    eth-query "^2.1.2"
     eth-rpc-errors "^4.0.2"
     ethereumjs-util "^7.0.10"
     ethjs-unit "^0.1.6"
@@ -5531,18 +5494,6 @@
     semver "^7.3.8"
     superstruct "^1.0.3"
 
-"@metamask/utils@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-6.2.0.tgz#7e63ad2db33117df6fef89449db3a86dcd6b42b5"
-  integrity sha512-nM5CujDd4STfwx4ic/gim9G1W9oZcWUGKN4WbAT4waEkqNSIluVmZeHgxUKvdajZ7iCFDnjDLajkD4sP7c/ClQ==
-  dependencies:
-    "@ethereumjs/tx" "^4.1.2"
-    "@noble/hashes" "^1.3.1"
-    "@types/debug" "^4.1.7"
-    debug "^4.3.4"
-    semver "^7.3.8"
-    superstruct "^1.0.3"
-
 "@ngraveio/bc-ur@^1.1.5", "@ngraveio/bc-ur@^1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@ngraveio/bc-ur/-/bc-ur-1.1.6.tgz#8f8c75fff22f6a5e4dfbc5a6b540d7fe8f42cd39"
@@ -5578,7 +5529,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
-"@noble/hashes@^1.3.0", "@noble/hashes@^1.3.1", "@noble/hashes@~1.3.0":
+"@noble/hashes@^1.3.0", "@noble/hashes@~1.3.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
   integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add `needs-qa` label when dev review is completed
5. Add `QA Passed` label when QA has signed off

**Description**

A recent `@metamask/controller-utils` update in https://github.com/MetaMask/metamask-mobile/pull/6874 caused the app to crash when switching to Linea because it removed the resolution for this package. Without that resolution, multiple copies of the package were introduced, but the Linea patch was only applied to one of them. The network controller was using a copy without the patch applied, resulting in the crash.

This was resolved by restoring the resolution. We can remove it again once we have deleted the patch.

Additionally, the patch for `@metamask/controller-utils` has been updated to restore constants (`MAINNET and `TESTNET_TICKER_SYMBOLS`) that were removed in v3.1.0 in a change that we missed when preparing the release (which is why it was omitted from the changelog and not recognized as breaking).

They have been restored until we no longer rely on packages that use `@metamask/controller-utils` at versions under v3.1.0.

**Issue**

No associated issue

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
