### PR TITLE
fix: Add Dependabot missing team label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "team-security"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-      - "team-security"
+      - "team-mobile-client"


### PR DESCRIPTION
## **Description**

All [dependabot PRs](https://github.com/MetaMask/metamask-mobile/pulls?q=is%3Apr+dependabot+) currently failing CI due to
> No team labels found

This simply fixes that ^

_Presuming previous labels are being added automagically_
- _dependencies_
- _javascript_

## **Manual testing steps**

Re-trigger a dependabot PR
or wait for the next one

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Related issues**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
