### PR TITLE
fix(action): octokit not supported on MetaMask repos

### DIFF
--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -20,12 +20,16 @@ jobs:
       - name: Create bug report issue on planning repo
         if: env.version
         run: |
+          payload=$(cat <<EOF
+          {
+            "title": "v${{ env.version }} Bug Report",
+            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch \`release/${{ env.version }}\` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the \`release/${{ env.version }}\` branch merges into \`main\`, another GitHub action will automatically close this epic.",
+            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
+          }
+          EOF
+          )
           curl -X POST \
             -H "Authorization: token ${{ secrets.BUG_REPORT_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/MetaMask/mobile-planning/issues \
-            -d '{
-            "title": "v${{ env.version }} Bug Report",
-            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ env.version }}` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the `release/${{ env.version }}` branch merges into `main`, another GitHub action will automatically close this epic.",
-            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
-            }'
+            -d "$payload"

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -19,29 +19,13 @@ jobs:
 
       - name: Create bug report issue on planning repo
         if: env.version
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/MetaMask/mobile-planning/issues
-          owner: MetaMask
-          title: v${{ env.version }} Bug Report
-          body: |
-            This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ env.version }}` (release cut).
-
-
-            **Expected actions for release engineers:**
-
-            1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.
-
-            2. After completing the first regression run, move this epic to "Regression Completed" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ env.version }},release-task).
-
-
-            Note that once the release is prepared for store submission, meaning the `release/${{ env.version }}` branch merges into `main`, another GitHub action will automatically close this epic.
-
-          labels: |
-            [
-              "type-bug",
-              "regression-RC",
-              "release-${{ env.version }}"
-            ]
-        env:
-          GITHUB_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.BUG_REPORT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/MetaMask/mobile-planning/issues \
+            -d '{
+            "title": "v${{ env.version }} Bug Report",
+            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch `release/${{ env.version }}` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Mobile Release Regression board](https://app.zenhub.com/workspaces/mobile-release-regression-6249e5242464b70013315a98/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the `release/${{ env.version }}` branch merges into `main`, another GitHub action will automatically close this epic.",
+            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
+            }'


### PR DESCRIPTION
**Description**

The github action was constantly failing with the following error: octokit/request-action@v2.x is not allowed to be used in MetaMask/metamask-mobile.

The fix is to use a curl instead of using octokit.

**Screenshots/Recordings**

- See this PR: https://github.com/MetaMask/metamask-mobile/pull/6967

**Issue**

- None, it's just a fix to the PR mentioned above.

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
