### PR TITLE
fix: revert nonce logic in transaction controller

### DIFF
--- a/patches/@metamask+transaction-controller+5.0.0.patch
+++ b/patches/@metamask+transaction-controller+5.0.0.patch
@@ -366,7 +366,7 @@ index 0000000..8da9369
 +//# sourceMappingURL=IncomingTransactionHelper.js.map
 \ No newline at end of file
 diff --git a/node_modules/@metamask/transaction-controller/dist/TransactionController.d.ts b/node_modules/@metamask/transaction-controller/dist/TransactionController.d.ts
-index e242aed..7efd89a 100644
+index e242aed..9d96058 100644
 --- a/node_modules/@metamask/transaction-controller/dist/TransactionController.d.ts
 +++ b/node_modules/@metamask/transaction-controller/dist/TransactionController.d.ts
 @@ -2,8 +2,10 @@
@@ -565,7 +565,13 @@ index e242aed..7efd89a 100644
  /**
   * Multiplier used to determine a transaction's increased gas fee during cancellation
   */
-@@ -223,19 +93,10 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -217,25 +87,15 @@ export declare const SPEED_UP_RATE = 1.1;
+  */
+ export declare class TransactionController extends BaseController<TransactionConfig, TransactionState> {
+     private ethQuery;
+-    private nonceTracker;
+     private registry;
+     private provider;
      private handle?;
      private mutex;
      private getNetworkState;
@@ -587,7 +593,7 @@ index e242aed..7efd89a 100644
      /**
       * EventEmitter instance used to listen to specific transactional events
       */
-@@ -252,18 +113,33 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -252,18 +112,33 @@ export declare class TransactionController extends BaseController<TransactionCon
       * Creates a TransactionController instance.
       *
       * @param options - The controller options.
@@ -624,7 +630,7 @@ index e242aed..7efd89a 100644
      }, config?: Partial<TransactionConfig>, state?: Partial<TransactionState>);
      /**
       * Starts a new polling interval.
-@@ -284,11 +160,20 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -284,11 +159,20 @@ export declare class TransactionController extends BaseController<TransactionCon
       * if not provided. If A `<tx.id>:unapproved` hub event will be emitted once added.
       *
       * @param transaction - The transaction object to add.
@@ -648,7 +654,7 @@ index e242aed..7efd89a 100644
      prepareUnsignedEthTx(txParams: Record<string, unknown>): TypedTransaction;
      /**
       * `@ethereumjs/tx` uses `@ethereumjs/common` as a configuration tool for
-@@ -300,22 +185,6 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -300,22 +184,6 @@ export declare class TransactionController extends BaseController<TransactionCon
       * @returns {Common} common configuration object
       */
      getCommonConfiguration(): Common;
@@ -671,7 +677,7 @@ index e242aed..7efd89a 100644
      /**
       * Attempts to cancel a transaction based on its ID by setting its status to "rejected"
       * and emitting a `<tx.id>:finished` hub event.
-@@ -364,16 +233,6 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -364,16 +232,6 @@ export declare class TransactionController extends BaseController<TransactionCon
       * current network. If `true`, all transactions are wiped.
       */
      wipeTransactions(ignoreNetwork?: boolean): void;
@@ -688,7 +694,7 @@ index e242aed..7efd89a 100644
      /**
       * Trim the amount of transactions that are set on the state. Checks
       * if the length of the tx history is longer then desired persistence
-@@ -413,59 +272,37 @@ export declare class TransactionController extends BaseController<TransactionCon
+@@ -413,59 +271,36 @@ export declare class TransactionController extends BaseController<TransactionCon
       * @returns Whether the transaction has failed.
       */
      private checkTxReceiptStatusIsFailed;
@@ -766,7 +772,6 @@ index e242aed..7efd89a 100644
 +    private isTransactionCompleted;
 +    private onIncomingTransactions;
 +    private onUpdatedLastFetchedBlockNumbers;
