### PR TITLE
refactor: logger.js to typescript and optimize for dev

### DIFF
--- a/app/lib/ppom/PPOMView.tsx
+++ b/app/lib/ppom/PPOMView.tsx
@@ -3,7 +3,7 @@ import React, { Component, RefObject } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 
-import Logger from '../../util/Logger.js';
+import Logger from '../../util/Logger';
 import asyncInvoke from './invoke-lib';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore


### PR DESCRIPTION
## **Description**
- Migrate Logger.js to typescript 
- Optimize for faster output in dev
Previously the logger would start by synchronously accessing user preferences even in dev which is unnecessary since logs won't be sent to server.
It would also mess up the order of logs being printed depending on the time it takes to access the DefaultPreferences.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
