### PR TITLE
Feat/fix forget devices issue

### DIFF
--- a/app/actions/accounts/index.test.ts
+++ b/app/actions/accounts/index.test.ts
@@ -1,0 +1,19 @@
+import { setReloadAccounts } from '.';
+
+describe('accounts, reloadAccounts', () => {
+  describe('setReloadAccounts', () => {
+    it('should create an action to set reloadAccounts to true', () => {
+      expect(setReloadAccounts(true)).toEqual({
+        type: 'SET_RELOAD_ACCOUNTS',
+        reloadAccounts: true,
+      });
+    });
+
+    it('should create an action to set reloadAccounts to false', () => {
+      expect(setReloadAccounts(false)).toEqual({
+        type: 'SET_RELOAD_ACCOUNTS',
+        reloadAccounts: false,
+      });
+    });
+  });
+});

--- a/app/actions/accounts/index.ts
+++ b/app/actions/accounts/index.ts
@@ -3,7 +3,7 @@ import { Action } from 'redux';
 /**
  * Deference action types available for different RPC event flow
  */
-export enum ActionType {
+export enum AccountsActionType {
   SET_RELOAD_ACCOUNTS = 'SET_RELOAD_ACCOUNTS',
 }
 
@@ -16,7 +16,7 @@ export interface iAccountActions extends Action {
 
 export function setReloadAccounts(reloadAccounts: boolean): iAccountActions {
   return {
-    type: ActionType.SET_RELOAD_ACCOUNTS,
+    type: AccountsActionType.SET_RELOAD_ACCOUNTS,
     reloadAccounts,
   };
 }

--- a/app/actions/accounts/index.ts
+++ b/app/actions/accounts/index.ts
@@ -14,6 +14,11 @@ export interface iAccountActions extends Action {
   reloadAccounts: boolean;
 }
 
+/**
+ * setReloadAccounts action creator
+ * @param {boolean} reloadAccounts: true to reload accounts, false otherwise
+ * @returns {iAccountActions} - the action object to set reloadAccounts
+ */
 export function setReloadAccounts(reloadAccounts: boolean): iAccountActions {
   return {
     type: AccountsActionType.SET_RELOAD_ACCOUNTS,

--- a/app/actions/accounts/index.ts
+++ b/app/actions/accounts/index.ts
@@ -1,0 +1,22 @@
+import { Action } from 'redux';
+
+/**
+ * Deference action types available for different RPC event flow
+ */
+export enum ActionType {
+  SET_RELOAD_ACCOUNTS = 'SET_RELOAD_ACCOUNTS',
+}
+
+/**
+ * Extend redux Action interface to add rpcName, eventStage and error properties
+ */
+export interface iAccountActions extends Action {
+  reloadAccounts: boolean;
+}
+
+export function setReloadAccounts(reloadAccounts: boolean): iAccountActions {
+  return {
+    type: ActionType.SET_RELOAD_ACCOUNTS,
+    reloadAccounts,
+  };
+}

--- a/app/components/UI/TransactionReview/index.test.tsx
+++ b/app/components/UI/TransactionReview/index.test.tsx
@@ -270,21 +270,4 @@ describe('TransactionReview', () => {
     const confirmButton = getByRole('button', { name: 'Confirm' });
     expect(confirmButton.props.disabled).toBe(true);
   });
-
-  it('should have confirm button disabled if error is defined', async () => {
-    jest.mock('react-redux', () => ({
-      ...jest.requireActual('react-redux'),
-      useSelector: (fn: any) => fn(mockState),
-    }));
-    const { getByRole } = renderWithProvider(
-      <TransactionReview
-        EIP1559GasData={{}}
-        generateTransform={generateTransform}
-        error="You need 1 more ETH to complete the transaction"
-      />,
-      { state: mockState },
-    );
-    const confirmButton = getByRole('button', { name: 'Confirm' });
-    expect(confirmButton.props.disabled).toBe(true);
-  });
 });

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -1,5 +1,11 @@
 // Third party dependencies.
-import React, { Fragment, useCallback, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { InteractionManager, Platform, View } from 'react-native';
 
 // External dependencies.
@@ -31,17 +37,30 @@ import {
   AccountSelectorScreens,
 } from './AccountSelector.types';
 import styles from './AccountSelector.styles';
+import { useDispatch, useSelector } from 'react-redux';
+import { setReloadAccounts } from '../../../actions/accounts';
+import { RootState } from '../../../reducers';
 
 const AccountSelector = ({ route }: AccountSelectorProps) => {
+  const dispatch = useDispatch();
   const { onSelectAccount, checkBalanceError } = route.params || {};
+
+  const { reloadAccounts } = useSelector((state: RootState) => state.accounts);
   const Engine = UntypedEngine as any;
   const sheetRef = useRef<SheetBottomRef>(null);
   const { accounts, ensByAccountAddress } = useAccounts({
     checkBalanceError,
+    isLoading: reloadAccounts,
   });
   const [screen, setScreen] = useState<AccountSelectorScreens>(
     AccountSelectorScreens.AccountSelector,
   );
+
+  useEffect(() => {
+    if (reloadAccounts) {
+      dispatch(setReloadAccounts(false));
+    }
+  }, [reloadAccounts]);
 
   const _onSelectAccount = useCallback(
     (address: string) => {

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -60,7 +60,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     if (reloadAccounts) {
       dispatch(setReloadAccounts(false));
     }
-  }, [reloadAccounts]);
+  }, [dispatch, reloadAccounts]);
 
   const _onSelectAccount = useCallback(
     (address: string) => {

--- a/app/components/Views/LedgerAccountInfo/index.tsx
+++ b/app/components/Views/LedgerAccountInfo/index.tsx
@@ -10,8 +10,9 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
+import { setReloadAccounts } from '../../../actions/accounts';
 import { NO_RPC_BLOCK_EXPLORER, RPC } from '../../../constants/network';
 import Engine from '../../../core/Engine';
 import { forgetLedger, getLedgerKeyring } from '../../../core/Ledger/Ledger';
@@ -26,6 +27,9 @@ import {
 import Text from '../../Base/Text';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
 import AccountDetails from '../ConnectQRHardware/AccountDetails';
+
+import ledgerDeviceDarkImage from '../../../images/ledger-device-dark.png';
+import ledgerDeviceLightImage from '../../../images/ledger-device-light.png';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -70,10 +74,8 @@ const createStyles = (colors: any) =>
     },
   });
 
-const ledgerDeviceDarkImage = require('../../../images/ledger-device-dark.png');
-const ledgerDeviceLightImage = require('../../../images/ledger-device-light.png');
-
 const LedgerAccountInfo = () => {
+  const dispatch = useDispatch();
   const navigation = useNavigation();
   const [account, setAccount] = useState('');
   const [accountBalance, setAccountBalance] = useState<string>('0');
@@ -113,6 +115,7 @@ const LedgerAccountInfo = () => {
 
   const onForgetDevice = async () => {
     await forgetLedger();
+    dispatch(setReloadAccounts(true));
     navigation.goBack();
   };
 

--- a/app/reducers/accounts/index.test.ts
+++ b/app/reducers/accounts/index.test.ts
@@ -1,0 +1,44 @@
+import { iAccountActions } from 'app/actions/accounts';
+
+import reducer, { iAccountEvent } from '.';
+
+const intialState: Readonly<iAccountEvent> = {
+  reloadAccounts: false,
+};
+
+const emptyAction: iAccountActions = {
+  type: null,
+  reloadAccounts: false,
+};
+
+describe('accounts reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, emptyAction)).toEqual(intialState);
+  });
+
+  describe('setReloadAccount', () => {
+    it('setReloadAccount should return true when payload contain reloadAcounts: true', () => {
+      const state = reducer(undefined, emptyAction);
+
+      const action = {
+        type: 'SET_RELOAD_ACCOUNTS',
+        reloadAccounts: true,
+      };
+      expect(reducer(state, action)).toEqual({
+        reloadAccounts: true,
+      });
+    });
+
+    it('setReloadAccount should return false when payload contain reloadAcounts: false', () => {
+      const state = reducer(undefined, emptyAction);
+
+      const action = {
+        type: 'SET_RELOAD_ACCOUNTS',
+        reloadAccounts: false,
+      };
+      expect(reducer(state, action)).toEqual({
+        reloadAccounts: false,
+      });
+    });
+  });
+});

--- a/app/reducers/accounts/index.ts
+++ b/app/reducers/accounts/index.ts
@@ -1,1 +1,18 @@
-import { ActionType, iAccountActions } from '../../actions/accounts';
+import { AccountsActionType, iAccountActions } from '../../actions/accounts';
+
+const initialState = {
+  reloadAccounts: false,
+};
+
+const accountReducer = (state = initialState, action: iAccountActions) => {
+  switch (action.type) {
+    case AccountsActionType.SET_RELOAD_ACCOUNTS:
+      return {
+        ...state,
+        reloadAccounts: action.reloadAccounts,
+      };
+    default:
+      return state;
+  }
+};
+export default accountReducer;

--- a/app/reducers/accounts/index.ts
+++ b/app/reducers/accounts/index.ts
@@ -1,0 +1,1 @@
+import { ActionType, iAccountActions } from '../../actions/accounts';

--- a/app/reducers/accounts/index.ts
+++ b/app/reducers/accounts/index.ts
@@ -1,10 +1,32 @@
 import { AccountsActionType, iAccountActions } from '../../actions/accounts';
 
-const initialState = {
+/**
+ * Interface for defining what properties will be defined in store
+ */
+export interface iAccountEvent {
+  reloadAccounts: boolean;
+}
+
+/**
+ * Initial state of the Accounts event flow
+ */
+const initialState: iAccountEvent = {
   reloadAccounts: false,
 };
 
-const accountReducer = (state = initialState, action: iAccountActions) => {
+/**
+ * Reducer to Account relative event
+ * @param {iAccountEvent} state: the state of the Accounts event flow, default to initialState
+ * @param {iAccountActions} action: the action object contain type and payload to change state.
+ * @returns {iAccountEvent}: the new state of the Accounts event flow
+ */
+const accountReducer = (
+  state = initialState,
+  action: iAccountActions = {
+    type: '',
+    reloadAccounts: false,
+  },
+) => {
   switch (action.type) {
     case AccountsActionType.SET_RELOAD_ACCOUNTS:
       return {

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -21,6 +21,7 @@ import { combineReducers, Reducer } from 'redux';
 import experimentalSettingsReducer from './experimentalSettings';
 import { EngineState } from '../core/Engine';
 import rpcEventReducer from './rpcEvents';
+import accountsReducer from './accounts';
 
 /**
  * Infer state from a reducer
@@ -62,6 +63,7 @@ export interface RootState {
   // The experimentalSettings reducer is TypeScript but not yet a valid reducer
   experimentalSettings: any;
   rpcEvents: any;
+  accounts: any;
 }
 
 // TODO: Fix the Action type. It's set to `any` now because some of the
@@ -88,6 +90,7 @@ const rootReducer = combineReducers<RootState, any>({
   security: securityReducer,
   experimentalSettings: experimentalSettingsReducer,
   rpcEvents: rpcEventReducer,
+  accounts: accountsReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
## **Description**
Fix the `forget devices` in ledger didnt remove the ledger account in account lists.

Following have been done:
* Implement new actions and reducer for accounts relative actions.
* modify `LedgerAccountInfo/index.tsx` `onForgetDevice()` event to dispatch the account reload event.
* modify `accountSelector.tsx` to subscribe this actions and pass to useAccounts() hook so that, hook can reload the account cache when required.
* Fix some lint and implement some unit tests for relative codes.
