### PR TITLE
ci: Fix SonarCloud warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,9 @@ jobs:
         if: ${{ always() }}
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       - name: SonarCloud Scan
-        # v1.9.1
         if: ${{ env.HAVE_SONAR_TOKEN == 'true' }}
-        uses: SonarSource/sonarcloud-github-action@5875562561d22a34be0c657405578705a169af6c
+        # This is SonarSource/sonarcloud-github-action@v2.0.0
+        uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1
         env:
           HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The SonarCloud action has been updated to v2, which resolves the
warning we've been seeing about Java being out-of-date.

See the sonarcloud comment for evidence that this is working. It should no longer include a warning. Previously it said
> The version of Java (11.0.20) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.

**Issue**

No related issue

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
