### PR TITLE
fix: Unhandled exception on uncomplete ledger transaction

### DIFF
--- a/app/components/UI/ActionView/index.js
+++ b/app/components/UI/ActionView/index.js
@@ -52,6 +52,8 @@ export default function ActionView({
   style = undefined,
 }) {
   const { colors } = useTheme();
+  confirmText = confirmText || strings('action_view.confirm');
+  cancelText = cancelText || strings('action_view.cancel');
 
   return (
     <View style={baseStyles.flexGrow}>
@@ -110,9 +112,9 @@ export default function ActionView({
 }
 
 ActionView.defaultProps = {
-  cancelText: strings('action_view.cancel'),
+  cancelText: '',
   confirmButtonMode: 'normal',
-  confirmText: strings('action_view.confirm'),
+  confirmText: '',
   confirmTestID: '',
   confirmed: false,
   cancelTestID: '',

--- a/app/components/UI/LedgerModals/LedgerConfirmationModal.tsx
+++ b/app/components/UI/LedgerModals/LedgerConfirmationModal.tsx
@@ -143,6 +143,11 @@ const LedgerConfirmationModal = ({
           });
           break;
         case LedgerCommunicationErrors.UnknownError:
+            setErrorDetails({
+              title: strings('ledger.unknown_error'),
+              subtitle: strings('ledger.unknown_error_message'),
+            });
+            break;
         case LedgerCommunicationErrors.LedgerDisconnected:
         default:
           setErrorDetails({

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -474,23 +474,6 @@ class TransactionElement extends PureComponent {
     );
   };
 
-  renderLedgerSignButton = () => {
-    const colors = this.context.colors || mockTheme.colors;
-    const styles = createStyles(colors);
-    return (
-      <StyledButton
-        type={'normal'}
-        containerStyle={[
-          styles.actionContainerStyle,
-          styles.speedupActionContainerStyle,
-        ]}
-        style={styles.actionStyle}
-        onPress={this.showLedgerSigningModal}
-      >
-        {strings('ledger.sign_with_ledger')}
-      </StyledButton>
-    );
-  };
 
   renderQRSignButton = () => {
     const { colors, typography } = this.context || mockTheme;
@@ -511,8 +494,8 @@ class TransactionElement extends PureComponent {
   };
 
   renderLedgerSignButton = () => {
-    const colors = this.context.colors || mockTheme.colors;
-    const styles = createStyles(colors);
+    const { colors, typography } = this.context || mockTheme;
+    const styles = createStyles(colors, typography);
     return (
       <StyledButton
         type={'normal'}

--- a/app/components/UI/Transactions/RetryModal/index.tsx
+++ b/app/components/UI/Transactions/RetryModal/index.tsx
@@ -45,10 +45,10 @@ interface Props {
   retryIsOpen: boolean;
   onConfirmPress: () => void;
   onCancelPress: () => void;
-  errorMsg: string;
+  errorMsg: string | undefined;
 }
 
-const RetryModal = ({ retryIsOpen, onConfirmPress, onCancelPress, errorMsg = '' }: Props) => {
+const RetryModal = ({ retryIsOpen, onConfirmPress, onCancelPress, errorMsg }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 

--- a/app/components/UI/Transactions/RetryModal/index.tsx
+++ b/app/components/UI/Transactions/RetryModal/index.tsx
@@ -26,6 +26,13 @@ const createStyles = (colors: any) =>
       paddingVertical: 8,
       color: colors.text.default,
     },
+    modalErrText: {
+      ...(fontStyles.normal as any),
+      fontSize: 14,
+      textAlign: 'center',
+      paddingVertical: 8,
+      color: colors.error.default,
+    },
     modalTitle: {
       ...(fontStyles.bold as any),
       fontSize: 22,
@@ -41,7 +48,7 @@ interface Props {
   errorMsg: string;
 }
 
-const RetryModal = ({ retryIsOpen, onConfirmPress, onCancelPress }: Props) => {
+const RetryModal = ({ retryIsOpen, onConfirmPress, onCancelPress, errorMsg = '' }: Props) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
@@ -59,9 +66,15 @@ const RetryModal = ({ retryIsOpen, onConfirmPress, onCancelPress }: Props) => {
         <Text style={styles.modalTitle}>
           {strings('transaction_update_retry_modal.title')}
         </Text>
-        <Text style={styles.modalText}>
-          {strings('transaction_update_retry_modal.text')}
-        </Text>
+        { errorMsg ? 
+          <Text style={styles.modalErrText}>
+             { errorMsg }
+          </Text>
+          :
+          <Text style={styles.modalText}>
+            { strings('transaction_update_retry_modal.text')}
+          </Text>
+        }   
       </View>
     </ActionModal>
   );

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -608,6 +608,7 @@ class Transactions extends PureComponent {
       isQRHardwareAccount={this.state.isQRHardwareAccount}
       isLedgerAccount={this.state.isLedgerAccount}
       signQRTransaction={this.signQRTransaction}
+      signLedgerTransaction={this.signLedgerTransaction}
       cancelUnsignedQRTransaction={this.cancelUnsignedQRTransaction}
       onCancelAction={this.onCancelAction}
       testID={'txn-item'}

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -44,7 +44,7 @@ import { Authentication } from '../../../core/';
 
 import Device from '../../../util/device';
 import { strings } from '../../../../locales/i18n';
-import { isQRHardwareAccount } from '../../../util/address';
+import { isHardwareAccount } from '../../../util/address';
 import AppConstants from '../../../core/AppConstants';
 import { createStyles } from './styles';
 import { getNavigationOptionsTitle } from '../../../components/UI/Navbar';
@@ -141,7 +141,7 @@ const RevealPrivateCredential = ({
       }
     } catch (e: any) {
       let msg = strings('reveal_credential.warning_incorrect_password');
-      if (isQRHardwareAccount(selectedAddress)) {
+      if (isHardwareAccount(selectedAddress)) {
         msg = strings('reveal_credential.hardware_error');
       } else if (
         e.toString().toLowerCase() !== WRONG_PASSWORD_ERROR.toLowerCase()

--- a/app/core/Transaction/TransactionError.ts
+++ b/app/core/Transaction/TransactionError.ts
@@ -1,0 +1,26 @@
+class TransactionError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, TransactionError.prototype);
+
+    this.name = this.constructor.name
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
+  }
+}
+
+class ApproveTransactionError extends TransactionError{}
+
+class CancelTransactionError extends TransactionError{}
+
+class SpeedupTransactionError extends TransactionError{}
+
+export  {
+  TransactionError,
+  CancelTransactionError,
+  ApproveTransactionError,
+  SpeedupTransactionError
+}


### PR DESCRIPTION
**Description**
when cancel /speed up transaction with default value,  general ledger disconnect error was outputted, instead it should output correct error message

**Issue**
1. when cancel /speed up transaction, default value for fee suggestion is incorrect  (too low)
2. when cancel /speed up transaction with low value, no specific error handled, instead general ledger disconnect error

**step reproduce**
1. Pair ledger with imported SRP on MMM
2. Access [test dapp](https://metamask.github.io/test-dapp/)
3. Connect the dapp
4. use goerli testnet
5. create a token and approve on Ledger
6. while the contract has not complete
7. cancel / speed up the txn
8. it will say your device got disconnected


***Expected result:*** 
1. correct the fee suggestion -> (not to done in this ticket)
2. add validation error dialog when fee not correct  
3. ![IMG_9282.png](https://images.zenhubusercontent.com/64c3247a07477ba12c62a606/337be9e6-6276-46a6-b8ed-2c20d93d3917)
3. even validation pass, the transaction may still have error, should not show disconnected message, instead other  error message
![IMG_9281.png](https://images.zenhubusercontent.com/64c3247a07477ba12c62a606/e0724510-4c95-4504-b338-0eee8c859d1a)

***Actual result:***
error message"your device got disconnected" is showing

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
