### PR TITLE
test: build test dapp and run tests against localhost

### DIFF
--- a/e2e/create-static-server.js
+++ b/e2e/create-static-server.js
@@ -1,0 +1,22 @@
+/* eslint-disable import/no-nodejs-modules */
+import http from 'http';
+import path from 'path';
+import serveHandler from 'serve-handler';
+
+const createStaticServer = function (rootDirectory) {
+  return http.createServer((request, response) => {
+    if (request.url.startsWith('/node_modules/')) {
+      request.url = request.url.substr(14);
+      return serveHandler(request, response, {
+        directoryListing: false,
+        public: path.resolve('./node_modules'),
+      });
+    }
+    return serveHandler(request, response, {
+      directoryListing: false,
+      public: rootDirectory,
+    });
+  });
+};
+
+export default createStaticServer;

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 
-const DAPP_URL = 'metamask.github.io';
+const DAPP_URL = 'localhost';
 
 /**
  * FixtureBuilder class provides a fluent interface for building fixture data.

--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -1,9 +1,11 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, import/no-nodejs-modules */
 import FixtureServer from './fixture-server';
 import FixtureBuilder from './fixture-builder';
 import Ganache from '../../app/util/test/ganache';
 import GanacheSeeder from '../../app/util/test/ganache-seeder';
 import axios from 'axios';
+import path from 'path';
+import createStaticServer from '../create-static-server';
 
 const fixtureServer = new FixtureServer();
 
@@ -83,9 +85,16 @@ export async function withFixtures(options, testSuite) {
     restartDevice = false,
     ganacheOptions,
     smartContract,
+    dapp,
+    dappOptions,
+    dappPath = undefined,
+    dappPaths,
   } = options;
 
   const ganacheServer = new Ganache();
+  const dappBasePort = 8080;
+  let numberOfDapps = dapp ? 1 : 0;
+  const dappServer = [];
 
   try {
     let contractRegistry;
@@ -96,6 +105,34 @@ export async function withFixtures(options, testSuite) {
         const ganacheSeeder = new GanacheSeeder(ganacheServer.getProvider());
         await ganacheSeeder.deploySmartContract(smartContract);
         contractRegistry = ganacheSeeder.getContractRegistry();
+      }
+    }
+
+    if (dapp) {
+      if (dappOptions?.numberOfDapps) {
+        numberOfDapps = dappOptions.numberOfDapps;
+      }
+      for (let i = 0; i < numberOfDapps; i++) {
+        let dappDirectory;
+        if (dappPath || (dappPaths && dappPaths[i])) {
+          dappDirectory = path.resolve(__dirname, dappPath || dappPaths[i]);
+        } else {
+          dappDirectory = path.resolve(
+            __dirname,
+            '..',
+            '..',
+            'node_modules',
+            '@metamask',
+            'test-dapp',
+            'dist',
+          );
+        }
+        dappServer.push(createStaticServer(dappDirectory));
+        dappServer[i].listen(`${dappBasePort + i}`);
+        await new Promise((resolve, reject) => {
+          dappServer[i].on('listening', resolve);
+          dappServer[i].on('error', reject);
+        });
       }
     }
     // Start the fixture server

--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -155,6 +155,20 @@ export async function withFixtures(options, testSuite) {
     if (ganacheOptions) {
       await ganacheServer.quit();
     }
+    if (dapp) {
+      for (let i = 0; i < numberOfDapps; i++) {
+        if (dappServer[i] && dappServer[i].listening) {
+          await new Promise((resolve, reject) => {
+            dappServer[i].close((error) => {
+              if (error) {
+                return reject(error);
+              }
+              return resolve();
+            });
+          });
+        }
+      }
+    }
     await stopFixtureServer();
   }
 }

--- a/e2e/pages/TestDApp.js
+++ b/e2e/pages/TestDApp.js
@@ -55,10 +55,10 @@ export class TestDApp {
     await TestHelpers.delay(3000);
   }
 