-+    private getNonceTrackerTransactions;
  }
  export default TransactionController;
  //# sourceMappingURL=TransactionController.d.ts.map
@@ -780,7 +785,7 @@ index 07781b0..0000000
 -{"version":3,"file":"TransactionController.d.ts","sourceRoot":"","sources":["../src/TransactionController.ts"],"names":[],"mappings":";AAAA,OAAO,EAAE,YAAY,EAAE,MAAM,QAAQ,CAAC;AAKtC,OAAO,MAAM,MAAM,oBAAoB,CAAC;AACxC,OAAO,EAAsB,gBAAgB,EAAE,MAAM,gBAAgB,CAAC;AAGtE,OAAO,EACL,cAAc,EACd,UAAU,EACV,SAAS,EACV,MAAM,2BAA2B,CAAC;AACnC,OAAO,KAAK,EACV,YAAY,EACZ,aAAa,EACb,iBAAiB,EAClB,MAAM,8BAA8B,CAAC;AA4BtC;;;;GAIG;AACH,MAAM,WAAW,MAAM;IACrB,MAAM,EAAE,OAAO,CAAC,MAAM,CAAC,CAAC;IACxB,eAAe,EAAE,eAAe,CAAC;CAClC;AAED;;;;GAIG;AACH,MAAM,WAAW,eAAe;IAC9B,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,eAAe,CAAC,EAAE,MAAM,CAAC;CAC1B;AAED;;;;;;;;;;;;;GAaG;AACH,MAAM,WAAW,WAAW;IAC1B,OAAO,CAAC,EAAE,MAAM,CAAC;IACjB,IAAI,CAAC,EAAE,MAAM,CAAC;IACd,IAAI,EAAE,MAAM,CAAC;IACb,GAAG,CAAC,EAAE,MAAM,CAAC;IACb,QAAQ,CAAC,EAAE,MAAM,CAAC;IAClB,OAAO,CAAC,EAAE,MAAM,CAAC;IACjB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,EAAE,CAAC,EAAE,MAAM,CAAC;IACZ,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,YAAY,CAAC,EAAE,MAAM,CAAC;IACtB,oBAAoB,CAAC,EAAE,MAAM,CAAC;IAC9B,gBAAgB,CAAC,EAAE,MAAM,CAAC;IAC1B,gBAAgB,CAAC,EAAE,MAAM,CAAC;CAC3B;AAED,MAAM,WAAW,aAAa;IAC5B,QAAQ,EAAE,MAAM,CAAC;CAClB;AAED,MAAM,WAAW,sBAAsB;IACrC,YAAY,EAAE,MAAM,CAAC;IACrB,oBAAoB,EAAE,MAAM,CAAC;CAC9B;AAED;;;;GAIG;AACH,oBAAY,iBAAiB;IAC3B,QAAQ,aAAa;IACrB,SAAS,cAAc;IACvB,SAAS,cAAc;IACvB,MAAM,WAAW;IACjB,QAAQ,aAAa;IACrB,MAAM,WAAW;IACjB,SAAS,cAAc;IACvB,UAAU,eAAe;CAC1B;AAED;;GAEG;AACH,oBAAY,YAAY;IACtB,SAAS,oBAAoB;IAC7B,YAAY,uBAAuB;IACnC,KAAK,iBAAiB;CACvB;AAED,aAAK,mBAAmB,GAAG;IACzB,UAAU,CAAC,EAAE,OAAO,CAAC;IACrB,mBAAmB,CAAC,EAAE;QACpB,MAAM,EAAE,MAAM,CAAC;QACf,eAAe,EAAE,MAAM,CAAC;QACxB,QAAQ,EAAE,MAAM,CAAC;KAClB,CAAC;IACF,EAAE,EAAE,MAAM,CAAC;IACX,SAAS,CAAC,EAAE,MAAM,CAAC;IACnB,OAAO,CAAC,EAAE,MAAM,CAAC;IACjB,MAAM,CAAC,EAAE,MAAM,CAAC;IAChB,cAAc,CAAC,EAAE,MAAM,CAAC;IACxB,IAAI,EAAE,MAAM,CAAC;IACb,eAAe,CAAC,EAAE,OAAO,CAAC;IAC1B,WAAW,EAAE,WAAW,CAAC;IACzB,eAAe,CAAC,EAAE,MAAM,CAAC;IACzB,WAAW,CAAC,EAAE,MAAM,CAAC;IACrB,iBAAiB,CAAC,EAAE,YAAY,CAAC;IACjC,oBAAoB,CAAC,EAAE,OAAO,CAAC;CAChC,CAAC;AAEF;;;;;;;;;;;;;;;;GAgBG;AACH,oBAAY,eAAe,GACvB,CAAC;IACC,MAAM,EAAE,OAAO,CAAC,iBAAiB,EAAE,iBAAiB,CAAC,MAAM,CAAC,CAAC;CAC9D,GAAG,mBAAmB,CAAC,GACxB,CAAC;IAAE,MAAM,EAAE,iBAAiB,CAAC,MAAM,CAAC;IAAC,KAAK,EAAE,KAAK,CAAA;CAAE,GAAG,mBAAmB,CAAC,CAAC;AAE/E;;;;;;;;;;;;;;;;;;;;GAoBG;AACH,MAAM,WAAW,wBAAwB;IACvC,WAAW,EAAE,MAAM,CAAC;IACpB,SAAS,EAAE,MAAM,CAAC;IAClB,IAAI,EAAE,MAAM,CAAC;IACb,KAAK,EAAE,MAAM,CAAC;IACd,SAAS,EAAE,MAAM,CAAC;IAClB,gBAAgB,EAAE,MAAM,CAAC;IACzB,IAAI,EAAE,MAAM,CAAC;IACb,EAAE,EAAE,MAAM,CAAC;IACX,KAAK,EAAE,MAAM,CAAC;IACd,GAAG,EAAE,MAAM,CAAC;IACZ,QAAQ,EAAE,MAAM,CAAC;IACjB,iBAAiB,EAAE,MAAM,CAAC;IAC1B,OAAO,EAAE,MAAM,CAAC;IAChB,OAAO,EAAE,MAAM,CAAC;IAChB,gBAAgB,EAAE,MAAM,CAAC;IACzB,KAAK,EAAE,MAAM,CAAC;IACd,eAAe,EAAE,MAAM,CAAC;IACxB,aAAa,EAAE,MAAM,CAAC;IACtB,YAAY,EAAE,MAAM,CAAC;IACrB,WAAW,EAAE,MAAM,CAAC;CACrB;AAED;;;;;;;GAOG;AACH,MAAM,WAAW,iBAAkB,SAAQ,UAAU;IACnD,QAAQ,EAAE,MAAM,CAAC;IACjB,IAAI,CAAC,EAAE,CAAC,WAAW,EAAE,WAAW,EAAE,IAAI,EAAE,MAAM,KAAK,OAAO,CAAC,GAAG,CAAC,CAAC;IAChE,cAAc,EAAE,MAAM,CAAC;CACxB;AAED;;;;;;GAMG;AACH,MAAM,WAAW,UAAU;IACzB,cAAc,EAAE,MAAM,CAAC;IACvB,oBAAoB,EAAE,MAAM,CAAC,MAAM,EAAE,OAAO,CAAC,CAAC;CAC/C;AAED;;;;;;GAMG;AACH,MAAM,WAAW,gBAAiB,SAAQ,SAAS;IACjD,YAAY,EAAE,eAAe,EAAE,CAAC;IAChC,UAAU,EAAE;QAAE,CAAC,GAAG,EAAE,MAAM,GAAG,UAAU,CAAA;KAAE,CAAC;CAC3C;AAED;;GAEG;AACH,eAAO,MAAM,WAAW,MAAM,CAAC;AAE/B;;GAEG;AACH,eAAO,MAAM,aAAa,MAAM,CAAC;AAEjC;;GAEG;AACH,qBAAa,qBAAsB,SAAQ,cAAc,CACvD,iBAAiB,EACjB,gBAAgB,CACjB;IACC,OAAO,CAAC,QAAQ,CAAM;IAEtB,OAAO,CAAC,YAAY,CAAe;IAEnC,OAAO,CAAC,QAAQ,CAAM;IAEtB,OAAO,CAAC,QAAQ,CAAgB;IAEhC,OAAO,CAAC,MAAM,CAAC,CAAgC;IAE/C,OAAO,CAAC,KAAK,CAAe;IAE5B,OAAO,CAAC,eAAe,CAAqB;IAE5C,OAAO,CAAC,eAAe;YAUT,cAAc;IAM5B;;;;;;;;OAQG;IACH,OAAO,CAAC,WAAW;IA0CnB,OAAO,CAAC,gBAAgB,CA0CtB;IAEF;;OAEG;IACH,GAAG,eAAsB;IAEzB;;OAEG;IACM,IAAI,SAA2B;IAExC;;OAEG;IACH,IAAI,CAAC,EAAE,CACL,WAAW,EAAE,gBAAgB,EAC7B,IAAI,EAAE,MAAM,KACT,OAAO,CAAC,gBAAgB,CAAC,CAAC;IAE/B;;;;;;;;;;OAUG;gBAED,EACE,eAAe,EACf,oBAAoB,EACpB,QAAQ,EACR,YAAY,GACb,EAAE;QACD,eAAe,EAAE,MAAM,YAAY,CAAC;QACpC,oBAAoB,EAAE,CAAC,QAAQ,EAAE,CAAC,KAAK,EAAE,YAAY,KAAK,IAAI,KAAK,IAAI,CAAC;QACxE,QAAQ,EAAE,aAAa,CAAC;QACxB,YAAY,EAAE,iBAAiB,CAAC;KACjC,EACD,MAAM,CAAC,EAAE,OAAO,CAAC,iBAAiB,CAAC,EACnC,KAAK,CAAC,EAAE,OAAO,CAAC,gBAAgB,CAAC;IAyCnC;;;;OAIG;IACG,IAAI,CAAC,QAAQ,CAAC,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC;IAS5C;;;;;OAKG;IACG,gBAAgB,CAAC,cAAc,EAAE,MAAM,GAAG,OAAO,CAAC,UAAU,CAAC;IAoBnE;;;;;;;;;OASG;IACG,cAAc,CAClB,WAAW,EAAE,WAAW,EACxB,MAAM,CAAC,EAAE,MAAM,EACf,iBAAiB,CAAC,EAAE,YAAY,GAC/B,OAAO,CAAC,MAAM,CAAC;IAkElB,oBAAoB,CAAC,QAAQ,EAAE,MAAM,CAAC,MAAM,EAAE,OAAO,CAAC,GAAG,gBAAgB;IAOzE;;;;;;;;OAQG;IAEH,sBAAsB,IAAI,MAAM;IAuBhC;;;;;;;OAOG;IACG,kBAAkB,CAAC,aAAa,EAAE,MAAM;IAyF9C;;;;;OAKG;IACH,iBAAiB,CAAC,aAAa,EAAE,MAAM;IAevC;;;;;;OAMG;IACG,eAAe,CACnB,aAAa,EAAE,MAAM,EACrB,SAAS,CAAC,EAAE,aAAa,GAAG,sBAAsB;IA4FpD;;;;;OAKG;IACG,kBAAkB,CACtB,aAAa,EAAE,MAAM,EACrB,SAAS,CAAC,EAAE,aAAa,GAAG,sBAAsB;IAoHpD;;;;;OAKG;IACG,WAAW,CAAC,WAAW,EAAE,WAAW;;;;;;;;;IA6E1C;;;OAGG;IACG,wBAAwB;IAmC9B;;;;OAIG;IACH,iBAAiB,CAAC,eAAe,EAAE,eAAe;IAWlD;;;;;OAKG;IACH,gBAAgB,CAAC,aAAa,CAAC,EAAE,OAAO;IAwBxC;;;;;;;;OAQG;IACG,QAAQ,CACZ,OAAO,EAAE,MAAM,EACf,GAAG,CAAC,EAAE,eAAe,GACpB,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC;IAoFzB;;;;;;;;;;;;;OAaG;IACH,OAAO,CAAC,wBAAwB;IA0BhC;;;;;OAKG;IACH,OAAO,CAAC,YAAY;IASpB;;;;;OAKG;YACW,oCAAoC;IA4DlD;;;;;;;;OAQG;YACW,4BAA4B;IAa1C;;;;;;OAMG;IACH,OAAO,CAAC,mCAAmC;IA0B3C;;;;;;;OAOG;IACH,OAAO,CAAC,kBAAkB;IAY1B;;;;;;;;OAQG;IACH,OAAO,CAAC,sBAAsB;IAe9B;;;;;;OAMG;IACH,OAAO,CAAC,qBAAqB;IAiB7B;;;;;;;;OAQG;IACH,OAAO,CAAC,gBAAgB;IASxB;;;;;;OAMG;IACH,OAAO,CAAC,iBAAiB;CAM1B;AAED,eAAe,qBAAqB,CAAC"}
 \ No newline at end of file
 diff --git a/node_modules/@metamask/transaction-controller/dist/TransactionController.js b/node_modules/@metamask/transaction-controller/dist/TransactionController.js
