### PR TITLE
Feat/fix ledger UI feedback

### DIFF
--- a/app/component-library/components/Cells/Cell/foundation/CellBase/CellBase.styles.ts
+++ b/app/component-library/components/Cells/Cell/foundation/CellBase/CellBase.styles.ts
@@ -45,6 +45,7 @@ const styleSheet = (params: { theme: Theme; vars: CellBaseStyleSheetVars }) => {
     },
     tagLabel: {
       marginTop: 4,
+      height: 25,
     },
   });
 };

--- a/app/component-library/components/Cells/Cell/foundation/CellBase/__snapshots__/CellBase.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/foundation/CellBase/__snapshots__/CellBase.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`CellBase - Snapshot should render label when given 1`] = `
       label="Imported"
       style={
         Object {
+          "height": 25,
           "marginTop": 4,
         }
       }


### PR DESCRIPTION
## **Description**

Fix zenhub problem that ledger `g` has been cut off from screen.
also fix the unit tests broken due to styling change.

## **Screenshot**
![image](https://github.com/MetaMask/metamask-mobile/assets/7315988/30916dd1-027c-4459-a5a5-0b29e49b124f)
