### PR TITLE
fix: Add chaijs/get-func-name resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,8 +148,7 @@
     "oss-attribution-generator/**/debug": "^2.6.9",
     "d3-color": "3.1.0",
     "**/fast-xml-parser": "4.2.4",
-    "tough-cookie": "4.1.3",
-    "**/get-func-name": "2.0.2"
+    "tough-cookie": "4.1.3"
   },
   "dependencies": {
     "@consensys/on-ramp-sdk": "1.23.0",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "oss-attribution-generator/**/debug": "^2.6.9",
     "d3-color": "3.1.0",
     "**/fast-xml-parser": "4.2.4",
-    "tough-cookie": "4.1.3"
+    "tough-cookie": "4.1.3",
+    "**/get-func-name": "2.0.2"
   },
   "dependencies": {
     "@consensys/on-ramp-sdk": "1.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17377,10 +17377,10 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+get-func-name@2.0.2, get-func-name@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
 
 get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17377,7 +17377,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@2.0.2, get-func-name@^2.0.0:
+get-func-name@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==


### PR DESCRIPTION
## **Description**

Fix CI: https://github.com/MetaMask/metamask-mobile/actions/runs/6331863392/job/17197486695
By adding a Yarn <s>package.json</s> lockfile resolution

Then once
- https://github.com/ethereum-optimism/optimism/pull/7432

Merged we can remove the resolution and bump `ethereum-optimism`

Fixed in: https://github.com/chaijs/get-func-name/commit/f934b228b5e2cb94d6c8576d3aac05493f667c69

## **Manual testing steps**

`yarn audit:ci`

## **Related issues**

_Fixes https://github.com/chaijs/get-func-name/security/advisories/GHSA-4q6p-r6v2-jvc5_

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
