### PR TITLE
refactor: Simplify `handleNetworkSwitch` utility

### DIFF
--- a/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
+++ b/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
@@ -8,7 +8,6 @@ import { strings } from '../../../../../locales/i18n';
 import { showAlert } from '../../../../actions/alert';
 import { NetworkSwitchErrorType } from '../../../../constants/error';
 import Routes from '../../../../constants/navigation/Routes';
-import Engine from '../../../../core/Engine';
 import { selectNetwork } from '../../../../selectors/networkController';
 import { handleNetworkSwitch } from '../../../../util/networks';
 import { AddressTo } from '../../../UI/AddressInputs';
@@ -37,11 +36,7 @@ const SendFlowAddressTo = ({
 
   const onHandleNetworkSwitch = (chain_id: string) => {
     try {
-      const { NetworkController, CurrencyRateController } = Engine.context;
-      const networkSwitch = handleNetworkSwitch(chain_id, {
-        networkController: NetworkController,
-        currencyRateController: CurrencyRateController,
-      });
+      const networkSwitch = handleNetworkSwitch(chain_id);
 
       if (!networkSwitch) return;
 

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import Engine from '../../../../core/Engine';
 import Analytics from '../../../../core/Analytics/Analytics';
 import AddressList from './../AddressList';
 import Text from '../../../Base/Text';
@@ -248,12 +247,8 @@ class SendFlow extends PureComponent {
 
   handleNetworkSwitch = (chainId) => {
     try {
-      const { NetworkController, CurrencyRateController } = Engine.context;
       const { showAlert } = this.props;
-      const network = handleNetworkSwitch(chainId, {
-        networkController: NetworkController,
-        currencyRateController: CurrencyRateController,
-      });
+      const network = handleNetworkSwitch(chainId);
 
       if (!network) return;
 

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -47,11 +47,7 @@ class DeeplinkManager {
    * @param switchToChainId - Corresponding chain id for new network
    */
   _handleNetworkSwitch = (switchToChainId) => {
-    const { NetworkController, CurrencyRateController } = Engine.context;
-    const network = handleNetworkSwitch(switchToChainId, {
-      networkController: NetworkController,
-      currencyRateController: CurrencyRateController,
-    });
+    const network = handleNetworkSwitch(switchToChainId);
 
     if (!network) return;
 

--- a/app/util/networks/handleNetworkSwitch.test.ts
+++ b/app/util/networks/handleNetworkSwitch.test.ts
@@ -1,0 +1,110 @@
+import Engine from '../../core/Engine';
+import { NETWORKS_CHAIN_ID, SEPOLIA } from '../../constants/network';
+import handleNetworkSwitch from './handleNetworkSwitch';
+
+const mockEngine = Engine;
+
+jest.mock('../../core/Engine', () => ({
+  context: {
+    CurrencyRateController: {
+      setNativeCurrency: jest.fn(),
+    },
+    NetworkController: {
+      setActiveNetwork: jest.fn(),
+      setProviderType: jest.fn(),
+      state: {
+        network: 'loading',
+        isCustomNetwork: false,
+        networkConfigurations: {
+          networkId1: {
+            rpcUrl: 'custom-testnet-rpc-url',
+            chainId: '1338',
+            ticker: 'TEST',
+            nickname: 'Testnet',
+          },
+        },
+        providerConfig: {
+          type: 'mainnet',
+          chainId: '1',
+        },
+        networkDetails: {
+          isEIP1559Compatible: false,
+        },
+      },
+    },
+  },
+}));
+
+describe('useHandleNetworkSwitch', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('does nothing if not given a chain ID', () => {
+    const result = handleNetworkSwitch('');
+
+    expect(
+      mockEngine.context.CurrencyRateController.setNativeCurrency,
+    ).not.toBeCalled();
+    expect(
+      mockEngine.context.NetworkController.setActiveNetwork,
+    ).not.toBeCalled();
+    expect(
+      mockEngine.context.NetworkController.setProviderType,
+    ).not.toBeCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('does nothing if the chain ID matches the current global chain ID', () => {
+    const result = handleNetworkSwitch('1');
+
+    expect(
+      mockEngine.context.CurrencyRateController.setNativeCurrency,
+    ).not.toBeCalled();
+    expect(
+      mockEngine.context.NetworkController.setActiveNetwork,
+    ).not.toBeCalled();
+    expect(
+      mockEngine.context.NetworkController.setProviderType,
+    ).not.toBeCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('throws an error if the chain ID is not recognized', () => {
+    expect(() => handleNetworkSwitch('123456')).toThrow(
+      'Unknown network with id 123456',
+    );
+  });
+
+  it('switches to a custom network', () => {
+    const nickname = handleNetworkSwitch('1338');
+
+    expect(
+      mockEngine.context.CurrencyRateController.setNativeCurrency,
+    ).toBeCalledWith('TEST');
+    expect(
+      mockEngine.context.NetworkController.setActiveNetwork,
+    ).toBeCalledWith('networkId1');
+    expect(
+      mockEngine.context.NetworkController.setProviderType,
+    ).not.toBeCalled();
+    expect(nickname).toBe('Testnet');
+  });
+
+  it('switches to a built-in network', () => {
+    const networkType = handleNetworkSwitch(NETWORKS_CHAIN_ID.SEPOLIA);
+
+    // TODO: This is a bug, it should be set to SepoliaETH
+    expect(
+      mockEngine.context.CurrencyRateController.setNativeCurrency,
+    ).toBeCalledWith('ETH');
+    expect(mockEngine.context.NetworkController.setProviderType).toBeCalledWith(
+      SEPOLIA,
+    );
+    expect(
+      mockEngine.context.NetworkController.setActiveNetwork,
+    ).not.toBeCalled();
+    expect(networkType).toBe(SEPOLIA);
+  });
+});

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -23,7 +23,9 @@ const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
     .NetworkController as NetworkController;
 
   // If current network is the same as the one we want to switch to, do nothing
-  if (networkController.state.providerConfig.chainId === String(switchToChainId)) {
+  if (
+    networkController.state.providerConfig.chainId === String(switchToChainId)
+  ) {
     return;
   }
 

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -1,33 +1,35 @@
-import type { NetworkController } from '@metamask/network-controller';
+import { CurrencyRateController } from '@metamask/assets-controllers';
+import { NetworkType } from '@metamask/controller-utils';
+import { NetworkController } from '@metamask/network-controller';
 import { getNetworkTypeById } from './index';
-import type { CurrencyRateController } from '@metamask/assets-controllers';
+import Engine from '../../core/Engine';
 
-const handleNetworkSwitch = (
-  switchToChainId: string,
-  {
-    networkController,
-    currencyRateController,
-  }: {
-    networkController: NetworkController;
-    currencyRateController: CurrencyRateController;
-  },
-): string | undefined => {
+/**
+ * Switch to the given chain ID.
+ *
+ * @returns The network type of the build-in network switched to, or the
+ * network ID of the custom network switched to, or undefined if no switch
+ * occurred.
+ */
+const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
   // If not specified, use the current network
   if (!switchToChainId) {
     return;
   }
 
+  const currencyRateController = Engine.context
+    .CurrencyRateController as CurrencyRateController;
+  const networkController = Engine.context
+    .NetworkController as NetworkController;
+
   // If current network is the same as the one we want to switch to, do nothing
-  if (
-    networkController?.state?.providerConfig?.chainId ===
-    String(switchToChainId)
-  ) {
+  if (networkController.state.providerConfig.chainId === switchToChainId) {
     return;
   }
 
   const entry = Object.entries(
     networkController.state.networkConfigurations,
-  ).find(([, { chainId }]) => chainId === switchToChainId);
+  ).find(([, { chainId: configChainId }]) => configChainId === switchToChainId);
 
   if (entry) {
     const [networkConfigurationId, networkConfiguration] = entry;
@@ -41,7 +43,8 @@ const handleNetworkSwitch = (
 
   if (networkType) {
     currencyRateController.setNativeCurrency('ETH');
-    networkController.setProviderType(networkType);
+    // TODO: Align mobile and core types to remove this type cast
+    networkController.setProviderType(networkType as NetworkType);
     return networkType;
   }
 };

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -23,7 +23,7 @@ const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
     .NetworkController as NetworkController;
 
   // If current network is the same as the one we want to switch to, do nothing
-  if (networkController.state.providerConfig.chainId === switchToChainId) {
+  if (networkController.state.providerConfig.chainId === String(switchToChainId)) {
     return;
   }
 

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -5,7 +5,6 @@ import {
   getNetworkTypeById,
   findBlockExplorerForRpc,
   compareRpcUrls,
-  handleNetworkSwitch,
   getBlockExplorerAddressUrl,
   getBlockExplorerTxUrl,
 } from '.';
@@ -18,7 +17,6 @@ import {
   LINEA_MAINNET,
 } from '../../../app/constants/network';
 import { NetworkSwitchErrorType } from '../../../app/constants/error';
-import Engine from './../../core/Engine';
 
 jest.mock('./../../core/Engine', () => ({
   context: {
@@ -179,49 +177,6 @@ describe('NetworkUtils::compareRpcUrls', () => {
     const mockRpcOne = 'https://bsc-dataseed.binance.org/';
     const mockRpcTwo = 'https://mainnet.optimism.io/d03910331458';
     expect(compareRpcUrls(mockRpcOne, mockRpcTwo)).toBe(false);
-  });
-});
-
-describe('NetworkUtils::handleNetworkSwitch', () => {
-  const mockNeworkConfigurations = {
-    networkId1: {
-      rpcUrl: 'mainnet-rpc-url',
-      chainId: '1',
-      ticker: 'ETH',
-      nickname: 'Mainnet',
-    },
-    networkId2: {
-      rpcUrl: 'polygon-rpc-url',
-      chainId: '2',
-      ticker: 'MATIC',
-      nickname: 'Polygon',
-    },
-    networkId3: {
-      rpcUrl: 'avalanche-rpc-url',
-      chainId: '3',
-      ticker: 'AVAX',
-      nickname: 'Avalanche',
-    },
-  };
-
-  const { CurrencyRateController } = Engine.context as any;
-
-  it('should change networks to the provided one', () => {
-    const network = mockNeworkConfigurations.networkId1;
-    const newNetwork = handleNetworkSwitch(network.chainId, {
-      networkController: {
-        setActiveNetwork: () => jest.fn(),
-        setProviderType: () => jest.fn(),
-        state: {
-          providerConfig: {
-            chainId: '3',
-          },
-          networkConfigurations: mockNeworkConfigurations,
-        },
-      },
-      currencyRateController: CurrencyRateController,
-    });
-    expect(newNetwork).toBe(network.nickname);
   });
 });
 


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The `handleNetworkSwitch` no longer requires the network controller and currency rate controller instances to be passed in. This makes it simpler to use, and reduces the usage of global controller references (which in turn helps reduce the effort of managing breaking changes to those controllers).

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1015

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
