### PR TITLE
feat: github actions to automatically create and close bug report issue

### DIFF
--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -24,8 +24,8 @@ async function main(): Promise<void> {
 
   const bugReportRepo = process.env.BUG_REPORT_REPO;
   if (!bugReportRepo) {
-      core.setFailed('BUG_REPORT_REPO not found');
-      process.exit(1);
+    core.setFailed('BUG_REPORT_REPO not found');
+    process.exit(1);
   }
 
   // Extract branch name from the context
@@ -46,11 +46,11 @@ async function main(): Promise<void> {
 
   const bugReportIssue = await retrieveOpenBugReportIssue(octokit, repoOwner, bugReportRepo, releaseVersionNumber);
 
-  if(!bugReportIssue) {
+  if (!bugReportIssue) {
     throw new Error(`No open bug report issue was found for release ${releaseVersionNumber} on ${repoOwner}/${bugReportRepo} repo`);
   }
 
-  if(bugReportIssue.title?.toLocaleLowerCase() !== `v${releaseVersionNumber} Bug Report`.toLocaleLowerCase()) {
+  if (bugReportIssue.title?.toLocaleLowerCase() !== `v${releaseVersionNumber} Bug Report`.toLocaleLowerCase()) {
     throw new Error(`Unexpected bug report title: "${bugReportIssue.title}" instead of "v${releaseVersionNumber} Bug Report"`);
   }
 
@@ -67,7 +67,7 @@ async function retrieveOpenBugReportIssue(octokit: InstanceType<typeof GitHub>, 
   title: string;
 } | undefined> {
 
-const retrieveOpenBugReportIssueQuery = `
+  const retrieveOpenBugReportIssueQuery = `
   query RetrieveOpenBugReportIssue {
     search(query: "repo:${repoOwner}/${repoName} type:issue is:open in:title v${releaseVersionNumber} Bug Report", type: ISSUE, first: 1) {
       nodes {
@@ -80,25 +80,25 @@ const retrieveOpenBugReportIssueQuery = `
   }
 `;
 
-const retrieveOpenBugReportIssueQueryResult: {
-  search: {
+  const retrieveOpenBugReportIssueQueryResult: {
+    search: {
       nodes: {
-          id: string;
-          title: string;
+        id: string;
+        title: string;
       }[];
-  };
-} = await octokit.graphql(retrieveOpenBugReportIssueQuery);
+    };
+  } = await octokit.graphql(retrieveOpenBugReportIssueQuery);
 
-const bugReportIssues = retrieveOpenBugReportIssueQueryResult?.search?.nodes;
+  const bugReportIssues = retrieveOpenBugReportIssueQueryResult?.search?.nodes;
 
-return bugReportIssues?.length > 0 ? bugReportIssues[0] : undefined;
+  return bugReportIssues?.length > 0 ? bugReportIssues[0] : undefined;
 }
 
 
 // This function closes a Github issue, based on its ID
 async function closeIssue(octokit: InstanceType<typeof GitHub>, issueId: string): Promise<string> {
 
-    const closeIssueMutation = `
+  const closeIssueMutation = `
       mutation CloseIssue($issueId: ID!) {
         updateIssue(input: {id: $issueId, state: CLOSED}) {
           clientMutationId
@@ -106,15 +106,15 @@ async function closeIssue(octokit: InstanceType<typeof GitHub>, issueId: string)
       }
     `;
 
-    const closeIssueMutationResult: {
-      updateIssue: {
-        clientMutationId: string;
-      };
-    } = await octokit.graphql(closeIssueMutation, {
-      issueId,
-    });
+  const closeIssueMutationResult: {
+    updateIssue: {
+      clientMutationId: string;
+    };
+  } = await octokit.graphql(closeIssueMutation, {
+    issueId,
+  });
 
-    const clientMutationId = closeIssueMutationResult?.updateIssue?.clientMutationId;
+  const clientMutationId = closeIssueMutationResult?.updateIssue?.clientMutationId;
 
-    return clientMutationId;
-  }
+  return clientMutationId;
+}

--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -1,0 +1,120 @@
+import * as core from '@actions/core';
+import { context, getOctokit } from '@actions/github';
+import { GitHub } from '@actions/github/lib/utils';
+
+main().catch((error: Error): void => {
+  console.error(error);
+  process.exit(1);
+});
+
+async function main(): Promise<void> {
+  // "GITHUB_TOKEN" is an automatically generated, repository-specific access token provided by GitHub Actions.
+  // We can't use "GITHUB_TOKEN" here, as its permissions are scoped to the repository where the action is running.
+  // "GITHUB_TOKEN" does not have access to other repositories, even when they belong to the same organization.
+  // As we want to update bug report issues which are not located in the same repository,
+  // we need to create our own "BUG_REPORT_TOKEN" with "repo" permissions.
+  // Such a token allows to access other repositories of the MetaMask organisation.
+  const personalAccessToken = process.env.BUG_REPORT_TOKEN;
+  if (!personalAccessToken) {
+    core.setFailed('BUG_REPORT_TOKEN not found');
+    process.exit(1);
+  }
+
+  const repoOwner = context.repo.owner; // MetaMask
+
+  const bugReportRepo = process.env.BUG_REPORT_REPO;
+  if (!bugReportRepo) {
+      core.setFailed('BUG_REPORT_REPO not found');
+      process.exit(1);
+  }
+
+  // Extract branch name from the context
+  const branchName: string = context.payload.pull_request?.head.ref || "";
+
+  // Extract semver version number from the branch name
+  const releaseVersionNumberMatch = branchName.match(/^release\/(\d+\.\d+\.\d+)$/);
+
+  if (!releaseVersionNumberMatch) {
+    core.setFailed(`Failed to extract version number from branch name: ${branchName}`);
+    process.exit(1);
+  }
+
+  const releaseVersionNumber = releaseVersionNumberMatch[1];
+
+  // Initialise octokit, required to call Github GraphQL API
+  const octokit: InstanceType<typeof GitHub> = getOctokit(personalAccessToken);
+
+  const bugReportIssue = await retrieveOpenBugReportIssue(octokit, repoOwner, bugReportRepo, releaseVersionNumber);
+
+  if(!bugReportIssue) {
+    throw new Error(`No open bug report issue was found for release ${releaseVersionNumber} on ${repoOwner}/${bugReportRepo} repo`);
+  }
+
+  if(bugReportIssue.title?.toLocaleLowerCase() !== `v${releaseVersionNumber} Bug Report`.toLocaleLowerCase()) {
+    throw new Error(`Unexpected bug report title: "${bugReportIssue.title}" instead of "v${releaseVersionNumber} Bug Report"`);
+  }
+
+  console.log(`Closing bug report issue with title "${bugReportIssue.title}" and id: ${bugReportIssue.id}`);
+
+  await closeIssue(octokit, bugReportIssue.id);
+
+  console.log(`Issue with id: ${bugReportIssue.id} successfully closed`);
+}
+
+// This function retrieves the issue titled "vx.y.z Bug Report" on a specific repo
+async function retrieveOpenBugReportIssue(octokit: InstanceType<typeof GitHub>, repoOwner: string, repoName: string, releaseVersionNumber: string): Promise<{
+  id: string;
+  title: string;
+} | undefined> {
+
+const retrieveOpenBugReportIssueQuery = `
+  query RetrieveOpenBugReportIssue {
+    search(query: "repo:${repoOwner}/${repoName} type:issue is:open in:title v${releaseVersionNumber} Bug Report", type: ISSUE, first: 1) {
+      nodes {
+        ... on Issue {
+          id
+          title
+        }
+      }
+    }
+  }
+`;
+
+const retrieveOpenBugReportIssueQueryResult: {
+  search: {
+      nodes: {
+          id: string;
+          title: string;
+      }[];
+  };
+} = await octokit.graphql(retrieveOpenBugReportIssueQuery);
+
+const bugReportIssues = retrieveOpenBugReportIssueQueryResult?.search?.nodes;
+
+return bugReportIssues?.length > 0 ? bugReportIssues[0] : undefined;
+}
+
+
+// This function closes a Github issue, based on its ID
+async function closeIssue(octokit: InstanceType<typeof GitHub>, issueId: string): Promise<string> {
+
+    const closeIssueMutation = `
+      mutation CloseIssue($issueId: ID!) {
+        updateIssue(input: {id: $issueId, state: CLOSED}) {
+          clientMutationId
+        }
+      }
+    `;
+
+    const closeIssueMutationResult: {
+      updateIssue: {
+        clientMutationId: string;
+      };
+    } = await octokit.graphql(closeIssueMutation, {
+      issueId,
+    });
+
+    const clientMutationId = closeIssueMutationResult?.updateIssue?.clientMutationId;
+
+    return clientMutationId;
+  }

--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -37,4 +37,4 @@ jobs:
         env:
           RELEASE_LABEL_TOKEN: ${{ secrets.RELEASE_LABEL_TOKEN }}
           NEXT_SEMVER_VERSION: ${{ env.NEXT_SEMVER_VERSION }}
-        run: npm run add-release-label-to-pr-and-linked-issues
+        run: yarn run add-release-label-to-pr-and-linked-issues

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -35,4 +35,4 @@ jobs:
         id: check-pr-has-required-labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run check-pr-has-required-labels
+        run: yarn run check-pr-has-required-labels

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           BUG_REPORT_REPO: mobile-planning
           BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
-        run: npm run close-release-bug-report-issue
+        run: yarn run close-release-bug-report-issue

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -1,0 +1,34 @@
+name: Close release bug report issue when release branch gets merged
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  close-bug-report:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 1 # This retrieves only the latest commit.
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Close release bug report issue
+        id: close-release-bug-report-issue
+        env:
+          BUG_REPORT_REPO: mobile-planning
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: npm run close-release-bug-report-issue

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Extract version from branch name if release branch
         id: extract_version
         run: |
-          if [[ $GITHUB_REF == refs/heads/release/* ]]; then
-            version=${GITHUB_REF#refs/heads/release/}
+          if [[ "$GITHUB_REF" == "refs/heads/release/"* ]]; then
+            version="${GITHUB_REF#refs/heads/release/}"
             echo "New release branch($version), continue next steps"
             echo "version=$version" >> $GITHUB_ENV
           else

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -1,0 +1,42 @@
+name: Create release bug report issue when release branch gets created
+
+on:
+  create:
+    branches:
+      - 'release/*'
+
+jobs:
+  create-bug-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from branch name
+        id: extract_version
+        run: echo "::set-output name=version::${GITHUB_REF#refs/heads/release/}"
+
+      - name: Create bug report issue on planning repo
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/MetaMask/mobile-planning/issues
+          owner: MetaMask
+          title: v${{ steps.extract_version.outputs.version }} Bug Report
+          body: |
+            This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ steps.extract_version.outputs.version }}` (release cut).
+
+
+            **Expected actions for release engineers:**
+
+            1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.
+
+            2. After completing the first regression run, move this epic to "Regression Completed" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ steps.extract_version.outputs.version }},release-task).
+
+
+            Note that once the release is prepared for store submission, meaning the `release/${{ steps.extract_version.outputs.version }}` branch merges into `main`, another GitHub action will automatically close this epic.
+
+          labels: |
+            [
+              "type-bug",
+              "regression-RC",
+              "release-${{ steps.extract_version.outputs.version }}"
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -1,8 +1,6 @@
 name: Create release bug report issue when release branch gets created
 
-on:
-  create:
-    branches:
+on: create
 
 jobs:
   create-bug-report:
@@ -14,36 +12,36 @@ jobs:
           if [[ $GITHUB_REF == refs/heads/release/* ]]; then
             version=${GITHUB_REF#refs/heads/release/}
             echo "New release branch($version), continue next steps"
-            echo "::set-output name=version::$version"
+            echo "version=$version" >> $GITHUB_ENV
           else
             echo "Not a release branch, skip next steps"
           fi
 
       - name: Create bug report issue on planning repo
-        if: steps.extract_version.outputs.version
+        if: env.version
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/MetaMask/mobile-planning/issues
           owner: MetaMask
-          title: v${{ steps.extract_version.outputs.version }} Bug Report
+          title: v${{ env.version }} Bug Report
           body: |
-            This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ steps.extract_version.outputs.version }}` (release cut).
+            This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ env.version }}` (release cut).
 
 
             **Expected actions for release engineers:**
 
             1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.
 
-            2. After completing the first regression run, move this epic to "Regression Completed" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ steps.extract_version.outputs.version }},release-task).
+            2. After completing the first regression run, move this epic to "Regression Completed" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ env.version }},release-task).
 
 
-            Note that once the release is prepared for store submission, meaning the `release/${{ steps.extract_version.outputs.version }}` branch merges into `main`, another GitHub action will automatically close this epic.
+            Note that once the release is prepared for store submission, meaning the `release/${{ env.version }}` branch merges into `main`, another GitHub action will automatically close this epic.
 
           labels: |
             [
               "type-bug",
               "regression-RC",
-              "release-${{ steps.extract_version.outputs.version }}"
+              "release-${{ env.version }}"
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -3,17 +3,24 @@ name: Create release bug report issue when release branch gets created
 on:
   create:
     branches:
-      - 'release/*'
 
 jobs:
   create-bug-report:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version from branch name
+      - name: Extract version from branch name if release branch
         id: extract_version
-        run: echo "::set-output name=version::${GITHUB_REF#refs/heads/release/}"
+        run: |
+          if [[ $GITHUB_REF == refs/heads/release/* ]]; then
+            version=${GITHUB_REF#refs/heads/release/}
+            echo "New release branch($version), continue next steps"
+            echo "::set-output name=version::$version"
+          else
+            echo "Not a release branch, skip next steps"
+          fi
 
       - name: Create bug report issue on planning repo
+        if: steps.extract_version.outputs.version
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/MetaMask/mobile-planning/issues

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -12,7 +12,7 @@ jobs:
           if [[ "$GITHUB_REF" == "refs/heads/release/"* ]]; then
             version="${GITHUB_REF#refs/heads/release/}"
             echo "New release branch($version), continue next steps"
-            echo "version=$version" >> $GITHUB_ENV
+            echo "version=$version" >> "$GITHUB_ENV"
           else
             echo "Not a release branch, skip next steps"
           fi

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "prestorybook": "rnstl",
     "create-release": "./scripts/set-versions.sh && yarn update-changelog",
     "add-release-label-to-pr-and-linked-issues": "ts-node ./.github/scripts/add-release-label-to-pr-and-linked-issues.ts",
-    "check-pr-has-required-labels": "ts-node ./.github/scripts/check-pr-has-required-labels.ts"
+    "check-pr-has-required-labels": "ts-node ./.github/scripts/check-pr-has-required-labels.ts",
+    "close-release-bug-report-issue": "ts-node ./.github/scripts/close-release-bug-report-issue.ts"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**Description**

The purpose of these new Github actions is to automatically:
- create a bug report issue when a new release is cut, i.e. the upon the creation of release branch `release/x.y.z`.
- close the bug report issue when the release branch `release/x.y.z` gets merged

**Screenshots/Recordings**

Recording for bug report issue creation: https://recordit.co/zcmmMXjJPC
Recording for bug report issue closed: https://recordit.co/lkKNtcmXgb

**Issue**

Progresses https://github.com/MetaMask/mobile-planning/issues/1184

## Manual Testing Steps

- Create a public test Github repo
- Add these Github actions to the test repo
- Create a personal access token with "repo" permissions
- In your test repo's settings, add the personal access token as BUG_REPORT_TOKEN in section "Secrets and variables">"Actions">"Secrets">"New repository secret".
- In your test repo, create a new branch with the following format: `release/x.y.z`
- This shall create a new bug report issue in the MM planning repo, called "vx.y.z Bug Report"
- In your test repo, merge the `release/x.y.z` branch into master
- This shall close the bug report issue called "vx.y.z Bug Report" in the MM planning repo

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented

**Other**

- [Same PR for Extension](https://github.com/MetaMask/metamask-extension/pull/20391)