### PR TITLE
refactor: Use selectors for core network state access

### DIFF
--- a/app/components/UI/PersonalSign/PersonalSign.tsx
+++ b/app/components/UI/PersonalSign/PersonalSign.tsx
@@ -17,6 +17,8 @@ import { PersonalSignProps } from './types';
 import { useNavigation } from '@react-navigation/native';
 import createStyles from './styles';
 import AppConstants from '../../../core/AppConstants';
+import { selectChainId } from '../../../selectors/networkController';
+import { store } from '../../../store';
 
 /**
  * Component that supports personal_sign
@@ -45,8 +47,7 @@ const PersonalSign = ({
 
   const getAnalyticsParams = useCallback((): AnalyticsParams => {
     try {
-      const { NetworkController }: any = Engine.context;
-      const { chainId } = NetworkController?.state?.providerConfig || {};
+      const chainId = selectChainId(store.getState());
       const url = new URL(currentPageInformation?.url);
 
       return {

--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -17,6 +17,12 @@ import { createEngineStream } from 'json-rpc-middleware-stream';
 import RemotePort from './RemotePort';
 import WalletConnectPort from './WalletConnectPort';
 import Port from './Port';
+import {
+  selectChainId,
+  selectNetwork,
+  selectProviderConfig,
+} from '../../selectors/networkController';
+import { store } from '../../store';
 
 const createFilterMiddleware = require('eth-json-rpc-filters');
 const createSubscriptionManager = require('eth-json-rpc-filters/subscriptionManager');
@@ -65,9 +71,8 @@ export class BackgroundBridge extends EventEmitter {
 
     this.engine = null;
 
-    this.chainIdSent =
-      Engine.context.NetworkController.state.providerConfig.chainId;
-    this.networkVersionSent = Engine.context.NetworkController.state.network;
+    this.chainIdSent = selectChainId(store.getState());
+    this.networkVersionSent = selectNetwork(store.getState());
 
     // This will only be used for WalletConnect for now
     this.addressSent =
@@ -152,7 +157,7 @@ export class BackgroundBridge extends EventEmitter {
   }
 
   getProviderNetworkState({ network }) {
-    const { providerConfig } = Engine.context.NetworkController.state;
+    const providerConfig = selectProviderConfig(store.getState());
     const networkType = providerConfig.type;
 
     const isInitialNetwork =

--- a/app/core/BackgroundBridge/WalletConnectPort.ts
+++ b/app/core/BackgroundBridge/WalletConnectPort.ts
@@ -1,5 +1,7 @@
 import Engine from '../Engine';
 import AppConstants from '../AppConstants';
+import { selectChainId } from '../../selectors/networkController';
+import { store } from '../../store';
 
 // eslint-disable-next-line import/no-nodejs-modules, import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const EventEmitter = require('events').EventEmitter;
@@ -23,10 +25,7 @@ class WalletConnectPort extends EventEmitter {
           accounts: [selectedAddress],
         });
       } else if (msg?.data?.method === NOTIFICATION_NAMES.accountsChanged) {
-        const chainId =
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          Engine.context.NetworkController.state.providerConfig.chainId;
+        const chainId = selectChainId(store.getState());
         this._wcRequestActions?.updateSession?.({
           chainId: parseInt(chainId, 10),
           accounts: msg.data.params,

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -16,6 +16,8 @@ import {
 import { RPC } from '../constants/network';
 import { safeToChecksumAddress } from '../util/address';
 import ReviewManager from './ReviewManager';
+import { selectProviderType } from '../selectors/networkController';
+import { store } from '../store';
 
 const constructTitleAndMessage = (data) => {
   let title, message;
@@ -401,10 +403,9 @@ class NotificationManager {
       AccountTrackerController,
       TransactionController,
       PreferencesController,
-      NetworkController,
     } = Engine.context;
     const { selectedAddress } = PreferencesController.state;
-    const { type: networkType } = NetworkController.state.providerConfig;
+    const networkType = selectProviderType(store.getState());
 
     /// Find the incoming TX
     const { transactions } = TransactionController.state;

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -53,6 +53,7 @@ jest.mock('../../store', () => ({
     getState: jest.fn(),
   },
 }));
+
 const mockStore = store as { getState: jest.Mock };
 
 jest.mock('../Permissions', () => ({
@@ -210,13 +211,21 @@ function setupGlobalState({
   providerConfig?: ProviderConfig;
   selectedAddress?: string;
 }) {
-  if (activeTab) {
-    mockStore.getState.mockImplementation(() => ({
-      browser: {
-        activeTab,
+  mockStore.getState.mockImplementation(() => ({
+    browser: activeTab
+      ? {
+          activeTab,
+        }
+      : {},
+    engine: {
+      backgroundState: {
+        NetworkController: {
+          providerConfig: providerConfig || {},
+        },
+        PreferencesController: selectedAddress ? { selectedAddress } : {},
       },
-    }));
-  }
+    },
+  }));
   if (addTransactionResult) {
     MockEngine.context.TransactionController.addTransaction.mockImplementation(
       async () => ({ result: addTransactionResult }),
@@ -226,9 +235,6 @@ function setupGlobalState({
     mockGetPermittedAccounts.mockImplementation(
       (hostname) => permittedAccounts[hostname] || [],
     );
-  }
-  if (providerConfig) {
-    MockEngine.context.NetworkController.state.providerConfig = providerConfig;
   }
   if (selectedAddress) {
     MockEngine.context.PreferencesController.state.selectedAddress =

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -31,6 +31,12 @@ import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants';
 import { isSmartContractAddress } from '../../util/transactions';
 import { TOKEN_NOT_SUPPORTED_FOR_NETWORK } from '../../constants/error';
+import {
+  selectChainId,
+  selectProviderConfig,
+  selectProviderType,
+} from '../../selectors/networkController';
+
 const Engine = ImportedEngine as any;
 
 let appVersion = '';
@@ -111,7 +117,7 @@ export const checkActiveAccountAndChainId = async ({
   }
 
   if (chainId) {
-    const { providerConfig } = Engine.context.NetworkController.state;
+    const providerConfig = selectProviderConfig(store.getState());
     const networkType = providerConfig.type as NetworkType;
     const isInitialNetwork =
       networkType && getAllNetworks().includes(networkType);
@@ -367,7 +373,7 @@ export const getRpcMethodMiddleware = ({
         );
       },
       eth_chainId: async () => {
-        const { providerConfig } = Engine.context.NetworkController.state;
+        const providerConfig = selectProviderConfig(store.getState());
         const networkType = providerConfig.type as NetworkType;
         const isInitialNetwork =
           networkType && getAllNetworks().includes(networkType);
@@ -394,9 +400,7 @@ export const getRpcMethodMiddleware = ({
         res.result = true;
       },
       net_version: async () => {
-        const {
-          providerConfig: { type: networkType },
-        } = Engine.context.NetworkController.state;
+        const networkType = selectProviderType(store.getState());
 
         const isInitialNetwork =
           networkType && getAllNetworks().includes(networkType);
@@ -715,8 +719,8 @@ export const getRpcMethodMiddleware = ({
             type,
           },
         } = req;
-        const { TokensController, NetworkController } = Engine.context;
-        const { chainId } = NetworkController.state?.providerConfig || {};
+        const { TokensController } = Engine.context;
+        const chainId = selectChainId(store.getState());
 
         checkTabActive();
 

--- a/app/core/RPCMethods/wallet_addEthereumChain.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.js
@@ -11,6 +11,11 @@ import {
 import URL from 'url-parse';
 import { MetaMetricsEvents } from '../../core/Analytics';
 import AnalyticsV2 from '../../util/analyticsV2';
+import {
+  selectChainId,
+  selectNetworkConfigurations,
+} from '../../selectors/networkController';
+import { store } from '../../store';
 
 const waitForInteraction = async () =>
   new Promise((resolve) => {
@@ -114,7 +119,7 @@ const wallet_addEthereumChain = async ({
     );
   }
 
-  const networkConfigurations = NetworkController.state.networkConfigurations;
+  const networkConfigurations = selectNetworkConfigurations(store.getState());
   const existingEntry = Object.entries(networkConfigurations).find(
     ([, networkConfiguration]) =>
       networkConfiguration.chainId === chainIdDecimal,
@@ -122,7 +127,7 @@ const wallet_addEthereumChain = async ({
 
   if (existingEntry) {
     const [networkConfigurationId, networkConfiguration] = existingEntry;
-    const currentChainId = NetworkController.state.providerConfig.chainId;
+    const currentChainId = selectChainId(store.getState());
     if (currentChainId === chainIdDecimal) {
       res.result = null;
       return;

--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -32,6 +32,23 @@ jest.mock('../Engine', () => ({
   },
 }));
 
+jest.mock('../../store', () => ({
+  store: {
+    getState: jest.fn(() => ({
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurations: {},
+            providerConfig: {
+              chainId: '1',
+            },
+          },
+        },
+      },
+    })),
+  },
+}));
+
 describe('RPC Method - wallet_addEthereumChain', () => {
   let mockFetch;
   let otherOptions;

--- a/app/core/RPCMethods/wallet_switchEthereumChain.js
+++ b/app/core/RPCMethods/wallet_switchEthereumChain.js
@@ -7,6 +7,11 @@ import {
 } from '../../util/networks';
 import { MetaMetricsEvents } from '../../core/Analytics';
 import AnalyticsV2 from '../../util/analyticsV2';
+import {
+  selectChainId,
+  selectNetworkConfigurations,
+} from '../../selectors/networkController';
+import { store } from '../../store';
 
 const wallet_switchEthereumChain = async ({
   req,
@@ -54,14 +59,14 @@ const wallet_switchEthereumChain = async ({
 
   const chainIdDecimal = parseInt(_chainId, 16).toString(10);
 
-  const networkConfigurations = NetworkController.state.networkConfigurations;
+  const networkConfigurations = selectNetworkConfigurations(store.getState());
   const existingNetworkDefault = getDefaultNetworkByChainId(chainIdDecimal);
   const existingEntry = Object.entries(networkConfigurations).find(
     ([, networkConfiguration]) =>
       networkConfiguration.chainId === chainIdDecimal,
   );
   if (existingEntry || existingNetworkDefault) {
-    const currentChainId = NetworkController.state.providerConfig.chainId;
+    const currentChainId = selectChainId(store.getState());
     if (currentChainId === chainIdDecimal) {
       res.result = null;
       return;

--- a/app/core/WalletConnect/WalletConnect.js
+++ b/app/core/WalletConnect/WalletConnect.js
@@ -24,6 +24,7 @@ import NotificationManager from '../NotificationManager';
 import { msBetweenDates, msToHours } from '../../util/date';
 import URL from 'url-parse';
 import parseWalletConnectUri from './wc-utils';
+import { selectChainId } from '../../selectors/networkController';
 
 const hub = new EventEmitter();
 let connectors = [];
@@ -282,8 +283,9 @@ class WalletConnect {
   };
 
   startSession = async (sessionData, existing) => {
-    const chainId =
-      Engine.context.NetworkController.state.providerConfig.chainId;
+    const chainId = selectChainId({
+      engine: { backgroundState: Engine.context },
+    });
     const selectedAddress =
       Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
     const approveData = {

--- a/app/core/WalletConnect/WalletConnect.js
+++ b/app/core/WalletConnect/WalletConnect.js
@@ -24,6 +24,7 @@ import NotificationManager from '../NotificationManager';
 import { msBetweenDates, msToHours } from '../../util/date';
 import URL from 'url-parse';
 import parseWalletConnectUri from './wc-utils';
+import { store } from '../../store';
 import { selectChainId } from '../../selectors/networkController';
 
 const hub = new EventEmitter();
@@ -283,9 +284,7 @@ class WalletConnect {
   };
 
   startSession = async (sessionData, existing) => {
-    const chainId = selectChainId({
-      engine: { backgroundState: Engine.context },
-    });
+    const chainId = selectChainId(store.getState());
     const selectedAddress =
       Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
     const approveData = {

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -10,7 +10,6 @@ import { KeyringController } from '@metamask/keyring-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import Logger from '../../util/Logger';
 
-import { NetworkController } from '@metamask/network-controller';
 import {
   TransactionController,
   WalletDevice,
@@ -33,6 +32,8 @@ import METHODS_TO_REDIRECT from './wc-config';
 import parseWalletConnectUri, {
   waitForNetworkModalOnboarding,
 } from './wc-utils';
+import { selectChainId } from '../../selectors/networkController';
+import { store } from '../../store';
 
 const { PROJECT_ID } = AppConstants.WALLET_CONNECT;
 export const isWC2Enabled =
@@ -261,11 +262,8 @@ class WalletConnect2Session {
       methodParams,
     );
 
-    const networkController = (
-      Engine.context as { NetworkController: NetworkController }
-    ).NetworkController;
     // TODO: Misleading variable name, this is not the chain ID. This should be updated to use the chain ID.
-    const selectedChainId = parseInt(networkController.state.network);
+    const selectedChainId = parseInt(selectChainId(store.getState()));
 
     if (selectedChainId !== chainId) {
       await this.web3Wallet.rejectRequest({
@@ -359,12 +357,9 @@ export class WC2Manager {
       Engine.context as { PreferencesController: PreferencesController }
     ).PreferencesController;
 
-    const networkController = (
-      Engine.context as { NetworkController: NetworkController }
-    ).NetworkController;
     const selectedAddress = preferencesController.state.selectedAddress;
     // TODO: Misleading variable name, this is not the chain ID. This should be updated to use the chain ID.
-    const chainId = networkController.state.network;
+    const chainId = selectChainId(store.getState());
 
     Object.keys(sessions).forEach(async (sessionKey) => {
       try {
@@ -584,12 +579,9 @@ export class WC2Manager {
         Engine.context as { PreferencesController: PreferencesController }
       ).PreferencesController;
 
-      const networkController = (
-        Engine.context as { NetworkController: NetworkController }
-      ).NetworkController;
       const selectedAddress = preferencesController.state.selectedAddress;
       // TODO: Misleading variable name, this is not the chain ID. This should be updated to use the chain ID.
-      const chainId = networkController.state.network;
+      const chainId = selectChainId(store.getState());
 
       const activeSession = await this.web3Wallet.approveSession({
         id: proposal.id,

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -30,6 +30,8 @@ import {
 } from '../../../app/constants/error';
 import { PROTOCOLS } from '../../constants/deeplinks';
 import TransactionTypes from '../../core/TransactionTypes';
+import { selectNetwork } from '../../selectors/networkController';
+import { store } from '../../store';
 
 const {
   ASSET: { ERC721, ERC1155 },
@@ -108,8 +110,7 @@ export function renderSlightlyLongAddress(
  * @returns {String} - String corresponding to account name. If there is no name, returns the original short format address
  */
 export function renderAccountName(address, identities) {
-  const { NetworkController } = Engine.context;
-  const networkId = NetworkController.state.network;
+  const networkId = selectNetwork(store.getState());
   address = safeToChecksumAddress(address);
   if (identities && address && address in identities) {
     const identityName = identities[address].name;

--- a/app/util/confirmation/signatureUtils.js
+++ b/app/util/confirmation/signatureUtils.js
@@ -7,12 +7,13 @@ import { WALLET_CONNECT_ORIGIN } from '../walletconnect';
 import AppConstants from '../../core/AppConstants';
 import { InteractionManager } from 'react-native';
 import { strings } from '../../../locales/i18n';
+import { selectChainId } from '../../selectors/networkController';
+import { store } from '../../store';
 
 export const getAnalyticsParams = (messageParams, signType) => {
   try {
     const { currentPageInformation } = messageParams;
-    const { NetworkController } = Engine.context;
-    const { chainId } = NetworkController?.state?.providerConfig || {};
+    const chainId = selectChainId(store.getState());
     const url = new URL(currentPageInformation?.url);
     return {
       account_type: getAddressAccountType(messageParams.from),

--- a/app/util/networks/handleNetworkSwitch.test.ts
+++ b/app/util/networks/handleNetworkSwitch.test.ts
@@ -1,8 +1,10 @@
 import Engine from '../../core/Engine';
 import { NETWORKS_CHAIN_ID, SEPOLIA } from '../../constants/network';
+import { store } from '../../store';
 import handleNetworkSwitch from './handleNetworkSwitch';
 
 const mockEngine = Engine;
+const mockStore = jest.mocked(store);
 
 jest.mock('../../core/Engine', () => ({
   context: {
@@ -12,28 +14,47 @@ jest.mock('../../core/Engine', () => ({
     NetworkController: {
       setActiveNetwork: jest.fn(),
       setProviderType: jest.fn(),
-      state: {
-        network: 'loading',
-        isCustomNetwork: false,
-        networkConfigurations: {
-          networkId1: {
-            rpcUrl: 'custom-testnet-rpc-url',
-            chainId: '1338',
-            ticker: 'TEST',
-            nickname: 'Testnet',
-          },
-        },
-        providerConfig: {
-          type: 'mainnet',
-          chainId: '1',
-        },
-        networkDetails: {
-          isEIP1559Compatible: false,
-        },
-      },
     },
   },
 }));
+
+jest.mock('../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
+}));
+
+function setupGetStateMock() {
+  mockStore.getState.mockImplementation(
+    () =>
+      ({
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              network: 'loading',
+              isCustomNetwork: false,
+              networkConfigurations: {
+                networkId1: {
+                  rpcUrl: 'custom-testnet-rpc-url',
+                  chainId: '1338',
+                  ticker: 'TEST',
+                  nickname: 'Testnet',
+                },
+              },
+              providerConfig: {
+                type: 'mainnet',
+                chainId: '1',
+              },
+              networkDetails: {
+                isEIP1559Compatible: false,
+              },
+            },
+          },
+        },
+        // Cast to 'any' because we don't have a complete Redux mock to use
+      } as any),
+  );
+}
 
 describe('useHandleNetworkSwitch', () => {
   afterEach(() => {
@@ -42,6 +63,8 @@ describe('useHandleNetworkSwitch', () => {
   });
 
   it('does nothing if not given a chain ID', () => {
+    setupGetStateMock();
+
     const result = handleNetworkSwitch('');
 
     expect(
@@ -57,6 +80,8 @@ describe('useHandleNetworkSwitch', () => {
   });
 
   it('does nothing if the chain ID matches the current global chain ID', () => {
+    setupGetStateMock();
+
     const result = handleNetworkSwitch('1');
 
     expect(
@@ -72,12 +97,16 @@ describe('useHandleNetworkSwitch', () => {
   });
 
   it('throws an error if the chain ID is not recognized', () => {
+    setupGetStateMock();
+
     expect(() => handleNetworkSwitch('123456')).toThrow(
       'Unknown network with id 123456',
     );
   });
 
   it('switches to a custom network', () => {
+    setupGetStateMock();
+
     const nickname = handleNetworkSwitch('1338');
 
     expect(
@@ -93,6 +122,8 @@ describe('useHandleNetworkSwitch', () => {
   });
 
   it('switches to a built-in network', () => {
+    setupGetStateMock();
+
     const networkType = handleNetworkSwitch(NETWORKS_CHAIN_ID.SEPOLIA);
 
     // TODO: This is a bug, it should be set to SepoliaETH

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -3,6 +3,11 @@ import { NetworkType } from '@metamask/controller-utils';
 import { NetworkController } from '@metamask/network-controller';
 import { getNetworkTypeById } from './index';
 import Engine from '../../core/Engine';
+import {
+  selectChainId,
+  selectNetworkConfigurations,
+} from '../../selectors/networkController';
+import { store } from '../../store';
 
 /**
  * Switch to the given chain ID.
@@ -21,17 +26,17 @@ const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
     .CurrencyRateController as CurrencyRateController;
   const networkController = Engine.context
     .NetworkController as NetworkController;
+  const chainId = selectChainId(store.getState());
+  const networkConfigurations = selectNetworkConfigurations(store.getState());
 
   // If current network is the same as the one we want to switch to, do nothing
-  if (
-    networkController.state.providerConfig.chainId === String(switchToChainId)
-  ) {
+  if (chainId === String(switchToChainId)) {
     return;
   }
 
-  const entry = Object.entries(
-    networkController.state.networkConfigurations,
-  ).find(([, { chainId: configChainId }]) => configChainId === switchToChainId);
+  const entry = Object.entries(networkConfigurations).find(
+    ([, { chainId: configChainId }]) => configChainId === switchToChainId,
+  );
 
   if (entry) {
     const [networkConfigurationId, networkConfiguration] = entry;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

Replace direct references to NetworkController state with selectors. Most of these examples were skipped in previous selector refactors because they were outside of a React context, so there was no established way to get the Redux state as input for the selector. We can now do that by importing the Redux store directly and calling `getState`.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
