### PR TITLE
refactor: Fix documented return type of `handleNetworkSwitch`

### DIFF
--- a/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
+++ b/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
@@ -36,9 +36,9 @@ const SendFlowAddressTo = ({
 
   const onHandleNetworkSwitch = (chain_id: string) => {
     try {
-      const networkSwitch = handleNetworkSwitch(chain_id);
+      const networkName = handleNetworkSwitch(chain_id);
 
-      if (!networkSwitch) return;
+      if (!networkName) return;
 
       showAlertAction({
         isVisible: true,

--- a/app/components/Views/SendFlow/SendTo/index.js
+++ b/app/components/Views/SendFlow/SendTo/index.js
@@ -248,16 +248,16 @@ class SendFlow extends PureComponent {
   handleNetworkSwitch = (chainId) => {
     try {
       const { showAlert } = this.props;
-      const networkTypeOrRpcUrl = handleNetworkSwitch(chainId);
+      const networkName = handleNetworkSwitch(chainId);
 
-      if (!networkTypeOrRpcUrl) return;
+      if (!networkName) return;
 
       showAlert({
         isVisible: true,
         autodismiss: 5000,
         content: 'clipboard-alert',
         data: {
-          msg: strings('send.warn_network_change') + networkTypeOrRpcUrl,
+          msg: strings('send.warn_network_change') + networkName,
         },
       });
     } catch (e) {

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -47,16 +47,16 @@ class DeeplinkManager {
    * @param switchToChainId - Corresponding chain id for new network
    */
   _handleNetworkSwitch = (switchToChainId) => {
-    const networkTypeOrId = handleNetworkSwitch(switchToChainId);
+    const networkName = handleNetworkSwitch(switchToChainId);
 
-    if (!networkTypeOrId) return;
+    if (!networkName) return;
 
     this.dispatch(
       showAlert({
         isVisible: true,
         autodismiss: 5000,
         content: 'clipboard-alert',
-        data: { msg: strings('send.warn_network_change') + networkTypeOrId },
+        data: { msg: strings('send.warn_network_change') + networkName },
       }),
     );
   };

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -12,9 +12,9 @@ import { store } from '../../store';
 /**
  * Switch to the given chain ID.
  *
- * @returns The network type of the build-in network switched to, or the
- * network ID of the custom network switched to, or undefined if no switch
- * occurred.
+ * @returns The network name of the network switched to (i.e. the network type
+ * or nickname, for built-in or custom networks respectively), or undefined if
+ * no switch occurred.
  */
 const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
   // If not specified, use the current network


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The JSDoc comment for `handleNetworkSwitch` had a documented return type that suggested the network ID was returned when switching to a custom network. However this is not the case, instead the network nickname is returned.

The documentation has been corrected, and the network switch result variables throughout the codebase have been updated to be less misleading. No functional changes.

**Issue**

The mistake in the documentation was added recently in #7085

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
