### PR TITLE
fix: update linea goerli explorer url

### DIFF
--- a/patches/@metamask+controller-utils+3.4.0.patch
+++ b/patches/@metamask+controller-utils+3.4.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@metamask/controller-utils/dist/constants.d.ts b/node_modules/@metamask/controller-utils/dist/constants.d.ts
-index c8e8769..00e617f 100644
+index c8e8769..188da8f 100644
 --- a/node_modules/@metamask/controller-utils/dist/constants.d.ts
 +++ b/node_modules/@metamask/controller-utils/dist/constants.d.ts
 @@ -1,4 +1,7 @@
@@ -32,7 +32,7 @@ index c8e8769..00e617f 100644
 +        readonly chainId: NetworksChainId["linea-goerli"];
 +        readonly ticker: NetworksTicker["linea-goerli"];
 +        readonly rpcPrefs: {
-+            readonly blockExplorerUrl: "https://explorer.goerli.linea.build";
++            readonly blockExplorerUrl: "https://goerli.lineascan.build";
 +        };
 +    };
 +    readonly "linea-mainnet": {
@@ -46,7 +46,7 @@ index c8e8769..00e617f 100644
          readonly chainId: NetworksChainId.localhost;
          readonly blockExplorerUrl: undefined;
 diff --git a/node_modules/@metamask/controller-utils/dist/constants.js b/node_modules/@metamask/controller-utils/dist/constants.js
-index 7bef0e7..92c4143 100644
+index 7bef0e7..eea5474 100644
 --- a/node_modules/@metamask/controller-utils/dist/constants.js
 +++ b/node_modules/@metamask/controller-utils/dist/constants.js
 @@ -2,6 +2,9 @@
@@ -84,7 +84,7 @@ index 7bef0e7..92c4143 100644
 +        chainId: types_1.NetworksChainId["linea-goerli"],
 +        ticker: types_1.NetworksTicker["linea-goerli"],
 +        rpcPrefs: {
-+            blockExplorerUrl: 'https://explorer.goerli.linea.build',
++            blockExplorerUrl: 'https://goerli.lineascan.build',
 +        },
 +    },
 +    [types_1.NetworkType["linea-mainnet"]]: {
@@ -105,6 +105,7 @@ index 7bef0e7..92c4143 100644
 +    [types_1.NetworkId["linea-mainnet"]]: types_1.NetworkType["linea-mainnet"],
  };
  //# sourceMappingURL=constants.js.map
+\ No newline at end of file
 diff --git a/node_modules/@metamask/controller-utils/dist/types.d.ts b/node_modules/@metamask/controller-utils/dist/types.d.ts
 index 014dbb9..e7f7934 100644
 --- a/node_modules/@metamask/controller-utils/dist/types.d.ts


### PR DESCRIPTION
## **Description**
Updated Linea Goerli explorer url.
- Replaced `https://explorer.goerli.linea.build` with `https://goerli.lineascan.build`.
- Created a new `@metamask/controller-utils` patch


## **Manual testing steps**

_1. Step1: Send a transaction using the  Linea Goerli network_ 
_2. Step2: Open the transaction description_
_3. Step3: Click on the "View on Etherscan" button_
_4. Step4: Check that it redirects to `https://goerli.lineascan.build`_

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

_[screenshot]_

### **After**

_[screenshot]_

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
