### PR TITLE
fix: remove init launch app

### DIFF
--- a/e2e/init.js
+++ b/e2e/init.js
@@ -1,7 +1,0 @@
-import { getFixturesServerPort } from './fixtures/utils';
-
-beforeAll(async () => {
-  await device.launchApp({
-    launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
-  });
-});

--- a/e2e/specs/browser/browser-tests.spec.js
+++ b/e2e/specs/browser/browser-tests.spec.js
@@ -4,7 +4,6 @@ import { Smoke } from '../../tags';
 import Browser from '../../pages/Drawer/Browser';
 import { BROWSER_SCREEN_ID } from '../../../wdio/screen-objects/testIDs/BrowserScreen/BrowserScreen.testIds';
 import TabBarComponent from '../../pages/TabBarComponent';
-
 import { loginToApp } from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
@@ -28,7 +27,6 @@ describe(Smoke('Browser Tests'), () => {
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await device.launchApp({
-      delete: true,
       launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
     });
     await loginToApp();
@@ -64,7 +62,6 @@ describe(Smoke('Browser Tests'), () => {
     await Browser.tapAddToFavoritesButton();
     await Browser.isAddBookmarkScreenVisible();
     await Browser.tapAddBookmarksButton();
-
     await Browser.isAddBookmarkScreenNotVisible(); // Add bookmark screen should not be visible
   });
 
@@ -91,18 +88,15 @@ describe(Smoke('Browser Tests'), () => {
       METAMASK_TEST_DAPP_SHORTEN_URL_TEXT,
       0,
     );
-
     await Browser.isVisible();
   });
 
   it('should test invalid URL', async () => {
     await TestHelpers.delay(2000);
-
     await Browser.tapBottomSearchBar();
     // Clear text & Navigate to URL
     await Browser.navigateToURL(INVALID_URL);
     await Browser.waitForBrowserPageToLoad();
-
     await Browser.tapReturnHomeButton();
     // Check that we are on the browser screen
     if (!device.getPlatform() === 'android') {
@@ -116,10 +110,8 @@ describe(Smoke('Browser Tests'), () => {
     // Clear text & Navigate to URL
     await Browser.navigateToURL(PHISHING_SITE);
     await Browser.waitForBrowserPageToLoad();
-
     await Browser.isBackToSafetyButtonVisible();
     await Browser.tapBackToSafetyButton();
-
     // Check that we are on the browser screen
     if (!device.getPlatform() === 'android') {
       await TestHelpers.delay(1500);

--- a/e2e/specs/networks/add-custom-rpc.spec.js
+++ b/e2e/specs/networks/add-custom-rpc.spec.js
@@ -1,15 +1,11 @@
 'use strict';
 import TestHelpers from '../../helpers';
 import { Regression } from '../../tags';
-
 import NetworkView from '../../pages/Drawer/Settings/NetworksView';
-
 import WalletView from '../../pages/WalletView';
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
-
 import NetworkListModal from '../../pages/modals/NetworkListModal';
 import NetworkEducationModal from '../../pages/modals/NetworkEducationModal';
-
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import FixtureBuilder from '../../fixtures/fixture-builder';
@@ -33,7 +29,6 @@ describe(Regression('Custom RPC Tests'), () => {
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await device.launchApp({
-      delete: true,
       launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
     });
     await loginToApp();
@@ -58,7 +53,6 @@ describe(Regression('Custom RPC Tests'), () => {
     await TestHelpers.delay(3000);
     await NetworkView.tapAddNetworkButton();
     await NetworkView.switchToCustomNetworks();
-
     await NetworkView.typeInNetworkName('xDai');
     await NetworkView.typeInRpcUrl('abc'); // Input incorrect RPC URL
     await NetworkView.isRPCWarningVisble(); // Check that warning is displayed
@@ -66,7 +60,6 @@ describe(Regression('Custom RPC Tests'), () => {
     await NetworkView.typeInRpcUrl(XDAI_URL);
     await NetworkView.typeInChainId('100');
     await NetworkView.typeInNetworkSymbol('xDAI\n');
-
     if (device.getPlatform() === 'ios') {
       await NetworkView.swipeToRPCTitleAndDismissKeyboard(); // Focus outside of text input field
       await NetworkView.tapRpcNetworkAddButton();
@@ -75,6 +68,7 @@ describe(Regression('Custom RPC Tests'), () => {
     await WalletView.isVisible();
     await WalletView.isNetworkNameVisible('xDai');
   });
+
   it('should dismiss network education modal', async () => {
     await NetworkEducationModal.isVisible();
     await NetworkEducationModal.isNetworkNameCorrect('Xdai');
@@ -85,7 +79,6 @@ describe(Regression('Custom RPC Tests'), () => {
   it('should validate that xDai is added to network list', async () => {
     // Tap to prompt network list
     await WalletView.tapNetworksButtonOnNavBar();
-
     await NetworkListModal.isVisible();
     await NetworkListModal.isNetworkNameVisibleInListOfNetworks('xDai');
   });
@@ -93,26 +86,20 @@ describe(Regression('Custom RPC Tests'), () => {
   it('should switch to Goreli then dismiss the network education modal', async () => {
     await NetworkListModal.isTestNetworkToggleOn();
     await NetworkListModal.changeNetwork(GORELI);
-
     await NetworkEducationModal.isVisible();
     await NetworkEducationModal.isNetworkNameCorrect('Goreli Test Network');
-
     await NetworkEducationModal.tapGotItButton();
     await NetworkEducationModal.isNotVisible();
-
     await WalletView.isVisible();
   });
 
   it('should switch back to xDAI', async () => {
     await WalletView.isNetworkNameVisible(GORELI);
     await WalletView.tapNetworksButtonOnNavBar();
-
     await NetworkListModal.isVisible();
     await NetworkListModal.scrollToBottomOfNetworkList();
-
     // Change to back to xDai Network
     await NetworkListModal.changeNetwork('xDai');
-
     await WalletView.isVisible();
     await WalletView.isNetworkNameVisible('xDai');
     await NetworkEducationModal.isNotVisible();
@@ -120,16 +107,12 @@ describe(Regression('Custom RPC Tests'), () => {
 
   it('should go to settings networks and remove xDai network', async () => {
     await TestHelpers.delay(3000);
-
     await TabBarComponent.tapSettings();
     await SettingsView.tapNetworks();
-
     await NetworkView.isNetworkViewVisible();
     await NetworkView.removeNetwork(); // Tap on xDai to remove network
     await NetworkEducationModal.tapGotItButton();
-
     await TabBarComponent.tapWallet();
-
     await WalletView.isVisible();
     await WalletView.isNetworkNameVisible(MAINNET);
   });

--- a/e2e/specs/networks/connect-test-network.spec.js
+++ b/e2e/specs/networks/connect-test-network.spec.js
@@ -8,8 +8,9 @@ const GORELI = 'Goerli Test Network';
 const ETHEREUM = 'Ethereum Main Network';
 
 describe(Regression('Connect to a Test Network'), () => {
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(150000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {
@@ -23,7 +24,6 @@ describe(Regression('Connect to a Test Network'), () => {
     await NetworkListModal.tapTestNetworkSwitch();
     await NetworkListModal.isTestNetworkToggleOn();
     await NetworkListModal.changeNetwork(GORELI);
-
     await NetworkEducationModal.isVisible();
     await NetworkEducationModal.isNetworkNameCorrect(GORELI);
     await NetworkEducationModal.tapGotItButton();

--- a/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
@@ -1,21 +1,16 @@
 'use strict';
 import TestHelpers from '../../helpers';
 import { Regression } from '../../tags';
-
 import ProtectYourWalletView from '../../pages/Onboarding/ProtectYourWalletView';
 import CreatePasswordView from '../../pages/Onboarding/CreatePasswordView';
 import OnboardingView from '../../pages/Onboarding/OnboardingView';
 import OnboardingCarouselView from '../../pages/Onboarding/OnboardingCarouselView';
-
 import MetaMetricsOptIn from '../../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../../pages/WalletView';
 import EnableAutomaticSecurityChecksView from '../../pages/EnableAutomaticSecurityChecksView';
-
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
 import SecurityAndPrivacy from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
-
 import LoginView from '../../pages/LoginView';
-
 import SkipAccountSecurityModal from '../../pages/modals/SkipAccountSecurityModal';
 import OnboardingWizardModal from '../../pages/modals/OnboardingWizardModal';
 import ProtectYourWalletModal from '../../pages/modals/ProtectYourWalletModal';
@@ -28,16 +23,20 @@ const PASSWORD = '12345678';
 describe(
   Regression('Onboarding wizard opt-in, metametrics opt out from settings'),
   () => {
+    beforeAll(async () => {
+      jest.setTimeout(150000);
+      await device.launchApp();
+    });
+
     it('should be able to opt-in of the onboarding-wizard', async () => {
       await OnboardingCarouselView.tapOnGetStartedButton();
       await OnboardingView.tapCreateWallet();
-
       await MetaMetricsOptIn.isVisible();
       await MetaMetricsOptIn.tapAgreeButton();
       await acceptTermOfUse();
-
       await CreatePasswordView.isVisible();
     });
+
     it('should be able to create a new wallet', async () => {
       await CreatePasswordView.enterPassword(PASSWORD);
       await CreatePasswordView.reEnterPassword(PASSWORD);
@@ -49,7 +48,6 @@ describe(
       // Check that we are on the Secure your wallet screen
       await ProtectYourWalletView.isVisible();
       await ProtectYourWalletView.tapOnRemindMeLaterButton();
-
       await SkipAccountSecurityModal.tapIUnderstandCheckBox();
       await SkipAccountSecurityModal.tapSkipButton();
       await WalletView.isVisible();
@@ -87,30 +85,24 @@ describe(
     it('should dismiss the protect your wallet modal', async () => {
       await ProtectYourWalletModal.isCollapsedBackUpYourWalletModalVisible();
       await TestHelpers.delay(1000);
-
       await ProtectYourWalletModal.tapRemindMeLaterButton();
-
       await SkipAccountSecurityModal.tapIUnderstandCheckBox();
       await SkipAccountSecurityModal.tapSkipButton();
-
       await WalletView.isVisible();
     });
 
     it('should check that metametrics is enabled in settings', async () => {
       await TabBarComponent.tapSettings();
-
       await SettingsView.tapSecurityAndPrivacy();
       await SecurityAndPrivacy.scrollToMetaMetrics();
       TestHelpers.delay(2000);
       await SecurityAndPrivacy.isMetaMetricsToggleOn();
-
       TestHelpers.delay(4500);
     });
 
     it('should disable metametrics', async () => {
       await SecurityAndPrivacy.tapMetaMetricsToggle();
       // await SecurityAndPrivacy.isMetaMetricsToggleOff();
-
       TestHelpers.delay(1500);
       await SecurityAndPrivacy.tapOKAlertButton();
       await SecurityAndPrivacy.isMetaMetricsToggleOff();
@@ -120,10 +112,8 @@ describe(
       // Relaunch app
       await TestHelpers.relaunchApp();
       TestHelpers.delay(4500);
-
       await LoginView.isVisible();
       await LoginView.enterPassword(PASSWORD);
-
       await WalletView.isVisible();
     });
 
@@ -142,7 +132,6 @@ describe(
     it('should verify metametrics is turned off', async () => {
       await TabBarComponent.tapSettings();
       await SettingsView.tapSecurityAndPrivacy();
-
       await SecurityAndPrivacy.scrollToMetaMetrics();
       await SecurityAndPrivacy.isMetaMetricsToggleOff();
     });

--- a/e2e/specs/permission-systems/permission-system-delete-wallet.spec.js
+++ b/e2e/specs/permission-systems/permission-system-delete-wallet.spec.js
@@ -1,24 +1,18 @@
 'use strict';
 import TestHelpers from '../../helpers';
 import { Regression } from '../../tags';
-
 import OnboardingView from '../../pages/Onboarding/OnboardingView';
 import ProtectYourWalletView from '../../pages/Onboarding/ProtectYourWalletView';
 import CreatePasswordView from '../../pages/Onboarding/CreatePasswordView';
-
 import WalletView from '../../pages/WalletView';
-
 import Browser from '../../pages/Drawer/Browser';
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
-
 import TabBarComponent from '../../pages/TabBarComponent';
-
 import SkipAccountSecurityModal from '../../pages/modals/SkipAccountSecurityModal';
 import ConnectedAccountsModal from '../../pages/modals/ConnectedAccountsModal';
 import DeleteWalletModal from '../../pages/modals/DeleteWalletModal';
 import SecurityAndPrivacyView from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 import NetworkListModal from '../../pages/modals/NetworkListModal';
-
 import { loginToApp } from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import { withFixtures } from '../../fixtures/fixture-helper';
@@ -26,6 +20,7 @@ import MetaMetricsOptIn from '../../pages/Onboarding/MetaMetricsOptInView';
 import ProtectYourWalletModal from '../../pages/modals/ProtectYourWalletModal';
 
 const PASSWORD = '12345678';
+
 describe(
   Regression('Permission System: Deleting wallet after connecting to a dapp'),
   () => {

--- a/e2e/specs/permission-systems/permission-system-revoke-single-account.spec.js
+++ b/e2e/specs/permission-systems/permission-system-revoke-single-account.spec.js
@@ -1,11 +1,8 @@
 'use strict';
 import TestHelpers from '../../helpers';
 import { Smoke } from '../../tags';
-
 import Browser from '../../pages/Drawer/Browser';
-
 import TabBarComponent from '../../pages/TabBarComponent';
-
 import NetworkListModal from '../../pages/modals/NetworkListModal';
 import ConnectedAccountsModal from '../../pages/modals/ConnectedAccountsModal';
 import FixtureBuilder from '../../fixtures/fixture-builder';

--- a/e2e/specs/settings/addressbook-tests.spec.js
+++ b/e2e/specs/settings/addressbook-tests.spec.js
@@ -1,15 +1,12 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import SendView from '../../pages/SendView';
-
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
 import ContactsView from '../../pages/Drawer/Settings/Contacts/ContactsView';
 import AddContactView from '../../pages/Drawer/Settings/Contacts/AddContactView';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 import AddAddressModal from '../../pages/modals/AddAddressModal';
-
 import { loginToApp } from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
@@ -34,7 +31,6 @@ describe(Smoke('Addressbook Tests'), () => {
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await device.launchApp({
-      delete: true,
       launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
     });
     await loginToApp();
@@ -68,12 +64,10 @@ describe(Smoke('Addressbook Tests'), () => {
 
   it('should add a new address to address book via send flow', async () => {
     await SendView.tapAddAddressToAddressBook();
-
     await AddAddressModal.isVisible();
     await AddAddressModal.typeInAlias('Myth');
     await AddAddressModal.tapTitle();
     await AddAddressModal.tapSaveButton();
-
     await SendView.removeAddress();
     await SendView.isSavedAliasVisible('Myth'); // Check that the new account is on the address list
   });
@@ -82,34 +76,28 @@ describe(Smoke('Addressbook Tests'), () => {
     await SendView.tapCancelButton();
     await TabBarComponent.tapSettings();
     await SettingsView.tapContacts();
-
     await ContactsView.isVisible();
     await ContactsView.isContactAliasVisible('Myth');
   });
 
   it('should add an address via the contacts view', async () => {
     await ContactsView.tapAddContactButton();
-
     await AddContactView.isVisible();
     await AddContactView.typeInName('Ibrahim');
-
     // Input invalid address
     await AddContactView.typeInAddress(INVALID_ADDRESS);
     await AddContactView.isErrorMessageVisible();
     await AddContactView.isErrorMessageTextCorrect();
-
     await AddContactView.clearAddressInputBox();
     await AddContactView.typeInAddress('ibrahim.team.mask.eth');
     await AddContactView.typeInMemo(MEMO);
     await AddContactView.tapAddContactButton();
-
     await ContactsView.isVisible(); // Check that we are on the contacts screen
     await ContactsView.isContactAliasVisible('Ibrahim'); // Check that Ibrahim address is saved in the address book
   });
 
   it('should edit a contact', async () => {
     await ContactsView.tapOnAlias('Myth'); // Tap on Myth address
-
     await AddContactView.tapEditButton();
     await AddContactView.typeInName('Moon'); // Change name from Myth to Moon
     await AddContactView.tapEditContactCTA();
@@ -131,7 +119,6 @@ describe(Smoke('Addressbook Tests'), () => {
     // Tap on edit
     await AddContactView.tapEditButton();
     await AddContactView.tapDeleteContactCTA();
-
     await ContactsView.isContactAliasNotVisible('Moon');
   });
 
@@ -139,10 +126,8 @@ describe(Smoke('Addressbook Tests'), () => {
     // tap on the back arrow
     await AddContactView.tapBackButton();
     await TabBarComponent.tapWallet();
-
     await TabBarComponent.tapActions();
     await WalletActionsModal.tapSendButton();
-
     await SendView.isSavedAliasVisible('Ibrahim');
   });
 });

--- a/e2e/specs/settings/delete-wallet.spec.js
+++ b/e2e/specs/settings/delete-wallet.spec.js
@@ -1,17 +1,11 @@
 'use strict';
-
 import TestHelpers from '../../helpers';
 import { Smoke } from '../../tags';
-
 import OnboardingView from '../../pages/Onboarding/OnboardingView';
-
 import LoginView from '../../pages/LoginView';
-
 import SettingsView from '../../pages/Drawer/Settings/SettingsView';
-
 import SecurityAndPrivacyView from '../../pages/Drawer/Settings/SecurityAndPrivacy/SecurityAndPrivacyView';
 import ChangePasswordView from '../../pages/Drawer/Settings/SecurityAndPrivacy/ChangePasswordView';
-
 import DeleteWalletModal from '../../pages/modals/DeleteWalletModal';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';

--- a/e2e/specs/swaps/token-details.spec.js
+++ b/e2e/specs/swaps/token-details.spec.js
@@ -10,8 +10,9 @@ import {
 import Networks from '../../resources/networks.json';
 
 describe(Regression('Token Chart Tests'), () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     jest.setTimeout(150000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {

--- a/e2e/specs/wallet/create-wallet-account.spec.js
+++ b/e2e/specs/wallet/create-wallet-account.spec.js
@@ -1,15 +1,13 @@
 'use strict';
 import { Regression } from '../../tags';
-
 import WalletView from '../../pages/WalletView';
-
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
-
 import AccountListView from '../../pages/AccountListView';
 
 describe(Regression('Create wallet account'), () => {
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(200000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {
@@ -20,7 +18,6 @@ describe(Regression('Create wallet account'), () => {
     await WalletView.tapIdenticon();
     await AccountListView.isVisible();
     await AccountListView.tapAddAccountButton();
-
     // Tap on Create New Account
     await AccountListView.tapCreateAccountButton();
     await AccountListView.isNewAccountNameVisible();

--- a/e2e/specs/wallet/import-wallet-account.spec.js
+++ b/e2e/specs/wallet/import-wallet-account.spec.js
@@ -4,7 +4,6 @@ import WalletView from '../../pages/WalletView';
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
 import AccountListView from '../../pages/AccountListView';
 import ImportAccountView from '../../pages/ImportAccountView';
-import { async } from 'regenerator-runtime';
 
 describe(Regression('Import account via private to wallet'), () => {
   // This key is for testing private key import only

--- a/e2e/specs/wallet/import-wallet-account.spec.js
+++ b/e2e/specs/wallet/import-wallet-account.spec.js
@@ -1,12 +1,10 @@
 'use strict';
 import { Regression } from '../../tags';
-
 import WalletView from '../../pages/WalletView';
-
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
-
 import AccountListView from '../../pages/AccountListView';
 import ImportAccountView from '../../pages/ImportAccountView';
+import { async } from 'regenerator-runtime';
 
 describe(Regression('Import account via private to wallet'), () => {
   // This key is for testing private key import only
@@ -14,8 +12,9 @@ describe(Regression('Import account via private to wallet'), () => {
   const TEST_PRIVATE_KEY =
     'cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1';
 
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(200000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {
@@ -27,18 +26,14 @@ describe(Regression('Import account via private to wallet'), () => {
     await AccountListView.isVisible();
     await AccountListView.tapAddAccountButton();
     await AccountListView.tapImportAccountButton();
-
     await ImportAccountView.isVisible();
     // Tap on import button to make sure alert pops up
     await ImportAccountView.tapImportButton();
     await ImportAccountView.tapOKAlertButton();
-
     await ImportAccountView.enterPrivateKey(TEST_PRIVATE_KEY);
     await ImportAccountView.isImportSuccessSreenVisible();
     await ImportAccountView.tapCloseButtonOnImportSuccess();
-
     await AccountListView.swipeToDimssAccountsModal();
-
     await WalletView.isVisible();
     await WalletView.isAccountNameCorrect('Account 3');
   });

--- a/e2e/specs/wallet/request-token-flow.spec.js
+++ b/e2e/specs/wallet/request-token-flow.spec.js
@@ -1,15 +1,11 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import SendLinkView from '../../pages/SendLinkView';
 import RequestPaymentView from '../../pages/RequestPaymentView';
-
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
-
 import ProtectYourWalletModal from '../../pages/modals/ProtectYourWalletModal';
 import RequestPaymentModal from '../../pages/modals/RequestPaymentModal';
-
 import { loginToApp } from '../../viewHelper';
 import { withFixtures } from '../../fixtures/fixture-helper';
 import FixtureBuilder from '../../fixtures/fixture-builder';

--- a/e2e/specs/wallet/send-ERC-token.spec.js
+++ b/e2e/specs/wallet/send-ERC-token.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import TestHelpers from '../../helpers';
-
 import WalletView from '../../pages/WalletView';
 import NetworkEducationModal from '../../pages/modals/NetworkEducationModal';
 import AddCustomTokenView from '../../pages/AddCustomTokenView';
@@ -17,8 +15,9 @@ const TOKEN_ADDRESS = '0x779877A7B0D9E8603169DdbD7836e478b4624789';
 const SEND_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
 
 describe(Smoke('Send ERC Token'), () => {
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(150000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {
@@ -30,9 +29,9 @@ describe(Smoke('Send ERC Token'), () => {
     await TestHelpers.delay(2000);
     await NetworkListModal.tapTestNetworkSwitch();
     await NetworkListModal.isTestNetworkToggleOn();
-
     await NetworkListModal.changeNetwork('Sepolia Test Network');
   });
+
   it('should dismiss network education modal', async () => {
     await NetworkEducationModal.isVisible();
     await NetworkEducationModal.tapGotItButton();
@@ -62,7 +61,6 @@ describe(Smoke('Send ERC Token'), () => {
     await SendView.tapNextButton();
     await AmountView.typeInTransactionAmount('0.000001');
     await TestHelpers.delay(5000);
-
     await AmountView.tapNextButton();
     await TransactionConfirmationView.isAmountVisible('< 0.00001 LINK');
     await TransactionConfirmationView.tapConfirmButton();

--- a/e2e/specs/wallet/start-exploring.spec.js
+++ b/e2e/specs/wallet/start-exploring.spec.js
@@ -1,19 +1,14 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import TestHelpers from '../../helpers';
-
 import OnboardingView from '../../pages/Onboarding/OnboardingView';
 import OnboardingCarouselView from '../../pages/Onboarding/OnboardingCarouselView';
 import ProtectYourWalletView from '../../pages/Onboarding/ProtectYourWalletView';
 import CreatePasswordView from '../../pages/Onboarding/CreatePasswordView';
-
 import MetaMetricsOptIn from '../../pages/Onboarding/MetaMetricsOptInView';
 import WalletView from '../../pages/WalletView';
 import EnableAutomaticSecurityChecksView from '../../pages/EnableAutomaticSecurityChecksView';
-
 import Browser from '../../pages/Drawer/Browser';
-
 import SkipAccountSecurityModal from '../../pages/modals/SkipAccountSecurityModal';
 import OnboardingWizardModal from '../../pages/modals/OnboardingWizardModal';
 import WhatsNewModal from '../../pages/modals/WhatsNewModal';
@@ -23,20 +18,19 @@ const ACCOUNT = 'Test Account One';
 const PASSWORD = '12345678';
 
 describe(Smoke('Start Exploring'), () => {
-  beforeEach(() => {
+  beforeAll(async () => {
     jest.setTimeout(150000);
+    await device.launchApp();
   });
 
   it('should show the onboarding screen', async () => {
     // Check that we are on the onboarding carousel screen
     await OnboardingCarouselView.isVisible();
-
     await OnboardingCarouselView.isMetaMaskWelcomeTextVisible();
     await OnboardingCarouselView.isWelcomeToMetaMaskImageVisible();
     // Swipe left
     await OnboardingCarouselView.swipeCarousel();
     await OnboardingCarouselView.isManageYourDigitalTextVisible();
-
     // Check that title of screen 2 is correct
     await OnboardingCarouselView.isManageYourDigitalTextVisible();
     await OnboardingCarouselView.isManageYourDigitalImageVisible();
@@ -52,7 +46,6 @@ describe(Smoke('Start Exploring'), () => {
 
   it('should be able to opt-out of the onboarding-wizard', async () => {
     await OnboardingView.tapCreateWallet();
-
     await MetaMetricsOptIn.isVisible();
     await MetaMetricsOptIn.tapNoThanksButton();
     await acceptTermOfUse();
@@ -70,7 +63,6 @@ describe(Smoke('Start Exploring'), () => {
     // Check that we are on the Secure your wallet screen
     await ProtectYourWalletView.isVisible();
     await ProtectYourWalletView.tapOnRemindMeLaterButton();
-
     await SkipAccountSecurityModal.tapIUnderstandCheckBox();
     await SkipAccountSecurityModal.tapSkipButton();
     await WalletView.isVisible();
@@ -84,61 +76,44 @@ describe(Smoke('Start Exploring'), () => {
 
   it('should go through the onboarding wizard flow', async () => {
     // Check that Take the tour CTA is visible and tap it
-
     await TestHelpers.delay(3000);
-
     await OnboardingWizardModal.isVisible();
     await OnboardingWizardModal.tapTakeTourButton();
-
     await OnboardingWizardModal.isYourAccountsTutorialStepVisible();
     await OnboardingWizardModal.tapGotItButton();
-
     // Ensure step 3 is shown correctly
     await OnboardingWizardModal.isEditAccountNameTutorialStepVisible();
-
     // await WalletView.editAccountName(ACCOUNT);
-
     await OnboardingWizardModal.tapGotItButton();
-
     await WalletView.isAccountNameCorrect(ACCOUNT);
-
     // Ensure step 4 is shown correctly
     await OnboardingWizardModal.isMainNavigationTutorialStepVisible();
-
     await OnboardingWizardModal.tapGotItButton();
     // Ensure step 5 is shown correctly
-
     await OnboardingWizardModal.isExploreTheBrowserTutorialStepVisible();
     // Tap on Back
     await OnboardingWizardModal.tapBackButton();
-
     // Ensure step 4 is shown correctly
     await OnboardingWizardModal.isMainNavigationTutorialStepVisible();
     await OnboardingWizardModal.tapGotItButton();
-
     // Ensure step 5 is shown correctly
     await OnboardingWizardModal.isExploreTheBrowserTutorialStepVisible();
     await OnboardingWizardModal.tapGotItButton();
-
     // Ensure step 6 is shown correctly
     await OnboardingWizardModal.isBrowserSearchStepTutorialVisible();
     await OnboardingWizardModal.tapBackButton();
     // Ensure step 5 is shown correctly
     await OnboardingWizardModal.isExploreTheBrowserTutorialStepVisible();
     await OnboardingWizardModal.tapBackButton();
-
     // Ensure step 4 is shown correctly
     await OnboardingWizardModal.isMainNavigationTutorialStepVisible();
     await OnboardingWizardModal.tapGotItButton();
-
     await OnboardingWizardModal.isExploreTheBrowserTutorialStepVisible();
     await OnboardingWizardModal.tapGotItButton();
-
     // Ensure step 6 is shown correctly
     await OnboardingWizardModal.isBrowserSearchStepTutorialVisible();
     await OnboardingWizardModal.tapGotItButton();
     // Check that we are on the Browser page
-
     // dealing with flakiness on bitrise.
     await TestHelpers.delay(2500);
     try {

--- a/e2e/specs/wallet/wallet-tests.spec.js
+++ b/e2e/specs/wallet/wallet-tests.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 import { Smoke } from '../../tags';
-
 import TestHelpers from '../../helpers';
 import WalletView from '../../pages/WalletView';
 import AddCustomTokenView from '../../pages/AddCustomTokenView';
@@ -17,8 +16,9 @@ describe(Smoke('Wallet Tests'), () => {
   // This key is for testing private key import only
   // I should NEVER hold any eth or token
 
-  beforeEach(() => {
-    jest.setTimeout(200000);
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+    await device.launchApp();
   });
 
   it('should import wallet and go to the wallet view', async () => {
@@ -47,32 +47,23 @@ describe(Smoke('Wallet Tests'), () => {
     await WalletView.scrollDownOnNFTsTab();
     // Tap on the add collectibles button
     await WalletView.tapImportNFTButton();
-
     await AddCustomTokenView.isVisible();
-
     // Input incorrect contract address
     await AddCustomTokenView.typeInNFTAddress('1234');
     await AddCustomTokenView.typeInNFTIdentifier('');
-
     await AddCustomTokenView.isNFTAddressWarningVisible();
     await AddCustomTokenView.tapBackButton();
-
     await WalletView.tapImportNFTButton();
-
     await AddCustomTokenView.isVisible();
     await AddCustomTokenView.typeInNFTAddress(Collectibles.erc1155tokenAddress);
     await AddCustomTokenView.typeInNFTIdentifier(Collectibles.erc1155tokenID);
-
     await WalletView.isVisible();
     // Wait for asset to load
     await TestHelpers.delay(3000);
-
     await WalletView.isNFTVisibleInWallet(Collectibles.erc1155collectionName);
     // Tap on Collectible
     await WalletView.tapOnNFTInWallet(Collectibles.erc1155collectionName);
-
     await WalletView.isNFTNameVisible(Collectibles.erc1155tokenName);
-
     await WalletView.scrollUpOnNFTsTab();
   });
 
@@ -80,7 +71,6 @@ describe(Smoke('Wallet Tests'), () => {
     await WalletView.isVisible();
     await WalletView.tapTokensTab();
     await WalletView.tapNetworksButtonOnNavBar();
-
     await NetworkListModal.isVisible();
     await NetworkListModal.changeNetwork(ETHEREUM);
     await WalletView.isNetworkNameVisible(ETHEREUM);
@@ -97,14 +87,11 @@ describe(Smoke('Wallet Tests'), () => {
     // Search for XRPL but select RPL
     await ImportTokensView.typeInTokenName('XRPL');
     await TestHelpers.delay(2000);
-
     await ImportTokensView.tapOnToken(); // taps the first token in the returned list
     await TestHelpers.delay(500);
-
     await ImportTokensView.tapImportButton();
     await WalletView.isVisible();
     await TestHelpers.delay(8000); // to prevent flakey behavior in bitrise
-
     await WalletView.isTokenVisibleInWallet('0 RPL');
     await WalletView.removeTokenFromWallet('0 RPL');
     await TestHelpers.delay(1500);


### PR DESCRIPTION
## **Description**
Our automated tests are launching the app multiple times at the start of the tests.  To improve performance and stability of tests the tests should only launch the app once at the beginning of tests.

Didn't remove `init.js` because there is an error that occurs when running tests without `init.js`. 

## **Related issues**

Fixes: #https://github.com/MetaMask/mobile-planning/issues/1348

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
App would launch twice at the start of tests.

### **After**
App launches only once at the start of tests.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
