### PR TITLE
fix: missing redirect on deepllink after connection

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -140,8 +140,6 @@ class WalletConnect2Session {
     if (!this.deeplink) return;
 
     setTimeout(() => {
-      // Reset the status of deeplink after each redirect
-      this.deeplink = false;
       Minimizer.goBack();
     }, 300);
   };


### PR DESCRIPTION
## **Description**
Sometime the deeplink status is not fully detected and automatically resetting it would lead to wallet not redirecting to dapp after user action.

## **Manual testing steps**

Follow steps on related issue.

_Fixes https://github.com/MetaMask/metamask-mobile/issues/7084
