### PR TITLE
fix: Fix inconsistency in incoming transaction notifications

### DIFF
--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -2,7 +2,6 @@
 
 import PushNotification from 'react-native-push-notification';
 import Engine from './Engine';
-import Networks, { isKnownNetwork } from '../util/networks';
 import { hexToBN, renderFromWei } from '../util/number';
 import Device from '../util/device';
 import { strings } from '../../locales/i18n';
@@ -13,10 +12,9 @@ import {
   PUSH_NOTIFICATIONS_PROMPT_COUNT,
   PUSH_NOTIFICATIONS_PROMPT_TIME,
 } from '../constants/storage';
-import { RPC } from '../constants/network';
 import { safeToChecksumAddress } from '../util/address';
 import ReviewManager from './ReviewManager';
-import { selectProviderType } from '../selectors/networkController';
+import { selectChainId } from '../selectors/networkController';
 import { store } from '../store';
 
 const constructTitleAndMessage = (data) => {
@@ -405,11 +403,10 @@ class NotificationManager {
       PreferencesController,
     } = Engine.context;
     const { selectedAddress } = PreferencesController.state;
-    const networkType = selectProviderType(store.getState());
+    const chainId = selectChainId(store.getState());
 
     /// Find the incoming TX
     const { transactions } = TransactionController.state;
-    const { networkId } = Networks[networkType];
 
     // If a TX has been confirmed more than 10 min ago, it's considered old
     const oldestTimeAllowed = Date.now() - 1000 * 60 * 10;
@@ -421,8 +418,7 @@ class NotificationManager {
           (tx) =>
             safeToChecksumAddress(tx.transaction?.to) === selectedAddress &&
             safeToChecksumAddress(tx.transaction?.from) !== selectedAddress &&
-            ((networkId && networkId.toString() === tx.networkID) ||
-              (networkType === RPC && !isKnownNetwork(tx.networkID))) &&
+            tx.chainId === chainId &&
             tx.status === 'confirmed' &&
             lastBlock <= parseInt(tx.blockNumber, 10) &&
             tx.time > oldestTimeAllowed,

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -230,13 +230,6 @@ export function hasBlockExplorer(key) {
   return key.toLowerCase() !== RPC;
 }
 
-export function isKnownNetwork(id) {
-  const knownNetworks = NetworkListKeys.map(
-    (key) => NetworkList[key].networkId,
-  ).filter((id) => id !== undefined);
-  return knownNetworks.includes(parseInt(id, 10));
-}
-
 export function isprivateConnection(hostname) {
   return (
     hostname === 'localhost' ||


### PR DESCRIPTION
**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

Incoming transaction notifications were incorrectly being triggered for transactions on networks different than the current selected network. This situation only occurs when a custom network is selected, and when an incoming transaction is detected on a _different_ custom network. In all other circumstances, we only show incoming transaction notifications for the current selected network.
    
This problem date back to the original implementation of incoming transaction notifications (see https://github.com/MetaMask/metamask-mobile/pull/447/files#r261268602)

The filter has been updated to use chain ID rather than network ID, and to filter in the same way for built-in and custom networks.

**Screenshots/Recordings**

Testing this is not really feasible because the use-case isn't normally possible except in cases of a race condition. The buggy situation is where you get an incoming transaction on a custom network that is different from the current selected custom network, but in general incoming transaction polling is only active for the current network. So you'd need to switch at the _exact_ right time to demonstrate the problem, and even then it wouldn't be evident from the recording exactly what had happened.

I have prepared a recording that shows that incoming transaction notifications still work correctly on this branch though: https://recordit.co/ee4wSwZkm7

**Issue**

This relates to https://github.com/MetaMask/mobile-planning/issues/1226

**Checklist**

* [x] There is a related GitHub issue
* [ ] Tests are included if applicable
* [x] Any added code is fully documented
