### PR TITLE
fix: wc2 invalid origin in analytics

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -34,6 +34,7 @@ import parseWalletConnectUri, {
 } from './wc-utils';
 import { selectChainId } from '../../selectors/networkController';
 import { store } from '../../store';
+import { WALLET_CONNECT_ORIGIN } from '../../../app/util/walletconnect';
 
 const { PROJECT_ID } = AppConstants.WALLET_CONNECT;
 export const isWC2Enabled =
@@ -253,6 +254,7 @@ class WalletConnect2Session {
 
     const verified = requestEvent.verifyContext?.verified;
     const hostname = verified?.origin;
+    const origin = WALLET_CONNECT_ORIGIN + hostname; // allow correct origin for analytics with eth_sendTtansaction
 
     let method = requestEvent.params.request.method;
     const chainId = parseInt(requestEvent.params.chainId);
@@ -288,7 +290,7 @@ class WalletConnect2Session {
           methodParams[0],
           {
             deviceConfirmedOn: WalletDevice.MM_MOBILE,
-            origin: hostname,
+            origin,
           },
         );
         const hash = await trx.result;
@@ -312,7 +314,7 @@ class WalletConnect2Session {
         method,
         params: methodParams,
       },
-      origin: hostname,
+      origin,
     });
   };
 }


### PR DESCRIPTION
## **Description**

Analytics sending invalid request source on wallet connect transaction because the origin wasn't parsed correctly.

fixes https://app.zenhub.com/workspaces/metamask-sdk-6359297a36f20292c13feca0/issues/gh/metamask/metamask-sdk/269

## **Manual testing steps**

Use wallet connect v2 dapp to send a transaction to mobile wallet. https://github.com/WalletConnect/walletconnect-example-dapp

### **Before**
```
 LOG  [MetaMask DEBUG]: Analytics 'trackEventWithParameters' - {"category": "Dapp Transaction Cancelled"} {"account_type": "MetaMask", "active_currency": "ETH", "asset_type": "ETH", "chain_id": "5", "dapp_host_name": "http://localhost:3000", "gas_estimate_type": undefined, "gas_mode": "Advanced", "request_source": "In-App-Browser", "speed_set": undefined} undefined undefined
 ```
### **After**
```
 LOG  [MetaMask DEBUG]: Analytics 'trackEventWithParameters' - {"category": "Dapp Transaction Cancelled"} {"account_type": "MetaMask", "active_currency": "ETH", "asset_type": "ETH", "chain_id": "5", "dapp_host_name": "wc::http://localhost:3000", "gas_estimate_type": undefined, "gas_mode": "Advanced", "request_source": "WalletConnect", "speed_set": undefined} undefined undefined
 ```