-index 814a899..d2da0a2 100644
+index 814a899..9db773e 100644
 --- a/node_modules/@metamask/transaction-controller/dist/TransactionController.js
 +++ b/node_modules/@metamask/transaction-controller/dist/TransactionController.js
 @@ -12,7 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
@@ -792,9 +797,11 @@ index 814a899..d2da0a2 100644
  const events_1 = require("events");
  const ethereumjs_util_1 = require("ethereumjs-util");
  const eth_rpc_errors_1 = require("eth-rpc-errors");
-@@ -26,32 +26,14 @@ const base_controller_1 = require("@metamask/base-controller");
+@@ -24,34 +24,15 @@ const uuid_1 = require("uuid");
+ const async_mutex_1 = require("async-mutex");
+ const base_controller_1 = require("@metamask/base-controller");
  const controller_utils_1 = require("@metamask/controller-utils");
- const nonce_tracker_1 = __importDefault(require("nonce-tracker"));
+-const nonce_tracker_1 = __importDefault(require("nonce-tracker"));
  const utils_1 = require("./utils");
 +const IncomingTransactionHelper_1 = require("./IncomingTransactionHelper");
 +const EtherscanRemoteTransactionSource_1 = require("./EtherscanRemoteTransactionSource");
@@ -830,7 +837,7 @@ index 814a899..d2da0a2 100644
  /**
   * Multiplier used to determine a transaction's increased gas fee during cancellation
   */
