### PR TITLE
chore: transfer DeeplinkManager.js file to TS

### DIFF
--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -29,7 +29,12 @@ export const PREFIXES = {
   [ACTIONS.DAPP]: 'https://',
   [ACTIONS.SEND]: 'ethereum:',
   [ACTIONS.APPROVE]: 'ethereum:',
+  [ACTIONS.PAYMENT]: '',
   [ACTIONS.FOCUS]: '',
+  [ACTIONS.WC]: '',
+  [ACTIONS.CONNECT]: '',
+  [ACTIONS.ANDROID_SDK]: '',
+  [ACTIONS.BUY_CRYPTO]: '',
   [ACTIONS.EMPTY]: '',
   METAMASK: 'metamask://',
 };


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Transfer the DeeplinkManager.js file from JS to TS to have type safety.

## **Related issues**

Fixes: #

## **Manual testing steps**


1. Test the deep links behavior with the `devnext` project on a testing device.
2.  Test the deep links behavior with the `devreactnative` project on a testing device.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
