### PR TITLE
fix: Use network name in switch alert

### DIFF
--- a/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
+++ b/app/components/Views/SendFlow/AddressTo/AddressTo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -8,7 +8,6 @@ import { strings } from '../../../../../locales/i18n';
 import { showAlert } from '../../../../actions/alert';
 import { NetworkSwitchErrorType } from '../../../../constants/error';
 import Routes from '../../../../constants/navigation/Routes';
-import { selectNetwork } from '../../../../selectors/networkController';
 import { handleNetworkSwitch } from '../../../../util/networks';
 import { AddressTo } from '../../../UI/AddressInputs';
 import { createQRScannerNavDetails } from '../../QRScanner';
@@ -30,8 +29,6 @@ const SendFlowAddressTo = ({
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  const networkId = useSelector(selectNetwork);
-
   const showAlertAction = (config: any) => dispatch(showAlert(config));
 
   const onHandleNetworkSwitch = (chain_id: string) => {
@@ -44,7 +41,7 @@ const SendFlowAddressTo = ({
         isVisible: true,
         autodismiss: 5000,
         content: 'clipboard-alert',
-        data: { msg: strings('send.warn_network_change') + networkId },
+        data: { msg: strings('send.warn_network_change') + networkName },
       });
     } catch (e: any) {
       let alertMessage;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

In the send flow, scanning a QR code to fill out the "to" field can also trigger a network switch, which shows an alert to the user. Elsewhere in the codebase where this alert is shown, the network name is used in the alert. But here in the send flow, the network ID was used. It also used the wrong ID; it showed the ID you were switching from, rather than the ID of the network you are switching to.

Now the network name is used everywhere. The network name is the name users are likely to understand; we don't expect users to memorize or understand network IDs.

**Manual Testing Instructions**

* Enter the "Send" flow
* Click the QR scan icon in the "to" field
* Scan a QR code for an address on a specific chain, a different chain than what you have currently selected
  * This QR code should be formatted according to [EIP-681](https://eips.ethereum.org/EIPS/eip-681), with a chain ID set (e.g. `ethereum:0x1111111111111111111111111111111111111111@1` for an Ethereum Mainnet address)
* Before:
  * You should see an alert that says "Network changed to [networkId]" (e.g. "Network changed to 1" for Ethereum mainnet)
  * Note that this alert would incorrectly show the ID of the chain you are switching _from_, rather than the one you are switching _to_.
* After:
  * You should see an alert that says "Network changed to [networkName]" (e.g. "Network changed to mainnet" for Ethereum mainnet)
  * It should correctly show the network name you are switching _to_.
  
**Screenshots/Recordings**

Thanks @SamuelSalas for helping to test this out and getting these screenshots!

Before:

<img src="https://github.com/MetaMask/metamask-mobile/assets/2459287/9d8421c7-fb30-4788-926d-3074ad6d72c3.png" width=50% height=50%>

After:

<img src="https://github.com/MetaMask/metamask-mobile/assets/2459287/de193cb2-fb2f-4ece-a9ee-49ca5010a32b.png" width=50% height=50%>

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
