### PR TITLE
fix: Fix Sentry sourcemap upload step

### DIFF
--- a/package.json
+++ b/package.json
@@ -515,7 +515,7 @@
       "@eth-optimism/contracts>@ethersproject/hardware-wallets>@ledgerhq/hw-transport-node-hid>usb": false,
       "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>keccak": true,
       "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>secp256k1": true,
-      "@sentry/react-native>@sentry/cli": false,
+      "@sentry/react-native>@sentry/cli": true,
       "@storybook/addon-actions>core-js": false,
       "@storybook/addon-knobs>@storybook/addons>core-js": false,
       "@storybook/addon-knobs>@storybook/api>core-js": false,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Development & PR Process**
1. Follow MetaMask [Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/coding_guidelines/CODING_GUIDELINES.md)
2. Add `release-xx` label to identify the PR slated for a upcoming release (will be used in release discussion)
3. Add `needs-dev-review` label when work is completed
4. Add the appropiate QA label when dev review is completed
    - `needs-qa`: PR requires manual QA.
    - `No QA/E2E only`: PR does not require any manual QA effort. Prior to merging, ensure that you have successful end-to-end test runs in Bitrise. 
    - `Spot check on release build`: PR does not require feature QA but needs non-automated verification. In the description section, provide test scenarios. Add screenshots, and or recordings of what was tested.
5. Add `QA Passed` label when QA has signed off (Only required if the PR was labeled with `needs-qa`)
6. Add your team's label, i.e. label starting with `team-` (or `external-contributor` label if your not a MetaMask employee)

**Description**

The build step where sourcemaps are uploaded to Sentry was broken because the Sentry CLI was not installed. The Sentry CLI postinstall script was disabled recently in #7032. It has now been enabled again.

**Issue**

No related issue

**Checklist**

* [ ] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
