### PR TITLE
chore: Remove unused `getNetworkName` utility function

### DIFF
--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -151,9 +151,6 @@ export const isLineaMainnetByChainId = (chainId) =>
 export const isMultiLayerFeeNetwork = (chainId) =>
   chainId === NETWORKS_CHAIN_ID.OPTIMISM;
 
-export const getNetworkName = (id) =>
-  NetworkListKeys.find((key) => NetworkList[key].networkId === Number(id));
-
 /**
  * Gets the test network image icon.
  *

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -2,7 +2,6 @@ import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import {
   isMainNet,
   isTestNet,
-  getNetworkName,
   getAllNetworks,
   getNetworkTypeById,
   findBlockExplorerForRpc,
@@ -79,38 +78,6 @@ describe('NetworkUtils::isTestNet', () => {
 
   it(`should return false if the given chain ID is not a known testnet`, () => {
     expect(isTestNet('42')).toEqual(false);
-  });
-});
-
-describe('NetworkUtils::getNetworkName', () => {
-  it(`should get network name for ${MAINNET} id`, () => {
-    const main = getNetworkName(String(1));
-    expect(main).toEqual(MAINNET);
-  });
-
-  it(`should get network name for ${GOERLI} id`, () => {
-    const main = getNetworkName(String(5));
-    expect(main).toEqual(GOERLI);
-  });
-
-  it(`should get network name for ${SEPOLIA} id`, () => {
-    const main = getNetworkName(String(11155111));
-    expect(main).toEqual(SEPOLIA);
-  });
-
-  it(`should get network name for ${LINEA_GOERLI} id`, () => {
-    const main = getNetworkName(String(59140));
-    expect(main).toEqual(LINEA_GOERLI);
-  });
-
-  it(`should get network name for ${LINEA_MAINNET} id`, () => {
-    const main = getNetworkName(String(59144));
-    expect(main).toEqual(LINEA_MAINNET);
-  });
-
-  it(`should return undefined for unknown network id`, () => {
-    const main = getNetworkName(String(99));
-    expect(main).toEqual(undefined);
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

This `getNetworkName` utility function was not used. It has been removed to simplify the process of updating the network controller.

**Issue**

Relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
