### PR TITLE
feat: Show link on blockaid banner to report false positives

### DIFF
--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -56,7 +56,6 @@ import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
 import {
   isBlockaidFeatureEnabled,
   getBlockaidMetricsParams,
-  showBlockaidUI,
 } from '../../../util/blockaid';
 import { withNavigation } from '@react-navigation/compat';
 import {
@@ -540,16 +539,14 @@ class ApproveTransactionReview extends PureComponent {
           : AppConstants.REQUEST_SOURCES.IN_APP_BROWSER,
       };
 
-      if (showBlockaidUI()) {
-        const blockaidParams = getBlockaidMetricsParams(
-          transaction.securityAlertResponse,
-        );
+      const blockaidParams = getBlockaidMetricsParams(
+        transaction.securityAlertResponse,
+      );
 
-        params = {
-          ...params,
-          ...blockaidParams,
-        };
-      }
+      params = {
+        ...params,
+        ...blockaidParams,
+      };
       // Send analytics params to parent component so it's available when cancelling and confirming
       onSetAnalyticsParams && onSetAnalyticsParams(params);
 
@@ -689,6 +686,17 @@ class ApproveTransactionReview extends PureComponent {
     }
   };
 
+  onContactUsClicked = () => {
+    const analyticsParams = {
+      ...this.getAnalyticsParams(),
+      external_link_clicked: 'security_alert_support_link',
+    };
+    AnalyticsV2.trackEvent(
+      MetaMetricsEvents.CONTRACT_ADDRESS_COPIED,
+      analyticsParams,
+    );
+  };
+
   renderDetails = () => {
     const {
       originalApproveAmount,
@@ -811,6 +819,7 @@ class ApproveTransactionReview extends PureComponent {
                       <BlockaidBanner
                         securityAlertResponse={securityAlertResponse}
                         style={styles.blockaidWarning}
+                        onContactUsClicked={this.onContactUsClicked}
                       />
                     )}
                     <Text

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.constants.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.constants.ts
@@ -1,4 +1,6 @@
 export const ATTRIBUTION_LINE_TEST_ID = 'blockaid-banner-attribution-line';
+export const FALSE_POSITIVE_REPOST_LINE_TEST_ID =
+  'blockaid-banner-false-positive-report-line';
 
 import { Reason } from './BlockaidBanner.types';
 
@@ -20,6 +22,7 @@ export const REASON_DESCRIPTION_I18N_KEY_MAP = Object.freeze({
   [Reason.transferFarming]: 'blockaid_banner.transfer_farming_description',
   [Reason.transferFromFarming]: 'blockaid_banner.transfer_farming_description',
   [Reason.unfairTrade]: 'blockaid_banner.unfair_trade_description',
+  [Reason.notApplicable]: 'not_applicable',
 });
 
 export const REASON_TITLE_I18N_KEY_MAP: Record<string, string> = Object.freeze({

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.styles.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.styles.ts
@@ -20,6 +20,7 @@ const styleSheet = (_params: {
       flexDirection: 'row',
       justifyContent: 'flex-start',
       alignItems: 'flex-start',
+      marginTop: 8,
     } as ViewStyle),
     attributionItem: {
       marginRight: 4,

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.test.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.test.tsx
@@ -6,7 +6,10 @@ import { TESTID_ACCORDION_CONTENT } from '../../../component-library/components/
 import { TESTID_ACCORDIONHEADER } from '../../../component-library/components/Accordions/Accordion/foundation/AccordionHeader/AccordionHeader.constants';
 import { BANNERALERT_TEST_ID } from '../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.constants';
 import BlockaidBanner from './BlockaidBanner';
-import { ATTRIBUTION_LINE_TEST_ID } from './BlockaidBanner.constants';
+import {
+  ATTRIBUTION_LINE_TEST_ID,
+  FALSE_POSITIVE_REPOST_LINE_TEST_ID,
+} from './BlockaidBanner.constants';
 import { ResultType, Reason } from './BlockaidBanner.types';
 
 jest.mock('../../../util/blockaid', () => ({
@@ -109,6 +112,32 @@ describe('BlockaidBanner', () => {
       await wrapper.queryByText(
         'Operator is untrusted according to previous activity',
       ),
+    ).toBeDefined();
+  });
+
+  it('should render something does not look right with contact us link when expanded', async () => {
+    const wrapper = render(
+      <BlockaidBanner
+        securityAlertResponse={{
+          resultType: ResultType.Malicious,
+          reason: Reason.approvalFarming,
+          features: mockFeatures,
+        }}
+      />,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+    expect(await wrapper.queryByTestId(TESTID_ACCORDIONHEADER)).toBeDefined();
+    expect(await wrapper.queryByTestId(TESTID_ACCORDION_CONTENT)).toBeNull();
+
+    fireEvent.press(await wrapper.getByText('See details'));
+
+    expect(await wrapper.queryByTestId(TESTID_ACCORDION_CONTENT)).toBeDefined();
+    expect(
+      await wrapper.queryByTestId(FALSE_POSITIVE_REPOST_LINE_TEST_ID),
+    ).toBeDefined();
+    expect(
+      await wrapper.queryByText('Something doesn’t look right?'),
     ).toBeDefined();
   });
 

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
@@ -18,9 +18,9 @@ import Icon from '../../../component-library/components/Icons/Icon/Icon';
 import Text from '../../../component-library/components/Texts/Text/Text';
 import { useStyles } from '../../../component-library/hooks/useStyles';
 import { isBlockaidFeatureEnabled } from '../../../util/blockaid';
-import AttributionLink from './AttributionLink';
 import {
   ATTRIBUTION_LINE_TEST_ID,
+  FALSE_POSITIVE_REPOST_LINE_TEST_ID,
   REASON_DESCRIPTION_I18N_KEY_MAP,
   REASON_TITLE_I18N_KEY_MAP,
 } from './BlockaidBanner.constants';
@@ -30,6 +30,11 @@ import {
   Reason,
   ResultType,
 } from './BlockaidBanner.types';
+import BlockaidBannerLink from './BlockaidBannerLink';
+import {
+  BLOCKAID_ATTRIBUTION_LINK,
+  BLOCKAID_SUPPORT_LINK,
+} from '../../../constants/urls';
 
 const getTitle = (reason: Reason): string =>
   strings(
@@ -44,7 +49,12 @@ const getDescription = (reason: Reason) =>
   );
 
 const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
-  const { style, securityAlertResponse, onToggleShowDetails } = bannerProps;
+  const {
+    style,
+    securityAlertResponse,
+    onToggleShowDetails,
+    onContactUsClicked,
+  } = bannerProps;
   const { styles } = useStyles(styleSheet, { style });
 
   if (!securityAlertResponse || !isBlockaidFeatureEnabled()) {
@@ -89,6 +99,23 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
             </Text>
           ))}
         </View>
+        <View style={styles.attributionBase}>
+          <View style={styles.attributionItem}>
+            <Text
+              variant={DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT}
+              data-testid={FALSE_POSITIVE_REPOST_LINE_TEST_ID}
+            >
+              {strings('blockaid_banner.does_not_look_right')}
+            </Text>
+          </View>
+          <View style={styles.attributionItem}>
+            <BlockaidBannerLink
+              text={strings('app_information.contact_us')}
+              link={BLOCKAID_SUPPORT_LINK}
+              onContactUsClicked={onContactUsClicked}
+            />
+          </View>
+        </View>
       </Accordion>
     );
 
@@ -123,7 +150,10 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
           </Text>
         </View>
         <View style={styles.attributionItem}>
-          <AttributionLink />
+          <BlockaidBannerLink
+            text={strings('blockaid_banner.attribution_link_name')}
+            link={BLOCKAID_ATTRIBUTION_LINK}
+          />
         </View>
       </View>
     </BannerAlert>

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
@@ -36,6 +36,7 @@ export interface SecurityAlertResponse {
 type BlockaidBannerAllProps = BannerAlertProps & {
   securityAlertResponse?: SecurityAlertResponse;
   onToggleShowDetails?: () => void;
+  onContactUsClicked?: () => void;
 };
 
 export type BlockaidBannerProps = Omit<BlockaidBannerAllProps, 'severity'>;

--- a/app/components/UI/BlockaidBanner/BlockaidBannerLink.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBannerLink.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Linking, StyleSheet } from 'react-native';
-
-import { strings } from '../../../../locales/i18n';
 import { DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT } from '../../../component-library/components/Banners/Banner/foundation/BannerBase/BannerBase.constants';
 import Text from '../../../component-library/components/Texts/Text/Text';
 import { useTheme } from '../../../util/theme';
@@ -11,7 +9,15 @@ const createStyles = (colors: any) =>
     attributionLink: { color: colors.primary.default },
   });
 
-const AttributionLink = () => {
+const BlockaidBannerLink = ({
+  text,
+  link,
+  onContactUsClicked,
+}: {
+  text: string;
+  link: string;
+  onContactUsClicked?: () => void | undefined;
+}) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
@@ -21,12 +27,13 @@ const AttributionLink = () => {
       style={styles.attributionLink}
       variant={DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT}
       onPress={() => {
-        Linking.openURL(strings('blockaid_banner.attribution_link'));
+        onContactUsClicked?.();
+        Linking.openURL(link);
       }}
     >
-      {strings('blockaid_banner.attribution_link_name')}
+      {text}
     </Text>
   );
 };
 
-export default AttributionLink;
+export default BlockaidBannerLink;

--- a/app/components/UI/BlockaidBanner/__snapshots__/BlockaidBanner.test.tsx.snap
+++ b/app/components/UI/BlockaidBanner/__snapshots__/BlockaidBanner.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`BlockaidBanner should render correctly 1`] = `
           "flexDirection": "row",
           "height": 24,
           "justifyContent": "flex-start",
+          "marginTop": 8,
         }
       }
     >
@@ -398,6 +399,7 @@ exports[`BlockaidBanner should render correctly with list attack details 1`] = `
           "flexDirection": "row",
           "height": 24,
           "justifyContent": "flex-start",
+          "marginTop": 8,
         }
       }
     >
