### PR TITLE
fix: Fix type errors in reducers

### DIFF
--- a/app/components/UI/Ramp/utils/index.ts
+++ b/app/components/UI/Ramp/utils/index.ts
@@ -6,7 +6,7 @@ import {
   toTokenMinimalUnit,
 } from '../../../../util/number';
 import { getOrders, FiatOrder } from '../../../../reducers/fiatOrders';
-import { RootState } from '../../../../reducers/fiatOrders/types';
+import { RootState } from '../../../../reducers';
 
 const isOverAnHour = (minutes: number) => minutes > 59;
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -133,7 +133,8 @@ type GlobalEvents =
   | PermissionControllerEvents
   | SignatureControllerEvents;
 
-type Permissions = ReturnType<typeof getPermissionSpecifications>;
+type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
+type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];
 
 export interface EngineState {
   AccountTrackerController: AccountTrackerState;

--- a/app/reducers/fiatOrders/index.test.ts
+++ b/app/reducers/fiatOrders/index.test.ts
@@ -1,5 +1,6 @@
 import { Order } from '@consensys/on-ramp-sdk';
 import { AggregatorNetwork } from '@consensys/on-ramp-sdk/dist/API';
+import { merge } from 'lodash';
 import fiatOrderReducer, {
   addActivationKey,
   addAuthenticationUrl,
@@ -36,6 +37,7 @@ import fiatOrderReducer, {
 } from '.';
 import { FIAT_ORDER_PROVIDERS } from '../../constants/on-ramp';
 import { CustomIdData, Action, FiatOrder, Region } from './types';
+import initialRootState from '../../util/test/initial-root-state';
 
 const mockOrder1 = {
   id: 'test-id-1',
@@ -572,7 +574,7 @@ describe('fiatOrderReducer', () => {
 describe('selectors', () => {
   describe('chainIdSelector', () => {
     it('should return the chainId', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -582,7 +584,7 @@ describe('selectors', () => {
             },
           },
         },
-      };
+      });
 
       expect(chainIdSelector(state)).toBe('56');
     });
@@ -590,7 +592,7 @@ describe('selectors', () => {
 
   describe('selectedAddressSelector', () => {
     it('should return the selected address', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             PreferencesController: {
@@ -598,7 +600,7 @@ describe('selectors', () => {
             },
           },
         },
-      };
+      });
 
       expect(selectedAddressSelector(state)).toBe('0x12345678');
     });
@@ -606,15 +608,14 @@ describe('selectors', () => {
 
   describe('fiatOrdersRegionSelectorAgg', () => {
     it('should return the selected region', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           selectedRegionAgg: {
             id: '/region/cl',
             name: 'Chile',
           },
         },
-      };
+      });
 
       expect(fiatOrdersRegionSelectorAgg(state)).toEqual({
         id: '/region/cl',
@@ -625,12 +626,11 @@ describe('selectors', () => {
 
   describe('fiatOrdersPaymentMethodSelectorAgg', () => {
     it('should return the selected payment method id', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           selectedPaymentMethodAgg: '/payment-method/test-payment-method',
         },
-      };
+      });
 
       expect(fiatOrdersPaymentMethodSelectorAgg(state)).toEqual(
         '/payment-method/test-payment-method',
@@ -640,12 +640,11 @@ describe('selectors', () => {
 
   describe('fiatOrdersGetStartedAgg', () => {
     it('should return the get started state', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           getStartedAgg: true,
         },
-      };
+      });
 
       expect(fiatOrdersGetStartedAgg(state)).toEqual(true);
     });
@@ -653,7 +652,7 @@ describe('selectors', () => {
 
   describe('getOrders', () => {
     it('should return the orders by address and chainId', () => {
-      const state1 = {
+      const state1 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -667,7 +666,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -707,9 +705,9 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
 
-      const state2 = {
+      const state2 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -723,7 +721,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -770,7 +767,7 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
 
       expect(getOrders(state1)).toHaveLength(2);
       expect(getOrders(state1).map((o) => o.id)).toEqual([
@@ -782,7 +779,7 @@ describe('selectors', () => {
     });
 
     it('it should return empty array by default', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -796,7 +793,7 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {},
-      };
+      });
 
       expect(getOrders(state)).toEqual([]);
     });
@@ -804,7 +801,7 @@ describe('selectors', () => {
 
   describe('getPendingOrders', () => {
     it('should return the orders by address and chainId and state pending', () => {
-      const state1 = {
+      const state1 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -818,7 +815,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -860,9 +856,9 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
 
-      const state2 = {
+      const state2 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -876,7 +872,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -924,7 +919,7 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
 
       expect(getPendingOrders(state1)).toHaveLength(2);
       expect(getPendingOrders(state1).map((o) => o.id)).toEqual([
@@ -938,7 +933,7 @@ describe('selectors', () => {
     });
 
     it('it should return empty array by default', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -952,7 +947,7 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {},
-      };
+      });
 
       expect(getPendingOrders(state)).toEqual([]);
     });
@@ -960,7 +955,7 @@ describe('selectors', () => {
 
   describe('customOrdersSelector', () => {
     it('should return the custom order ids by address and chainId', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -974,7 +969,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           customOrderIds: [
             {
               id: 'test-56-order-1',
@@ -998,7 +992,7 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
 
       expect(getCustomOrderIds(state)).toHaveLength(2);
       expect(getCustomOrderIds(state).map((c) => c.id)).toEqual([
@@ -1008,7 +1002,7 @@ describe('selectors', () => {
     });
 
     it('it should return empty array by default', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1022,7 +1016,7 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {},
-      };
+      });
 
       expect(getCustomOrderIds(state)).toEqual([]);
     });
@@ -1030,7 +1024,7 @@ describe('selectors', () => {
 
   describe('getOrderById', () => {
     it('should make selector and return the correct order id', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1044,7 +1038,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -1092,7 +1085,7 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
       const order = getOrderById(state, 'test-56-order-2');
       expect(order?.id).toBe('test-56-order-2');
     });
@@ -1100,7 +1093,7 @@ describe('selectors', () => {
 
   describe('getHasOrders', () => {
     it('should return true only if there are orders', () => {
-      const state1 = {
+      const state1 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1114,7 +1107,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -1162,8 +1154,8 @@ describe('selectors', () => {
             },
           ],
         },
-      };
-      const state2 = {
+      });
+      const state2 = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1177,7 +1169,6 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           orders: [
             {
               ...mockOrder1,
@@ -1225,7 +1216,7 @@ describe('selectors', () => {
             },
           ],
         },
-      };
+      });
       expect(getHasOrders(state1)).toBe(true);
       expect(getHasOrders(state2)).toBe(false);
     });
@@ -1233,74 +1224,70 @@ describe('selectors', () => {
 
   describe('getActivationKeys', () => {
     it('should return activation keys', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           activationKeys: [
             { key: 'test-activation-key-1', active: true },
             { key: 'test-activation-key-2', active: false },
           ],
         },
-      };
+      });
       expect(getActivationKeys(state)).toStrictEqual([
         { key: 'test-activation-key-1', active: true },
         { key: 'test-activation-key-2', active: false },
       ]);
     });
     it('should return empty array by default', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {},
-      };
+      });
       expect(getActivationKeys(state)).toStrictEqual([]);
     });
   });
 
   describe('getAuthenticationUrls', () => {
     it('should return authentication urls', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           authenticationUrls: [
             'test-authentication-url-1',
             'test-authentication-url-2',
           ],
         },
-      };
+      });
       expect(getAuthenticationUrls(state)).toStrictEqual([
         'test-authentication-url-1',
         'test-authentication-url-2',
       ]);
     });
     it('should return empty array by default', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {},
-      };
+      });
       expect(getAuthenticationUrls(state)).toStrictEqual([]);
     });
   });
 
   describe('getRampNetworks', () => {
     it('should return the correct ramp networks', () => {
-      const state = {
+      const state = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
           networks,
         },
-      };
-      const otherState = {
+      });
+      const otherState = merge({}, initialRootState, {
         fiatOrders: {
-          ...initialState,
-          networks: networks[1],
+          networks: [networks[1]],
         },
-      };
+      });
       expect(getRampNetworks(state)).toStrictEqual(networks);
-      expect(getRampNetworks(otherState)).toStrictEqual(networks[1]);
+      expect(getRampNetworks(otherState)).toStrictEqual([networks[1]]);
     });
   });
 
   describe('networkNameSelector', () => {
     it('should return the correct network name', () => {
-      const mainnetState = {
+      const mainnetState = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1311,12 +1298,11 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           networks,
         },
-      };
+      });
 
-      const auroraState = {
+      const auroraState = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1327,12 +1313,11 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           networks,
         },
-      };
+      });
 
-      const missingNetworkState = {
+      const missingNetworkState = merge({}, initialRootState, {
         engine: {
           backgroundState: {
             NetworkController: {
@@ -1343,10 +1328,9 @@ describe('selectors', () => {
           },
         },
         fiatOrders: {
-          ...initialState,
           networks,
         },
-      };
+      });
 
       expect(networkShortNameSelector(mainnetState)).toEqual('Ethereum');
       expect(networkShortNameSelector(auroraState)).toEqual('Aurora');

--- a/app/reducers/security/index.ts
+++ b/app/reducers/security/index.ts
@@ -2,7 +2,7 @@
 import { ActionType, Action } from '../../actions/security';
 import { SecuritySettingsState } from '../../actions/security/state';
 
-const initialState: Readonly<SecuritySettingsState> = {
+export const initialState: Readonly<SecuritySettingsState> = {
   allowLoginWithRememberMe: false,
   automaticSecurityChecksEnabled: false,
   hasUserSelectedAutomaticSecurityCheckOption: false,

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -1,0 +1,33 @@
+import type { RootState } from '../../reducers';
+import type { EngineState } from '../../core/Engine';
+import { initialState as initialFiatOrdersState } from '../../reducers/fiatOrders';
+import { initialState as initialSecurityState } from '../../reducers/security';
+import initialBackgroundState from './initial-background-state.json';
+
+// Cast because TypeScript is incorrectly inferring the type of this JSON object
+const backgroundState: EngineState = initialBackgroundState as any;
+
+const initialRootState: RootState = {
+  collectibles: undefined,
+  engine: { backgroundState },
+  privacy: undefined,
+  bookmarks: undefined,
+  browser: undefined,
+  modals: undefined,
+  settings: undefined,
+  alert: undefined,
+  transaction: undefined,
+  user: undefined,
+  wizard: undefined,
+  onboarding: undefined,
+  notification: undefined,
+  swaps: undefined,
+  fiatOrders: initialFiatOrdersState,
+  infuraAvailability: undefined,
+  navigation: undefined,
+  networkOnboarded: undefined,
+  security: initialSecurityState,
+  experimentalSettings: undefined,
+};
+
+export default initialRootState;

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -14,7 +14,7 @@
     "app/core/*.ts",
     "app/images/**/*",
     "app/lib/**/*",
-    // "app/reducers/**/*",
+    "app/reducers/**/*",
     "app/selectors/**/*",
     "app/store/**/*",
     "app/styles/**/*",


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

All type errors in the reducers have been fixed. An error in the EngineState type was exposed during this process as well, and has also been fixed (the `PermissionControllerState` was resolving to `never` because the wrong type parameter was passed in).

The `fiatOrders` unit tests used selectors quite a lot, so there was a need for a mock/initial root state shape. This was introduced in the `app/util/test` directory for use in unit tests. This initial state object represents just the minimal initial state that has been typed so far. After we migrate all reducers to TypeScript and fix their types, this state object will become increasingly complete/correct.

**Issue**

This is a follow-up to #7110, which laid the groundwork for these type fixes but also introduced some of them accidentally.

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
