### PR TITLE
feat: Fix the issue of keystone`forget devices`err

### DIFF
--- a/patches/@metamask+keyring-controller+6.1.0.patch
+++ b/patches/@metamask+keyring-controller+6.1.0.patch
@@ -1142,7 +1142,7 @@ index 0000000..f670fd3
 +            /**
 +             * ============================== PATCH INFORMATION ==============================
 +             * This patch addresses an issue regarding the forget device functionality. It
-+             * improves the logic  to correctly remove the QR accounts and update the 
++             * improves the logic  to correctly remove the QR accounts and update the
 +             * identities as needed.
 +             * ===============================================================================
 +             */
@@ -1232,3 +1232,33 @@ index 0000000..bf35006
 @@ -0,0 +1 @@
 +{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;AAAA,sDAAoC","sourcesContent":["export * from './KeyringController';\n"]}
 \ No newline at end of file
+diff --git a/node_modules/@metamask/keyring-controller/dist/KeyringController.js b/node_modules/@metamask/keyring-controller/dist/KeyringController.js
+index c905cc0..f670fd3 100644
+--- a/node_modules/@metamask/keyring-controller/dist/KeyringController.js
++++ b/node_modules/@metamask/keyring-controller/dist/KeyringController.js
+@@ -678,13 +678,21 @@ class KeyringController extends base_controller_1.BaseControllerV2 {
+     }
+     forgetQRDevice() {
+         return __awaiter(this, void 0, void 0, function* () {
++            /**
++             * ============================== PATCH INFORMATION ==============================
++             * This patch addresses an issue regarding the forget device functionality. It
++             * improves the logic  to correctly remove the QR accounts and update the
++             * identities as needed.
++             * ===============================================================================
++             */
+             const keyring = yield this.getOrAddQRKeyring();
++            const allAccounts = (yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts());
+             keyring.forgetDevice();
+-            const accounts = (yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts());
+-            accounts.forEach((account) => {
+-                this.setSelectedAddress(account);
+-            });
++            const remainingAccounts = (yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").getAccounts());
++            const removedAccounts = allAccounts.filter((address) => !remainingAccounts.includes(address));
++            this.updateIdentities(remainingAccounts);
+             yield __classPrivateFieldGet(this, _KeyringController_keyring, "f").persistAllKeyrings();
++            return { removedAccounts, remainingAccounts };
+         });
+     }
+ }


### PR DESCRIPTION
## **Description**

The current keystone hardware in ledger branch, when user click `forget devices`, the screen will output `Cannon read property ‘removedAccounts’ of undefined.` error message.
This patch fix will fix the issue.

