### PR TITLE
fix: add missed parentheses in the function call

### DIFF
--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -147,7 +147,7 @@ export default class Browser {
   }
 
   static async tapConnectButton() {
-    if (device.getPlatform === 'android') {
+    if (device.getPlatform() === 'android') {
       await TestHelpers.tapWebviewElement(WEBVIEW_TEST_DAPP_CONNECT_BUTTON_ID);
     } else {
       await TestHelpers.tapAtPoint(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**
PR [6384](https://github.com/MetaMask/metamask-mobile/pull/6384)
line 142: [Browser.js](https://github.com/MetaMask/metamask-mobile/pull/6384/files#diff-38d745e7eaf0fd2eb8ea7494eadf310a1ff3612513bcbf805518cd2a953a88b4)
getPlatform function is called without () which leads to incorrect platform detection.

fixes #???

Added ().

**Checklist**

* [x] There is a related GitHub issue: https://github.com/MetaMask/metamask-mobile/pull/6384
* [ N/A] Tests are included if applicable
* [x] Any added code is fully documented
