### PR TITLE
fix: ledger label display incorrect style

### DIFF
--- a/app/components/Views/SendFlow/AddressElement/AddressElement.styles.ts
+++ b/app/components/Views/SendFlow/AddressElement/AddressElement.styles.ts
@@ -32,6 +32,11 @@ const styleSheet = (colors: Colors) =>
       borderColor: colors.border.default,
       fontSize: 10,
     },
+    accountNameLabel: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
+++ b/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
@@ -66,18 +66,20 @@ const AddressElement: React.FC<AddressElementProps> = ({
         <Identicon address={address} diameter={28} />
       </View>
       <View style={styles.addressElementInformation}>
-        <Text
-          variant={TextVariant.BodyMD}
-          style={styles.addressTextNickname}
-          numberOfLines={1}
-        >
-          {primaryLabel}
-        </Text>
-        {importedOrHardwareLabel && (
-          <Text style={styles.accountNameLabelText}>
-            {strings(importedOrHardwareLabel)}
+        <View style={styles.accountNameLabel}>
+          <Text
+            variant={TextVariant.BodyMD}
+            style={styles.addressTextNickname}
+            numberOfLines={1}
+          >
+            {primaryLabel}
           </Text>
-        )}
+          {importedOrHardwareLabel && (
+            <Text style={styles.accountNameLabelText}>
+              {strings(importedOrHardwareLabel)}
+            </Text>
+          )}
+        </View>
         {!!secondaryLabel && (
           <Text
             variant={TextVariant.BodyMD}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->


**Description**

incorrect label style for ledger tag

fix it by adding a wrapper to wrap the tag and the account name 

**Screenshots/Recordings**
![image](https://github.com/MetaMask/metamask-mobile/assets/102275989/267b6df7-75ce-4414-8112-695bc7e4e259)


**Issue**



**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
