### PR TITLE
docs: Updating PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,40 +1,42 @@
 ## **Description**
-_Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:_
-_1. What is the reason for the change?_
-_2. What is the improvement/solution?_
 
-## **Manual testing steps**
-
-_1. Step1:_
-_2. Step2:_
-_3. ..._
-
-## **Screenshots/Recordings**
-
-_If applicable, add screenshots and/or recordings to visualize the before and after of your change._
-
-### **Before**
-
-_[screenshot]_
-
-### **After**
-
-_[screenshot]_
+<!--
+Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
+1. What is the reason for the change?
+2. What is the improvement/solution?
+-->
 
 ## **Related issues**
 
-_Fixes #???_
+Fixes: #
+
+## **Manual testing steps**
+
+1. Go to this page...
+2.
+3.
+
+## **Screenshots/Recordings**
+
+<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
+
+### **Before**
+
+<!-- [screenshots/recordings] -->
+
+### **After**
+
+<!-- [screenshots/recordings] -->
 
 ## **Pre-merge author checklist**
 
 - [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
-- [ ] I've clearly explained:
-  - [ ] What problem this PR is solving.
-  - [ ] How this problem was solved.
-  - [ ] How reviewers can test my changes.
-- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
-- [ ] I’ve included tests if applicable.
-- [ ] I’ve documented any added code.
+- [ ] I've clearly explained what problem this PR is solving and how it is solved.
+- [ ] I've linked related issues
+- [ ] I've included manual testing steps
+- [ ] I've included screenshots/recordings if applicable
+- [ ] I’ve included tests if applicable
+- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
 - [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
 - [ ] I’ve properly set the pull request status:
   - [ ] In case it's not yet "ready for review", I've set it to "draft".


### PR DESCRIPTION
## **Description**
Currently the PR template although comprehensive, could be improved with the intention of easing engineer workflow by removing italics, rearranging the sections and making the author checklist more concise and use the same language as the template itself.

## **Manual testing steps**

1. Read the PR template
2. Imagine filling it out
3. Do you feel it would help or hinder when creating a PR?
4. Comment with input

## **Screenshots/Recordings**

### **Before**

![Screenshot 2023-10-23 at 12 12 49 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/a0389bc4-62b5-4b25-9a77-94c0c9ff4ada)


### **After**

![Screenshot 2023-10-23 at 12 12 34 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/0561a321-7956-4d71-a9b3-3143d2e22764)


## **Related issues**

- Extension PR https://github.com/MetaMask/metamask-extension/pull/21377
-  Slack thread https://consensys.slack.com/archives/G1L7H42BT/p1697208312544229

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
