### PR TITLE
fix: incorrect label type warning on account type tag

### DIFF
--- a/app/components/UI/AddressInputs/index.js
+++ b/app/components/UI/AddressInputs/index.js
@@ -15,10 +15,7 @@ import {
   renderShortAddress,
   renderSlightlyLongAddress,
   isENS,
-  getAddressAccountType,
   getLabelTextByAddress,
-  isHardwareAccount,
-  isImportedAccount,
 } from '../../../util/address';
 import { strings } from '../../../../locales/i18n';
 import Text from '../../Base/Text';
@@ -255,12 +252,7 @@ export const AddressTo = (props) => {
     isFromAddressBook = false,
     layout = 'horizontal',
   } = props;
-  const isImportedOrHardwareAccount =
-    toSelectedAddress &&
-    (isHardwareAccount(toSelectedAddress) ||
-      isImportedAccount(toSelectedAddress));
-  const accountLabel =
-    isImportedOrHardwareAccount && getLabelTextByAddress(toSelectedAddress);
+  const accountLabel = getLabelTextByAddress(toSelectedAddress);
   const { colors, themeAppearance } = useTheme();
   const styles = createStyles(colors, layout);
 
@@ -588,11 +580,7 @@ export const AddressFrom = (props) => {
     fromAccountAddress,
     layout = 'horizontal',
   } = props;
-  const isImportedOrHardwareAccount =
-    getAddressAccountType(fromAccountAddress) !== 'MetaMask';
-  const accountLabel = isImportedOrHardwareAccount
-    ? getLabelTextByAddress(fromAccountAddress)
-    : '';
+  const accountLabel = getLabelTextByAddress(fromAccountAddress);
   const { colors } = useTheme();
   const styles = createStyles(colors, layout);
 
@@ -613,7 +601,7 @@ export const AddressFrom = (props) => {
         <View style={[baseStyles.flexGrow, styles.address]}>
           <View style={styles.accountNameLabel}>
             <Text style={styles.textAddress}>{fromAccountName}</Text>
-            {isImportedOrHardwareAccount && (
+            {accountLabel && (
               <Text style={styles.accountNameLabelText}>
                 {strings(accountLabel)}
               </Text>

--- a/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
+++ b/app/components/UI/ApproveTransactionHeader/ApproveTransactionHeader.tsx
@@ -123,7 +123,7 @@ const ApproveTransactionHeader = ({
     return FAV_ICON_URL(getHost(newUrl));
   }, [origin, isOriginWalletConnect, isOriginMMSDKRemoteConn]);
 
-  const importedOrHardwareLabel = getLabelTextByAddress(activeAddress);
+  const accountTypeLabel = getLabelTextByAddress(activeAddress);
 
   return (
     <View style={styles.transactionHeader}>
@@ -139,7 +139,7 @@ const ApproveTransactionHeader = ({
         accountTokenBalance={addressBalance}
         accountName={accountName}
         accountBalanceLabel={strings('transaction.balance')}
-        accountTypeLabel={importedOrHardwareLabel}
+        accountTypeLabel={accountTypeLabel}
         accountNetwork={networkName}
         badgeProps={{
           variant: BadgeVariant.Network,

--- a/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
+++ b/app/components/Views/SendFlow/AddressElement/AddressElement.tsx
@@ -52,7 +52,7 @@ const AddressElement: React.FC<AddressElementProps> = ({
       : renderShortAddress(address);
   const secondaryLabel =
     displayName && !displayName.startsWith(' ') && renderShortAddress(address);
-  const importedOrHardwareLabel = getLabelTextByAddress(address);
+  const accountTypeLabel = getLabelTextByAddress(address);
 
   return (
     <TouchableOpacity
@@ -74,9 +74,9 @@ const AddressElement: React.FC<AddressElementProps> = ({
           >
             {primaryLabel}
           </Text>
-          {importedOrHardwareLabel && (
+          {accountTypeLabel && (
             <Text style={styles.accountNameLabelText}>
-              {strings(importedOrHardwareLabel)}
+              {strings(accountTypeLabel)}
             </Text>
           )}
         </View>

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -220,6 +220,7 @@ export function isImportedAccount(address) {
  * @returns {String} - Returns address's i18n label text
  */
 export function getLabelTextByAddress(address) {
+  if (!address) return null;
   if (isHardwareAccount(address, [KeyringTypes.ledger]))
     return 'accounts.ledger';
   if (isHardwareAccount(address, [KeyringTypes.qr]))


### PR DESCRIPTION
- fix warning issue cause by incorrect prop type
- simplify account type checking on UI

**Description**
when sending a token from a imported or ledger account
select a non imported or ledger account 
a warning popup for incorrect props due to wrong syntax

**Screenshots/Recordings**

![image](https://github.com/MetaMask/metamask-mobile/assets/102275989/08a7dccc-ee1e-46ad-b4fd-7dc8ffc238fe)


**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
