### PR TITLE
fix: [7.6.0] - Token quotes on token details screen

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -196,14 +196,13 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
 
   let currentPrice = 0;
   let priceDiff = 0;
-  if (
-    conversionRate !== null &&
-    conversionRate !== undefined &&
-    exchangeRate !== null &&
-    exchangeRate !== undefined
-  ) {
-    currentPrice = asset.isETH ? conversionRate : exchangeRate * conversionRate;
+
+  if (asset.isETH) {
+    currentPrice = conversionRate || 0;
+  } else if (exchangeRate && conversionRate) {
+    currentPrice = exchangeRate * conversionRate;
   }
+
   const comparePrice = prices[0]?.[1] || 0;
   if (currentPrice !== undefined && currentPrice !== null) {
     priceDiff = currentPrice - comparePrice;


### PR DESCRIPTION
**Description**
Improving the logic when calculating the current price when it's main token of the network on the token details screen

**Screenshots/Recordings**
http://recordit.co/Ofo0ZlW6aV

**Issue**

fixes #7062 https://github.com/MetaMask/metamask-mobile/issues/7062

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
