### PR TITLE
fix: Fix console errors upon switching networks

### DIFF
--- a/patches/web3-provider-engine+16.0.3.patch
+++ b/patches/web3-provider-engine+16.0.3.patch
@@ -1,0 +1,34 @@
+diff --git a/node_modules/web3-provider-engine/index.js b/node_modules/web3-provider-engine/index.js
+index 3a1b7d5..15560d7 100644
+--- a/node_modules/web3-provider-engine/index.js
++++ b/node_modules/web3-provider-engine/index.js
+@@ -48,8 +48,29 @@ Web3ProviderEngine.prototype.start = function(cb = noop){
+ 
+   // on new block, request block body and emit as events
+   self._blockTracker.on('latest', (blockNumber) => {
++    // PATCH NOTE: These changes are needed temporarily to maintain
++    // compatibility between web3-provider-engine and
++    // @metamask/network-controller v6, v7, and v8. This can be dropped when
++    // we update to @metamask/network-controller v9 (core v53).
++    //
++    // Specifically, this is meant to prevent an error that happens upon
++    // switching networks. The network controller uses a proxied provider and
++    // block tracker as of v6, which migrates all event listeners to the new
++    // provider when the network is switched. In this case, we don't want
++    // this event listener migrated, but there is no straightforward way to
++    // prevent that. Instead we have made it a no-op after switching.
++    if (self._running === false) {
++      return;
++    }
+     // get block body
+     self._getBlockByNumberWithRetry(blockNumber, (err, block) => {
++      // PATCH NOTE: See the patch note above for more context.
++      // This additional condition prevents console warnings in the case where
++      // an `eth_getBlockByNumber` request was in-flight when the network was
++      // switched.
++      if (self._running === false) {
++        return;
++      }
+       if (err) {
+         this.emit('error', err)
+         return


### PR DESCRIPTION
## **Description**

On `main` two warnings were printed to the console repeatedly after switching networks. They were:

* Error: Callback was already called. Possible Unhandled Promise Rejection
* MaxListenersExceededWarning: Possible EventEmitter memory leak detected ...

This started happening after PR #6872. If you look at network traffic, you could see that this lines up with extra network calls being made to the previous network as well (the `eth_getBlockByNumber` method specifically).

These warnings were caused by a change made in
`@metamask/network-controller@6.0.0`, which was to proxy the provider and block tracker. This introduced an incompatibility between the `NetworkController` and `web3-provider-engine`, which was still using the unproxied block tracker. `web3-provider-engine` adds an event listener on the `latest` event from the block tracker, which calls `eth_getBlockByNumber` with a retry. This listener was migrated to the new network after switching, but would make that RPC call on the old provider.

The user effects of this are an increase in unnecessary network traffic, but is otherwise harmless.

The `web3-provider-engine` package has been patched to make the block tracker event listener into a no-op after the provider has been stopped. This isn't an ideal solution as it still leaves the listener attached, which is a small memory leak. But it resolves the warnings and prevents the unnecessary network calls. We will be updating to `@metamask/network-controller` v9 soon which will resolve this problem permanently by removing `web3-provider-engine`.



## **Manual testing steps**

- Switch networks
- See that the listed warnings are no longer printed to the console (the `yarn watch` console output)

## **Screenshots/Recordings**

### Before

https://recordit.co/SXZf4Vhnbz

### After

https://recordit.co/5CIOzb4srH

## **Related issues**

Fixes #7082

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