@@ -637,6 +639,7 @@ exports[`BlockaidBanner should render correctly with reason "raw_signature_farmi
           "flexDirection": "row",
           "height": 24,
           "justifyContent": "flex-start",
+          "marginTop": 8,
         }
       }
     >
@@ -793,6 +796,246 @@ exports[`BlockaidBanner should render normal banner alert if resultType is faile
     >
       If you approve this request, you might lose your assets.
     </Text>
+  </View>
+</View>
+`;
+
+exports[`BlockaidBanner should render something does not look right with contact us link when expanded 1`] = `
+<View
+  securityAlertResponse={
+    Object {
+      "features": Array [
+        "We found attack vectors in this request",
+        "This request shows a fake token name and icon.",
+        "If you approve this request, a third party known for scams might take all your assets.",
+        "Operator is an EOA",
+        "Operator is untrusted according to previous activity",
+      ],
+      "reason": "approval_farming",
+      "resultType": "Malicious",
+    }
+  }
+  style={
+    Object {
+      "backgroundColor": "#D7384719",
+      "borderColor": "#D73847",
+      "borderLeftWidth": 4,
+      "borderRadius": 4,
+      "flexDirection": "row",
+      "padding": 12,
+      "paddingLeft": 8,
+    }
+  }
+  testID="banneralert"
+>
+  <View
+    style={
+      Object {
+        "marginRight": 8,
+      }
+    }
+  >
+    <SvgMock
+      color="#D73847"
+      height={24}
+      name="Danger"
+      style={
+        Object {
+          "height": 24,
+          "width": 24,
+        }
+      }
+      width={24}
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      style={
+        Object {
+          "color": "#24272A",
+          "fontFamily": "Euclid Circular B",
+          "fontSize": 16,
+          "fontWeight": "500",
+          "letterSpacing": 0,
+          "lineHeight": 24,
+        }
+      }
+    >
+      This is a deceptive request
+    </Text>
+    <Text
+      accessibilityRole="text"
+      style={
+        Object {
+          "color": "#24272A",
+          "fontFamily": "Euclid Circular B",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0,
+          "lineHeight": 22,
+        }
+      }
+    >
+      If you approve this request, a third party known for scams might take all your assets.
+    </Text>
+    <TouchableOpacity
+      activeOpacity={0.5}
+      onPress={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "height": 24,
+          "justifyContent": "flex-start",
+        }
+      }
+      testID="accordionheader"
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          Object {
+            "color": "#0376C9",
+            "fontFamily": "Euclid Circular B",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+        testID="accordionheader-title"
+      >
+        See details
+      </Text>
+      <View
+        style={
+          Array [
+            Object {
+              "marginLeft": 4,
+            },
+            Object {
+              "transform": Array [
+                Object {
+                  "rotate": "0deg",
+                },
+              ],
+            },
+          ]
+        }
+        testID="accordionheader-arrow-icon-animation"
+      >
+        <SvgMock
+          color="#0376C9"
+          height={16}
+          name="ArrowUp"
+          style={
+            Object {
+              "height": 16,
+              "width": 16,
+            }
+          }
+          testID="accordionheader-arrow-icon"
+          width={16}
+        />
+      </View>
+    </TouchableOpacity>
+    <View
+      collapsable={false}
+      forwardedRef={[Function]}
+      style={
+        Object {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "height": 24,
+          "justifyContent": "flex-start",
+          "marginTop": 8,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        forwardedRef={[Function]}
+        style={
+          Object {
+            "marginRight": 4,
+          }
+        }
+      >
+        <SvgMock
+          color="#0376C9"
+          height={16}
+          name="SecurityTick"
+          style={
+            Object {
+              "height": 16,
+              "marginTop": 4,
+              "width": 16,
+            }
+          }
+          width={16}
+        />
+      </View>
+      <View
+        collapsable={false}
+        forwardedRef={[Function]}
+        style={
+          Object {
+            "marginRight": 4,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          data-testid="blockaid-banner-attribution-line"
+          style={
+            Object {
+              "color": "#24272A",
+              "fontFamily": "Euclid Circular B",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Security advice by
+        </Text>
+      </View>
+      <View
+        collapsable={false}
+        forwardedRef={[Function]}
+        style={
+          Object {
+            "marginRight": 4,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          onPress={[Function]}
+          style={
+            Object {
+              "color": "#0376C9",
+              "fontFamily": "Euclid Circular B",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Blockaid
+        </Text>
+      </View>
+    </View>
   </View>
 </View>
 `;

--- a/app/components/UI/MessageSign/MessageSign.tsx
+++ b/app/components/UI/MessageSign/MessageSign.tsx
@@ -82,7 +82,7 @@ class MessageSign extends PureComponent<MessageSignProps, MessageSignState> {
 
     AnalyticsV2.trackEvent(
       MetaMetricsEvents.SIGNATURE_REQUESTED,
-      getAnalyticsParams(messageParams, 'message_sign'),
+      getAnalyticsParams(messageParams, 'eth_sign'),
     );
     addSignatureErrorListener(messageParams.metamaskId, this.onSignatureError);
   };
@@ -99,7 +99,7 @@ class MessageSign extends PureComponent<MessageSignProps, MessageSignState> {
     if (error?.message.startsWith(KEYSTONE_TX_CANCELED)) {
       AnalyticsV2.trackEvent(
         MetaMetricsEvents.QR_HARDWARE_TRANSACTION_CANCELED,
-        getAnalyticsParams(messageParams, 'message_sign'),
+        getAnalyticsParams(messageParams, 'eth_sign'),
       );
     }
   };

--- a/app/components/UI/PersonalSign/PersonalSign.tsx
+++ b/app/components/UI/PersonalSign/PersonalSign.tsx
@@ -19,10 +19,7 @@ import createStyles from './styles';
 import AppConstants from '../../../core/AppConstants';
 import { selectChainId } from '../../../selectors/networkController';
 import { store } from '../../../store';
-import {
-  getBlockaidMetricsParams,
-  isBlockaidFeatureEnabled,
-} from '../../../util/blockaid';
+import { getBlockaidMetricsParams } from '../../../util/blockaid';
 import { SecurityAlertResponse } from '../BlockaidBanner/BlockaidBanner.types';
 
 /**
@@ -53,21 +50,19 @@ const PersonalSign = ({
   const getAnalyticsParams = useCallback((): AnalyticsParams => {
     try {
       const chainId = selectChainId(store.getState());
-      const url = new URL(currentPageInformation?.url);
+      const pageInfo = currentPageInformation || messageParams.meta;
+      const url = new URL(pageInfo.url);
 
-      let blockaidParams = {};
-      if (isBlockaidFeatureEnabled()) {
-        blockaidParams = getBlockaidMetricsParams(
-          messageParams.securityAlertResponse as SecurityAlertResponse,
-        );
-      }
+      const blockaidParams = getBlockaidMetricsParams(
+        messageParams.securityAlertResponse as SecurityAlertResponse,
+      );
 
       return {
         account_type: getAddressAccountType(messageParams.from),
         dapp_host_name: url?.host,
         chain_id: chainId,
         signature_type: 'personal_sign',
-        ...currentPageInformation?.analytics,
+        ...pageInfo?.analytics,
         ...blockaidParams,
       };
     } catch (error) {

--- a/app/components/UI/SignatureRequest/index.js
+++ b/app/components/UI/SignatureRequest/index.js
@@ -5,6 +5,7 @@ import { fontStyles } from '../../../styles/common';
 import { getHost } from '../../../util/browser';
 import { strings } from '../../../../locales/i18n';
 import { connect } from 'react-redux';
+import AnalyticsV2 from '../../../util/analyticsV2';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import WebsiteIcon from '../WebsiteIcon';
 import ActionView from '../ActionView';
@@ -19,6 +20,7 @@ import withQRHardwareAwareness from '../QRHardware/withQRHardwareAwareness';
 import QRSigningDetails from '../QRHardware/QRSigningDetails';
 import { selectProviderType } from '../../../selectors/networkController';
 import BlockaidBanner from '../BlockaidBanner/BlockaidBanner';
+import { getAnalyticsParams } from '../../../util/confirmation/signatureUtils';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -287,6 +289,24 @@ class SignatureRequest extends PureComponent {
     );
   };
 
+  onContactUsClicked = () => {
+    const { securityAlertResponse, fromAddress, type } = this.props;
+    const analyticsParams = {
+      ...getAnalyticsParams(
+        {
+          securityAlertResponse,
+          from: fromAddress,
+        },
+        type,
+      ),
+      external_link_clicked: 'security_alert_support_link',
+    };
+    AnalyticsV2.trackEvent(
+      MetaMetricsEvents.SIGNATURE_REQUESTED,
+      analyticsParams,
+    );
+  };
+
   renderSignatureRequest() {
     const { securityAlertResponse, showWarning, type } = this.props;
     let expandedHeight;
@@ -330,6 +350,7 @@ class SignatureRequest extends PureComponent {
               <BlockaidBanner
                 securityAlertResponse={securityAlertResponse}
                 style={styles.blockaidBanner}
+                onContactUsClicked={this.onContactUsClicked}
               />
             )}
             {this.renderActionViewChildren()}

--- a/app/components/UI/TransactionReview/index.test.tsx
+++ b/app/components/UI/TransactionReview/index.test.tsx
@@ -5,8 +5,14 @@ import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 // eslint-disable-next-line import/no-namespace
 import * as TransactionUtils from '../../../util/transactions';
+// eslint-disable-next-line import/no-namespace
+import * as BlockaidUtils from '../../../util/blockaid';
+import analyticsV2 from '../../../util/analyticsV2';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import initialBackgroundState from '../../../util/test/initial-background-state.json';
+import { fireEvent } from '@testing-library/react-native';
+import { TESTID_ACCORDION_CONTENT } from '../../../component-library/components/Accordions/Accordion/Accordion.constants';
+import { FALSE_POSITIVE_REPOST_LINE_TEST_ID } from '../BlockaidBanner/BlockaidBanner.constants';
 
 jest.mock('../../../util/transactions', () => ({
   ...jest.requireActual('../../../util/transactions'),
@@ -121,7 +127,24 @@ describe('TransactionReview', () => {
   });
 
   it('should display blockaid banner', async () => {
-    const { queryByText } = renderWithProvider(
+    const securityAlertResponse = {
+      resultType: 'Malicious',
+      reason: 'blur_farming',
+    };
+    const trackEventSypy = jest
+      .spyOn(analyticsV2, 'trackEvent')
+      .mockImplementation((name, params) => {
+        expect(name).toBeDefined();
+        expect(params).toBeDefined();
+      });
+
+    const blockaidMetricsParamsSpy = jest
+      .spyOn(BlockaidUtils, 'getBlockaidMetricsParams')
+      .mockImplementation(({ resultType, reason }) => ({
+        security_alert_response: resultType,
+        security_alert_reason: reason,
+      }));
+    const { queryByText, queryByTestId, getByText } = renderWithProvider(
       <TransactionReview
         EIP1559GasData={{}}
         generateTransform={generateTransform}
@@ -131,10 +154,7 @@ describe('TransactionReview', () => {
           ...mockState,
           transaction: {
             ...mockState.transaction,
-            securityAlertResponse: {
-              resultType: 'Malicious',
-              reason: 'blur_farming',
-            },
+            securityAlertResponse,
           },
         },
       },
@@ -145,6 +165,23 @@ describe('TransactionReview', () => {
         'If you approve this request, someone can steal your assets listed on Blur.',
       ),
     ).toBeDefined();
+
+    fireEvent.press(await getByText('See details'));
+
+    expect(await queryByTestId(TESTID_ACCORDION_CONTENT)).toBeDefined();
+    expect(
+      await queryByTestId(FALSE_POSITIVE_REPOST_LINE_TEST_ID),
+    ).toBeDefined();
+    expect(await queryByText('Something doesn’t look right?')).toBeDefined();
+    expect(await queryByText('Contact Us')).toBeDefined();
+
+    fireEvent.press(await getByText('Contact Us'));
+
+    expect(trackEventSypy).toHaveBeenCalledTimes(1);
+    expect(blockaidMetricsParamsSpy).toHaveBeenCalledTimes(2);
+    expect(blockaidMetricsParamsSpy).toHaveBeenCalledWith(
+      securityAlertResponse,
+    );
   });
 
   it('should have enabled confirm button if from account has balance', async () => {

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -688,7 +688,7 @@ class Send extends PureComponent {
   getTrackingParams = () => {
     const {
       networkType,
-      transaction: { selectedAsset, assetType, securityAlertResponse },
+      transaction: { selectedAsset, assetType },
     } = this.props;
 
     return {

--- a/app/components/Views/Send/index.js
+++ b/app/components/Views/Send/index.js
@@ -59,10 +59,6 @@ import {
   selectSelectedAddress,
 } from '../../../selectors/preferencesController';
 import { ethErrors } from 'eth-rpc-errors';
-import {
-  getBlockaidMetricsParams,
-  isBlockaidFeatureEnabled,
-} from '../../../util/blockaid';
 
 const REVIEW = 'review';
 const EDIT = 'edit';
@@ -695,11 +691,6 @@ class Send extends PureComponent {
       transaction: { selectedAsset, assetType, securityAlertResponse },
     } = this.props;
 
-    let blockaidParams = {};
-    if (isBlockaidFeatureEnabled()) {
-      blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
-    }
-
     return {
       view: SEND,
       network: networkType,
@@ -708,7 +699,6 @@ class Send extends PureComponent {
           (selectedAsset.symbol || selectedAsset.contractName)) ||
         'ETH',
       assetType,
-      ...blockaidParams,
     };
   };
 

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -57,3 +57,6 @@ export const MM_PLAY_STORE_LINK = `market://details?id=${AppConstants.BUNDLE_IDS
 
 // SDK
 export const MM_SDK_DEEPLINK = `https://${AppConstants.MM_UNIVERSAL_LINK_HOST}/connect?`;
+
+export const BLOCKAID_ATTRIBUTION_LINK = 'https://blockaid.me';
+export const BLOCKAID_SUPPORT_LINK = 'https://support.metamask.io/hc/en-us';

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -13,7 +13,7 @@ export const getBlockaidMetricsParams = (
 ) => {
   const additionalParams: Record<string, any> = {};
 
-  if (securityAlertResponse) {
+  if (securityAlertResponse && isBlockaidFeatureEnabled()) {
     const { resultType, reason } = securityAlertResponse;
     let uiCustomizations;
 

--- a/app/util/confirmation/signatureUtils.js
+++ b/app/util/confirmation/signatureUtils.js
@@ -19,9 +19,12 @@ export const typedSign = {
 
 export const getAnalyticsParams = (messageParams, signType) => {
   try {
-    const { currentPageInformation } = messageParams;
+    const { currentPageInformation, meta } = messageParams;
+    const pageInfo = meta || currentPageInformation || {};
+
     const chainId = selectChainId(store.getState());
-    const url = new URL(currentPageInformation?.url);
+
+    const url = pageInfo.url && new URL(pageInfo?.url);
 
     const blockaidParams = getBlockaidMetricsParams(
       messageParams.securityAlertResponse,
@@ -29,11 +32,11 @@ export const getAnalyticsParams = (messageParams, signType) => {
 
     return {
       account_type: getAddressAccountType(messageParams.from),
-      dapp_host_name: url?.host,
+      dapp_host_name: url && url?.host,
       chain_id: chainId,
       signature_type: signType,
       version: messageParams?.version,
-      ...currentPageInformation?.analytics,
+      ...pageInfo?.analytics,
       ...blockaidParams,
     };
   } catch (error) {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2,7 +2,6 @@
   "blockaid_banner": {
     "approval_farming_description": "If you approve this request, a third party known for scams might take all your assets.",
     "attribution": "Security advice by",
-    "attribution_link": "https://blockaid.me",
     "attribution_link_name": "Blockaid",
     "blur_farming_description": "If you approve this request, someone can steal your assets listed on Blur.",
     "deceptive_request_title": "This is a deceptive request",
@@ -13,6 +12,7 @@
     "raw_signature_farming_description": "If you approve this request, you might lose your assets.",
     "seaport_farming_description": "If you approve this request, someone can steal your assets listed on OpenSea.",
     "see_details": "See details",
+    "does_not_look_right": "Something doesn’t look right?",
     "suspicious_request_title": "This is a suspicious request",
     "trade_order_farming_description": "If you approve this request, you might lose your assets.",
     "transfer_farming_description": "If you approve this request, a third party known for scams will take all your assets.",


### PR DESCRIPTION
**Description**
We need to allow MetaMask users and developers to report false positives.

Following the guidelines [here](https://www.figma.com/file/Q69vHaA7Or7Rxz4vdzjVHC/Support-for-tx-security-providers-(MVP)?type=design&node-id=6065-12121&mode=design&t=KNanPwmcsjTor5Ej-0), we add a link to when clicked opens the MetaMask support page

Tasks

- [x] Add an option on the UI to report a false positive (see design). Clicking on the link should direct the users to customer support (link: https://support.metamask.io/hc/en-us - the link might change to an specific one for this feature)
- [x] Add new property to transactions and signatures events named external_link_clicked and pass the value security_alert_support_link to it whenever the user clicks on the above link within the warning.


**Screenshots/Recordings**

*Before*


<img width="426" alt="Screenshot 2023-09-13 at 23 03 49" src="https://github.com/MetaMask/metamask-mobile/assets/44811/04f011e8-e6a8-4b34-bb8e-bb079f5dd56c">

<img width="432" alt="Screenshot 2023-09-13 at 23 03 57" src="https://github.com/MetaMask/metamask-mobile/assets/44811/4955a00d-86c0-49ca-ba80-0de6cc44618b">

*After*

<img width="415" alt="Screenshot 2023-09-21 at 17 58 01" src="https://github.com/MetaMask/metamask-mobile/assets/44811/766f95ab-29c7-4347-90ef-0ef81340b94f">

<img width="432" alt="Screenshot 2023-09-21 at 17 58 43" src="https://github.com/MetaMask/metamask-mobile/assets/44811/9909639c-afd1-405d-8dbe-d61c12573841">


**Issue**

See [#1126](https://github.com/MetaMask/MetaMask-planning/issues/1126)

Bitrise: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/f4d0a5b4-5394-4d4d-b938-e39466cf3b2a

**Checklist**

* [x] There is a related GitHub issue
* [x] Tests are included if applicable
* [x] Any added code is fully documented
