### PR TITLE
docs: Update Yarn V1 README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ The code is built using React-Native and running code locally requires a Mac or 
 
 -   Install [Yarn v1](https://yarnpkg.com/en/docs/install)
 
+    One way to install Yarn v1 is by using brew:
+    ```bash
+    brew install yarn@1.22.19
+    ```
+
+    To check you've installed the right version:
+
+    ```bash
+    yarn --version
+    ```
+
 -   Install the shared [React Native dependencies](https://reactnative.dev/docs/environment-setup#installing-dependencies) (`React Native CLI`, _not_ `Expo CLI`)
     -   XCode version `14.2` or below
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The code is built using React-Native and running code locally requires a Mac or 
 
 -   Install [cocoapods](https://guides.cocoapods.org/using/getting-started.html) by running:
 
-```bash
-sudo gem install cocoapods -v 1.12.1
-```
+    ```bash
+    sudo gem install cocoapods -v 1.12.1
+    ```
 
 -   Install [Python](https://www.python.org/downloads/) **version ^3.10**
     - _Note_: M1 User might need to stay with **version 3.10**
@@ -53,9 +53,9 @@ sudo gem install cocoapods -v 1.12.1
 #### Android
 
 -   Install [Java](https://www.java.com/en/download/). To check if Java is already installed, run:
-```
-  java -version
-```
+    ```
+    java -version
+    ```
 -   Install the Android SDK, via [Android Studio](https://developer.android.com/studio).
     -   _MetaMask Only:_ To create production builds, you need to install Google Play Licensing Library via the SDK Manager in Android Studio.
 -   Install the Android NDK (version `21.4.7075529`), via [Android Studio](https://developer.android.com/studio)'s SDK Manager.


### PR DESCRIPTION
## **Description**
Add instructions to ensure the right version is installed. Yarn v4 will not work. Devs should use Yarn V1 
