### PR TITLE
chore: adds the fixture env variable to debug android builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:e2e:ios": "detox build -c ios.sim.release && detox test -c ios.sim.release",
     "test:e2e:ios:debug": "IS_TEST='true' detox build -c ios.sim.debug && detox test -c ios.sim.debug",
     "test:e2e:ios:debug:single": "detox test -c ios.sim.debug",
-    "test:e2e:android:debug": "detox build -c android.emu.debug && detox test -c android.emu.debug",
+    "test:e2e:android:debug": "IS_TEST='true' detox build -c android.emu.debug && detox test -c android.emu.debug",
     "test:e2e:android:bitrise:debug": "IS_TEST='true' detox build -c android.emu.bitrise.debug && detox test -c android.emu.bitrise.debug --headless",
     "test:e2e:android:debug:single": "detox test -c android.emu.debug",
     "test:e2e:android": "detox build -c android.emu.release && detox test -c android.emu.release --record-videos failing",


### PR DESCRIPTION
## **Description**

Adds `IS_TEST='true'` to android debug builds.