-@@ -68,44 +50,23 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -68,44 +49,23 @@ class TransactionController extends base_controller_1.BaseController {
       * Creates a TransactionController instance.
       *
       * @param options - The controller options.
@@ -884,7 +891,7 @@ index 814a899..d2da0a2 100644
          /**
           * EventEmitter instance used to listen to specific transactional events
           */
-@@ -121,18 +82,36 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -121,18 +81,30 @@ class TransactionController extends base_controller_1.BaseController {
          this.defaultState = {
              methodData: {},
              transactions: [],
@@ -895,17 +902,13 @@ index 814a899..d2da0a2 100644
          this.getNetworkState = getNetworkState;
          this.ethQuery = new eth_query_1.default(provider);
          this.registry = new eth_method_registry_1.default({ provider });
+-        this.nonceTracker = new nonce_tracker_1.default({
+-            provider,
 +        this.messagingSystem = messenger;
-         this.nonceTracker = new nonce_tracker_1.default({
-             provider,
++        this.incomingTransactionHelper = new IncomingTransactionHelper_1.IncomingTransactionHelper({
              blockTracker,
 -            getPendingTransactions: (address) => (0, utils_1.getAndFormatTransactionsForNonceTracker)(address, TransactionStatus.submitted, this.state.transactions),
 -            getConfirmedTransactions: (address) => (0, utils_1.getAndFormatTransactionsForNonceTracker)(address, TransactionStatus.confirmed, this.state.transactions),
-+            getPendingTransactions: this.getNonceTrackerTransactions.bind(this, types_1.TransactionStatus.submitted),
-+            getConfirmedTransactions: this.getNonceTrackerTransactions.bind(this, types_1.TransactionStatus.confirmed),
-+        });
-+        this.incomingTransactionHelper = new IncomingTransactionHelper_1.IncomingTransactionHelper({
-+            blockTracker,
 +            getCurrentAccount: getSelectedAddress,
 +            getLastFetchedBlockNumbers: () => this.state.lastFetchedBlockNumbers,
 +            getLocalTransactions: () => this.state.transactions,
@@ -923,7 +926,7 @@ index 814a899..d2da0a2 100644
          onNetworkStateChange(() => {
              this.ethQuery = new eth_query_1.default(this.provider);
              this.registry = new eth_method_registry_1.default({ provider: this.provider });
-@@ -140,7 +119,7 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -140,7 +112,7 @@ class TransactionController extends base_controller_1.BaseController {
          this.poll();
      }
      failTransaction(transactionMeta, error) {
@@ -932,7 +935,7 @@ index 814a899..d2da0a2 100644
          this.updateTransaction(newTransactionMeta);
          this.hub.emit(`${transactionMeta.id}:finished`, newTransactionMeta);
      }
-@@ -151,43 +130,6 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -151,43 +123,6 @@ class TransactionController extends base_controller_1.BaseController {
              return { registryMethod, parsedRegistryMethod };
          });
      }
@@ -976,7 +979,7 @@ index 814a899..d2da0a2 100644
      /**
       * Starts a new polling interval.
       *
-@@ -235,11 +177,13 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -235,11 +170,13 @@ class TransactionController extends base_controller_1.BaseController {
       * if not provided. If A `<tx.id>:unapproved` hub event will be emitted once added.
       *
       * @param transaction - The transaction object to add.
@@ -993,7 +996,7 @@ index 814a899..d2da0a2 100644
          return __awaiter(this, void 0, void 0, function* () {
              const { providerConfig, networkId } = this.getNetworkState();
              const { transactions } = this.state;
-@@ -250,11 +194,12 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -250,11 +187,12 @@ class TransactionController extends base_controller_1.BaseController {
                  networkID: networkId !== null && networkId !== void 0 ? networkId : undefined,
                  chainId: providerConfig.chainId,
                  origin,
@@ -1007,7 +1010,7 @@ index 814a899..d2da0a2 100644
              };
              try {
                  const { gas, estimateGasError } = yield this.estimateGas(transaction);
-@@ -265,27 +210,24 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -265,27 +203,24 @@ class TransactionController extends base_controller_1.BaseController {
                  this.failTransaction(transactionMeta, error);
                  return Promise.reject(error);
              }
@@ -1050,7 +1053,7 @@ index 814a899..d2da0a2 100644
          });
      }
      prepareUnsignedEthTx(txParams) {
-@@ -305,7 +247,9 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -305,7 +240,9 @@ class TransactionController extends base_controller_1.BaseController {
       */
      getCommonConfiguration() {
          const { networkId, providerConfig: { type: chain, chainId, nickname: name }, } = this.getNetworkState();
@@ -1061,7 +1064,7 @@ index 814a899..d2da0a2 100644
              return new common_1.default({ chain, hardfork: HARDFORK });
          }
          const customChainParams = {
-@@ -315,100 +259,6 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -315,100 +252,6 @@ class TransactionController extends base_controller_1.BaseController {
          };
          return common_1.default.forCustomChain(controller_utils_1.NetworkType.mainnet, customChainParams, HARDFORK);
      }
@@ -1162,7 +1165,7 @@ index 814a899..d2da0a2 100644
      /**
       * Attempts to cancel a transaction based on its ID by setting its status to "rejected"
       * and emitting a `<tx.id>:finished` hub event.
-@@ -472,7 +322,7 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -472,7 +315,7 @@ class TransactionController extends base_controller_1.BaseController {
              const signedTx = yield this.sign(unsignedEthTx, transactionMeta.transaction.from);
              const rawTransaction = (0, ethereumjs_util_1.bufferToHex)(signedTx.serialize());
              yield (0, controller_utils_1.query)(this.ethQuery, 'sendRawTransaction', [rawTransaction]);
@@ -1171,7 +1174,7 @@ index 814a899..d2da0a2 100644
              this.hub.emit(`${transactionMeta.id}:finished`, transactionMeta);
          });
      }
-@@ -673,70 +523,6 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -673,70 +516,6 @@ class TransactionController extends base_controller_1.BaseController {
              transactions: this.trimTransactionsForState(newTransactions),
          });
      }
@@ -1242,7 +1245,7 @@ index 814a899..d2da0a2 100644
      /**
       * Trim the amount of transactions that are set on the state. Checks
       * if the length of the tx history is longer then desired persistence
-@@ -753,7 +539,9 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -753,7 +532,9 @@ class TransactionController extends base_controller_1.BaseController {
       */
      trimTransactionsForState(transactions) {
          const nonceNetworkSet = new Set();
@@ -1253,7 +1256,7 @@ index 814a899..d2da0a2 100644
              const { chainId, networkID, status, transaction, time } = tx;
              if (transaction) {
                  const key = `${transaction.nonce}-${chainId !== null && chainId !== void 0 ? chainId : networkID}-${new Date(time).toDateString()}`;
-@@ -768,7 +556,7 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -768,7 +549,7 @@ class TransactionController extends base_controller_1.BaseController {
              }
              return false;
          });
@@ -1262,7 +1265,7 @@ index 814a899..d2da0a2 100644
          return txsToKeep;
      }
      /**
-@@ -778,10 +566,10 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -778,10 +559,10 @@ class TransactionController extends base_controller_1.BaseController {
       * @returns Whether the transaction is in a final state.
       */
      isFinalState(status) {
@@ -1277,7 +1280,7 @@ index 814a899..d2da0a2 100644
      }
      /**
       * Method to verify the state of a transaction using the Blockchain as a source of truth.
-@@ -793,7 +581,7 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -793,7 +574,7 @@ class TransactionController extends base_controller_1.BaseController {
          return __awaiter(this, void 0, void 0, function* () {
              const { status, transactionHash } = meta;
              switch (status) {
@@ -1286,7 +1289,7 @@ index 814a899..d2da0a2 100644
                      const txReceipt = yield (0, controller_utils_1.query)(this.ethQuery, 'getTransactionReceipt', [
                          transactionHash,
                      ]);
-@@ -810,7 +598,7 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -810,7 +591,7 @@ class TransactionController extends base_controller_1.BaseController {
                          return [meta, false];
                      }
                      return [meta, true];
@@ -1295,7 +1298,7 @@ index 814a899..d2da0a2 100644
                      const txObj = yield (0, controller_utils_1.query)(this.ethQuery, 'getTransactionByHash', [
                          transactionHash,
                      ]);
-@@ -825,9 +613,17 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -825,9 +606,17 @@ class TransactionController extends base_controller_1.BaseController {
                      }
                      /* istanbul ignore next */
                      if (txObj === null || txObj === void 0 ? void 0 : txObj.blockNumber) {
@@ -1316,7 +1319,7 @@ index 814a899..d2da0a2 100644
                      }
                      return [meta, false];
                  default:
-@@ -856,88 +652,209 @@ class TransactionController extends base_controller_1.BaseController {
+@@ -856,88 +645,195 @@ class TransactionController extends base_controller_1.BaseController {
              return Number(txReceipt.status) === 0;
          });
      }
@@ -1438,7 +1441,6 @@ index 814a899..d2da0a2 100644
 +            const index = transactions.findIndex(({ id }) => transactionID === id);
 +            const transactionMeta = transactions[index];
 +            const { transaction: { nonce, from }, } = transactionMeta;
-+            let nonceLock;
 +            try {
 +                if (!this.sign) {
 +                    releaseLock();
@@ -1452,15 +1454,10 @@ index 814a899..d2da0a2 100644
 +                }
 +                const chainId = parseInt(currentChainId, undefined);
 +                const { approved: status } = types_1.TransactionStatus;
-+                let nonceToUse = nonce;
-+                // if a nonce already exists on the transactionMeta it means this is a speedup or cancel transaction
-+                // so we want to reuse that nonce and hope that it beats the previous attempt to chain. Otherwise use a new locked nonce
-+                if (!nonceToUse) {
-+                    nonceLock = yield this.nonceTracker.getNonceLock(from);
-+                    nonceToUse = (0, ethereumjs_util_1.addHexPrefix)(nonceLock.nextNonce.toString(16));
-+                }
++                const txNonce = nonce ||
++                    (yield (0, controller_utils_1.query)(this.ethQuery, 'getTransactionCount', [from, 'pending']));
 +                transactionMeta.status = status;
-+                transactionMeta.transaction.nonce = nonceToUse;
++                transactionMeta.transaction.nonce = txNonce;
 +                transactionMeta.transaction.chainId = chainId;
 +                const baseTxParams = Object.assign(Object.assign({}, transactionMeta.transaction), { gasLimit: transactionMeta.transaction.gas });
 +                const isEIP1559 = (0, utils_1.isEIP1559Transaction)(transactionMeta.transaction);
@@ -1491,10 +1488,6 @@ index 814a899..d2da0a2 100644
 +                this.failTransaction(transactionMeta, error);
 +            }
 +            finally {
-+                // must set transaction to submitted/failed before releasing lock
-+                if (nonceLock) {
-+                    nonceLock.releaseLock();
-+                }
 +                releaseLock();
 +            }
          });
@@ -1584,10 +1577,6 @@ index 814a899..d2da0a2 100644
 +    onUpdatedLastFetchedBlockNumbers({ lastFetchedBlockNumbers, blockNumber, }) {
 +        this.update({ lastFetchedBlockNumbers });
 +        this.hub.emit('incomingTransactionBlock', blockNumber);
-+    }
-+    getNonceTrackerTransactions(status, address) {
-+        const { chainId: currentChainId } = this.getNetworkState().providerConfig;
-+        return (0, utils_1.getAndFormatTransactionsForNonceTracker)(currentChainId, address, status, this.state.transactions);
      }
  }
  exports.TransactionController = TransactionController;


### PR DESCRIPTION
## **Description**

The `TransactionController` was recently upgraded to a version using the `NonceTracker` package.

This looks at local transactions for the same address and chain to determine the best `nonce` value.

Since the mobile client monitors incoming token transfers, this was resulting in incorrect `nonce` values due to the associated transactions having the `from` address of the account sending the balance, rather than the address of the account creating the transaction. 

The temporary fix is to revert the nonce logic in the `TransactionController` by removing usage of the `NonceTracker`.

## **Related issues**

Fixes: #7646 

## **Manual testing steps**

1. Add account X to the wallet.
2. Add a token balance to account X.
3. Send an approve transaction from account X for the same token to account Y. 
4. Send a `transferFrom` transaction from account Y (ideally from a different wallet), that transfers the token from account X.
5. Wait for the incoming transaction to be detected, this is not visible in the activity list but polled every ~30 seconds.
6. Try and send any transaction from account X and confirm the nonce is not the transfer nonce from account Y + 1.

## **Screenshots/Recordings**

### **Before**

### **After**

See comments.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
