### PR TITLE
refactor: move ganache from hooks to fixtures

### DIFF
--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -121,3 +121,10 @@ export async function withFixtures(options, testSuite) {
     await stopFixtureServer();
   }
 }
+
+// SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
+export const defaultGanacheOptions = {
+  hardfork: 'london',
+  mnemonic:
+    'drive manage close raven tape average sausage pledge riot furnace august tip',
+};

--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -115,7 +115,9 @@ export async function withFixtures(options, testSuite) {
     console.error(error);
     throw error;
   } finally {
-    await ganacheServer.quit();
+    if (ganacheOptions) {
+      await ganacheServer.quit();
+    }
     await stopFixtureServer();
   }
 }

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -5,7 +5,7 @@ import SendView from '../../pages/SendView';
 import AmountView from '../../pages/AmountView';
 import TransactionConfirmationView from '../../pages/TransactionConfirmView';
 import { loginToApp } from '../../viewHelper';
-import { FixtureBuilder } from '../../fixtures/fixture-builder';
+import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
   withFixtures,
   defaultGanacheOptions,

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -19,8 +19,12 @@ describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
     mnemonic:
       'drive manage close raven tape average sausage pledge riot furnace august tip',
   };
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(170000);
+    if (device.getPlatform() === 'android') {
+      await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
+      await device.reverseTcpPort('8545');
+    }
   });
 
   it('should edit priority gas settings and send ETH', async () => {

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -5,74 +5,71 @@ import WalletView from '../../pages/WalletView';
 import SendView from '../../pages/SendView';
 import AmountView from '../../pages/AmountView';
 import TransactionConfirmationView from '../../pages/TransactionConfirmView';
-import {
-  importWalletWithRecoveryPhrase,
-  switchToGoreliNetwork,
-} from '../../viewHelper';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import { withFixtures } from '../../fixtures/fixture-helper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 
 const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
 
 describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
+  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
+  const ganacheOptions = {
+    hardfork: 'london',
+    mnemonic:
+      'drive manage close raven tape average sausage pledge riot furnace august tip',
+  };
   beforeEach(() => {
     jest.setTimeout(170000);
   });
 
-  it('should import wallet and go to send view', async () => {
-    await importWalletWithRecoveryPhrase();
-    await switchToGoreliNetwork();
-    // Check that we are on the wallet screen
-    await WalletView.isVisible();
-    //Tap send Icon
-    await TabBarComponent.tapActions();
-    await WalletActionsModal.tapSendButton();
+  it('should edit priority gas settings and send ETH', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withGanacheNetwork().build(),
+        restartDevice: true,
+        ganacheOptions,
+      },
+      async () => {
+        await loginToApp();
 
-    await SendView.inputAddress(VALID_ADDRESS);
-    await SendView.tapNextButton();
-    // Check that we are on the amount view
-    await AmountView.isVisible();
-  });
+        // Check that we are on the wallet screen
+        await WalletView.isVisible();
+        //Tap send Icon
+        await TabBarComponent.tapActions();
+        await WalletActionsModal.tapSendButton();
 
-  it('should edit priority gas settings', async () => {
-    // Input acceptable value
-    await AmountView.typeInTransactionAmount('0.00004');
-    await AmountView.tapNextButton();
+        await SendView.inputAddress(VALID_ADDRESS);
+        await SendView.tapNextButton();
+        // Check that we are on the amount view
+        await AmountView.isVisible();
 
-    // Check that we are on the confirm view
-    await TransactionConfirmationView.isVisible();
+        // Input acceptable value
+        await AmountView.typeInTransactionAmount('0.00004');
+        await AmountView.tapNextButton();
 
-    // Check that the amount is correct
-    await TransactionConfirmationView.isTransactionTotalCorrect(
-      '0.00004 GoerliETH',
+        // Check that we are on the confirm view
+        await TransactionConfirmationView.isVisible();
+
+        // Check different gas options
+        await TransactionConfirmationView.tapEstimatedGasLink();
+        await TransactionConfirmationView.isPriorityEditScreenVisible();
+        await TransactionConfirmationView.tapLowPriorityGasOption();
+        await TransactionConfirmationView.tapAdvancedOptionsPriorityGasOption();
+        await TransactionConfirmationView.tapMarketPriorityGasOption();
+        await TransactionConfirmationView.isMaxPriorityFeeCorrect('1.5');
+        await TransactionConfirmationView.tapAggressivePriorityGasOption();
+        await TransactionConfirmationView.isMaxPriorityFeeCorrect('2');
+        await TransactionConfirmationView.tapMaxPriorityFeeSaveButton();
+        await TransactionConfirmationView.isVisible();
+
+        // Tap on the send button
+        await TransactionConfirmationView.tapConfirmButton();
+
+        // Check that we are on the wallet screen
+        await WalletView.isVisible();
+      },
     );
-
-    await TransactionConfirmationView.tapEstimatedGasLink();
-
-    await TransactionConfirmationView.isPriorityEditScreenVisible();
-
-    await TransactionConfirmationView.tapLowPriorityGasOption();
-
-    await TransactionConfirmationView.tapAdvancedOptionsPriorityGasOption();
-
-    await TransactionConfirmationView.tapMarketPriorityGasOption();
-
-    await TransactionConfirmationView.isMaxPriorityFeeCorrect('1.5');
-
-    await TransactionConfirmationView.tapAggressivePriorityGasOption();
-
-    await TransactionConfirmationView.isMaxPriorityFeeCorrect('2');
-
-    await TransactionConfirmationView.tapMaxPriorityFeeSaveButton();
-
-    await TransactionConfirmationView.isVisible();
-  });
-
-  it('should send eth', async () => {
-    // Tap on the send button
-    await TransactionConfirmationView.tapConfirmButton();
-
-    // Check that we are on the wallet screen
-    await WalletView.isVisible();
   });
 });

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -29,7 +29,7 @@ describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        defaultGanacheOptions,
+        ganacheOptions: defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -5,20 +5,17 @@ import SendView from '../../pages/SendView';
 import AmountView from '../../pages/AmountView';
 import TransactionConfirmationView from '../../pages/TransactionConfirmView';
 import { loginToApp } from '../../viewHelper';
