### PR TITLE
fix: revert PR 6958

### DIFF
--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -146,7 +146,7 @@ export default class Browser {
     }
   }
 
-  // Deprecated, do not use
+  /** @deprecated **/
   static async tapConnectButton() {
     if (device.getPlatform === 'android') {
       await TestHelpers.tapWebviewElement(WEBVIEW_TEST_DAPP_CONNECT_BUTTON_ID);

--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -146,7 +146,7 @@ export default class Browser {
     }
   }
 
-  // Deprecated, do not use 
+  // Deprecated, do not use
   static async tapConnectButton() {
     if (device.getPlatform === 'android') {
       await TestHelpers.tapWebviewElement(WEBVIEW_TEST_DAPP_CONNECT_BUTTON_ID);

--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -146,7 +146,21 @@ export default class Browser {
     }
   }
 
+  // Deprecated, do not use 
   static async tapConnectButton() {
+    if (device.getPlatform === 'android') {
+      await TestHelpers.tapWebviewElement(WEBVIEW_TEST_DAPP_CONNECT_BUTTON_ID);
+    } else {
+      await TestHelpers.tapAtPoint(
+        BROWSER_SCREEN_ID,
+        testDappConnectButtonCooridinates,
+      );
+    }
+  }
+
+  // The tapConnectButton() above has incorrect logic - "()" are missed
+  // Please change existing tests to use the following method
+  static async tapConnectButtonNew() {
     if (device.getPlatform() === 'android') {
       await TestHelpers.tapWebviewElement(WEBVIEW_TEST_DAPP_CONNECT_BUTTON_ID);
     } else {
@@ -156,6 +170,7 @@ export default class Browser {
       );
     }
   }
+
   static async tapSendEIP1559() {
     // this method only works for android // at this moment in time only android supports interacting with webviews:https://wix.github.io/Detox/docs/api/webviews
 


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

This [commit](https://github.com/MetaMask/metamask-mobile/commit/023bbc9c21d48382358790b2c3281cb2324283c3) breaks e2e tests. Current PR reverts [PR](https://github.com/MetaMask/metamask-mobile/pull/6958).

E2E: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/02eddbdc-c5a3-40c5-a1b5-98852740c232



* [x] There is a related GitHub issue: https://github.com/MetaMask/metamask-mobile/pull/6958   https://github.com/MetaMask/metamask-mobile/commit/023bbc9c21d48382358790b2c3281cb2324283c3
* [ N/A] Tests are included if applicable
* [x] Any added code is fully documented
