### PR TITLE
fix: Fix all Engine type errors

### DIFF
--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -157,4 +157,4 @@ export default {
     TERMS_OF_USE_URL_WITHOUT_COOKIES:
       'https://legal.consensys.io/plain/terms-of-use/',
   },
-};
+} as const;

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -920,6 +920,11 @@ class Engine {
   }
 }
 
+/**
+ * Assert that the given Engine instance has been initialized
+ *
+ * @param instance Either an Engine instance, or null
+ */
 function assertEngineExists(
   instance: Engine | null,
 ): asserts instance is Engine {

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -920,25 +920,27 @@ class Engine {
   }
 }
 
+function assertEngineExists(
+  instance: Engine | null,
+): asserts instance is Engine {
+  if (!instance) {
+    throw new Error('Engine does not exist');
+  }
+}
+
 let instance: Engine | null;
 
 export default {
   get context() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.context;
   },
   get controllerMessenger() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.controllerMessenger;
   },
   get state() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     const {
       AccountTrackerController,
       AddressBookController,
@@ -996,27 +998,19 @@ export default {
     };
   },
   get datamodel() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.datamodel;
   },
   getTotalFiatAccountBalance() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.getTotalFiatAccountBalance();
   },
   hasFunds() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.hasFunds();
   },
   resetState() {
-    if (!instance) {
-      throw new Error('Engine does not exist');
-    }
+    assertEngineExists(instance);
     return instance.resetState();
   },
   destroyEngine() {

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1,37 +1,59 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import {
   AccountTrackerController,
+  AccountTrackerState,
   AssetsContractController,
   CurrencyRateController,
+  CurrencyRateState,
   CurrencyRateStateChange,
   GetCurrencyRateState,
   GetTokenListState,
   NftController,
   NftDetectionController,
+  NftState,
   TokenBalancesController,
+  TokenBalancesState,
   TokenDetectionController,
   TokenListController,
+  TokenListState,
   TokenListStateChange,
   TokenRatesController,
+  TokenRatesState,
   TokensController,
+  TokensState,
 } from '@metamask/assets-controllers';
-import { AddressBookController } from '@metamask/address-book-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import {
+  AddressBookController,
+  AddressBookState,
+} from '@metamask/address-book-controller';
+import { BaseState, ControllerMessenger } from '@metamask/base-controller';
 import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
+  KeyringState,
   SignTypedDataVersion,
 } from '@metamask/keyring-controller';
 import {
   NetworkController,
   NetworkControllerActions,
   NetworkControllerEvents,
+  NetworkState,
 } from '@metamask/network-controller';
-import { PhishingController } from '@metamask/phishing-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
-import { TransactionController } from '@metamask/transaction-controller';
+import {
+  PhishingController,
+  PhishingState,
+} from '@metamask/phishing-controller';
+import {
+  PreferencesController,
+  PreferencesState,
+} from '@metamask/preferences-controller';
+import {
+  TransactionController,
+  TransactionState,
+} from '@metamask/transaction-controller';
 import {
   GasFeeController,
+  GasFeeState,
   GasFeeStateChange,
   GetGasFeeState,
 } from '@metamask/gas-fee-controller';
@@ -40,11 +62,13 @@ import {
   ApprovalController,
   ApprovalControllerActions,
   ApprovalControllerEvents,
+  ApprovalControllerState,
 } from '@metamask/approval-controller';
 import {
   PermissionController,
   PermissionControllerActions,
   PermissionControllerEvents,
+  PermissionControllerState,
 } from '@metamask/permission-controller';
 import SwapsController, { swapsUtils } from '@metamask/swaps-controller';
 import { MetaMaskKeyring as QRHardwareKeyring } from '@keystonehq/metamask-airgapped-keyring';
@@ -55,7 +79,8 @@ import {
   fetchEstimatedMultiLayerL1Fee,
 } from '../util/networks';
 import AppConstants from './AppConstants';
