### PR TITLE
test:  Signatures refactor with fixtures

### DIFF
--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -594,6 +594,14 @@ class FixtureBuilder {
     return this;
   }
 
+  withPreferencesController(data) {
+    merge(
+      this.fixture.state.engine.backgroundState.PreferencesController,
+      data,
+    );
+    return this;
+  }
+
   /**
    * Build and return the fixture object.
    * @returns {Object} - The built fixture object.

--- a/e2e/pages/Drawer/Browser.js
+++ b/e2e/pages/Drawer/Browser.js
@@ -23,7 +23,7 @@ import {
   testDappConnectButtonCooridinates,
   testDappSendEIP1559ButtonCoordinates,
 } from '../../viewHelper';
-import { TEST_DAPP_URL } from '../TestDApp';
+import { TEST_DAPP_LOCAL_URL } from '../TestDApp';
 
 const TEST_DAPP = 'https://metamask.github.io/test-dapp/';
 
@@ -231,7 +231,7 @@ export default class Browser {
 
   static async navigateToTestDApp() {
     await Browser.tapUrlInputBox();
-    await Browser.navigateToURL(TEST_DAPP_URL);
+    await Browser.navigateToURL(TEST_DAPP_LOCAL_URL);
     await TestHelpers.delay(3000);
   }
 }

--- a/e2e/pages/TestDApp.js
+++ b/e2e/pages/TestDApp.js
@@ -5,7 +5,6 @@ import { BROWSER_WEBVIEW_ID } from '../../app/constants/test-ids';
 import Browser from './Drawer/Browser';
 import root from '../../locales/languages/en.json';
 
-export const TEST_DAPP_URL = 'https://metamask.github.io/test-dapp/';
 export const TEST_DAPP_LOCAL_URL = 'http://localhost:8080';
 
 const BUTTON_RELATIVE_PONT = { x: 200, y: 5 };
@@ -58,7 +57,7 @@ export class TestDApp {
   static async scrollToButton(buttonId) {
     await Browser.tapUrlInputBox();
     await Browser.navigateToURL(
-      `${TEST_DAPP_URL}?scrollTo=${buttonId}&time=${Date.now()}`,
+      `${TEST_DAPP_LOCAL_URL}?scrollTo=${buttonId}&time=${Date.now()}`,
     );
     await TestHelpers.delay(3000);
   }
@@ -75,9 +74,11 @@ export class TestDApp {
     await TestHelpers.delay(3000);
   }
 
-  static async navigateToTestDappWithContract(testDappUrl, contractAddress) {
+  static async navigateToTestDappWithContract(contractAddress) {
     await Browser.tapUrlInputBox();
-    await Browser.navigateToURL(`${testDappUrl}?contract=${contractAddress}`);
+    await Browser.navigateToURL(
+      `${TEST_DAPP_LOCAL_URL}?contract=${contractAddress}`,
+    );
   }
 
   static async tapTransferFromButton(contractAddress) {

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -4,7 +4,7 @@ import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
-import { TEST_DAPP_LOCAL_URL, TestDApp } from '../../pages/TestDApp';
+import { TestDApp } from '../../pages/TestDApp';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
   withFixtures,
@@ -20,7 +20,6 @@ describe(Regression('ERC721 tokens'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
-      await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
       await device.reverseTcpPort('8545'); // ganache
       await device.reverseTcpPort('8080'); // test-dapp
     }
@@ -48,10 +47,7 @@ describe(Regression('ERC721 tokens'), () => {
         await TabBarComponent.tapBrowser();
 
         // Navigate to the ERC721 url
-        await TestDApp.navigateToTestDappWithContract(
-          TEST_DAPP_LOCAL_URL,
-          nftsAddress,
-        );
+        await TestDApp.navigateToTestDappWithContract(nftsAddress);
 
         // Transfer NFT
         await TestDApp.tapTransferFromButton(nftsAddress);

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -1,137 +1,303 @@
 'use strict';
 import Browser from '../../pages/Drawer/Browser';
 import TabBarComponent from '../../pages/TabBarComponent';
-import { importWalletWithRecoveryPhrase } from '../../viewHelper';
+import { loginToApp } from '../../viewHelper';
 import SigningModal from '../../pages/modals/SigningModal';
 import { TestDApp } from '../../pages/TestDApp';
-import SettingsView from '../../pages/Drawer/Settings/SettingsView';
-import AdvancedSettingsView from '../../pages/Drawer/Settings/AdvancedView';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
 import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
-import ToggleEthSignModal from '../../pages/modals/ToggleEthSignModal';
 
 const MAX_ATTEMPTS = 3;
 
 describe(Regression('Sign Messages'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
-  });
-
-  it('should import wallet and go to the wallet view', async () => {
-    await importWalletWithRecoveryPhrase();
-  });
-
-  it('should navigate to browser', async () => {
-    await TabBarComponent.tapBrowser();
-    await Browser.isVisible();
-  });
-
-  it('should connect to the test dapp', async () => {
-    await Browser.navigateToTestDApp();
-    await TestDApp.connect();
+    await device.reverseTcpPort('8545'); // ganache
+    await device.reverseTcpPort('8080'); // test-dapp
   });
 
   it('should sign personal message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapPersonalSignButton();
-      await SigningModal.isPersonalRequestVisible();
-      await SigningModal.tapSignButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapPersonalSignButton();
+          await SigningModal.isPersonalRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should cancel personal message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapPersonalSignButton();
-      await SigningModal.isPersonalRequestVisible();
-      await SigningModal.tapCancelButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapPersonalSignButton();
+          await SigningModal.isPersonalRequestVisible();
+          await SigningModal.tapCancelButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should sign typed message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedSignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapSignButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedSignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should cancel typed message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedSignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapCancelButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedSignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapCancelButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should sign typed V3 message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedV3SignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapSignButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedV3SignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should cancel typed V3 message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedV3SignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapCancelButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedV3SignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should sign typed V4 message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedV4SignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapSignButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedV4SignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should cancel typed V4 message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapTypedV4SignButton();
-      await SigningModal.isTypedRequestVisible();
-      await SigningModal.tapCancelButton();
-      await SigningModal.isNotVisible();
-    });
-  });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
 
-  it('should allow eth_sign in advanced settings', async () => {
-    await TabBarComponent.tapSettings();
-    await SettingsView.tapAdvanced();
-    await AdvancedSettingsView.tapEthSignSwitch();
-    await ToggleEthSignModal.isVisible();
-    await ToggleEthSignModal.tapIUnderstandCheckbox();
-    await ToggleEthSignModal.tapContinueButton();
-    await ToggleEthSignModal.enterIUnderstandToContinue(
-      'I only sign what I understand',
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapTypedV4SignButton();
+          await SigningModal.isTypedRequestVisible();
+          await SigningModal.tapCancelButton();
+          await SigningModal.isNotVisible();
+        });
+      },
     );
-    await ToggleEthSignModal.tapContinueButton();
-    await TabBarComponent.tapBrowser();
   });
 
   it('should sign eth_sign message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapEthSignButton();
-      await SigningModal.isEthRequestVisible();
-      await SigningModal.tapSignButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPreferencesController({
+            disabledRpcMethodPreferences: {
+              eth_sign: true,
+            },
+          })
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapEthSignButton();
+          await SigningModal.isEthRequestVisible();
+          await SigningModal.tapSignButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 
   it('should cancel eth_sign message', async () => {
-    await TestHelpers.retry(MAX_ATTEMPTS, async () => {
-      await TestDApp.tapEthSignButton();
-      await SigningModal.isEthRequestVisible();
-      await SigningModal.tapCancelButton();
-      await SigningModal.isNotVisible();
-    });
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPreferencesController({
+            disabledRpcMethodPreferences: {
+              eth_sign: true,
+            },
+          })
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestHelpers.retry(MAX_ATTEMPTS, async () => {
+          await TestDApp.tapEthSignButton();
+          await SigningModal.isEthRequestVisible();
+          await SigningModal.tapCancelButton();
+          await SigningModal.isNotVisible();
+        });
+      },
+    );
   });
 });

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -9,12 +9,12 @@ import {
   withFixtures,
   defaultGanacheOptions,
 } from '../../fixtures/fixture-helper';
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 
 const MAX_ATTEMPTS = 3;
 
-describe(Smoke('Sign Messages'), () => {
+describe(Regression('Sign Messages'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     await device.reverseTcpPort('8545'); // ganache

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -9,12 +9,12 @@ import {
   withFixtures,
   defaultGanacheOptions,
 } from '../../fixtures/fixture-helper';
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 
 const MAX_ATTEMPTS = 3;
 
-describe(Regression('Sign Messages'), () => {
+describe(Smoke('Sign Messages'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     await device.reverseTcpPort('8545'); // ganache


### PR DESCRIPTION
## Description
This PR refactors the Signatures e2e tests in order to use fixtures and get closer parity with Extension tests. It does the following:
- Skips the onboarding process
- Runs ganache on the background and use ganache as the default network
- Starts the test dapp server locally and run the test against it, instead of going on the live site
- Sets permissions so your account is connected to the test-dapp, instead of connecting to it manually
- Use Preference Controllers fixtures for enable the `eth_sign` and skip the steps of going to settings and changing the toggle manually


The successful Bitrise run is [here](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/cfa23c0f-b5f1-4273-b281-5c9d3a20bc43) (Signatures test was run because it was set as "Smoke" temporarily for running the e2e job, you can check on the logs of ci)

## Screenshots/Recordings
Notice fixtures working: you skip onboarding, you start with Ganache network, you go to localhost test-dapp, you are already connected to the test dapp

https://github.com/MetaMask/metamask-mobile/assets/54408225/b6c6f4dd-8ac2-448a-bfeb-6ceb31790499


**Issue**

fixes https://github.com/MetaMask/mobile-planning/issues/1085

**Checklist**

* [X] There is a related GitHub issue
* [X] Tests are included if applicable
* [X] Any added code is fully documented
