### PR TITLE
refactor: use ganache seeder and connected to dapp fixture on ERC721 test

### DIFF
--- a/app/util/test/ganache-seeder.js
+++ b/app/util/test/ganache-seeder.js
@@ -44,7 +44,7 @@ class GanacheSeeder {
     await contract.deployTransaction.wait();
 
     if (contractName === SMART_CONTRACTS.NFTS) {
-      const transaction = await contract.mintCollectibles(1, {
+      const transaction = await contract.mintNFTs(1, {
         from: fromAddress,
       });
       await transaction.wait();

--- a/app/util/test/smart-contracts.js
+++ b/app/util/test/smart-contracts.js
@@ -3,8 +3,8 @@ import {
   hstAbi,
   piggybankBytecode,
   piggybankAbi,
-  collectiblesAbi,
-  collectiblesBytecode,
+  nftsAbi,
+  nftsBytecode,
   erc1155Abi,
   erc1155Bytecode,
   failingContractAbi,
@@ -23,8 +23,8 @@ const hstFactory = {
 };
 
 const nftsFactory = {
-  bytecode: collectiblesBytecode,
-  abi: collectiblesAbi,
+  bytecode: nftsBytecode,
+  abi: nftsAbi,
 };
 
 const erc1155Factory = {

--- a/e2e/pages/TestDApp.js
+++ b/e2e/pages/TestDApp.js
@@ -74,9 +74,9 @@ export class TestDApp {
     await TestHelpers.delay(3000);
   }
 
-  static async navigateToErc721Contract(testDappUrl, erc721Address) {
+  static async navigateToTestDappWithContract(testDappUrl, contractAddress) {
     await Browser.tapUrlInputBox();
-    await Browser.navigateToURL(testDappUrl + '?contract=' + erc721Address);
+    await Browser.navigateToURL(`${testDappUrl}?contract=${contractAddress}`);
   }
 
   static async tapTransferFromButton(contractAddress) {


### PR DESCRIPTION
## Description
This PR does some small refactor on the ERC721 testcase, with the following changes:

- Use `withPermissionControllerConnectedToTestDapp` fixture
- Use ganache seeder for deploying an ERC721 contract
- Update contract method name since test-dapp package bump here https://github.com/MetaMask/metamask-mobile/pull/7101

## Screenshots/Recordings

![Screenshot from 2023-09-06 19-08-44](https://github.com/MetaMask/metamask-mobile/assets/54408225/aa4deb3d-1ce2-4fdc-9fbd-70f5839156d0)

Notice:
- you skip the onboarding process
- ERC721 contract is deployed on the background server (Ganache)
- you are already connected to the test dapp

https://github.com/MetaMask/metamask-mobile/assets/54408225/c296dd8f-9b86-4122-9e04-f9229841a546

- Bitrise run https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/09a3ee66-c49e-443d-b0df-d1cad9c696c5

## Issue

fixes https://github.com/MetaMask/mobile-planning/issues/1239

## Checklist

* [X] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented
