### PR TITLE
fix: ledger incorrect ga tag

### DIFF
--- a/app/components/UI/MessageSign/MessageSign.tsx
+++ b/app/components/UI/MessageSign/MessageSign.tsx
@@ -121,7 +121,7 @@ class MessageSign extends PureComponent<MessageSignProps, MessageSignState> {
           onReject,
           onConfirm,
           messageParams,
-          'eth',
+          'eth_sign',
         )),
       );
     }


### PR DESCRIPTION
**Description**

Previous rebase has update the name of GA for message sign 
"ethSign" => "eth_sign"
"personalSign" => "personal_sign"
"typed" => "eth_signTypedData", "eth_signTypedData_v3", "eth_signTypedData_v4"

actual:
some code pieces from ledger is not using above type

expected:
code pieces from ledger should using above type



**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
