### PR TITLE
feat: Add metrics for provider calls coming from ppom on mobile

### DIFF
--- a/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
@@ -31,6 +31,7 @@ export interface SecurityAlertResponse {
   reason: Reason;
   features: string[];
   resultType: ResultType;
+  providerRequestsCount: Record<string, number>;
 }
 
 type BlockaidBannerAllProps = BannerAlertProps & {

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
@@ -31,7 +31,7 @@ export interface SecurityAlertResponse {
   reason: Reason;
   features: string[];
   resultType: ResultType;
-  providerRequestsCount: Record<string, number>;
+  providerRequestsCount?: Record<string, number>;
 }
 
 type BlockaidBannerAllProps = BannerAlertProps & {

--- a/app/components/UI/TransactionReview/index.test.tsx
+++ b/app/components/UI/TransactionReview/index.test.tsx
@@ -130,6 +130,7 @@ describe('TransactionReview', () => {
     const securityAlertResponse = {
       resultType: 'Malicious',
       reason: 'blur_farming',
+      providerRequestsCount: {},
     };
     const trackEventSypy = jest
       .spyOn(analyticsV2, 'trackEvent')
@@ -140,9 +141,10 @@ describe('TransactionReview', () => {
 
     const blockaidMetricsParamsSpy = jest
       .spyOn(BlockaidUtils, 'getBlockaidMetricsParams')
-      .mockImplementation(({ resultType, reason }) => ({
+      .mockImplementation(({ resultType, reason, providerRequestsCount }) => ({
         security_alert_response: resultType,
         security_alert_reason: reason,
+        security_alert_provider_requests_count: providerRequestsCount,
       }));
     const { queryByText, queryByTestId, getByText } = renderWithProvider(
       <TransactionReview

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -31,4 +31,36 @@ describe('getBlockaidMetricsParams', () => {
       ppom_eth_getCode_count: 3,
     });
   });
+
+  it('should not return eth call counts if providerRequestsCount is empty', () => {
+    const securityAlertResponse: SecurityAlertResponse = {
+      resultType: ResultType.Malicious,
+      reason: Reason.notApplicable,
+      features: [],
+      providerRequestsCount: {},
+    };
+
+    const result = getBlockaidMetricsParams(securityAlertResponse);
+    expect(result).toEqual({
+      ui_customizations: ['flagged_as_malicious'],
+      security_alert_response: ResultType.Malicious,
+      security_alert_reason: Reason.notApplicable,
+    });
+  });
+
+  it('should not return eth call counts if providerRequestsCount is undefined', () => {
+    const securityAlertResponse: SecurityAlertResponse = {
+      resultType: ResultType.Malicious,
+      reason: Reason.notApplicable,
+      features: [],
+      providerRequestsCount: undefined,
+    };
+
+    const result = getBlockaidMetricsParams(securityAlertResponse);
+    expect(result).toEqual({
+      ui_customizations: ['flagged_as_malicious'],
+      security_alert_response: ResultType.Malicious,
+      security_alert_reason: Reason.notApplicable,
+    });
+  });
 });

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -1,0 +1,34 @@
+import { getBlockaidMetricsParams } from '.';
+import {
+  Reason,
+  ResultType,
+  SecurityAlertResponse,
+} from '../../components/UI/BlockaidBanner/BlockaidBanner.types';
+
+describe('getBlockaidMetricsParams', () => {
+  it('should return empty object when securityAlertResponse is not defined', () => {
+    const result = getBlockaidMetricsParams(undefined);
+    expect(result).toStrictEqual({});
+  });
+
+  it('should return additionalParams object when securityAlertResponse defined', () => {
+    const securityAlertResponse: SecurityAlertResponse = {
+      resultType: ResultType.Malicious,
+      reason: Reason.notApplicable,
+      providerRequestsCount: {
+        eth_call: 5,
+        eth_getCode: 3,
+      },
+      features: [],
+    };
+
+    const result = getBlockaidMetricsParams(securityAlertResponse);
+    expect(result).toEqual({
+      ui_customizations: ['flagged_as_malicious'],
+      security_alert_response: ResultType.Malicious,
+      security_alert_reason: Reason.notApplicable,
+      ppom_eth_call_count: 5,
+      ppom_eth_getCode_count: 3,
+    });
+  });
+});

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -9,19 +9,16 @@ export const isBlockaidFeatureEnabled = () =>
   process.env.MM_BLOCKAID_UI_ENABLED === 'true';
 
 export const getBlockaidMetricsParams = (
-  securityAlertResponse: SecurityAlertResponse,
+  securityAlertResponse?: SecurityAlertResponse,
 ) => {
   const additionalParams: Record<string, any> = {};
 
   if (securityAlertResponse && isBlockaidFeatureEnabled()) {
-    const { resultType, reason } = securityAlertResponse;
-    let uiCustomizations;
+    const { resultType, reason, providerRequestsCount } = securityAlertResponse;
 
     if (resultType === ResultType.Malicious) {
-      uiCustomizations = ['flagged_as_malicious'];
+      additionalParams.ui_customizations = ['flagged_as_malicious'];
     }
-
-    additionalParams.ui_customizations = uiCustomizations;
 
     if (resultType !== ResultType.Benign) {
       additionalParams.security_alert_reason = Reason.notApplicable;
@@ -30,6 +27,14 @@ export const getBlockaidMetricsParams = (
         additionalParams.security_alert_response = resultType;
         additionalParams.security_alert_reason = reason;
       }
+    }
+
+    // add counts of each RPC call
+    if (providerRequestsCount) {
+      Object.keys(providerRequestsCount).forEach((key: string) => {
+        const metricKey = `ppom_${key}_count`;
+        additionalParams[metricKey] = providerRequestsCount[key];
+      });
     }
   }
 


### PR DESCRIPTION
## **Description**

We need to add metrics to help measure and estimate the usage and cost of Infura by ppom. 

This fix uses the `providerRequestsCount` object returned as part of the securityAlertResponse of transaction object and gets only the keys that matches the below specified requests.

### Proposal
Add new properties to Transactions and Signature events where which property will count the number of rpc requests made by ppom to evaluate that specific transaction or signature.

- [x] `ppom_eth_call_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_eth_createAccessList_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_eth_getStorageAt_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_eth_getCode_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_eth_getTrasanctionCount_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_eth_getBalance_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature
- [x] `ppom_trace_call_count` - counts the number of eth_call rpc requests made by ppom to evaluate that transaction or signature

### References
- [ppom provider usage benchmark](https://wobbly-nutmeg-8a5.notion.site/MM-JSON-RPC-Benchmark-37d4a3bd74914b0fbe9147582c0cde51)
- [ppom required json-rpcs](https://docs.google.com/document/d/1aOjVIsGHc0twc96V82OcXmpduGKrPjRScL_jwfgjkj0/edit?usp=sharing)


## **Related issues**
_Fixes [#1357](https://github.com/MetaMask/MetaMask-planning/issues/1357)


## **Testing**
1. Start extension with blockaid enabled
2. Go to test-dapp and initiate a blockaid transaction
3. When blockaid banner is shown, check that the above keys (or some of it at least) are part of the metrics transaction or signature events

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

Bitrise: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/855ec13d-b519-46d5-b3d6-f0067fe9fd57

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