-import { store } from '../store';
+// @ts-expect-error Type errors in store
+import { store as importedStore } from '../store';
 import {
   renderFromTokenMinimalUnit,
   balanceToFiatNumber,
@@ -78,9 +103,14 @@ import {
   SignatureControllerActions,
   SignatureControllerEvents,
 } from '@metamask/signature-controller';
-import { Json } from '@metamask/controller-utils';
+import { hasProperty, Json } from '@metamask/controller-utils';
+// TODO: Export this type from the package directly
+import { SwapsState } from '@metamask/swaps-controller/dist/SwapsController';
 
 const NON_EMPTY = 'NON_EMPTY';
+
+// @ts-expect-error Type errors in store
+const store: any = importedStore;
 
 const encryptor = new Encryptor();
 let currentChainId: any;
@@ -101,6 +131,32 @@ type GlobalEvents =
   | NetworkControllerEvents
   | PermissionControllerEvents
   | SignatureControllerEvents;
+
+type Permissions = ReturnType<typeof getPermissionSpecifications>;
+
+export interface EngineState {
+  AccountTrackerController: AccountTrackerState;
+  AddressBookController: AddressBookState;
+  AssetsContractController: BaseState;
+  NftController: NftState;
+  TokenListController: TokenListState;
+  CurrencyRateController: CurrencyRateState;
+  KeyringController: KeyringState;
+  NetworkController: NetworkState;
+  PreferencesController: PreferencesState;
+  PhishingController: PhishingState;
+  TokenBalancesController: TokenBalancesState;
+  TokenRatesController: TokenRatesState;
+  TransactionController: TransactionState;
+  SwapsController: SwapsState;
+  GasFeeController: GasFeeState;
+  TokensController: TokensState;
+  TokenDetectionController: BaseState;
+  NftDetectionController: BaseState;
+  PermissionController: PermissionControllerState<Permissions>;
+  ApprovalController: ApprovalControllerState;
+}
+
 /**
  * Core controller responsible for composing other metamask controllers together
  * and exposing convenience methods for common wallet operations.
@@ -109,7 +165,34 @@ class Engine {
   /**
    * The global Engine singleton
    */
-  static instance: Engine;
+  static instance: Engine | null;
+  /**
+   * A collection of all controller instances
+   */
+  context: {
+    AccountTrackerController: AccountTrackerController;
+    AddressBookController: AddressBookController;
+    ApprovalController: ApprovalController;
+    AssetsContractController: AssetsContractController;
+    CurrencyRateController: CurrencyRateController;
+    GasFeeController: GasFeeController;
+    KeyringController: KeyringController;
+    NetworkController: NetworkController;
+    NftController: NftController;
+    NftDetectionController: NftDetectionController;
+    // TODO: Fix permission types
+    PermissionController: PermissionController<any, any>;
+    PhishingController: PhishingController;
+    PreferencesController: PreferencesController;
+    TokenBalancesController: TokenBalancesController;
+    TokenListController: TokenListController;
+    TokenDetectionController: TokenDetectionController;
+    TokenRatesController: TokenRatesController;
+    TokensController: TokensController;
+    TransactionController: TransactionController;
+    SignatureController: SignatureController;
+    SwapsController: SwapsController;
+  };
   /**
    * The global controller messenger.
    */
@@ -117,7 +200,7 @@ class Engine {
   /**
    * ComposableController reference containing all child controllers
    */
-  datamodel;
+  datamodel: ComposableController;
 
   /**
    * Object containing the info for the latest incoming tx block
@@ -129,14 +212,18 @@ class Engine {
    * Creates a CoreController instance
    */
   // eslint-disable-next-line @typescript-eslint/default-param-last
-  constructor(initialState = {}, initialKeyringState) {
+  constructor(
+    initialState: Partial<EngineState> = {},
+    initialKeyringState?: KeyringState | null,
+  ) {
     this.controllerMessenger = new ControllerMessenger();
 
     const approvalController = new ApprovalController({
+      // @ts-expect-error Error might be caused by base controller version mismatch
       messenger: this.controllerMessenger.getRestricted({
         name: 'ApprovalController',
       }),
-      showApprovalRequest: () => null,
+      showApprovalRequest: () => undefined,
       typesExcludedFromRateLimiting: [
         // TODO: Replace with ApprovalType enum from @metamask/controller-utils when breaking change is fixed
         'eth_sign',
@@ -217,6 +304,7 @@ class Engine {
         ),
       },
       {
+        // @ts-expect-error NftController constructor config type is wrong
         useIPFSSubdomains: false,
         chainId: networkController.state.providerConfig.chainId,
       },
@@ -237,6 +325,7 @@ class Engine {
         name: 'TokensController',
         allowedActions: [`${approvalController.name}:addRequest`],
       }),
+      // @ts-expect-error This is added in a patch, but types weren't updated
       getERC20TokenName: assetsContractController.getERC20TokenName.bind(
         assetsContractController,
       ),
@@ -249,16 +338,23 @@ class Engine {
           AppConstants.NETWORK_STATE_CHANGE_EVENT,
           listener,
         ),
-      messenger: this.controllerMessenger,
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'TokenListController',
+        allowedEvents: ['NetworkController:providerConfigChange'],
+      }),
     });
     const currencyRateController = new CurrencyRateController({
-      messenger: this.controllerMessenger,
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'CurrencyRateController',
+      }),
       state: initialState.CurrencyRateController,
     });
     currencyRateController.start();
 
     const gasFeeController = new GasFeeController({
-      messenger: this.controllerMessenger,
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'GasFeeController',
+      }),
       getProvider: () =>
         networkController.getProviderAndBlockTracker().provider,
       onNetworkStateChange: (listener) =>
