### PR TITLE
feat: inform user of existing wc2 session

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -675,15 +675,18 @@ export class WC2Manager {
         );
         if (activeSession) {
           this.sessions[activeSession.topic]?.setDeeplink(isDeepLink);
-          NotificationManager.showSimpleNotification({
-            duration: 5000,
-            title: strings('walletconnect_sessions.session_already_exist'),
-            description: strings(
-              'walletconnect_sessions.close_current_session',
-            ),
-            status: 'error',
-          });
-          return;
+
+          if (!isDeepLink) {
+            NotificationManager.showSimpleNotification({
+              duration: 5000,
+              title: strings('walletconnect_sessions.session_already_exist'),
+              description: strings(
+                'walletconnect_sessions.close_current_session',
+              ),
+              status: 'error',
+            });
+            return;
+          }
         }
 
         // cleanup uri before pairing.
@@ -708,7 +711,12 @@ export class WC2Manager {
         console.warn(`Invalid wallet connect uri`, wcUri);
       }
     } catch (err) {
-      console.error(`Failed to connect uri=${wcUri}`, err);
+      if (
+        err instanceof Error &&
+        !err.message.startsWith('Pairing already exists')
+      ) {
+        console.error(`Failed to connect uri=${wcUri}`, err);
+      }
     }
   }
 }

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -14,6 +14,8 @@ import {
   TransactionController,
   WalletDevice,
 } from '@metamask/transaction-controller';
+import NotificationManager from '../NotificationManager';
+import { strings } from '../../../locales/i18n';
 
 import AsyncStorage from '../../store/async-storage-wrapper';
 import { Core } from '@walletconnect/core';
@@ -673,6 +675,14 @@ export class WC2Manager {
         );
         if (activeSession) {
           this.sessions[activeSession.topic]?.setDeeplink(isDeepLink);
+          NotificationManager.showSimpleNotification({
+            duration: 5000,
+            title: strings('walletconnect_sessions.session_already_exist'),
+            description: strings(
+              'walletconnect_sessions.close_current_session',
+            ),
+            status: 'error',
+          });
           return;
         }
 


### PR DESCRIPTION
## **Description**
Since wallet connect v2, we didn't notify user of existing active connection.

## **Manual testing steps**

Follow steps on related issue.

_Fixes https://github.com/MetaMask/metamask-mobile/issues/6609
