### PR TITLE
refactor: Bump test-dapp to `v7.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
     "@metamask/eslint-config": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.0",
     "@metamask/mobile-provider": "^2.1.0",
-    "@metamask/test-dapp": "^6.1.0",
+    "@metamask/test-dapp": "^7.1.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "@rpii/wdio-html-reporter": "^7.7.1",
     "@storybook/addon-actions": "^5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5502,10 +5502,10 @@
     human-standard-token-abi "^2.0.0"
     web3 "^0.20.7"
 
-"@metamask/test-dapp@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-6.1.0.tgz#5d751fb89d49280df3b3289f52303e8951956825"
-  integrity sha512-Es/vEmja/tgKYk2mdEDhVFkTa90QxTAqTUuMWVBjy6rKdwk4p3y9eNMNbXnLn/2p2cGoDAvDKDxHxPvCjWqMVw==
+"@metamask/test-dapp@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-7.1.0.tgz#e7119f12b1dc7a600b0b726e58971900c29b88a7"
+  integrity sha512-uqnno8JmpNMuyxDqQ6rq8+T9hf6Rsuy7rJnHHQd0RFRmva02v6N8rJZpEmftM61ciAaMolSB8XbZPPRsMIdQ8w==
 
 "@metamask/transaction-controller@^4.0.1":
   version "4.0.1"


### PR DESCRIPTION
## Description
Bump test-dapp to `v7.1.0`. This module is exclusively used in e2e. Changes from this version include:
- Add PPOM testing section (https://github.com/MetaMask/test-dapp/pull/253)
- Watch NFT by id instead of generating a watch NFT button for each token id (https://github.com/MetaMask/test-dapp/pull/247)

See more [here](https://github.com/MetaMask/test-dapp/pull/254).

**Note**: at the moment Mobile e2e uses test-dapp only for retrieving contracts, but it does not build the dapp locally and run the tests against localhost. Instead, it goes to the [live page](https://metamask.github.io/test-dapp/). A future refactor should tackle this, so we run against localhost in a controlled environment and we use the same approach in both platforms. Task [here](https://github.com/MetaMask/mobile-planning/issues/1231).

## Screenshots/Recordings
Here you can see the new PPOM section added in the new release of the test dapp.

https://github.com/MetaMask/metamask-mobile/assets/54408225/c34bce30-f849-46e7-9514-eabbd59a5834



## Issue

- fixes https://github.com/MetaMask/mobile-planning/issues/1230

## Checklist

* [X] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented
