### PR TITLE
fix: Copy changes, Security advice by > Powered by

### DIFF
--- a/app/components/UI/BlockaidBanner/__snapshots__/BlockaidBanner.test.tsx.snap
+++ b/app/components/UI/BlockaidBanner/__snapshots__/BlockaidBanner.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`BlockaidBanner should render correctly 1`] = `
             }
           }
         >
-          Security advice by
+          Powered by
         </Text>
       </View>
       <View
@@ -449,7 +449,7 @@ exports[`BlockaidBanner should render correctly with list attack details 1`] = `
             }
           }
         >
-          Security advice by
+          Powered by
         </Text>
       </View>
       <View
@@ -689,7 +689,7 @@ exports[`BlockaidBanner should render correctly with reason "raw_signature_farmi
             }
           }
         >
-          Security advice by
+          Powered by
         </Text>
       </View>
       <View
@@ -1005,7 +1005,7 @@ exports[`BlockaidBanner should render something does not look right with contact
             }
           }
         >
-          Security advice by
+          Powered by
         </Text>
       </View>
       <View

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1,7 +1,7 @@
 {
   "blockaid_banner": {
     "approval_farming_description": "If you approve this request, a third party known for scams might take all your assets.",
-    "attribution": "Security advice by",
+    "attribution": "Powered by",
     "attribution_link_name": "Blockaid",
     "blur_farming_description": "If you approve this request, someone can steal your assets listed on Blur.",
     "deceptive_request_title": "This is a deceptive request",


### PR DESCRIPTION
## **Description**

**Problem:** In Extension we show `Powered by Blockaid` wheres in Mobile we show `Security advice by Blockaid`.
Should we consolidate this into the same message? cc @bschorchit 

### Expected behavior

Show Powered by in mobile too

## **Related issues**

Fixes: #7515 

## **Manual testing steps**
1. Enable Blockaid
2. Go to the test dapp
3. Trigger a malicious signature
4. See text

## **Screenshots/Recordings**

### **Before**

![Screenshot from 2023-10-16 13-07-24](https://github.com/MetaMask/metamask-mobile/assets/54408225/444d454b-8f3b-406e-a4d4-74565f356d36)

### **After**

<img width="433" alt="Screenshot 2023-10-25 at 13 47 11" src="https://github.com/MetaMask/metamask-mobile/assets/44811/9e1c47ad-39b5-4b48-8494-4a70f3bbb04f">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