-  static async scrollToButton(buttonId, testDappUrl) {
+  static async scrollToButton(buttonId) {
     await Browser.tapUrlInputBox();
     await Browser.navigateToURL(
-      `${testDappUrl}?scrollTo=${buttonId}&time=${Date.now()}`,
+      `${TEST_DAPP_URL}?scrollTo=${buttonId}&time=${Date.now()}`,
     );
     await TestHelpers.delay(3000);
   }
@@ -67,11 +67,10 @@ export class TestDApp {
     buttonId,
     parameterName,
     parameterValue,
-    testDappUrl,
   ) {
     await Browser.tapUrlInputBox();
     await Browser.navigateToURL(
-      `${testDappUrl}?scrollTo=${buttonId}&time=${Date.now()}&${parameterName}=${parameterValue}`,
+      `${TEST_DAPP_LOCAL_URL}?scrollTo=${buttonId}&time=${Date.now()}&${parameterName}=${parameterValue}`,
     );
     await TestHelpers.delay(3000);
   }
@@ -81,7 +80,7 @@ export class TestDApp {
     await Browser.navigateToURL(`${testDappUrl}?contract=${contractAddress}`);
   }
 
-  static async tapTransferFromButton(contractAddress, testDappUrl) {
+  static async tapTransferFromButton(contractAddress) {
     if (device.getPlatform() === 'android') {
       await TestHelpers.waitForWebElementToBeVisibleById(
         WEBVIEW_TEST_DAPP_TRANSFER_FROM_BUTTON_ID,
@@ -95,7 +94,6 @@ export class TestDApp {
         'transferFromButton',
         'contract',
         contractAddress,
-        testDappUrl,
       );
       await TestHelpers.tapAtPoint(BROWSER_WEBVIEW_ID, BUTTON_RELATIVE_PONT);
     }

--- a/e2e/pages/TestDApp.js
+++ b/e2e/pages/TestDApp.js
@@ -6,6 +6,7 @@ import Browser from './Drawer/Browser';
 import root from '../../locales/languages/en.json';
 
 export const TEST_DAPP_URL = 'https://metamask.github.io/test-dapp/';
+export const TEST_DAPP_LOCAL_URL = 'http://localhost:8080';
 
 const BUTTON_RELATIVE_PONT = { x: 200, y: 5 };
 const WEBVIEW_TEST_DAPP_TRANSFER_FROM_BUTTON_ID = 'transferFromButton';
@@ -54,10 +55,10 @@ export class TestDApp {
     await TestHelpers.delay(3000);
   }
 
-  static async scrollToButton(buttonId) {
+  static async scrollToButton(buttonId, testDappUrl) {
     await Browser.tapUrlInputBox();
     await Browser.navigateToURL(
-      `${TEST_DAPP_URL}?scrollTo=${buttonId}&time=${Date.now()}`,
+      `${testDappUrl}?scrollTo=${buttonId}&time=${Date.now()}`,
     );
     await TestHelpers.delay(3000);
   }
@@ -66,10 +67,11 @@ export class TestDApp {
     buttonId,
     parameterName,
     parameterValue,
+    testDappUrl,
   ) {
     await Browser.tapUrlInputBox();
     await Browser.navigateToURL(
-      `${TEST_DAPP_URL}?scrollTo=${buttonId}&time=${Date.now()}&${parameterName}=${parameterValue}`,
+      `${testDappUrl}?scrollTo=${buttonId}&time=${Date.now()}&${parameterName}=${parameterValue}`,
     );
     await TestHelpers.delay(3000);
   }
@@ -79,7 +81,7 @@ export class TestDApp {
     await Browser.navigateToURL(`${testDappUrl}?contract=${contractAddress}`);
   }
 
-  static async tapTransferFromButton(contractAddress) {
+  static async tapTransferFromButton(contractAddress, testDappUrl) {
     if (device.getPlatform() === 'android') {
       await TestHelpers.waitForWebElementToBeVisibleById(
         WEBVIEW_TEST_DAPP_TRANSFER_FROM_BUTTON_ID,
@@ -93,6 +95,7 @@ export class TestDApp {
         'transferFromButton',
         'contract',
         contractAddress,
+        testDappUrl,
       );
       await TestHelpers.tapAtPoint(BROWSER_WEBVIEW_ID, BUTTON_RELATIVE_PONT);
     }

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
@@ -13,7 +13,7 @@ import {
 import root from '../../../locales/languages/en.json';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Smoke('ERC721 tokens'), () => {
+describe(Regression('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
 

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
-import { TEST_DAPP_URL, TestDApp } from '../../pages/TestDApp';
+import { TestDApp } from '../../pages/TestDApp';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
   withFixtures,
@@ -13,20 +13,24 @@ import {
 import root from '../../../locales/languages/en.json';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Regression('ERC721 tokens'), () => {
+describe(Smoke('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
+  const TEST_DAPP_URL = 'http://localhost:8080';
+
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
       await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
-      await device.reverseTcpPort('8545');
+      await device.reverseTcpPort('8545'); // ganache
+      await device.reverseTcpPort('8080'); // test-dapp
     }
   });
 
   it('send an ERC721 token from a dapp', async () => {
     await withFixtures(
       {
+        dapp: true,
         fixture: new FixtureBuilder()
           .withGanacheNetwork()
           .withPermissionControllerConnectedToTestDapp()

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -54,7 +54,7 @@ describe(Smoke('ERC721 tokens'), () => {
         );
 
         // Transfer NFT
-        await TestDApp.tapTransferFromButton(nftsAddress, TEST_DAPP_LOCAL_URL);
+        await TestDApp.tapTransferFromButton(nftsAddress);
         await TestHelpers.delay(3000);
 
         await TestDApp.tapConfirmButton();

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -4,7 +4,7 @@ import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
-import { TestDApp } from '../../pages/TestDApp';
+import { TEST_DAPP_LOCAL_URL, TestDApp } from '../../pages/TestDApp';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
   withFixtures,
@@ -16,7 +16,6 @@ import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 describe(Smoke('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
-  const TEST_DAPP_URL = 'http://localhost:8080';
 
   beforeAll(async () => {
     jest.setTimeout(150000);
@@ -50,12 +49,12 @@ describe(Smoke('ERC721 tokens'), () => {
 
         // Navigate to the ERC721 url
         await TestDApp.navigateToTestDappWithContract(
-          TEST_DAPP_URL,
+          TEST_DAPP_LOCAL_URL,
           nftsAddress,
         );
 
         // Transfer NFT
-        await TestDApp.tapTransferFromButton(nftsAddress);
+        await TestDApp.tapTransferFromButton(nftsAddress, TEST_DAPP_LOCAL_URL);
         await TestHelpers.delay(3000);
 
         await TestDApp.tapConfirmButton();

--- a/package.json
+++ b/package.json
@@ -452,6 +452,7 @@
     "react-test-renderer": "18.2.0",
     "regenerator-runtime": "0.13.9",
     "rn-nodeify": "10.3.0",
+    "serve-handler": "^6.1.5",
     "stack-beautifier": "1.0.2",
     "ts-node": "^10.5.0",
     "typescript": "~4.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10828,6 +10828,11 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+  integrity sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==
+
 content-disposition@0.5.4, content-disposition@~0.5.2:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
@@ -14087,6 +14092,13 @@ fast-text-encoding@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+
+fast-url-parser@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
+  integrity sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==
+  dependencies:
+    punycode "^1.3.2"
 
 fast-xml-parser@4.2.4, fast-xml-parser@^4.0.12:
   version "4.2.4"
@@ -19295,6 +19307,18 @@ mime-db@1.52.0, mime-db@^1.28.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+  integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
+
+mime-types@2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
+  dependencies:
+    mime-db "~1.33.0"
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
@@ -19351,7 +19375,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@5.1.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2, minimatch@^5.0.0, minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^6.0.4, minimatch@~3.0.2:
+minimatch@3.1.2, minimatch@5.1.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2, minimatch@^5.0.0, minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^6.0.4, minimatch@~3.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
@@ -20854,6 +20878,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-is-inside@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -20873,6 +20902,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
+path-to-regexp@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
+  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -21576,6 +21610,11 @@ punycode@2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
   integrity sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=
 
+punycode@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -21758,6 +21797,11 @@ randomstring@^1.1.5:
   dependencies:
     array-uniq "1.0.2"
     randombytes "2.0.3"
+
+range-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+  integrity sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -23693,6 +23737,20 @@ serve-favicon@^2.4.5:
     ms "2.1.1"
     parseurl "~1.3.2"
     safe-buffer "5.1.1"
+
+serve-handler@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.5.tgz#a4a0964f5c55c7e37a02a633232b6f0d6f068375"
+  integrity sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==
+  dependencies:
+    bytes "3.0.0"
+    content-disposition "0.5.2"
+    fast-url-parser "1.1.3"
+    mime-types "2.1.18"
+    minimatch "3.1.2"
+    path-is-inside "1.0.2"
+    path-to-regexp "2.2.1"
+    range-parser "1.2.0"
 
 serve-static@1.15.0:
   version "1.15.0"


### PR DESCRIPTION
## Description
This PR adds logic for running (one/many) dapp server(s) locally whenever we run the e2e tests. This way we can run the tests in a controlled environment (against localhost) instead of on a live site.

Here some highlights on how it is done (based on existing Extension implementation):

- we leverage `test-dapp` node module and `serve-handler` for building a static server
- we add the corresponding options on the `withFixtures` method, in order to indicate if we want a dapp server and how many(if more than one)
- on the test, we just need to pass `dapp: true` to start the test dapp server locally

Test on ci continue to work:
- Bitrise run : https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/296f9b58-fb20-4e89-94da-0a475ec04caa

![Screenshot from 2023-09-12 18-59-46](https://github.com/MetaMask/metamask-mobile/assets/54408225/5e85010c-9281-417e-8320-dc764d7d07ad)

## Screenshots/Recordings
Notice how we are now going to `localhost` in the browser for accessing the test dapp

https://github.com/MetaMask/metamask-mobile/assets/54408225/ffbaa904-ae83-47d6-a423-e2210dfe26e5



## Issue

- fixes https://github.com/MetaMask/mobile-planning/issues/1253



## Checklist

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
