### PR TITLE
fix: crowdin action upload

### DIFF
--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - fix/crowdin-action-upload
   schedule:
     - cron: "0 */12 * * *"
 
@@ -24,7 +23,7 @@ jobs:
     - name: crowdin action
       uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
       with:
-        upload_translations: false #disabled to prevent translations overwriting Blends translations
+        upload_translations: false # disabled to prevent translations overwriting Blends translations
         download_translations: true
         github_user_name: metamaskbot
         github_user_email: metamaskbot@users.noreply.github.com

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -24,7 +24,7 @@ jobs:
     - name: crowdin action
       uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
       with:
-        upload_translations: false
+        upload_translations: false #disabled to prevent translations overwriting Blends translations
         download_translations: true
         github_user_name: metamaskbot
         github_user_email: metamaskbot@users.noreply.github.com

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - fix/crowdin-action-upload
   schedule:
     - cron: "0 */12 * * *"
 

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -23,7 +23,7 @@ jobs:
     - name: crowdin action
       uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
       with:
-        upload_translations: true
+        upload_translations: false
         download_translations: true
         github_user_name: metamaskbot
         github_user_email: metamaskbot@users.noreply.github.com

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,8 +4,8 @@
 
 "preserve_hierarchy": true
 
-# This array identifies the files that should be the source for translations. If a translations key is used this
-# indicates that translations from the identified files will be pushed up to Crowdin.
+# This array identifies the files that should be the source for translations. If a translation key is required to be used
+# the uploading of these translation paths is disabled in the .github/workflows/crowdin_action.yml file on line 27.
 files: [
  {
   "source" : "locales/languages/en.json",

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,12 +5,14 @@
 "preserve_hierarchy": true
 
 # This array identifies the files that should be the source for translations. If a translations key is used this
-# indicates that translations from the idneified files will be pushed up to Crowdin.
+# indicates that translations from the identified files will be pushed up to Crowdin.
 files: [
  {
   "source" : "locales/languages/en.json",
+  "translation" : "",
  },
  {
    "source" : "app/videos/subtitles/secretPhrase/subtitles-en.vtt",
+   "translation" : "",
  }
 ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,10 +9,10 @@
 files: [
  {
   "source" : "locales/languages/en.json",
-  "translation" : "",
+  "translation" : "/locales/languages/%two_letters_code%.json",
  },
  {
    "source" : "app/videos/subtitles/secretPhrase/subtitles-en.vtt",
-   "translation" : "",
+   "translation" : "/app/videos/subtitles/secretPhrase/subtitles-%two_letters_code%.vtt",
  }
 ]


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

This PR fixes the broken Crowdin Action. A previous PR was introduced to disable the uploading of translations to Crowdin but the PR broke the action. The changes added the translation files back and disabled the uploading in the action. For some reason the GH action requires a translation path, if you disable the upload in the action file it doesn't upload translations  as desired.

**Evidence Links/Screenshots/Recordings**

Link to a successful [Crowdin Action](https://github.com/MetaMask/metamask-mobile/actions/runs/5932184707)

**Checklist**

* [NA] There is a related GitHub issue
* [x] Tests are included if applicable
* [NA] Any added code is fully documented
