### PR TITLE
fix: Update terms of use header to match new copy

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2370,7 +2370,7 @@
     "description": "Automatically checking for updates may expose your IP address to GitHub servers. This only indicates that your IP address is using MetaMask. No other information or account addresses are exposed."
   },
   "terms_of_use_modal": {
-    "title": "Our Terms of Use have been updated",
+    "title": "Review our latest Terms of Use",
     "terms_of_use_check_description": "I agree to the Terms of Use, which apply to my use of MetaMask and all of its features",
     "accept_cta": "Accept",
     "accept_helper_description": "Please scroll to read all sections"


### PR DESCRIPTION
**Description**

Update copy on Terms of Use modal header to improve UX.


**Screenshots/Recordings**
![terms-header-updated](https://github.com/MetaMask/metamask-mobile/assets/141057783/c0d375ec-f1a3-4ba4-9742-8dd1a1302666)



**Issue**

fixes https://github.com/MetaMask/mobile-planning/issues/1205

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
