### PR TITLE
Feat/fix lint tsc ledger

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -40,6 +40,7 @@ ignores:
   - 'react-native-svg-asset-plugin'
   - 'regenerator-runtime'
   - 'rn-nodeify'
+  - 'browserify-zlib'
 
   ## Unused devDependencies to investigate
   - '@ethersproject/abi'

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.types.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.types.ts
@@ -27,6 +27,11 @@ export interface PickerAccountProps extends Omit<PickerBaseProps, 'children'> {
    * cell account contianer style.
    */
   cellAccountContainerStyle?: ViewStyle;
+
+  /**
+   * Account type label.
+   */
+  accountTypeLabel?: string;
 }
 
 /**

--- a/app/core/BackupVault/backupVault.ts
+++ b/app/core/BackupVault/backupVault.ts
@@ -1,4 +1,4 @@
-import { KeyringState } from '@metamask/keyring-controller';
+import { KeyringControllerState } from '@metamask/keyring-controller';
 import Logger from '../../util/Logger';
 import {
   getInternetCredentials,
@@ -35,7 +35,7 @@ interface KeyringBackupResponse {
   }
  */
 export async function backupVault(
-  keyringState: KeyringState,
+  keyringState: KeyringControllerState,
 ): Promise<KeyringBackupResponse> {
   if (keyringState.vault) {
     const backupResult = await setInternetCredentials(

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -23,10 +23,6 @@ import {
   TokensState,
 } from '@metamask/assets-controllers';
 import {
-  PersonalMessageParams,
-  TypedMessageParams,
-} from '@metamask/message-manager';
-import {
   AddressBookController,
   AddressBookState,
 } from '@metamask/address-book-controller';
@@ -35,7 +31,6 @@ import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
   KeyringControllerState,
-  SignTypedDataVersion,
   KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
 import {

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -30,7 +30,7 @@ import { BaseState, ControllerMessenger } from '@metamask/base-controller';
 import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
-  KeyringState,
+  KeyringControllerState,
   SignTypedDataVersion,
 } from '@metamask/keyring-controller';
 import {
@@ -145,7 +145,7 @@ export interface EngineState {
   NftController: NftState;
   TokenListController: TokenListState;
   CurrencyRateController: CurrencyRateState;
-  KeyringController: KeyringState;
+  KeyringController: KeyringControllerState;
   NetworkController: NetworkState;
   PreferencesController: PreferencesState;
   PhishingController: PhishingState;
@@ -221,7 +221,7 @@ class Engine {
   // eslint-disable-next-line @typescript-eslint/default-param-last
   constructor(
     initialState: Partial<EngineState> = {},
-    initialKeyringState?: KeyringState | null,
+    initialKeyringState?: KeyringControllerState | null,
   ) {
     this.controllerMessenger = new ControllerMessenger();
 
@@ -424,7 +424,7 @@ class Engine {
       setAccountLabel: preferencesController.setAccountLabel.bind(
         preferencesController,
       ),
-      // @ts-expect-error Error expected.
+      // Error expected.
       encryptor,
       // @ts-expect-error Error expected.
       messenger: this.controllerMessenger.getRestricted({
@@ -740,21 +740,19 @@ class Engine {
   }
 
   handleVaultBackup() {
-    // @ts-expect-error Expect type error
-    this.controllerMessenger.subscribe(
-      'KeyringController:stateChange',
-      (state: any) =>
-        backupVault(state)
-          .then((result) => {
-            if (result.success) {
-              Logger.log('Engine', 'Vault back up successful');
-            } else {
-              Logger.log('Engine', 'Vault backup failed', result.error);
-            }
-          })
-          .catch((error) => {
-            Logger.error(error, 'Engine Vault backup failed');
-          }),
+    const { KeyringController } = this.context;
+    KeyringController.subscribe((state: any) =>
+      backupVault(state)
+        .then((result) => {
+          if (result.success) {
+            Logger.log('Engine', 'Vault back up successful');
+          } else {
+            Logger.log('Engine', 'Vault backup failed', result.error);
+          }
+        })
+        .catch((error) => {
+          Logger.error(error, 'Engine Vault backup failed');
+        }),
     );
   }
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -22,6 +22,7 @@ import {
   TokensController,
   TokensState,
 } from '@metamask/assets-controllers';
+import { PersonalMessageParams } from '@metamask/message-manager';
 import {
   AddressBookController,
   AddressBookState,
@@ -32,6 +33,7 @@ import {
   KeyringController,
   KeyringControllerState,
   KeyringControllerStateChangeEvent,
+  SignTypedDataVersion,
 } from '@metamask/keyring-controller';
 import {
   NetworkController,
@@ -624,7 +626,16 @@ class Engine {
         getAllState: () => store.getState(),
         getCurrentChainId: () =>
           toHexadecimal(networkController.state.providerConfig.chainId),
-        keyringController,
+        keyringController: {
+          signMessage: keyringController.signMessage.bind(keyringController),
+          signPersonalMessage: (messageParams: PersonalMessageParams) =>
+            keyringController.signPersonalMessage(messageParams),
+          signTypedMessage: (msgParams, { version }) =>
+            keyringController.signTypedMessage(
+              msgParams,
+              version as SignTypedDataVersion,
+            ),
+        },
       }),
     ];
 

--- a/app/selectors/types.ts
+++ b/app/selectors/types.ts
@@ -13,7 +13,7 @@ import SwapsController from '@metamask/swaps-controller';
 import { NetworkState } from '@metamask/network-controller';
 import { AddressBookState } from '@metamask/address-book-controller';
 import { BaseState } from '@metamask/base-controller';
-import { KeyringMemState } from '@metamask/keyring-controller';
+import { KeyringControllerState } from '@metamask/keyring-controller';
 import { PreferencesState } from '@metamask/preferences-controller';
 import { PhishingState } from '@metamask/phishing-controller';
 import { TransactionState } from '@metamask/transaction-controller';
@@ -30,7 +30,7 @@ export interface EngineState {
       NftController: NftState;
       TokenListController: TokenListState;
       CurrencyRateController: CurrencyRateState;
-      KeyringController: KeyringMemState;
+      KeyringController: KeyringControllerState;
       NetworkController: NetworkState;
       PreferencesController: PreferencesState;
       PhishingController: PhishingState;

--- a/app/selectors/types.ts
+++ b/app/selectors/types.ts
@@ -13,7 +13,7 @@ import SwapsController from '@metamask/swaps-controller';
 import { NetworkState } from '@metamask/network-controller';
 import { AddressBookState } from '@metamask/address-book-controller';
 import { BaseState } from '@metamask/base-controller';
-import { KeyringControllerState } from '@metamask/keyring-controller';
+import { KeyringControllerMemState } from '@metamask/keyring-controller';
 import { PreferencesState } from '@metamask/preferences-controller';
 import { PhishingState } from '@metamask/phishing-controller';
 import { TransactionState } from '@metamask/transaction-controller';
@@ -30,7 +30,7 @@ export interface EngineState {
       NftController: NftState;
       TokenListController: TokenListState;
       CurrencyRateController: CurrencyRateState;
-      KeyringController: KeyringControllerState;
+      KeyringController: KeyringControllerMemState;
       NetworkController: NetworkState;
       PreferencesController: PreferencesState;
       PhishingController: PhishingState;

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -28,6 +28,7 @@ const initialRootState: RootState = {
   networkOnboarded: undefined,
   security: initialSecurityState,
   experimentalSettings: undefined,
+  rpcEvents: undefined,
 };
 
 export default initialRootState;

--- a/package.json
+++ b/package.json
@@ -342,7 +342,6 @@
     "rxjs": "^7.5.5",
     "socket.io-client": "^4.5.3",
     "stream-browserify": "1.0.0",
-    "swappable-obj-proxy": "^1.1.0",
     "through2": "3.0.1",
     "unicode-confusables": "^0.1.1",
     "url": "0.11.0",


### PR DESCRIPTION
**Description**
This PR will provide the code fix for all CI lint relative pipeline. Following changes have been made in this PR
1. change to use `KeyringControllerState` to replace old `KeyringState` from '@metamask/keyring-controller'
2. Big code changed  in `engine.ts` to fix KeyringController relative compile issue due to type mismatch and use deprecative type.
3. Fix a reducer `root.ts`  in `test` package due to missing declaration in test.
4. Removed unused lib in package.json which was detected by `yarn depcheck`.
5. add `browserify-zlib` into .`depcheckrc.yml` file to ignore dep check for that library.






