### PR TITLE
refactor: Refactor `isTestNet` to accept chain ID

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -162,10 +162,6 @@ class ApproveTransactionReview extends PureComponent {
      */
     navigation: PropTypes.object,
     /**
-     * Network id
-     */
-    networkId: PropTypes.string,
-    /**
      * True if transaction is over the available funds
      */
     over: PropTypes.bool,
@@ -699,7 +695,7 @@ class ApproveTransactionReview extends PureComponent {
       gasError,
       activeTabUrl,
       transaction: { origin, from, to },
-      networkId,
+      chainId,
       over,
       gasEstimateType,
       onUpdatingValuesStart,
@@ -721,7 +717,7 @@ class ApproveTransactionReview extends PureComponent {
       isGasEstimateStatusIn,
     } = this.props;
     const styles = this.getStyles();
-    const isTestNetwork = isTestNet(networkId);
+    const isTestNetwork = isTestNet(chainId);
 
     const originIsDeeplink =
       origin === ORIGIN_DEEPLINK || origin === ORIGIN_QR_CODE;

--- a/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/UI/TransactionReview/TransactionReviewInformation/index.js
@@ -43,7 +43,6 @@ import AppConstants from '../../../../core/AppConstants';
 import WarningMessage from '../../../Views/SendFlow/WarningMessage';
 import {
   selectChainId,
-  selectNetwork,
   selectTicker,
 } from '../../../../selectors/networkController';
 import {
@@ -181,9 +180,9 @@ class TransactionReviewInformation extends PureComponent {
      */
     onCancelPress: PropTypes.func,
     /**
-     * Network id
+     * The chain ID for the current selected network
      */
-    networkId: PropTypes.string,
+    chainId: PropTypes.string,
     /**
      * Indicates whether custom nonce should be shown in transaction editor
      */
@@ -357,8 +356,8 @@ class TransactionReviewInformation extends PureComponent {
   };
 
   isTestNetwork = () => {
-    const { networkId } = this.props;
-    return isTestNet(networkId);
+    const { chainId } = this.props;
+    return isTestNet(chainId);
   };
 
   getRenderTotalsEIP1559 = ({
@@ -721,7 +720,7 @@ class TransactionReviewInformation extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-  networkId: selectNetwork(state),
+  chainId: selectChainId(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   nativeCurrency: selectNativeCurrency(state),

--- a/app/components/UI/TransactionReview/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionReview/__snapshots__/index.test.tsx.snap
@@ -355,6 +355,7 @@ Array [
               "paddingBottom": 4,
               "paddingTop": 16,
               "textAlign": "center",
+              "textTransform": "uppercase",
             }
           }
         />

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -85,7 +85,6 @@ import {
 } from '../../../../core/GasPolling/GasPolling';
 import {
   selectChainId,
-  selectNetwork,
   selectProviderType,
   selectTicker,
 } from '../../../../selectors/networkController';
@@ -166,10 +165,6 @@ class Confirm extends PureComponent {
      * Chain Id
      */
     chainId: PropTypes.string,
-    /**
-     * Network id
-     */
-    networkId: PropTypes.string,
     /**
      * Indicates whether hex data should be shown in transaction editor
      */
@@ -937,7 +932,6 @@ class Confirm extends PureComponent {
       showHexData,
       showCustomNonce,
       primaryCurrency,
-      networkId,
       chainId,
       gasEstimateType,
       isNativeTokenBuySupported,
@@ -968,7 +962,7 @@ class Confirm extends PureComponent {
       gasEstimateType === GAS_ESTIMATE_TYPES.NONE;
     const isQRHardwareWalletDevice = isQRHardwareAccount(fromSelectedAddress);
 
-    const isTestNetwork = isTestNet(networkId);
+    const isTestNetwork = isTestNet(chainId);
 
     const errorPress = isTestNetwork ? this.goToFaucet : this.buyEth;
     const errorLinkText = isTestNetwork
@@ -1144,7 +1138,6 @@ const mapStateToProps = (state) => ({
   contractBalances: selectContractBalances(state),
   conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
-  networkId: selectNetwork(state),
   providerType: selectProviderType(state),
   showHexData: state.settings.showHexData,
   showCustomNonce: state.settings.showCustomNonce,

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -15,7 +15,11 @@ import {
   LINEA_MAINNET,
 } from '../../../app/constants/network';
 import { NetworkSwitchErrorType } from '../../../app/constants/error';
-import { query } from '@metamask/controller-utils';
+import {
+  NetworksChainId,
+  NetworkType,
+  query,
+} from '@metamask/controller-utils';
 import Engine from '../../core/Engine';
 import { toLowerCaseEquals } from '../general';
 import { fastSplit } from '../number';
@@ -178,15 +182,22 @@ export const getTestNetImageByChainId = (chainId) => {
   }
 };
 
-export const isTestNet = (networkId) => {
-  const networkName = getNetworkName(networkId);
+/**
+ * A list of chain IDs for known testnets
+ */
+const TESTNET_CHAIN_IDS = [
+  NetworksChainId[NetworkType.goerli],
+  NetworksChainId[NetworkType.sepolia],
+  NetworksChainId[NetworkType['linea-goerli']],
+];
 
-  return (
-    networkName === GOERLI ||
-    networkName === SEPOLIA ||
-    networkName === LINEA_GOERLI
-  );
-};
+/**
+ * Determine whether the given chain ID is for a known testnet.
+ *
+ * @param {string} chainId - The chain ID of the network to check
+ * @returns {boolean} `true` if the given chain ID is for a known testnet, `false` otherwise
+ */
+export const isTestNet = (chainId) => TESTNET_CHAIN_IDS.includes(chainId);
 
 export function getNetworkTypeById(id) {
   if (!id) {

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -1,5 +1,7 @@
+import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import {
   isMainNet,
+  isTestNet,
   getNetworkName,
   getAllNetworks,
   getNetworkTypeById,
@@ -59,6 +61,24 @@ describe('NetworkUtils::isMainNet', () => {
   });
   it(`should return false if the selected network is not Ethereum Mainnet`, () => {
     expect(isMainNet('42')).toEqual(false);
+  });
+});
+
+describe('NetworkUtils::isTestNet', () => {
+  const testnets = [
+    NetworkType.goerli,
+    NetworkType.sepolia,
+    NetworkType['linea-goerli'],
+  ];
+
+  for (const networkType of testnets) {
+    it(`should return true if the given chain ID is for '${networkType}'`, () => {
+      expect(isTestNet(NetworksChainId[networkType])).toEqual(true);
+    });
+  }
+
+  it(`should return false if the given chain ID is not a known testnet`, () => {
+    expect(isTestNet('42')).toEqual(false);
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The `isTestNet` utility function now accepts a chain ID rather than a network ID. The chain ID is easier for us to access because we know the chain ID for all networks statically, as it's a required network configuration property. The network ID on the other hand is looked up at runtime, and is sometimes not present.

In practice we had already been passing in chain ID as network ID in many places. This hasn't caused issues because they are equivalent for most (though not all) networks.

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
