### PR TITLE
fix(ramp): use os browser in android

### DIFF
--- a/app/components/UI/Ramp/hooks/useInAppBrowser.ts
+++ b/app/components/UI/Ramp/hooks/useInAppBrowser.ts
@@ -5,6 +5,7 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { OrderStatusEnum, Provider } from '@consensys/on-ramp-sdk';
 import BuyAction from '@consensys/on-ramp-sdk/dist/regions/BuyAction';
 import useAnalytics from './useAnalytics';
+import useHandleSuccessfulOrder from './useHandleSuccessfulOrder';
 import { callbackBaseDeeplink, SDK, useFiatOnRampSDK } from '../sdk';
 import { createCustomOrderIdData } from '../orderProcessor/customOrderId';
 import { aggregatorOrderToFiatOrder } from '../orderProcessor/aggregator';
@@ -15,7 +16,7 @@ import {
 } from '../../../../reducers/fiatOrders';
 import { setLockTime } from '../../../../actions/settings';
 import Logger from '../../../../util/Logger';
-import useHandleSuccessfulOrder from './useHandleSuccessfulOrder';
+import Device from '../../../../util/device';
 
 export default function useInAppBrowser() {
   const {
@@ -53,7 +54,7 @@ export default function useInAppBrowser() {
         dispatch(addFiatCustomIdData(customIdData));
       }
 
-      if (!(await InAppBrowser.isAvailable())) {
+      if (Device.isAndroid() || !(await InAppBrowser.isAvailable())) {
         Linking.openURL(url);
       } else {
         const prevLockTime = lockTime;


### PR DESCRIPTION
## **Description**
This PR fixes an Android only issue with the InAppBrowser package where the Chrome Custom Tab gets dismissed as soon as the user switches the application, making the provider website context to get lost. The fix is to not rely on a Chrome Custom Tab and open the native OS Browser instead.

## **Manual testing steps**

1.  Perform a purchase with a provider or payment method that uses InAppBrowser on Android (eg: PayPal, Google Pay)
2. When loading the provider URL, confirm the native OS browser is used instead of a Chrome Custom Tab
3. After finishing the flow in the provider website, confirm the redirection to MetaMask
4. An order should appear in the Purchases tab in the Activity View.

<!-- ## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

_[screenshot]_

### **After**

_[screenshot]_ 

## **Related issues**

_Fixes #???_ -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
