### PR TITLE
fix: Transaction Error when approve a token on ledger account

### DIFF
--- a/app/components/Approvals/TransactionApproval/TransactionApproval.tsx
+++ b/app/components/Approvals/TransactionApproval/TransactionApproval.tsx
@@ -49,7 +49,13 @@ const TransactionApprovalInternal = (props: TransactionApprovalProps) => {
   }
 
   if (props.transactionType === TransactionModalType.Transaction) {
-    return <Approve modalVisible hideModal={onComplete} />;
+    return (
+      <Approve
+        modalVisible
+        hideModal={onComplete}
+        navigation={props.navigation}
+      />
+    );
   }
 
   if (props.isSigningQRObject && !props.transactionType) {


### PR DESCRIPTION
**Description**
some code piece in transaction approval page contain legacy code , which no longer using in react native 0.72
it will generate error when nonce too low for transaction

**Step to reproduce** 
1. use testnet
2. access [test dapp](https://metamask.github.io/test-dapp/)
3. Connect the dapp
4. create a token
5. approve a tokens
6. error waring prompt

**expected:**
transaction approval flow should not prompt error

**actual**   
transaction approval flow prompt error

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
