### PR TITLE
test: increase Confirmations e2e stability by terminating ganache on hooks

### DIFF
--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -147,14 +147,11 @@ export async function withFixtures(options, testSuite) {
       await device.launchApp({ delete: true });
     }
 
-    await testSuite({ contractRegistry });
+    await testSuite({ contractRegistry, ganacheServer });
   } catch (error) {
     console.error(error);
     throw error;
   } finally {
-    if (ganacheOptions) {
-      await ganacheServer.quit();
-    }
     if (dapp) {
       for (let i = 0; i < numberOfDapps; i++) {
         if (dappServer[i] && dappServer[i].listening) {

--- a/e2e/specs/confirmations/advanced-gas-fees.spec.js
+++ b/e2e/specs/confirmations/advanced-gas-fees.spec.js
@@ -12,16 +12,22 @@ import {
 } from '../../fixtures/fixture-helper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
+import TestHelpers from '../../helpers';
 
 const VALID_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
 
 describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
+  let ganache;
   beforeAll(async () => {
     jest.setTimeout(170000);
     if (device.getPlatform() === 'android') {
-      await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
-      await device.reverseTcpPort('8545');
+      await device.reverseTcpPort('8545'); // ganache
     }
+  });
+
+  afterEach(async () => {
+    await ganache.quit();
+    await TestHelpers.delay(3000);
   });
 
   it('should edit priority gas settings and send ETH', async () => {
@@ -31,7 +37,8 @@ describe(Smoke('Advanced Gas Fees and Priority Tests'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         // Check that we are on the wallet screen

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
@@ -13,7 +13,7 @@ import {
 import root from '../../../locales/languages/en.json';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Smoke('ERC721 tokens'), () => {
+describe(Regression('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
   let ganache;

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -16,6 +16,7 @@ import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 describe(Regression('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
+  let ganache;
 
   beforeAll(async () => {
     jest.setTimeout(150000);
@@ -23,6 +24,11 @@ describe(Regression('ERC721 tokens'), () => {
       await device.reverseTcpPort('8545'); // ganache
       await device.reverseTcpPort('8080'); // test-dapp
     }
+  });
+
+  afterEach(async () => {
+    await ganache.quit();
+    await TestHelpers.delay(3000);
   });
 
   it('send an ERC721 token from a dapp', async () => {
@@ -37,7 +43,8 @@ describe(Regression('ERC721 tokens'), () => {
         ganacheOptions: defaultGanacheOptions,
         smartContract: NFT_CONTRACT,
       },
-      async ({ contractRegistry }) => {
+      async ({ contractRegistry, ganacheServer }) => {
+        ganache = ganacheServer;
         const nftsAddress = await contractRegistry.getContractAddress(
           NFT_CONTRACT,
         );

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
@@ -13,7 +13,7 @@ import {
 import root from '../../../locales/languages/en.json';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Regression('ERC721 tokens'), () => {
+describe(Smoke('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
   const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
   let ganache;

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 import AmountView from '../../pages/AmountView';
 import SendView from '../../pages/SendView';
@@ -16,7 +16,7 @@ import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 
 const MYTH_ADDRESS = '0x1FDb169Ef12954F20A15852980e1F0C122BfC1D6';
 
-describe(Smoke('Send ETH Tests'), () => {
+describe(Regression('Send ETH Tests'), () => {
   let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 import AmountView from '../../pages/AmountView';
 import SendView from '../../pages/SendView';
@@ -16,7 +16,7 @@ import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 
 const MYTH_ADDRESS = '0x1FDb169Ef12954F20A15852980e1F0C122BfC1D6';
 
-describe(Regression('Send ETH Tests'), () => {
+describe(Smoke('Send ETH Tests'), () => {
   let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);

--- a/e2e/specs/confirmations/send-eth-flow.spec.js
+++ b/e2e/specs/confirmations/send-eth-flow.spec.js
@@ -17,12 +17,17 @@ import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 const MYTH_ADDRESS = '0x1FDb169Ef12954F20A15852980e1F0C122BfC1D6';
 
 describe(Regression('Send ETH Tests'), () => {
+  let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);
     if (device.getPlatform() === 'android') {
-      await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
-      await device.reverseTcpPort('8545');
+      await device.reverseTcpPort('8545'); // ganache
     }
+  });
+
+  afterEach(async () => {
+    await ganache.quit();
+    await TestHelpers.delay(3000);
   });
 
   it('should send ETH to an EOA', async () => {
@@ -32,7 +37,8 @@ describe(Regression('Send ETH Tests'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapActions();

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 
 import AmountView from '../../pages/AmountView';
@@ -17,7 +17,7 @@ import {
 } from '../../fixtures/fixture-helper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Smoke('Send ETH to Multisig'), () => {
+describe(Regression('Send ETH to Multisig'), () => {
   const MULTISIG_CONTRACT = SMART_CONTRACTS.MULTISIG;
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -21,13 +21,18 @@ describe(Regression('Send ETH to Multisig'), () => {
   const MULTISIG_CONTRACT = SMART_CONTRACTS.MULTISIG;
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;
+  let ganache;
 
   beforeAll(async () => {
     jest.setTimeout(2500000);
     if (device.getPlatform() === 'android') {
-      await device.reverseTcpPort('8081'); // because on android we need to expose the localhost ports to run ganache
-      await device.reverseTcpPort('8545');
+      await device.reverseTcpPort('8545'); // ganache
     }
+  });
+
+  afterEach(async () => {
+    await ganache.quit();
+    await TestHelpers.delay(3000);
   });
 
   it('Send ETH to a Multisig address from inside MetaMask wallet', async () => {
@@ -38,7 +43,8 @@ describe(Regression('Send ETH to Multisig'), () => {
         ganacheOptions: defaultGanacheOptions,
         smartContract: MULTISIG_CONTRACT,
       },
-      async ({ contractRegistry }) => {
+      async ({ contractRegistry, ganacheServer }) => {
+        ganache = ganacheServer;
         const multisigAddress = await contractRegistry.getContractAddress(
           MULTISIG_CONTRACT,
         );

--- a/e2e/specs/confirmations/send-eth-multisig.spec.js
+++ b/e2e/specs/confirmations/send-eth-multisig.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 
 import AmountView from '../../pages/AmountView';
@@ -17,7 +17,7 @@ import {
 } from '../../fixtures/fixture-helper';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
-describe(Regression('Send ETH to Multisig'), () => {
+describe(Smoke('Send ETH to Multisig'), () => {
   const MULTISIG_CONTRACT = SMART_CONTRACTS.MULTISIG;
   const AMOUNT_TO_SEND = '0.12345';
   const TOKEN_NAME = root.unit.eth;

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -9,12 +9,12 @@ import {
   withFixtures,
   defaultGanacheOptions,
 } from '../../fixtures/fixture-helper';
-import { Smoke } from '../../tags';
+import { Regression } from '../../tags';
 import TestHelpers from '../../helpers';
 
 const MAX_ATTEMPTS = 3;
 
-describe(Smoke('Sign Messages'), () => {
+describe(Regression('Sign Messages'), () => {
   let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -9,12 +9,12 @@ import {
   withFixtures,
   defaultGanacheOptions,
 } from '../../fixtures/fixture-helper';
-import { Regression } from '../../tags';
+import { Smoke } from '../../tags';
 import TestHelpers from '../../helpers';
 
 const MAX_ATTEMPTS = 3;
 
-describe(Regression('Sign Messages'), () => {
+describe(Smoke('Sign Messages'), () => {
   let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);

--- a/e2e/specs/confirmations/sign-messages.spec.js
+++ b/e2e/specs/confirmations/sign-messages.spec.js
@@ -15,10 +15,16 @@ import TestHelpers from '../../helpers';
 const MAX_ATTEMPTS = 3;
 
 describe(Regression('Sign Messages'), () => {
+  let ganache;
   beforeAll(async () => {
     jest.setTimeout(150000);
     await device.reverseTcpPort('8545'); // ganache
     await device.reverseTcpPort('8080'); // test-dapp
+  });
+
+  afterEach(async () => {
+    await ganache.quit();
+    await TestHelpers.delay(3000);
   });
 
   it('should sign personal message', async () => {
@@ -32,7 +38,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -59,7 +66,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -86,7 +94,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -113,7 +122,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -140,7 +150,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -167,7 +178,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -194,7 +206,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -221,7 +234,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -253,7 +267,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();
@@ -285,7 +300,8 @@ describe(Regression('Sign Messages'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
       },
-      async () => {
+      async ({ ganacheServer }) => {
+        ganache = ganacheServer;
         await loginToApp();
 
         await TabBarComponent.tapBrowser();


### PR DESCRIPTION
## **Description**
It has been observed that in some Android runs, relative to confirmations, tests were sometimes flaky due to Ganache not terminating properly. 
This was not evident on regular runs as only Smoke tests are run (with 1 test using ganache) but it shines in the case you run all the Confirmations e2e (more than 1 test using ganache, needing the server to terminate and start everytime).
([Context](https://consensys.slack.com/archives/C02U025CVU4/p1694462076620829))
This change increase confirmations e2e stability by terminating the ganache server in the `afterEach` hooks instead of inside the `withFixtures` method.

## **Manual testing steps**
- Run the tests locally
- Run the tests on Bitrise. Test run here: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/12c59c1c-7265-4c9e-aa79-e9af0c867d92

## **Screenshots/Recordings**

![Screenshot from 2023-09-21 19-24-56](https://github.com/MetaMask/metamask-mobile/assets/54408225/038c92e3-88c7-433e-8ba2-50e5c6628a11)


### **Before**

Intermittent Android failures

### **After**

All runs are passing now in Android

## **Related issues**

- Fixes  https://github.com/MetaMask/mobile-planning/issues/1277

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [X] I’ve included tests if applicable.
- [X] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