@@ -268,6 +364,7 @@ class Engine {
         ),
       getCurrentNetworkEIP1559Compatibility: async () =>
         await networkController.getEIP1559Compatibility(),
+      // @ts-expect-error Incompatible string types, fixed in upcoming version
       getChainId: () => networkController.state.providerConfig.chainId,
       getCurrentNetworkLegacyGasAPICompatibility: () => {
         const chainId = networkController.state.providerConfig.chainId;
@@ -291,11 +388,11 @@ class Engine {
 
     const getIdentities = () => {
       const identities = preferencesController.state.identities;
-      const newIdentities = {};
+      const lowerCasedIdentities: PreferencesState['identities'] = {};
       Object.keys(identities).forEach((key) => {
-        newIdentities[key.toLowerCase()] = identities[key];
+        lowerCasedIdentities[key.toLowerCase()] = identities[key];
       });
-      return newIdentities;
+      return lowerCasedIdentities;
     };
 
     const keyringState = initialKeyringState || initialState.KeyringController;
@@ -328,8 +425,10 @@ class Engine {
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         getIdentities: () => preferencesController.state.identities,
+        // @ts-expect-error This is added in a patch, but types weren't updated
         getSelectedAddress: () => preferencesController.state.selectedAddress,
         getMultiAccountBalancesEnabled: () =>
+          // @ts-expect-error This is added in a patch, but types weren't updated
           preferencesController.state.isMultiAccountBalancesEnabled,
       }),
       new AddressBookController(),
@@ -350,7 +449,7 @@ class Engine {
             `${tokenListController.name}:stateChange`,
             listener,
           ),
-        addDetectedTokens: (tokens) => {
+        addDetectedTokens: async (tokens) => {
           // Track detected tokens event
           AnalyticsV2.trackEvent(MetaMetricsEvents.TOKEN_DETECTED, {
             token_standard: 'ERC20',
@@ -361,7 +460,9 @@ class Engine {
           });
           tokensController.addDetectedTokens(tokens);
         },
+        // @ts-expect-error This is added in a patch, but types weren't updated
         updateTokensName: (tokenList) =>
+          // @ts-expect-error This is added in a patch, but types weren't updated
           tokensController.updateTokensName(tokenList),
         getTokensState: () => tokensController.state,
         getTokenListState: () => tokenListController.state,
@@ -442,7 +543,9 @@ class Engine {
       }),
       new SwapsController(
         {
+          // @ts-expect-error TODO: Resolve mismatch between gas fee and swaps controller types
           fetchGasFeeEstimates: () => gasFeeController.fetchGasFeeEstimates(),
+          // @ts-expect-error TODO: Resolve mismatch between gas fee and swaps controller types
           fetchEstimatedMultiLayerL1Fee,
         },
         {
@@ -466,6 +569,7 @@ class Engine {
       gasFeeController,
       approvalController,
       new PermissionController({
+        // @ts-expect-error Error might be caused by base controller version mismatch
         messenger: this.controllerMessenger.getRestricted({
           name: 'PermissionController',
           allowedActions: [
@@ -477,6 +581,7 @@ class Engine {
         }),
         state: initialState.PermissionController,
         caveatSpecifications: getCaveatSpecifications({ getIdentities }),
+        // @ts-expect-error Inferred permission specification type is incorrect, fix after migrating to TypeScript
         permissionSpecifications: {
           ...getPermissionSpecifications({
             getAllAccounts: () => keyringController.getAccounts(),
@@ -488,6 +593,7 @@ class Engine {
         unrestrictedMethods,
       }),
       new SignatureController({
+        // @ts-expect-error Error might be caused by base controller version mismatch
         messenger: this.controllerMessenger.getRestricted({
           name: 'SignatureController',
           allowedActions: [`${approvalController.name}:addRequest`],
@@ -505,6 +611,7 @@ class Engine {
             keyringController.signPersonalMessage.bind(keyringController),
           signTypedMessage: (msgParams, { version }) =>
             keyringController.signTypedMessage(
+              // @ts-expect-error Error might be caused by base controller version mismatch
               msgParams,
               version as SignTypedDataVersion,
             ),
@@ -520,19 +627,28 @@ class Engine {
     // The check for `controller.subscribe !== undefined` is to filter out BaseControllerV2
     // controllers. They should be initialized via the constructor instead.
     for (const controller of controllers) {
-      if (initialState[controller.name] && controller.subscribe !== undefined) {
+      if (
+        hasProperty(initialState, controller.name) &&
+        controller.subscribe !== undefined
+      ) {
+        // The following type error can be addressed by passing initial state into controller constructors instead
+        // @ts-expect-error No type-level guarantee that the correct state is being applied to the correct controller here.
         controller.update(initialState[controller.name]);
       }
     }
 
     this.datamodel = new ComposableController(
+      // @ts-expect-error The ComposableController needs to be updated to support BaseControllerV2
       controllers,
       this.controllerMessenger,
     );
-    this.context = controllers.reduce((context, controller) => {
-      context[controller.name] = controller;
-      return context;
-    }, {});
+    this.context = controllers.reduce<Partial<typeof this.context>>(
+      (context, controller) => ({
+        ...context,
+        [controller.name]: controller,
+      }),
+      {},
+    ) as typeof this.context;
 
     const {
       NftController: nfts,
@@ -540,7 +656,9 @@ class Engine {
       TransactionController: transaction,
     } = this.context;
 
-    nfts.setApiKey(process.env.MM_OPENSEA_KEY);
+    if (process.env.MM_OPENSEA_KEY) {
+      nfts.setApiKey(process.env.MM_OPENSEA_KEY);
+    }
 
     transaction.configure({ sign: keyring.signTransaction.bind(keyring) });
 
@@ -623,7 +741,6 @@ class Engine {
       chainId: NetworkController.state?.providerConfig?.chainId,
       pollCountLimit: AppConstants.SWAPS.POLL_COUNT_LIMIT,
     });
-    TransactionController.configure({ provider });
     TransactionController.hub.emit('networkChange');
     TokenDetectionController.detectTokens();
     NftDetectionController.detectNfts();
@@ -662,11 +779,7 @@ class Engine {
       const { contractExchangeRates: tokenExchangeRates } =
         TokenRatesController.state;
       tokens.forEach(
-        (item: {
-          address: string;
-          balance: string | undefined;
-          decimals: number;
-        }) => {
+        (item: { address: string; balance?: string; decimals: number }) => {
           const exchangeRate =
             item.address in tokenExchangeRates
               ? tokenExchangeRates[item.address]
@@ -680,6 +793,8 @@ class Engine {
                 )
               : undefined);
           const tokenBalanceFiat = balanceToFiatNumber(
+            // TODO: Fix this by handling or eliminating the undefined case
+            // @ts-expect-error This variable can be `undefined`, which would break here.
             tokenBalance,
             conversionRate,
             exchangeRate,
@@ -702,6 +817,7 @@ class Engine {
       const {
         engine: { backgroundState },
       } = store.getState();
+      // TODO: Check `allNfts[currentChainId]` property instead
       const nfts = backgroundState.NftController.nfts;
       const tokens = backgroundState.TokensController.tokens;
       const tokenBalances =
@@ -764,8 +880,6 @@ class Engine {
     TokenRatesController.update({ contractExchangeRates: {} });
 
     TransactionController.update({
-      internalTransactions: [],
-      swapsTransactions: {},
       methodData: {},
       transactions: [],
       lastFetchedBlockNumbers: {},
@@ -806,16 +920,25 @@ class Engine {
   }
 }
 
-let instance: Engine;
+let instance: Engine | null;
 
 export default {
   get context() {
-    return instance?.context;
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
+    return instance.context;
   },
   get controllerMessenger() {
-    return instance?.controllerMessenger;
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
+    return instance.controllerMessenger;
   },
   get state() {
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
     const {
       AccountTrackerController,
       AddressBookController,
@@ -873,15 +996,27 @@ export default {
     };
   },
   get datamodel() {
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
     return instance.datamodel;
   },
   getTotalFiatAccountBalance() {
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
     return instance.getTotalFiatAccountBalance();
   },
   hasFunds() {
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
     return instance.hasFunds();
   },
   resetState() {
+    if (!instance) {
+      throw new Error('Engine does not exist');
+    }
     return instance.resetState();
   },
   destroyEngine() {

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -923,7 +923,7 @@ class Engine {
 /**
  * Assert that the given Engine instance has been initialized
  *
- * @param instance Either an Engine instance, or null
+ * @param instance - Either an Engine instance, or null
  */
 function assertEngineExists(
   instance: Engine | null,

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -1,6 +1,7 @@
 import UntypedEngine from '../Engine';
 import AppConstants from '../AppConstants';
 import { getVaultFromBackup } from '../BackupVault';
+// @ts-expect-error Type errors in store
 import { store as importedStore } from '../../store';
 import {
   NO_VAULT_IN_BACKUP_ERROR,
@@ -105,6 +106,7 @@ class EngineService {
    */
   async initializeVaultFromBackup(): Promise<InitializeEngineResult> {
     const keyringState = await getVaultFromBackup();
+    // @ts-expect-error Type errors in store
     const reduxState = importedStore.getState?.();
     const state = reduxState?.engine?.backgroundState || {};
     const Engine = UntypedEngine as any;
@@ -118,6 +120,7 @@ class EngineService {
       };
       const instance = Engine.init(state, newKeyringState);
       if (instance) {
+        // @ts-expect-error Type errors in store
         this.updateControllers(importedStore, instance);
         // this is a hack to give the engine time to reinitialize
         await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -73,7 +73,6 @@ export const getCaveatSpecifications = ({ getIdentities }) => ({
  *
  * @param {{
  *   getAllAccounts: () => Promise<string[]>,
- *   getIdentities: () => Record<string, Identity>,
  * }} options - Options bag.
  * @param options.getAllAccounts - A function that returns all Ethereum accounts
  * in the current MetaMask instance.

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -28,7 +28,7 @@ import { removeBookmark } from '../../actions/bookmarks';
 import setOnboardingWizardStep from '../../actions/wizard';
 import { v1 as random } from 'uuid';
 import { getPermittedAccounts } from '../Permissions';
-import AppConstants from '../AppConstants.js';
+import AppConstants from '../AppConstants';
 import { isSmartContractAddress } from '../../util/transactions';
 import { TOKEN_NOT_SUPPORTED_FOR_NETWORK } from '../../constants/error';
 const Engine = ImportedEngine as any;

--- a/app/reducers/fiatOrders/types.ts
+++ b/app/reducers/fiatOrders/types.ts
@@ -22,6 +22,7 @@ import {
   FIAT_ORDER_PROVIDERS,
   FIAT_ORDER_STATES,
 } from '../../constants/on-ramp';
+// @ts-expect-error Type errors in store
 import { store } from '../../store';
 
 interface WyreOrder {
@@ -31,6 +32,7 @@ interface WyreOrder {
 
 // Source: https://redux.js.org/tutorials/typescript-quick-start
 // Infer the `RootState` and `AppDispatch` types from the store itself
+// @ts-expect-error Type errors in store
 export type RootState = ReturnType<typeof store.getState>;
 
 export interface FiatOrder {

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -524,7 +524,7 @@ export function addCurrencySymbol(
 /**
  * Converts wei expressed as a BN instance into a human-readable fiat string
  *
- * @param {number} wei - BN corresponding to an amount of wei
+ * @param {number|string} wei - BN corresponding to an amount of wei
  * @param {number} conversionRate - ETH to current currency conversion rate
  * @param {Number} decimalsToShow - Decimals to 5
  * @returns {Number} - The converted balance

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -11,6 +11,7 @@
     // "app/components/**/*",
     "app/constants/**/*",
     // "app/core/**/*",
+    "app/core/*.ts",
     "app/images/**/*",
     "app/lib/**/*",
     // "app/reducers/**/*",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

All errors in Engine.ts have been resolved. This file is frequently imported throughout the application, so fixing type errors here is essential for making progress with eliminating type errors.

A few errors were caused by dependency issues that will be resolved soon after additional dependency updates, but I made note of some cases that require further investigation and fixes.

As part of this effort, a `EngineState` type has been added as well. This will be useful in later refactors related to controller upgrades.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
