### PR TITLE
Test ext contributor sonar cloud token update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,10 @@ jobs:
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       - name: SonarCloud Scan
         # v1.9.1
+        if: ${{ env.HAVE_SONAR_TOKEN == 'true' }}
         uses: SonarSource/sonarcloud-github-action@5875562561d22a34be0c657405578705a169af6c
         env:
+          HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
**Description**

Testing the same code updates https://github.com/MetaMask/metamask-mobile/pull/7086 as a non-codeowner. Once passing this PR can be closed

"This PR checks to see if sonar cloud can be run and skips it if the user is an external contributor and does not have access to the SONAR_TOKEN"

**Screenshots/Recordings**

NA

**Issue**

fixes NA

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
