### PR TITLE
fix: Signature events rename values.

### DIFF
--- a/app/components/UI/MessageSign/MessageSign.tsx
+++ b/app/components/UI/MessageSign/MessageSign.tsx
@@ -106,12 +106,12 @@ class MessageSign extends PureComponent<MessageSignProps, MessageSignState> {
 
   rejectSignature = async () => {
     const { messageParams, onReject } = this.props;
-    await handleSignatureAction(onReject, messageParams, 'eth', false);
+    await handleSignatureAction(onReject, messageParams, 'eth_sign', false);
   };
 
   confirmSignature = async () => {
     const { messageParams, onConfirm } = this.props;
-    await handleSignatureAction(onConfirm, messageParams, 'eth', true);
+    await handleSignatureAction(onConfirm, messageParams, 'eth_sign', true);
   };
 
   getStyles = () => {

--- a/app/components/UI/PersonalSign/PersonalSign.tsx
+++ b/app/components/UI/PersonalSign/PersonalSign.tsx
@@ -41,7 +41,7 @@ const PersonalSign = ({
     account_type?: string;
     dapp_host_name?: string;
     chain_id?: string;
-    sign_type?: string;
+    signature_type?: string;
     [key: string]: string | undefined;
   }
 
@@ -54,7 +54,7 @@ const PersonalSign = ({
         account_type: getAddressAccountType(messageParams.from),
         dapp_host_name: url?.host,
         chain_id: chainId,
-        sign_type: 'personal',
+        signature_type: 'personal_sign',
         ...currentPageInformation?.analytics,
       };
     } catch (error) {

--- a/app/components/UI/TypedSign/index.js
+++ b/app/components/UI/TypedSign/index.js
@@ -18,6 +18,7 @@ import {
   handleSignatureAction,
   removeSignatureErrorListener,
   showWalletConnectNotification,
+  typedSign,
 } from '../../../util/confirmation/signatureUtils';
 
 const createStyles = (colors) =>
@@ -114,12 +115,22 @@ class TypedSign extends PureComponent {
 
   rejectSignature = async () => {
     const { messageParams, onReject } = this.props;
-    await handleSignatureAction(onReject, messageParams, 'typed', false);
+    await handleSignatureAction(
+      onReject,
+      messageParams,
+      typedSign[messageParams.version],
+      false,
+    );
   };
 
   confirmSignature = async () => {
     const { messageParams, onConfirm } = this.props;
-    await handleSignatureAction(onConfirm, messageParams, 'typed', true);
+    await handleSignatureAction(
+      onConfirm,
+      messageParams,
+      typedSign[messageParams.version],
+      true,
+    );
   };
 
   shouldTruncateMessage = (e) => {

--- a/app/util/confirmation/signatureUtils.js
+++ b/app/util/confirmation/signatureUtils.js
@@ -10,6 +10,12 @@ import { strings } from '../../../locales/i18n';
 import { selectChainId } from '../../selectors/networkController';
 import { store } from '../../store';
 
+export const typedSign = {
+  V1: 'eth_signTypedData',
+  V3: 'eth_signTypedData_v3',
+  V4: 'eth_signTypedData_v4',
+};
+
 export const getAnalyticsParams = (messageParams, signType) => {
   try {
     const { currentPageInformation } = messageParams;
@@ -19,7 +25,7 @@ export const getAnalyticsParams = (messageParams, signType) => {
       account_type: getAddressAccountType(messageParams.from),
       dapp_host_name: url?.host,
       chain_id: chainId,
-      sign_type: signType,
+      signature_type: signType,
       version: messageParams?.version,
       ...currentPageInformation?.analytics,
     };


### PR DESCRIPTION
**Description**

We want to bring mobile and extension metrics closer to parity. This task is to make the signature event property `signature_type` and it's values  the same on both platforms.

**Task**

- [x] Rename `sign_type` property to `signature_type`
- [x] Rename `personal` value to `personal_sign`
- [x] Rename `typed` value to `eth_signTypedData`, `eth_signTypedData_v3` or `eth_signTypedData_v4` according with the specific method being used
- [x] Rename `eth` value to `eth_sign`

**Issue**

Fixes: [1127](https://github.com/MetaMask/MetaMask-planning/issues/1127)

### References
1. Signature events documentation in the segment schema repo: https://github.com/ConsenSys/segment-schema/tree/main/libraries/events/metamask-transactions

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented