### PR TITLE
feat: switch sdk init outside navigation to unlock e2e

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -349,7 +349,7 @@ const App = ({ userLoggedIn }) => {
   }, []);
 
   useEffect(() => {
-    if (navigator && !sdkInit.current && onboarded) {
+    if (navigator?.getCurrentRoute && !sdkInit.current && onboarded) {
       SDKConnect.getInstance()
         .init({ navigation: navigator })
         .then(() => {

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -227,6 +227,8 @@ const App = ({ userLoggedIn }) => {
   const [animationPlayed, setAnimationPlayed] = useState(false);
   const { colors } = useTheme();
   const { toastRef } = useContext(ToastContext);
+  const sdkInit = useRef(false);
+  const [onboarded, setOnboarded] = useState(false);
   const dispatch = useDispatch();
   const triggerSetCurrentRoute = (route) => {
     dispatch(setCurrentRoute(route));
@@ -348,15 +350,17 @@ const App = ({ userLoggedIn }) => {
 
   const sdkInit = useRef(false);
   useEffect(() => {
-    if (navigator && !sdkInit.current) {
-      sdkInit.current = true;
+    if (navigator && !sdkInit.current && onboarded) {
       SDKConnect.getInstance()
         .init({ navigation: navigator })
+        .then(() => {
+          sdkInit.current = true;
+        })
         .catch((err) => {
           console.error(`Cannot initialize SDKConnect`, err);
         });
     }
-  }, [navigator]);
+  }, [navigator, onboarded]);
 
   useEffect(() => {
     if (isWC2Enabled) {
@@ -369,6 +373,7 @@ const App = ({ userLoggedIn }) => {
   useEffect(() => {
     async function checkExisting() {
       const existingUser = await AsyncStorage.getItem(EXISTING_USER);
+      setOnboarded(!!existingUser);
       const route = !existingUser
         ? Routes.ONBOARDING.ROOT_NAV
         : Routes.ONBOARDING.LOGIN;

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -348,7 +348,6 @@ const App = ({ userLoggedIn }) => {
     initAnalytics();
   }, []);
 
-  const sdkInit = useRef(false);
   useEffect(() => {
     if (navigator && !sdkInit.current && onboarded) {
       SDKConnect.getInstance()


### PR DESCRIPTION
**Description**

Fixes issue with e2e test being delayed.
Problem was that sdk initialized and wait for keychain to unlock which doesn't happen on a clean install with the onboarding modal. 

The PR delay the initialization of the sdk until onboarding has been completed.