### PR TITLE
refactor: Add tests for `checkAddress` and fix types

### DIFF
--- a/app/util/checkAddress.test.ts
+++ b/app/util/checkAddress.test.ts
@@ -1,0 +1,184 @@
+import { AddressBookState } from '@metamask/address-book-controller';
+import checkIfAddressIsSaved from './checkAddress';
+
+describe('checkIfAddressIsSaved', () => {
+  it(`returns an empty array if the transaction recipient is unset`, () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const addressBook: AddressBookState['addressBook'] = {
+      '1': {
+        [mockAddress]: {
+          address: mockAddress,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {};
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([]);
+  });
+
+  // TODO: Update this case to return undefined to improve consistency
+  it('returns undefined if the address book is empty', () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const addressBook: AddressBookState['addressBook'] = {};
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toBeUndefined();
+  });
+
+  it('returns an empty array if transaction recipient is not in the address book', () => {
+    const mockAddress1 = '0x0000000000000000000000000000000000000001';
+    const mockAddress2 = '0x0000000000000000000000000000000000000002';
+    const addressBook: AddressBookState['addressBook'] = {
+      '1': {
+        [mockAddress2]: {
+          address: mockAddress2,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress1,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([]);
+  });
+
+  it('returns an empty array if transaction recipient is not in the address book for the given network', () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const addressBook: AddressBookState['addressBook'] = {
+      '2': {
+        [mockAddress]: {
+          address: mockAddress,
+          name: 'name',
+          chainId: '2',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([]);
+  });
+
+  it('returns an address book entry', () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const addressBook: AddressBookState['addressBook'] = {
+      '1': {
+        [mockAddress]: {
+          address: mockAddress,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([
+      {
+        address: mockAddress,
+        nickname: 'name',
+      },
+    ]);
+  });
+
+  it('returns an address book entry with a checksummed address', () => {
+    const mockAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const mockAddressChecksummed = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa';
+    const addressBook: AddressBookState['addressBook'] = {
+      '1': {
+        [mockAddress]: {
+          address: mockAddress,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([
+      {
+        address: mockAddressChecksummed,
+        nickname: 'name',
+      },
+    ]);
+  });
+
+  // TODO: Investigate this case, it should not be possible
+  it('returns multiple address book entries', () => {
+    const mockAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const mockAddressChecksummed = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa';
+    const addressBook: AddressBookState['addressBook'] = {
+      '1': {
+        [mockAddress]: {
+          address: mockAddress,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+        [mockAddressChecksummed]: {
+          address: mockAddressChecksummed,
+          name: 'name',
+          chainId: '1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+    const networkId = '1';
+    const transaction = {
+      to: mockAddress,
+    };
+
+    expect(
+      checkIfAddressIsSaved(addressBook, networkId, transaction),
+    ).toStrictEqual([
+      {
+        address: mockAddressChecksummed,
+        nickname: 'name',
+      },
+      {
+        address: mockAddressChecksummed,
+        nickname: 'name',
+      },
+    ]);
+  });
+});

--- a/app/util/checkAddress.ts
+++ b/app/util/checkAddress.ts
@@ -1,7 +1,8 @@
+import type { AddressBookState } from '@metamask/address-book-controller';
 import { toChecksumAddress } from 'ethereumjs-util';
 
 const checkIfAddressIsSaved = (
-  addressBook: [],
+  addressBook: AddressBookState['addressBook'],
   networkId: string,
   transaction: any,
 ) => {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The `checkIfAddressIsSaved` utility function now has complete unit test coverage. One type mistake was fixed as well; the `addressBook` parameter was typed as a static empty array, but it should have been an object.

**Issue**

These tests were written to help ensure no regressions were introduced in an upcoming address book refactor PR that relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
