### PR TITLE
fix: getAddressAccountType move out from pickupaccount

### DIFF
--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -3,12 +3,11 @@
 // Third party dependencies.
 import React, { forwardRef } from 'react';
 import { Platform, TouchableOpacity, View } from 'react-native';
-import { KeyringTypes } from '@metamask/keyring-controller';
 
 // External dependencies.
 import Avatar, { AvatarSize, AvatarVariants } from '../../Avatars/Avatar';
 import Text, { TextVariant } from '../../Texts/Text';
-import { formatAddress, getAddressAccountType } from '../../../../util/address';
+import { formatAddress } from '../../../../util/address';
 import { useStyles } from '../../../hooks';
 import { strings } from '../../../../../locales/i18n';
 
@@ -28,6 +27,7 @@ const PickerAccount: React.ForwardRefRenderFunction<
     accountAddress,
     accountName,
     accountAvatarType,
+    accountTypeLabel,
     showAddress = true,
     cellAccountContainerStyle = {},
     ...props
@@ -39,9 +39,6 @@ const PickerAccount: React.ForwardRefRenderFunction<
     cellAccountContainerStyle,
   });
   const shortenedAddress = formatAddress(accountAddress, 'short');
-  const ledgerLabel = KeyringTypes.ledger;
-  const isLedgerAccount = getAddressAccountType(accountAddress) === ledgerLabel;
-  const label = strings(`accounts.${KeyringTypes.ledger.toLowerCase()}`);
 
   const renderCellAccount = () => (
     <View style={styles.cellAccount}>
@@ -59,8 +56,10 @@ const PickerAccount: React.ForwardRefRenderFunction<
         >
           {accountName}
         </Text>
-        {isLedgerAccount && (
-          <Text style={styles.accountNameLabelText}>{label}</Text>
+        {accountTypeLabel && (
+          <Text style={styles.accountNameLabelText}>
+            {strings(accountTypeLabel)}
+          </Text>
         )}
         {showAddress && (
           <Text variant={TextVariant.BodyMD} style={styles.accountAddressLabel}>

--- a/app/components/UI/WalletAccount/WalletAccount.tsx
+++ b/app/components/UI/WalletAccount/WalletAccount.tsx
@@ -38,6 +38,8 @@ import {
   WALLET_ACCOUNT_ICON,
   MAIN_WALLET_ACCOUNT_ACTIONS,
 } from '../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
+import { isHardwareAccount } from '../../../util/address';
+import { KeyringTypes } from '@metamask/keyring-controller';
 
 const WalletAccount = ({ style }: WalletAccountProps, ref: React.Ref<any>) => {
   const { styles } = useStyles(styleSheet, { style });
@@ -105,6 +107,13 @@ const WalletAccount = ({ style }: WalletAccountProps, ref: React.Ref<any>) => {
         onPress={() => {
           navigate(...createAccountSelectorNavDetails({}));
         }}
+        //Currently only show account type label for ledger accounts for unknown reasons
+        //TODO: should display account type label for all hardware wallets and imported accounts after confirmed
+        accountTypeLabel={
+          isHardwareAccount(account.address, [KeyringTypes.ledger])
+            ? 'accounts.ledger'
+            : ''
+        }
         showAddress={false}
         cellAccountContainerStyle={styles.account}
         style={styles.accountPicker}


### PR DESCRIPTION
**Description**

Move ledger label logic to UI level

ledger label determination should not stick in PickerAccount, 
PickerAccount is a component in component library
As ledger label determination relied on state, which component library's component should be stateless

**Remark**:
Account type label should be display for all hardware wallets and imported accounts 
but current handle is just for ledger account, will be implemented when confirmed

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
