### PR TITLE
cherry-pick fix: vault recovery & invalid password error (#6957)

### DIFF
--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -18,11 +18,7 @@ import CheckBox from '@react-native-community/checkbox';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { connect } from 'react-redux';
-import {
-  passwordSet,
-  passwordUnset,
-  seedphraseNotBackedUp,
-} from '../../../actions/user';
+import { passwordSet, seedphraseNotBackedUp } from '../../../actions/user';
 import { setLockTime } from '../../../actions/settings';
 import StyledButton from '../../UI/StyledButton';
 import Engine from '../../../core/Engine';
@@ -837,7 +833,6 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   passwordSet: () => dispatch(passwordSet()),
-  passwordUnset: () => dispatch(passwordUnset()),
   setLockTime: (time) => dispatch(setLockTime(time)),
   seedphraseNotBackedUp: () => dispatch(seedphraseNotBackedUp()),
 });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -12,7 +12,13 @@ import {
   SEED_PHRASE_HINTS,
 } from '../../constants/storage';
 import Logger from '../../util/Logger';
-import { authSuccess, authError, logIn, logOut } from '../../actions/user';
+import {
+  authSuccess,
+  authError,
+  logIn,
+  logOut,
+  passwordSet,
+} from '../../actions/user';
 import AUTHENTICATION_TYPE from '../../constants/userProperties';
 import { Store } from 'redux';
 import AuthenticationError from './AuthenticationError';
@@ -62,6 +68,16 @@ class AuthenticationService {
     } else {
       Logger.log(
         'Attempted to dispatch logIn action but dispatch was not initialized',
+      );
+    }
+  }
+
+  private dispatchPasswordSet(): void {
+    if (this.store) {
+      this.store.dispatch(passwordSet());
+    } else {
+      Logger.log(
+        'Attempted to dispatch passwordSet action but dispatch was not initialized',
       );
     }
   }
@@ -396,6 +412,7 @@ class AuthenticationService {
       await this.storePassword(password, authData.currentAuthType);
       this.dispatchLogin();
       this.authData = authData;
+      this.dispatchPasswordSet();
     } catch (e: any) {
       this.lockApp(false);
       throw new AuthenticationError(
@@ -435,6 +452,7 @@ class AuthenticationService {
       await this.loginVaultCreation(password, selectedAddress);
       this.dispatchLogin();
       this.store?.dispatch(authSuccess(bioStateMachineId));
+      this.dispatchPasswordSet();
     } catch (e: any) {
       this.store?.dispatch(authError(bioStateMachineId));
       !disableAutoLogout && this.lockApp(false);

--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -1,0 +1,18 @@
+import EngineService from './EngineService';
+import Engine from '../Engine';
+import { store } from '../../store';
+
+jest.unmock('../Engine');
+
+describe('EngineService', () => {
+  EngineService.initalizeEngine(store);
+  it('should have Engine initialized', () => {
+    expect(Engine.context).toBeDefined();
+  });
+  it('should have recovered vault on redux store ', async () => {
+    const { success } = await EngineService.initializeVaultFromBackup();
+    expect(success).toBeTruthy();
+    const { KeyringController } = store.getState().engine.backgroundState;
+    expect(KeyringController.vault).toBeDefined();
+  });
+});

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -110,8 +110,13 @@ class EngineService {
     const Engine = UntypedEngine as any;
     // This ensures we create an entirely new engine
     await Engine.destroyEngine();
+    this.engineInitialized = false;
     if (keyringState) {
-      const instance = Engine.init(state, keyringState);
+      const newKeyringState = {
+        keyrings: [],
+        vault: keyringState.vault,
+      };
+      const instance = Engine.init(state, newKeyringState);
       if (instance) {
         this.updateControllers(importedStore, instance);
         // this is a hack to give the engine time to reinitialize

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -115,7 +115,10 @@ jest.mock('react-native-keychain', () => ({
   setInternetCredentials: jest
     .fn(('server', 'username', 'password'))
     .mockResolvedValue({ service: 'metamask', storage: 'storage' }),
-  resetInternetCredentials: jest.fn(),
+  getInternetCredentials: jest
+    .fn()
+    .mockResolvedValue({ password: 'mock-credentials-password' }),
+  resetInternetCredentials: jest.fn().mockResolvedValue(),
   ACCESSIBLE: {
     WHEN_UNLOCKED: 'AccessibleWhenUnlocked',
     AFTER_FIRST_UNLOCK: 'AccessibleAfterFirstUnlock',


### PR DESCRIPTION
* ResetPassword: remove unused redux action passwordUnset

* Authentication: set `state.user.passwordSet` boolean after successful auth

* Vault Recovery: reset engine initialization

set EngineService engineInitialized instance to false to ensure we dispatch INIT_BG_STATE_KEY. This will save KeyringController state object to be saved into redux store state

* EngineService: add unit tests

---------

<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**
Cherry-picked 6957 from main branch.

**Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change_

**Issue**

fixes #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
