### PR TITLE
chore: run `yarn install` as part of `yarn deduplicate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cache: yarn
       - run: yarn setup:node
       - name: Deduplicate dependencies
-        run: yarn deduplicate && yarn
+        run: yarn deduplicate
       - name: Print error if duplicates found
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "stacktrace:ios": "stack-beautifier sourcemaps/ios/index.js.map -t sourcemaps/trace.txt",
     "update-changelog": "./scripts/auto-changelog.sh",
     "prestorybook": "rnstl",
-    "deduplicate": "yarn yarn-deduplicate",
+    "deduplicate": "yarn yarn-deduplicate && yarn install",
     "create-release": "./scripts/set-versions.sh && yarn update-changelog",
     "add-release-label-to-pr-and-linked-issues": "ts-node ./.github/scripts/add-release-label-to-pr-and-linked-issues.ts",
     "check-e2e-smoke-trigger": "ts-node ./.github/scripts/check-bitrise-e2e-smoke/check-e2e-smoke-trigger.ts",


### PR DESCRIPTION
## **Description**

Running `yarn install` seems necessary to sync lockfile after `yarn deduplicate`.

This was already done in CI. This makes it happen when running the script locally, too.

## **Manual testing steps**

1. Update/install a package introducing a dupe
2. Run `yarn deduplicate` and commit result
3. Observe CI not complaining

## **Related issues**

- #7131 


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
