### PR TITLE
refactor: Update ENS utils to accept chain ID

### DIFF
--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.tsx
@@ -6,7 +6,7 @@ import TransactionTypes from '../../../core/TransactionTypes';
 import useAddressBalance from '../../../components/hooks/useAddressBalance/useAddressBalance';
 import { strings } from '../../../../locales/i18n';
 import {
-  selectNetwork,
+  selectChainId,
   selectTicker,
 } from '../../../selectors/networkController';
 import { selectIdentities } from '../../../selectors/preferencesController';
@@ -24,7 +24,7 @@ import { AccountFromToInfoCardProps } from './AccountFromToInfoCard.types';
 const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
   const {
     identities,
-    networkId,
+    chainId,
     onPressFromAddressIcon,
     ticker,
     transactionState,
@@ -64,7 +64,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
       return;
     }
     (async () => {
-      const fromEns = await doENSReverseLookup(fromAddress, networkId);
+      const fromEns = await doENSReverseLookup(fromAddress, chainId);
       if (fromEns) {
         setFromAccountName(fromEns);
       } else {
@@ -72,7 +72,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
         setFromAccountName(fromName);
       }
     })();
-  }, [fromAddress, identities, transactionFromName, networkId]);
+  }, [fromAddress, identities, transactionFromName, chainId]);
 
   useEffect(() => {
     if (existingToAddress) {
@@ -80,7 +80,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
       return;
     }
     (async () => {
-      const toEns = await doENSReverseLookup(toAddress, networkId);
+      const toEns = await doENSReverseLookup(toAddress, chainId);
       if (toEns) {
         setToAccountName(toEns);
       } else if (identities[toAddress]) {
@@ -88,7 +88,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
         setToAccountName(toName);
       }
     })();
-  }, [existingToAddress, identities, networkId, toAddress, transactionToName]);
+  }, [existingToAddress, identities, chainId, toAddress, transactionToName]);
 
   useEffect(() => {
     const accountNames =
@@ -174,7 +174,7 @@ const AccountFromToInfoCard = (props: AccountFromToInfoCardProps) => {
 
 const mapStateToProps = (state: any) => ({
   identities: selectIdentities(state),
-  networkId: selectNetwork(state),
+  chainId: selectChainId(state),
   ticker: selectTicker(state),
 });
 

--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.types.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.types.tsx
@@ -27,7 +27,7 @@ export interface Transaction {
 
 export interface AccountFromToInfoCardProps {
   identities: Identities;
-  networkId: string;
+  chainId: string;
   onPressFromAddressIcon?: () => void;
   ticker?: string;
   transactionState: Transaction;

--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -38,7 +38,7 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import Analytics from '../../../core/Analytics/Analytics';
 import AppConstants from '../../../core/AppConstants';
 import Engine from '../../../core/Engine';
-import { selectNetwork } from '../../../selectors/networkController';
+import { selectChainId } from '../../../selectors/networkController';
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import {
   selectIdentities,
@@ -196,9 +196,9 @@ class AccountOverview extends PureComponent {
      */
     toggleReceiveModal: PropTypes.func,
     /**
-     * ID of the current network
+     * The chain ID for the current selected network
      */
-    networkId: PropTypes.string,
+    chainId: PropTypes.string,
     /**
      * Current opens tabs in browser
      */
@@ -245,7 +245,7 @@ class AccountOverview extends PureComponent {
   componentDidUpdate(prevProps) {
     if (
       prevProps.account.address !== this.props.account.address ||
-      prevProps.networkId !== this.props.networkId
+      prevProps.chainId !== this.props.chainId
     ) {
       requestAnimationFrame(() => {
         this.doENSLookup();
@@ -304,9 +304,9 @@ class AccountOverview extends PureComponent {
   };
 
   doENSLookup = async () => {
-    const { networkId, account } = this.props;
+    const { chainId, account } = this.props;
     try {
-      const ens = await doENSReverseLookup(account.address, networkId);
+      const ens = await doENSReverseLookup(account.address, chainId);
       this.setState({ ens });
       // eslint-disable-next-line no-empty
     } catch {}
@@ -458,7 +458,7 @@ const mapStateToProps = (state) => ({
   selectedAddress: selectSelectedAddress(state),
   identities: selectIdentities(state),
   currentCurrency: selectCurrentCurrency(state),
-  networkId: String(selectNetwork(state)),
+  chainId: selectChainId(state),
   browserTabs: state.browser.tabs,
 });
 

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -47,6 +47,7 @@ import AnalyticsV2 from '../../../util/analyticsV2';
 import { KEYSTONE_TX_CANCELED } from '../../../constants/error';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import {
+  selectChainId,
   selectNetwork,
   selectProviderType,
 } from '../../../selectors/networkController';
@@ -119,6 +120,10 @@ class Send extends PureComponent {
      * Network id
      */
     networkId: PropTypes.string,
+    /**
+     * The chain ID of the current selected network
+     */
+    chainId: PropTypes.string,
     /**
      * List of accounts from the PreferencesController
      */
@@ -280,7 +285,7 @@ class Send extends PureComponent {
    * Handle deeplink txMeta recipient
    */
   handleNewTxMetaRecipient = async (recipient) => {
-    const to = await getAddress(recipient, this.props.networkId);
+    const to = await getAddress(recipient, this.props.chainId);
 
     if (!to) {
       NotificationManager.showSimpleNotification({
@@ -770,6 +775,7 @@ const mapStateToProps = (state) => ({
   networkType: selectProviderType(state),
   tokens: selectTokens(state),
   networkId: selectNetwork(state),
+  chainId: selectChainId(state),
   identities: selectIdentities(state),
   selectedAddress: selectSelectedAddress(state),
   dappTransactionModalVisible: state.modals.dappTransactionModalVisible,

--- a/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
+++ b/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
@@ -11,7 +11,7 @@ import { useSelector } from 'react-redux';
 import { useTheme } from '../../../../util/theme';
 import Text from '../../../../component-library/components/Texts/Text/Text';
 import { TextVariant } from '../../../../component-library/components/Texts/Text';
-import { selectNetwork } from '../../../../selectors/networkController';
+import { selectChainId } from '../../../../selectors/networkController';
 import { doENSReverseLookup } from '../../../../util/ENSUtils';
 
 // Internal dependecies
@@ -29,14 +29,14 @@ const AddressElement: React.FC<AddressElementProps> = ({
   const { colors } = useTheme();
   const styles = styleSheet(colors);
 
-  const networkId = useSelector(selectNetwork);
+  const chainId = useSelector(selectChainId);
 
   const fetchENSName = useCallback(async () => {
     if (!displayName) {
-      const ensName = await doENSReverseLookup(address, networkId);
+      const ensName = await doENSReverseLookup(address, chainId);
       setDisplayName(ensName);
     }
-  }, [displayName, address, networkId]);
+  }, [displayName, address, chainId]);
 
   useEffect(() => {
     fetchENSName();

--- a/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/SendFlow/AddressFrom/AddressFrom.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../actions/transaction';
 import Routes from '../../../../constants/navigation/Routes';
 import {
-  selectNetwork,
+  selectChainId,
   selectTicker,
 } from '../../../../selectors/networkController';
 import { selectAccounts } from '../../../../selectors/accountTrackerController';
@@ -32,7 +32,7 @@ const SendFlowAddressFrom = ({
 
   const accounts = useSelector(selectAccounts);
 
-  const networkId = useSelector((state: any) => selectNetwork(state));
+  const chainId = useSelector(selectChainId);
   const ticker = useSelector(selectTicker);
 
   const selectedAddress = useSelector(selectSelectedAddress);
@@ -75,7 +75,7 @@ const SendFlowAddressFrom = ({
 
   useEffect(() => {
     async function getAccount() {
-      const ens = await doENSReverseLookup(selectedAddress, networkId);
+      const ens = await doENSReverseLookup(selectedAddress, chainId);
       const balance = `${renderFromWei(
         accounts[selectedAddress].balance,
       )} ${getTicker(ticker)}`;
@@ -89,7 +89,7 @@ const SendFlowAddressFrom = ({
     accounts,
     selectedAddress,
     ticker,
-    networkId,
+    chainId,
     identities,
     fromAccountBalanceState,
   ]);

--- a/app/components/hooks/useAccounts/useAccounts.ts
+++ b/app/components/hooks/useAccounts/useAccounts.ts
@@ -19,8 +19,8 @@ import {
   UseAccountsParams,
 } from './useAccounts.types';
 import {
+  selectChainId,
   selectTicker,
-  selectNetwork,
 } from '../../../selectors/networkController';
 import {
   selectConversionRate,
@@ -49,7 +49,7 @@ const useAccounts = ({
     useState<EnsByAccountAddress>({});
 
   const identities = useSelector(selectIdentities);
-  const networkId = useSelector(selectNetwork);
+  const chainId = useSelector(selectChainId);
   const accountInfoByAddress = useSelector(selectAccounts, isEqual);
   const selectedAddress = useSelector(selectSelectedAddress);
   const conversionRate = useSelector(selectConversionRate);
@@ -84,7 +84,7 @@ const useAccounts = ({
         try {
           const ens: string | undefined = await doENSReverseLookup(
             address,
-            networkId,
+            chainId,
           );
           if (ens) {
             latestENSbyAccountAddress = {
@@ -111,7 +111,7 @@ const useAccounts = ({
         setENSByAccountAddress(latestENSbyAccountAddress);
       }
     },
-    [networkId],
+    [chainId],
   );
 
   const getAccounts = useCallback(() => {

--- a/app/util/ENSUtils.js
+++ b/app/util/ENSUtils.js
@@ -26,14 +26,14 @@ export class ENSCache {
  *
  * Ropsten is excluded because we no longer support Ropsten.
  */
-const ENS_SUPPORTED_CHAIN_IDS = [NetworksChainId[NetworkType.ETHEREUM]];
+const ENS_SUPPORTED_CHAIN_IDS = [NetworksChainId[NetworkType.mainnet]];
 
 /**
  * A map of chain ID to network ID for networks supported by the current
  * legacy ENS library we are using.
  */
 const CHAIN_ID_TO_NETWORK_ID = {
-  [NetworksChainId[NetworkType.ETHEREUM]]: NetworkId[NetworkType.ETHEREUM],
+  [NetworksChainId[NetworkType.mainnet]]: NetworkId[NetworkType.mainnet],
 };
 
 export async function doENSReverseLookup(address, chainId) {

--- a/app/util/ENSUtils.js
+++ b/app/util/ENSUtils.js
@@ -15,6 +15,8 @@ import { EMPTY_ADDRESS } from '../constants/transaction';
 /**
  * Utility class with the single responsibility
  * of caching ENS names
+ *
+ * TODO: Replace this entire module and cache with the core ENS controller
  */
 export class ENSCache {
   static cache = {};
@@ -35,6 +37,26 @@ const ENS_SUPPORTED_CHAIN_IDS = [NetworksChainId[NetworkType.mainnet]];
 const CHAIN_ID_TO_NETWORK_ID = {
   [NetworksChainId[NetworkType.mainnet]]: NetworkId[NetworkType.mainnet],
 };
+
+/**
+ * Get a cached ENS name.
+ *
+ * @param {string} address - The address to lookup.
+ * @param {string} chainId - The chain ID for the cached ENS name.
+ * @returns {string|undefined} The cached ENS name, or undefined if the name
+ * was not found in the cache.
+ */
+export function getCachedENSName(address, chainId) {
+  const networkHasEnsSupport = ENS_SUPPORTED_CHAIN_IDS.includes(chainId);
+
+  if (!networkHasEnsSupport) {
+    return undefined;
+  }
+
+  const networkId = CHAIN_ID_TO_NETWORK_ID[chainId];
+  const cacheEntry = ENSCache.cache[networkId + address];
+  return cacheEntry?.name;
+}
 
 export async function doENSReverseLookup(address, chainId) {
   const { provider } =

--- a/app/util/ENSUtils.test.ts
+++ b/app/util/ENSUtils.test.ts
@@ -1,4 +1,49 @@
-import { isDefaultAccountName } from './ENSUtils';
+import { isDefaultAccountName, getCachedENSName, ENSCache } from './ENSUtils';
+
+const mockAddress = '0x0000000000000000000000000000000000000001';
+
+// TODO: Stub this in individual tests using `jest.replaceProperty` after the
+// update to Jest v29
+let originalCacheContents: typeof ENSCache.cache;
+
+describe('getCachedENSName', () => {
+  beforeEach(() => {
+    originalCacheContents = ENSCache.cache;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    // This prevents
+    ENSCache.cache = originalCacheContents;
+  });
+
+  it('returns undefined for unsupported chain IDs', () => {
+    ENSCache.cache = {};
+
+    expect(getCachedENSName(mockAddress, '12345')).toBeUndefined();
+  });
+
+  it('returns undefined if there is no cached entry', () => {
+    ENSCache.cache = {};
+
+    expect(getCachedENSName(mockAddress, '1')).toBeUndefined();
+  });
+
+  it('returns a cached ENS name', () => {
+    const networkId = '1';
+    ENSCache.cache = {
+      [`${networkId}${mockAddress}`]: {
+        name: 'cachedname.metamask.eth',
+        timestamp: Date.now(),
+      },
+    };
+
+    expect(getCachedENSName(mockAddress, networkId)).toBe(
+      'cachedname.metamask.eth',
+    );
+  });
+});
 
 describe('isDefaultAccountName', () => {
   const accountNameDefaultOne = 'Account 1';

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -15,7 +15,7 @@ import { tlc } from '../general';
 import {
   doENSLookup,
   doENSReverseLookup,
-  ENSCache,
+  getCachedENSName,
   isDefaultAccountName,
 } from '../../util/ENSUtils';
 import {
@@ -30,7 +30,7 @@ import {
 } from '../../../app/constants/error';
 import { PROTOCOLS } from '../../constants/deeplinks';
 import TransactionTypes from '../../core/TransactionTypes';
-import { selectNetwork } from '../../selectors/networkController';
+import { selectChainId } from '../../selectors/networkController';
 import { store } from '../../store';
 
 const {
@@ -110,11 +110,11 @@ export function renderSlightlyLongAddress(
  * @returns {String} - String corresponding to account name. If there is no name, returns the original short format address
  */
 export function renderAccountName(address, identities) {
-  const networkId = selectNetwork(store.getState());
+  const chainId = selectChainId(store.getState());
   address = safeToChecksumAddress(address);
   if (identities && address && address in identities) {
     const identityName = identities[address].name;
-    const ensName = ENSCache.cache[`${networkId}${address}`]?.name || '';
+    const ensName = getCachedENSName(address, chainId) || '';
     return isDefaultAccountName(identityName) && ensName
       ? ensName
       : identityName;

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -395,7 +395,7 @@ export async function validateAddressOrENS(params) {
   } else if (isENS(toAccount)) {
     toEnsName = toAccount;
     confusableCollection = collectConfusables(toEnsName);
-    const resolvedAddress = await doENSLookup(toAccount, networkId);
+    const resolvedAddress = await doENSLookup(toAccount, chainId);
     const contactAlreadySaved = checkIfAddressAlreadySaved({
       address: resolvedAddress,
       addressBook,
@@ -461,13 +461,14 @@ export const stripHexPrefix = (str) => {
 
 /**
  * Method to check if address is ENS and return the address
+ *
  * @param {String} toAccount - Address or ENS
- * @param {String} networkId - Network id
+ * @param {String} chainId - The chain ID for the given address
  * @returns {String} - Address or null
  */
-export async function getAddress(toAccount, networkId) {
+export async function getAddress(toAccount, chainId) {
   if (isENS(toAccount)) {
-    return await doENSLookup(toAccount, networkId);
+    return await doENSLookup(toAccount, chainId);
   }
   if (isValidHexAddress(toAccount, { mixedCaseUseChecksum: true })) {
     return toAccount;

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -147,10 +147,10 @@ describe('getAddress', () => {
   const validENSAddress = 'test.eth';
 
   it('should resolve ENS if ENS is valid', async () => {
-    const networkId = '1';
+    const chainId = '1';
     const doENSLookup = jest.fn();
-    await doENSLookup(validENSAddress, networkId);
-    expect(doENSLookup).toHaveBeenCalledWith(validENSAddress, networkId);
+    await doENSLookup(validENSAddress, chainId);
+    expect(doENSLookup).toHaveBeenCalledWith(validENSAddress, chainId);
   });
 
   it('should return address if address is valid', async () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The ENS utility functions now accept chain ID instead of network ID. Chain ID is easier for us to access because we know the chain ID for all configured networks at all times, as it's a required property. The network ID has to be looked up dynamically at runtime, meaning that we don't know what it is until after the network has loaded.

The network ID is still used internally by the ENS utility functions because the library we use for ENS support still expects network ID rather than chain ID.

This was done to simplify the upcoming network controller update. The new update replaces `network` with `networkId` and `networkStatus`, where the ID is `null` while the network is loading. This forces us to handle that loading state anywhere the network ID had been used. Reducing the usages of network ID means avoiding that work.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
