### PR TITLE
fix: android os connection issue

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,8 +137,8 @@ android {
         applicationId "io.metamask"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1174
-        versionName "7.8.0"
+        versionCode 1179
+        versionName "7.9.0"
         testBuildType System.getProperty('testBuildType', 'debug')
         missingDimensionStrategy 'react-native-camera', 'general'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -27,6 +27,7 @@ import WC2Manager from './WalletConnect/WalletConnectV2';
 import { chainIdSelector, getRampNetworks } from '../reducers/fiatOrders';
 import { isNetworkBuySupported } from '../components/UI/Ramp/utils';
 import { Minimizer } from './NativeModules';
+import DevLogger from './SDKConnect/utils/DevLogger';
 
 class DeeplinkManager {
   constructor({ navigation, dispatch }) {
@@ -216,7 +217,9 @@ class DeeplinkManager {
       }
     }
 
+    // Double log entry because the Logger is too slow and display the message in incorrect order.
     Logger.log(`DeepLinkManager: parsing url=${url} origin=${origin}`);
+    DevLogger.log(`DeepLinkManager: parsing url=${url} origin=${origin}`);
 
     const handled = () => (onHandled ? onHandled() : false);
 
@@ -234,7 +237,7 @@ class DeeplinkManager {
           const action = urlObj.pathname.split('/')[1];
 
           if (action === ACTIONS.ANDROID_SDK) {
-            Logger.log(
+            DevLogger.log(
               `DeeplinkManager:: metamask launched via android sdk universal link`,
             );
             SDKConnect.getInstance().bindAndroidSDK();
@@ -365,7 +368,7 @@ class DeeplinkManager {
       case PROTOCOLS.METAMASK:
         handled();
         if (url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.ANDROID_SDK}`)) {
-          Logger.log(
+          DevLogger.log(
             `DeeplinkManager:: metamask launched via android sdk deeplink`,
           );
           SDKConnect.getInstance().bindAndroidSDK();

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -59,12 +59,14 @@ export default class AndroidService extends EventEmitter2 {
 
   private async setupEventListeners(): Promise<void> {
     try {
-      await wait(200); // Extra wait to make sure ui is ready
       // Wait for keychain to be unlocked before handling rpc calls.
       const keyringController = (
         Engine.context as { KeyringController: KeyringController }
       ).KeyringController;
-      await waitForKeychainUnlocked({ keyringController });
+      await waitForKeychainUnlocked({
+        keyringController,
+        context: 'AndroidService::setupEventListener',
+      });
 
       const rawConnections =
         await SDKConnect.getInstance().loadAndroidConnections();
@@ -121,7 +123,10 @@ export default class AndroidService extends EventEmitter2 {
       ).KeyringController;
 
       const handleEventAsync = async () => {
-        await waitForKeychainUnlocked({ keyringController });
+        await waitForKeychainUnlocked({
+          keyringController,
+          context: 'AndroidService::setupOnClientsConnectedListener',
+        });
 
         try {
           if (!this.connectedClients?.[clientInfo.clientId]) {
@@ -198,7 +203,10 @@ export default class AndroidService extends EventEmitter2 {
           const keyringController = (
             Engine.context as { KeyringController: KeyringController }
           ).KeyringController;
-          await waitForKeychainUnlocked({ keyringController });
+          await waitForKeychainUnlocked({
+            keyringController,
+            context: 'AndroidService::setupOnMessageReceivedListener',
+          });
         } catch (error) {
           Logger.log(error, `AndroidService::onMessageReceived error`);
         }

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -37,6 +37,7 @@ import RPCQueueManager from '../RPCQueueManager';
 import AndroidSDKEventHandler from './AndroidNativeSDKEventHandler';
 import { AndroidClient } from './android-sdk-types';
 import { PROTOCOLS } from '../../../constants/deeplinks';
+import DevLogger from '../utils/DevLogger';
 
 export default class AndroidService extends EventEmitter2 {
   private communicationClient = NativeModules.CommunicationClient;
@@ -50,6 +51,9 @@ export default class AndroidService extends EventEmitter2 {
     this.eventHandler = new AndroidSDKEventHandler();
     this.setupEventListeners()
       .then(() => {
+        DevLogger.log(
+          `AndroidService::constructor event listeners setup completed`,
+        );
         //
       })
       .catch((err) => {
@@ -59,6 +63,7 @@ export default class AndroidService extends EventEmitter2 {
 
   private async setupEventListeners(): Promise<void> {
     try {
+      await wait(200);
       // Wait for keychain to be unlocked before handling rpc calls.
       const keyringController = (
         Engine.context as { KeyringController: KeyringController }
@@ -130,6 +135,7 @@ export default class AndroidService extends EventEmitter2 {
 
         try {
           if (!this.connectedClients?.[clientInfo.clientId]) {
+            await this.requestApproval(clientInfo);
             this.setupBridge(clientInfo);
             // Save session to SDKConnect
             SDKConnect.getInstance().addAndroidConnection({
@@ -337,6 +343,7 @@ export default class AndroidService extends EventEmitter2 {
       return;
     }
 
+    DevLogger.log(`AndroidService::setupBridge`);
     const bridge = new BackgroundBridge({
       webview: null,
       isMMSDK: true,

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -125,7 +125,6 @@ export default class AndroidService extends EventEmitter2 {
 
         try {
           if (!this.connectedClients?.[clientInfo.clientId]) {
-            this.setupBridge(clientInfo);
             // Save session to SDKConnect
             SDKConnect.getInstance().addAndroidConnection({
               id: clientInfo.clientId,

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -130,6 +130,7 @@ export default class AndroidService extends EventEmitter2 {
 
         try {
           if (!this.connectedClients?.[clientInfo.clientId]) {
+            this.setupBridge(clientInfo);
             // Save session to SDKConnect
             SDKConnect.getInstance().addAndroidConnection({
               id: clientInfo.clientId,

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -214,6 +214,10 @@ export class Connection extends EventEmitter2 {
 
     this.setLoading(true);
 
+    DevLogger.log(
+      `Connection::constructor() id=${this.channelId} initialConnection=${this.initialConnection} lastAuthorized=${this.lastAuthorized}`,
+    );
+
     this.remote = new RemoteCommunication({
       platformType: AppConstants.MM_SDK.PLATFORM as 'metamask-mobile',
       communicationServerUrl: AppConstants.MM_SDK.SERVER_URL,
@@ -664,7 +668,7 @@ export class Connection extends EventEmitter2 {
       !!lastAuthorized && Date.now() - lastAuthorized < OTPExpirationDuration;
 
     DevLogger.log(
-      `SDKConnect checkPermissions lastAuthorized=${lastAuthorized} OTPExpirationDuration ${OTPExpirationDuration} channelWasActiveRecently ${channelWasActiveRecently}`,
+      `SDKConnect checkPermissions initialConnection=${this.initialConnection} lastAuthorized=${lastAuthorized} OTPExpirationDuration ${OTPExpirationDuration} channelWasActiveRecently ${channelWasActiveRecently}`,
     );
     // only ask approval if needed
     const approved = this.isApproved({
@@ -1366,11 +1370,15 @@ export class SDKConnect extends EventEmitter2 {
     if (this.disabledHosts[host]) {
       // Might be useful for future feature.
     } else {
+      const now = Date.now();
       // Host is approved for 24h.
-      this.approvedHosts[host] = Date.now() + DAY_IN_MS;
+      this.approvedHosts[host] = now + DAY_IN_MS;
       DevLogger.log(`SDKConnect approveHost ${host}`, this.approvedHosts);
       if (this.connections[channelId]) {
-        this.connections[channelId].lastAuthorized = Date.now();
+        this.connections[channelId].lastAuthorized = now;
+      }
+      if (this.connected[channelId]) {
+        this.connected[channelId].lastAuthorized = now;
       }
       // Prevent disabled hosts from being persisted.
       DefaultPreference.set(

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -1228,12 +1228,17 @@ export class SDKConnect extends EventEmitter2 {
 
     if (!rawConnections) return {};
 
-    return JSON.parse(rawConnections);
+    const parsed = JSON.parse(rawConnections);
+    DevLogger.log(
+      `SDKConnect::loadAndroidConnections found ${Object.keys(parsed).length}`,
+    );
+    return parsed;
   }
 
-  addAndroidConnection(connection: ConnectionProps) {
+  async addAndroidConnection(connection: ConnectionProps) {
     this.connections[connection.id] = connection;
-    DefaultPreference.set(
+    DevLogger.log(`SDKConnect::addAndroidConnection`, connection);
+    await DefaultPreference.set(
       AppConstants.MM_SDK.ANDROID_CONNECTIONS,
       JSON.stringify(this.connections),
     ).catch((err) => {

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -304,7 +304,8 @@ export class Connection extends EventEmitter2 {
           return;
         }
 
-        // TODO following logic blocksshould be simplified
+        // TODO following logic blocks should be simplified (too many conditions)
+        // Should be done in a separate PR to avoid breaking changes and separate SDKConnect / Connection logic in different files.
         if (
           this.initialConnection &&
           this.origin === AppConstants.DEEPLINKS.ORIGIN_QR_CODE

--- a/app/core/SDKConnect/utils/DevLogger.ts
+++ b/app/core/SDKConnect/utils/DevLogger.ts
@@ -1,0 +1,10 @@
+const DevLogger = {
+  log: (...args: any[]) => {
+    if (process.env.SDK_DEV === 'DEV') {
+      // eslint-disable-next-line no-console
+      console.debug(...args);
+    }
+  },
+};
+
+export default DevLogger;

--- a/app/core/SDKConnect/utils/wait.util.ts
+++ b/app/core/SDKConnect/utils/wait.util.ts
@@ -47,6 +47,9 @@ export const waitForKeychainUnlocked = async ({
   keyringController: KeyringController;
 }) => {
   let i = 0;
+  if (!keyringController) {
+    console.warn('Keyring controller not found');
+  }
   while (!keyringController.isUnlocked()) {
     await new Promise<void>((res) => setTimeout(() => res(), 600));
     if (i++ > 60) break;

--- a/app/core/SDKConnect/utils/wait.util.ts
+++ b/app/core/SDKConnect/utils/wait.util.ts
@@ -2,8 +2,9 @@ import { KeyringController } from '@metamask/keyring-controller';
 import { AndroidClient } from '../AndroidSDK/android-sdk-types';
 import RPCQueueManager from '../RPCQueueManager';
 import { Connection, SDKConnect } from '../SDKConnect';
+import DevLogger from './DevLogger';
 
-export const MAX_QUEUE_LOOP = 50; // 50 seconds
+export const MAX_QUEUE_LOOP = Infinity;
 export const wait = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -42,18 +43,32 @@ export const waitForConnectionReadiness = async ({
 };
 
 export const waitForKeychainUnlocked = async ({
+  context,
   keyringController,
 }: {
   keyringController: KeyringController;
+  context?: string;
 }) => {
-  let i = 0;
+  let i = 1;
   if (!keyringController) {
     console.warn('Keyring controller not found');
   }
-  while (!keyringController.isUnlocked()) {
-    await new Promise<void>((res) => setTimeout(() => res(), 600));
-    if (i++ > 60) break;
+  let unlocked = keyringController.isUnlocked();
+  DevLogger.log(
+    `SDKConnect:: waitForKeyChainUnlocked[${context}] unlocked: ${unlocked}`,
+  );
+  while (!unlocked) {
+    await wait(1000);
+    if (i % 60 === 0) {
+      console.warn(
+        `SDKConnect [${context}] Waiting for keychain unlock... attempt ${i}`,
+      );
+    }
+    unlocked = keyringController.isUnlocked();
+    i += 1;
   }
+
+  return unlocked;
 };
 
 export const waitForAndroidServiceBinding = async () => {

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -611,7 +611,10 @@ export class WC2Manager {
     const keyringController = (
       Engine.context as { KeyringController: KeyringController }
     ).KeyringController;
-    await waitForKeychainUnlocked({ keyringController });
+    await waitForKeychainUnlocked({
+      keyringController,
+      context: 'WalletConnectV2::onSessionRequest',
+    });
 
     try {
       const session = this.sessions[requestEvent.topic];

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -800,10 +800,10 @@ app:
       PROJECT_LOCATION_IOS: ios
     - opts:
         is_expand: false
-      VERSION_NAME: 7.8.0
+      VERSION_NAME: 7.9.0
     - opts:
         is_expand: false
-      VERSION_NUMBER: 1174
+      VERSION_NUMBER: 1179
     - opts:
         is_expand: false
       ANDROID_APK_LINK: ''

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1039,7 +1039,7 @@
 				CODE_SIGN_ENTITLEMENTS = MetaMask/MetaMaskDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1174;
+				CURRENT_PROJECT_VERSION = 1179;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 48XVW22RCG;
@@ -1073,7 +1073,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.8.0;
+				MARKETING_VERSION = 7.9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1105,7 +1105,7 @@
 				CODE_SIGN_ENTITLEMENTS = MetaMask/MetaMask.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1174;
+				CURRENT_PROJECT_VERSION = 1179;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 48XVW22RCG;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 48XVW22RCG;
@@ -1139,7 +1139,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.8.0;
+				MARKETING_VERSION = 7.9.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1251,7 +1251,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1174;
+				CURRENT_PROJECT_VERSION = 1179;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 48XVW22RCG;
@@ -1288,7 +1288,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.8.0;
+				MARKETING_VERSION = 7.9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1320,7 +1320,7 @@
 				CODE_SIGN_ENTITLEMENTS = MetaMask/MetaMask.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1174;
+				CURRENT_PROJECT_VERSION = 1179;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 48XVW22RCG;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 48XVW22RCG;
@@ -1357,7 +1357,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.8.0;
+				MARKETING_VERSION = 7.9.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",


### PR DESCRIPTION
## **Description**
Fixes edge case on android when the connection is recovered after MetaMask is killed. There was an issue on android creating double conflicting connections.

This PR prevents the reconnection conflict on android (IOS doesn't have this issue).

We also added overall logging capabilities to help debug connection related issue. Logging is non intrusive and can only be enabled when setting `export SDK_DEV='DEV'` in `.js.env`.

## **Manual testing steps**

_1. Connect on android via deeplink
_2. Sign request
_3. Kill Metamask
_4. Sign again on dapp via deeplink (previously it would generate warnings and instabilities)

## **Screenshots/Recordings**

N/A

### **Before**

_[screenshot]_

### **After**

_[screenshot]_

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