-import FixtureBuilder from '../../fixtures/fixture-builder';
-import { withFixtures } from '../../fixtures/fixture-helper';
+import { FixtureBuilder } from '../../fixtures/fixture-builder';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 
 const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
 
 describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
-  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
-  const ganacheOptions = {
-    hardfork: 'london',
-    mnemonic:
-      'drive manage close raven tape average sausage pledge riot furnace august tip',
-  };
   beforeAll(async () => {
     jest.setTimeout(170000);
     if (device.getPlatform() === 'android') {
@@ -32,7 +29,7 @@ describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        ganacheOptions,
+        defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import WalletView from '../../pages/WalletView';
 import SendView from '../../pages/SendView';
 import AmountView from '../../pages/AmountView';
@@ -61,6 +60,7 @@ describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
         await TransactionConfirmationView.isMaxPriorityFeeCorrect('1.5');
         await TransactionConfirmationView.tapAggressivePriorityGasOption();
         await TransactionConfirmationView.isMaxPriorityFeeCorrect('2');
+        await TransactionConfirmationView.tapAdvancedOptionsPriorityGasOption();
         await TransactionConfirmationView.tapMaxPriorityFeeSaveButton();
         await TransactionConfirmationView.isVisible();
 

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -29,7 +29,7 @@ describe(Regression('sendERC721 tokens test'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        defaultGanacheOptions,
+        ganacheOptions: defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -6,20 +6,16 @@ import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import { TEST_DAPP_URL, TestDApp } from '../../pages/TestDApp';
 import FixtureBuilder from '../../fixtures/fixture-builder';
-import { withFixtures } from '../../fixtures/fixture-helper';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
 import root from '../../../locales/languages/en.json';
 
 const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
 const ERC721_ADDRESS = '0x26D6C3e7aEFCE970fe3BE5d589DbAbFD30026924';
 
 describe(Regression('sendERC721 tokens test'), () => {
-  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
-  const ganacheOptions = {
-    hardfork: 'london',
-    mnemonic:
-      'drive manage close raven tape average sausage pledge riot furnace august tip',
-  };
-
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
@@ -33,7 +29,7 @@ describe(Regression('sendERC721 tokens test'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        ganacheOptions,
+        defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -2,62 +2,65 @@
 
 import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
-import {
-  importWalletWithRecoveryPhrase,
-  addLocalhostNetwork,
-} from '../../viewHelper';
+import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
-import Accounts from '../../../wdio/helpers/Accounts';
-import Ganache from '../../../app/util/test/ganache';
 import { TEST_DAPP_URL, TestDApp } from '../../pages/TestDApp';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import { withFixtures } from '../../fixtures/fixture-helper';
 import root from '../../../locales/languages/en.json';
 
 const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
-const validAccount = Accounts.getValidAccount();
 const ERC721_ADDRESS = '0x26D6C3e7aEFCE970fe3BE5d589DbAbFD30026924';
 
 describe(Regression('sendERC721 tokens test'), () => {
-  let ganacheServer;
+  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
+  const ganacheOptions = {
+    hardfork: 'london',
+    mnemonic:
+      'drive manage close raven tape average sausage pledge riot furnace august tip',
+  };
+
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
       await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
       await device.reverseTcpPort('8545');
     }
-    ganacheServer = new Ganache();
-    await ganacheServer.start({ mnemonic: validAccount.seedPhrase });
-  });
-
-  afterAll(async () => {
-    await ganacheServer.quit();
   });
 
   it('Send an ERC721 token', async () => {
-    // Setup
-    await importWalletWithRecoveryPhrase();
-    await addLocalhostNetwork();
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withGanacheNetwork().build(),
+        restartDevice: true,
+        ganacheOptions,
+      },
+      async () => {
+        await loginToApp();
 
-    // Navigate to the browser screen
-    await TabBarComponent.tapBrowser();
+        // Navigate to the browser screen
+        await TabBarComponent.tapBrowser();
 
-    // Navigate to the ERC721 url
-    await TestDApp.navigateToErc721Contract(TEST_DAPP_URL, ERC721_ADDRESS);
+        // Navigate to the ERC721 url
+        await TestDApp.navigateToErc721Contract(TEST_DAPP_URL, ERC721_ADDRESS);
 
-    // Connect account
-    await TestDApp.connect();
+        // Connect account
+        await TestDApp.connect();
 
-    // Transfer NFT
-    await TestDApp.tapTransferFromButton(ERC721_ADDRESS);
-    await TestHelpers.delay(3000);
+        // Transfer NFT
+        await TestDApp.tapTransferFromButton(ERC721_ADDRESS);
+        await TestHelpers.delay(3000);
 
-    await TestDApp.tapConfirmButton();
+        await TestDApp.tapConfirmButton();
 
-    // Navigate to the activity screen
-    await TabBarComponent.tapActivity();
+        // Navigate to the activity screen
+        await TabBarComponent.tapActivity();
 
-    // Assert collectible is sent
-    await TestHelpers.checkIfElementByTextIsVisible(
-      SENT_COLLECTIBLE_MESSAGE_TEXT,
+        // Assert collectible is sent
+        await TestHelpers.checkIfElementByTextIsVisible(
+          SENT_COLLECTIBLE_MESSAGE_TEXT,
+        );
+      },
     );
   });
 });

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -2,99 +2,95 @@
 
 import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
-
 import AmountView from '../../pages/AmountView';
 import SendView from '../../pages/SendView';
 import TransactionConfirmationView from '../../pages/TransactionConfirmView';
-import {
-  importWalletWithRecoveryPhrase,
-  addLocalhostNetwork,
-} from '../../viewHelper';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import { withFixtures } from '../../fixtures/fixture-helper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
-import Accounts from '../../../wdio/helpers/Accounts';
-import Ganache from '../../../app/util/test/ganache';
 
-const validAccount = Accounts.getValidAccount();
 const MYTH_ADDRESS = '0x1FDb169Ef12954F20A15852980e1F0C122BfC1D6';
 
 describe(Regression('Send ETH Tests'), () => {
-  let ganacheServer;
+  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
+  const ganacheOptions = {
+    hardfork: 'london',
+    mnemonic:
+      'drive manage close raven tape average sausage pledge riot furnace august tip',
+  };
+
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
       await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
       await device.reverseTcpPort('8545');
     }
-    ganacheServer = new Ganache();
-    await ganacheServer.start({ mnemonic: validAccount.seedPhrase });
   });
 
-  afterAll(async () => {
-    await ganacheServer.quit();
-  });
+  it('should send ETH to an EOA', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withGanacheNetwork().build(),
+        restartDevice: true,
+        ganacheOptions,
+      },
+      async () => {
+        await loginToApp();
 
-  it('should go to send view', async () => {
-    await importWalletWithRecoveryPhrase();
-    await addLocalhostNetwork();
-    await TestHelpers.delay(4000);
-    // Navigate to send flow
-    await TabBarComponent.tapActions();
-    await WalletActionsModal.tapSendButton();
-    // Make sure view with my accounts visible
-    await SendView.isMyAccountsVisisble();
-  });
+        await TabBarComponent.tapActions();
+        await WalletActionsModal.tapSendButton();
+        // Make sure view with my accounts visible
+        await SendView.isMyAccountsVisisble();
 
-  it('should input a valid address to send to', async () => {
-    await SendView.inputAddress(MYTH_ADDRESS);
-    await SendView.noEthWarningMessageIsVisible();
-    await SendView.tapNextButton();
-    // Check that we are on the amount view
-    await AmountView.isVisible();
-  });
+        await SendView.inputAddress(MYTH_ADDRESS);
+        await SendView.noEthWarningMessageIsVisible();
+        await SendView.tapNextButton();
+        // Check that we are on the amount view
+        await AmountView.isVisible();
 
-  it('should switch currency from crypto to fiat and back to crypto', async () => {
-    await AmountView.typeInTransactionAmount('0.004');
-    await TestHelpers.delay(2500);
+        await AmountView.typeInTransactionAmount('0.004');
+        await TestHelpers.delay(2500);
 
-    await AmountView.tapCurrencySwitch();
-    await TestHelpers.delay(2500); // android is running a bit quicker and it is having a hard time asserting that the text is visible.
-    await AmountView.isTransactionAmountConversionValueCorrect('0.004 ETH');
-    await TestHelpers.delay(4000);
-    await AmountView.tapCurrencySwitch();
-    await TestHelpers.delay(2500);
+        await AmountView.tapCurrencySwitch();
+        await TestHelpers.delay(2500); // android is running a bit quicker and it is having a hard time asserting that the text is visible.
+        await AmountView.isTransactionAmountConversionValueCorrect('0.004 ETH');
+        await TestHelpers.delay(4000);
+        await AmountView.tapCurrencySwitch();
+        await TestHelpers.delay(2500);
 
-    await AmountView.isTransactionAmountCorrect('0.004');
-  });
+        await AmountView.isTransactionAmountCorrect('0.004');
 
-  it('should input and validate amount', async () => {
-    // Type in a non numeric value
-    await AmountView.typeInTransactionAmount('0xA');
-    // Click next and check that error is shown
-    await TestHelpers.delay(3000);
-    await AmountView.tapNextButton();
-    await AmountView.isAmountErrorVisible();
-    // Type in a negative value
-    await AmountView.typeInTransactionAmount('-10');
-    // Click next and check that error is shown
-    await AmountView.tapNextButton();
-    await AmountView.isAmountErrorVisible();
-    // Input acceptable value
-    await AmountView.typeInTransactionAmount('0.00001');
-    await AmountView.tapNextButton();
+        // Type in a non numeric value
+        await AmountView.typeInTransactionAmount('0xA');
+        // Click next and check that error is shown
+        await TestHelpers.delay(3000);
+        await AmountView.tapNextButton();
+        await AmountView.isAmountErrorVisible();
+        // Type in a negative value
+        await AmountView.typeInTransactionAmount('-10');
+        // Click next and check that error is shown
+        await AmountView.tapNextButton();
+        await AmountView.isAmountErrorVisible();
+        // Input acceptable value
+        await AmountView.typeInTransactionAmount('0.00001');
+        await AmountView.tapNextButton();
 
-    // Check that we are on the confirm view
-    await TransactionConfirmationView.isVisible();
-  });
+        // Check that we are on the confirm view
+        await TransactionConfirmationView.isVisible();
 
-  it('should send ETH to Account 2', async () => {
-    await TestHelpers.delay(2000);
+        await TestHelpers.delay(2000);
 
-    // Check that the amount is correct
-    await TransactionConfirmationView.isTransactionTotalCorrect('0.00001 ETH');
-    // Tap on the Send CTA
-    await TransactionConfirmationView.tapConfirmButton();
-    // Check that we are on the wallet screen
-    //await WalletView.isVisible();
+        // Check that the amount is correct
+        await TransactionConfirmationView.isTransactionTotalCorrect(
+          '0.00001 ETH',
+        );
+        // Tap on the Send CTA
+        await TransactionConfirmationView.tapConfirmButton();
+        // Check that we are on the wallet screen
+        //await WalletView.isVisible();
+      },
+    );
   });
 });

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -7,20 +7,16 @@ import SendView from '../../pages/SendView';
 import TransactionConfirmationView from '../../pages/TransactionConfirmView';
 import { loginToApp } from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
-import { withFixtures } from '../../fixtures/fixture-helper';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 
 const MYTH_ADDRESS = '0x1FDb169Ef12954F20A15852980e1F0C122BfC1D6';
 
 describe(Regression('Send ETH Tests'), () => {
-  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
-  const ganacheOptions = {
-    hardfork: 'london',
-    mnemonic:
-      'drive manage close raven tape average sausage pledge riot furnace august tip',
-  };
-
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
@@ -34,7 +30,7 @@ describe(Regression('Send ETH Tests'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        ganacheOptions,
+        defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -30,7 +30,7 @@ describe(Regression('Send ETH Tests'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        defaultGanacheOptions,
+        ganacheOptions: defaultGanacheOptions,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -9,25 +9,22 @@ import TransactionConfirmationView from '../../pages/TransactionConfirmView';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
-import Ganache from '../../../app/util/test/ganache';
-import GanacheSeeder from '../../../app/util/test/ganache-seeder';
 import root from '../../../locales/languages/en.json';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import { withFixtures } from '../../fixtures/fixture-helper';
-
-// SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
-const seedPhrase =
-  'drive manage close raven tape average sausage pledge riot furnace august tip';
-
-const MULTISIG = 'multisig';
-const AMOUNT_TO_SEND = '0.12345';
-const TOKEN_NAME = root.unit.eth;
+import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(Regression('Send ETH to Multisig'), () => {
-  let ganacheServer;
-  let ganacheSeeder;
-  let contractRegistry;
-  let multisig;
+  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
+  const ganacheOptions = {
+    hardfork: 'london',
+    mnemonic:
+      'drive manage close raven tape average sausage pledge riot furnace august tip',
+  };
+  const smartContract = SMART_CONTRACTS.MULTISIG;
+
+  const AMOUNT_TO_SEND = '0.12345';
+  const TOKEN_NAME = root.unit.eth;
 
   beforeAll(async () => {
     jest.setTimeout(2500000);
@@ -35,38 +32,38 @@ describe(Regression('Send ETH to Multisig'), () => {
       await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
       await device.reverseTcpPort('8545');
     }
-    ganacheServer = new Ganache();
-    await ganacheServer.start({ mnemonic: seedPhrase });
-    ganacheSeeder = new GanacheSeeder(ganacheServer.getProvider());
-    await ganacheSeeder.deploySmartContract(MULTISIG);
-    contractRegistry = ganacheSeeder.getContractRegistry();
-    multisig = contractRegistry.getContractAddress(MULTISIG);
-  });
-
-  afterAll(async () => {
-    await ganacheServer.quit();
   });
 
   it('Send ETH to a Multisig address from inside MetaMask wallet', async () => {
-    const fixture = new FixtureBuilder().withGanacheNetwork().build();
-    await withFixtures({ fixture, restartDevice: true }, async () => {
-      await loginToApp();
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withGanacheNetwork().build(),
+        restartDevice: true,
+        ganacheOptions,
+        smartContract,
+      },
+      async ({ contractRegistry }) => {
+        const multisig = await contractRegistry.getContractAddress(
+          smartContract,
+        );
+        await loginToApp();
 
-      await TabBarComponent.tapActions();
-      await WalletActionsModal.tapSendButton();
+        await TabBarComponent.tapActions();
+        await WalletActionsModal.tapSendButton();
 
-      await SendView.inputAddress(multisig);
-      await SendView.tapNextButton();
+        await SendView.inputAddress(multisig);
+        await SendView.tapNextButton();
 
-      await AmountView.typeInTransactionAmount(AMOUNT_TO_SEND);
-      await AmountView.tapNextButton();
+        await AmountView.typeInTransactionAmount(AMOUNT_TO_SEND);
+        await AmountView.tapNextButton();
 
-      await TransactionConfirmationView.tapConfirmButton();
-      await TabBarComponent.tapActivity();
+        await TransactionConfirmationView.tapConfirmButton();
+        await TabBarComponent.tapActivity();
 
-      await TestHelpers.checkIfElementByTextIsVisible(
-        `${AMOUNT_TO_SEND} ${TOKEN_NAME}`,
-      );
-    });
+        await TestHelpers.checkIfElementByTextIsVisible(
+          `${AMOUNT_TO_SEND} ${TOKEN_NAME}`,
+        );
+      },
+    );
   });
 });

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -18,7 +18,7 @@ import {
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(Regression('Send ETH to Multisig'), () => {
-  const smartContract = SMART_CONTRACTS.MULTISIG;
+  const multisig = SMART_CONTRACTS.MULTISIG;
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;
 
@@ -35,8 +35,8 @@ describe(Regression('Send ETH to Multisig'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        defaultGanacheOptions,
-        smartContract,
+        ganacheOptions: defaultGanacheOptions,
+        smartContract: multisig,
       },
       async ({ contractRegistry }) => {
         const multisig = await contractRegistry.getContractAddress(

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -18,7 +18,7 @@ import {
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(Regression('Send ETH to Multisig'), () => {
-  const multisig = SMART_CONTRACTS.MULTISIG;
+  const MULTISIG_CONTRACT = SMART_CONTRACTS.MULTISIG;
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;
 
@@ -36,18 +36,18 @@ describe(Regression('Send ETH to Multisig'), () => {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        smartContract: multisig,
+        smartContract: MULTISIG_CONTRACT,
       },
       async ({ contractRegistry }) => {
-        const multisig = await contractRegistry.getContractAddress(
-          smartContract,
+        const multisigAddress = await contractRegistry.getContractAddress(
+          MULTISIG_CONTRACT,
         );
         await loginToApp();
 
         await TabBarComponent.tapActions();
         await WalletActionsModal.tapSendButton();
 
-        await SendView.inputAddress(multisig);
+        await SendView.inputAddress(multisigAddress);
         await SendView.tapNextButton();
 
         await AmountView.typeInTransactionAmount(AMOUNT_TO_SEND);

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -11,18 +11,14 @@ import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 import root from '../../../locales/languages/en.json';
 import FixtureBuilder from '../../fixtures/fixture-builder';
-import { withFixtures } from '../../fixtures/fixture-helper';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(Regression('Send ETH to Multisig'), () => {
-  // SRP corresponding to the vault set in the default fixtures - it's an empty test account, not secret
-  const ganacheOptions = {
-    hardfork: 'london',
-    mnemonic:
-      'drive manage close raven tape average sausage pledge riot furnace august tip',
-  };
   const smartContract = SMART_CONTRACTS.MULTISIG;
-
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;
 
@@ -39,7 +35,7 @@ describe(Regression('Send ETH to Multisig'), () => {
       {
         fixture: new FixtureBuilder().withGanacheNetwork().build(),
         restartDevice: true,
-        ganacheOptions,
+        defaultGanacheOptions,
         smartContract,
       },
       async ({ contractRegistry }) => {


### PR DESCRIPTION
## Description
- This PR moves the ganache server and contract seeder inside fixtures, instead of previously having it in `beforeAll` hooks. This cleans up the tests, as well as help us reach code parity with Extension repo
- This PR adds the `login` fixture and `withGanache` fixture in all Confirmations test, except the signatures one (since it would need a big refactor of all tests, so it will be done in a sub-sequent PR)

## Result
- All confirmations tests continue to pass
- All confirmations tests start with the wallet setup, skipping the onboarding
- All confirmations tests start with ganache running and selected network, as well as the account seeded with ETH and using the `london` hardfork (EIP1559 gas)

## Screenshots/Recordings
- Bitrise run https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/5eb7c3b2-4f15-46f8-bdf0-56397884b445

![Screenshot from 2023-09-04 14-33-36](https://github.com/MetaMask/metamask-mobile/assets/54408225/fbb84978-6daf-44bf-a4f0-9ba9987f3e9f)

![Screenshot from 2023-09-04 14-38-20](https://github.com/MetaMask/metamask-mobile/assets/54408225/d085dd91-07a8-42ac-ac40-843090d55db6)

![Screenshot from 2023-09-04 14-41-27](https://github.com/MetaMask/metamask-mobile/assets/54408225/2f706026-ccec-4056-af92-74b40c1d64fb)

![Screenshot from 2023-09-04 15-21-44](https://github.com/MetaMask/metamask-mobile/assets/54408225/15854d64-6973-4ac4-9603-f394bbdf8464)


## Issue

fixes https://github.com/MetaMask/MetaMask-planning/issues/1206

This also closes:
- https://github.com/MetaMask/mobile-planning/issues/931
- https://github.com/MetaMask/mobile-planning/issues/932

## Checklist

* [X] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented
