### PR TITLE
fix(action): bug report creation was not working

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -28,6 +28,12 @@ jobs:
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
+          # The last step of this workflow creates a release branch, which shall itself
+          # trigger another workflow: 'create-bug-report.yml'. However, there is a security
+          # feature in Github that prevents workflows from triggering other workflows by default.
+          # The workaround is to use a personal access token (BUG_REPORT_TOKEN) instead of
+          # the default GITHUB_TOKEN for the checkout action.
+          token: ${{ secrets.BUG_REPORT_TOKEN }}
       - name: Get Node.js version
         id: nvm
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## **Description**
The last step of the create-release-pr.yml workflow creates a release branch, which shall itself trigger another workflow: create-bug-report.yml. However, there is a security feature in Github that prevents workflows from triggering other workflows by default. The workaround is to use a personal access token (BUG_REPORT_TOKEN) instead of the default GITHUB_TOKEN for the checkout action.

## **Manual testing steps**

Available in original PR: https://github.com/MetaMask/metamask-mobile/pull/6967

## **Screenshots/Recordings**

Available in original PR: https://github.com/MetaMask/metamask-mobile/pull/6967

### **Before**

_[screenshot]_

### **After**

_[screenshot]_

## **Related issues**

Fixes https://github.com/MetaMask/mobile-planning/issues/1184

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
