### PR TITLE
fix(action): update fetch-depth parameter to fetch only the last commit

### DIFF
--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-            fetch-depth: 0 # This is needed to checkout all branches
+            fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
## **Description**
Update `fetch-depth` parameter to fetch only the last commit, rather than the whole commit history

We used to fetch the whole commit history which wasn't useful for this github action. This change allows to fetch only the latest commit which makes the workflow more efficient. This improvement is not a game changer, but it's worth doing it as the workflow runs quite often (multiple times for every PR), as it's triggered every time PR labels are updated.

Same [PR](https://github.com/MetaMask/metamask-extension/pull/21119) for Extension.

## **Manual testing steps**

1. Add a team label on this PR, the job shall turn to green
2. Remove team label from this PR, the job shall turn to red

## **Screenshots/Recordings**

See recording [here](https://github.com/MetaMask/metamask-extension/pull/19984)

### **Before**

_[screenshot]_

### **After**

_[screenshot]_

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
