### PR TITLE
fix: Fix Engine `controllerMessenger` type errors

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -2,14 +2,18 @@
 import {
   AccountTrackerController,
   AssetsContractController,
-  TokenListController,
   CurrencyRateController,
+  CurrencyRateStateChange,
+  GetCurrencyRateState,
+  GetTokenListState,
+  NftController,
+  NftDetectionController,
   TokenBalancesController,
+  TokenDetectionController,
+  TokenListController,
+  TokenListStateChange,
   TokenRatesController,
   TokensController,
-  NftController,
-  TokenDetectionController,
-  NftDetectionController,
 } from '@metamask/assets-controllers';
 import { AddressBookController } from '@metamask/address-book-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
@@ -18,16 +22,30 @@ import {
   KeyringController,
   SignTypedDataVersion,
 } from '@metamask/keyring-controller';
-import { NetworkController } from '@metamask/network-controller';
+import {
+  NetworkController,
+  NetworkControllerActions,
+  NetworkControllerEvents,
+} from '@metamask/network-controller';
 import { PhishingController } from '@metamask/phishing-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { TransactionController } from '@metamask/transaction-controller';
-import { GasFeeController } from '@metamask/gas-fee-controller';
+import {
+  GasFeeController,
+  GasFeeStateChange,
+  GetGasFeeState,
+} from '@metamask/gas-fee-controller';
 import {
   AcceptOptions,
   ApprovalController,
+  ApprovalControllerActions,
+  ApprovalControllerEvents,
 } from '@metamask/approval-controller';
-import { PermissionController } from '@metamask/permission-controller';
+import {
+  PermissionController,
+  PermissionControllerActions,
+  PermissionControllerEvents,
+} from '@metamask/permission-controller';
 import SwapsController, { swapsUtils } from '@metamask/swaps-controller';
 import { MetaMaskKeyring as QRHardwareKeyring } from '@keystonehq/metamask-airgapped-keyring';
 import Encryptor from './Encryptor';
@@ -55,7 +73,11 @@ import {
   unrestrictedMethods,
 } from './Permissions/specifications.js';
 import { backupVault } from './BackupVault';
-import { SignatureController } from '@metamask/signature-controller';
+import {
+  SignatureController,
+  SignatureControllerActions,
+  SignatureControllerEvents,
+} from '@metamask/signature-controller';
 import { Json } from '@metamask/controller-utils';
 
 const NON_EMPTY = 'NON_EMPTY';
@@ -63,6 +85,22 @@ const NON_EMPTY = 'NON_EMPTY';
 const encryptor = new Encryptor();
 let currentChainId: any;
 
+type GlobalActions =
+  | ApprovalControllerActions
+  | GetCurrencyRateState
+  | GetGasFeeState
+  | GetTokenListState
+  | NetworkControllerActions
+  | PermissionControllerActions
+  | SignatureControllerActions;
+type GlobalEvents =
+  | ApprovalControllerEvents
+  | CurrencyRateStateChange
+  | GasFeeStateChange
+  | TokenListStateChange
+  | NetworkControllerEvents
+  | PermissionControllerEvents
+  | SignatureControllerEvents;
 /**
  * Core controller responsible for composing other metamask controllers together
  * and exposing convenience methods for common wallet operations.
@@ -72,6 +110,10 @@ class Engine {
    * The global Engine singleton
    */
   static instance: Engine;
+  /**
+   * The global controller messenger.
+   */
+  controllerMessenger: ControllerMessenger<GlobalActions, GlobalEvents>;
   /**
    * ComposableController reference containing all child controllers
    */


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The type errors related to the Engine `controllerMessenger` property have been fixed. The controller messenger is now declared correctly with all global actions and events.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1015

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
