### PR TITLE
feat: configure metro listener port

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -43,3 +43,6 @@ export WALLET_CONNECT_PROJECT_ID=""
 export BLOCKAID_FILE_CDN=""
 export BLOCKAID_PUBLIC_KEY=""
 export MM_BLOCKAID_UI_ENABLED=""
+
+# Default PORT for metro
+export WATCHER_PORT=8081

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ yarn setup # not the usual install command, this will run a lengthy postinstall 
 yarn watch
 ```
 
+- You can change the default port (8081) from metro using the WATCHER_PORT environment variable. For example:
+```bash
+WATCHER_PORT=8082 yarn watch
+# This value can also be set directly inside .js.env file
+```
+
+```bash
 #### Android
 ```bash
 yarn start:android

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ WATCHER_PORT=8082 yarn watch
 # This value can also be set directly inside .js.env file
 ```
 
-```bash
 #### Android
 ```bash
 yarn start:android

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ PRE_RELEASE=false
 JS_ENV_FILE=".js.env"
 ANDROID_ENV_FILE=".android.env"
 IOS_ENV_FILE=".ios.env"
-
+WATCHER_PORT=${WATCHER_PORT:-8081}
 
 envFileMissing() {
 	FILE="$1"
@@ -151,24 +151,24 @@ prebuild_android(){
 
 buildAndroidRun(){
 	prebuild_android
-	react-native run-android --variant=prodDebug --active-arch-only
+	react-native run-android --port=$WATCHER_PORT --variant=prodDebug --active-arch-only
 }
 
 buildAndroidRunQA(){
 	prebuild_android
-	react-native run-android --variant=qaDebug --active-arch-only
+	react-native run-android --port=$WATCHER_PORT --variant=qaDebug --active-arch-only
 }
 
 buildIosSimulator(){
 	prebuild_ios
 	SIM="${IOS_SIMULATOR:-"iPhone 13 Pro"}"
-	react-native run-ios --simulator "$SIM"
+	react-native run-ios --port=$WATCHER_PORT --simulator "$SIM"
 }
 
 buildIosSimulatorQA(){
 	prebuild_ios
 	SIM="${IOS_SIMULATOR:-"iPhone 13 Pro"}"
-	react-native run-ios --simulator "$SIM" --scheme "MetaMask-QA"
+	react-native run-ios --port=$WATCHER_PORT --simulator "$SIM" --scheme "MetaMask-QA"
 }
 
 buildIosSimulatorE2E(){
@@ -187,12 +187,12 @@ runIosE2E(){
 
 buildIosDevice(){
 	prebuild_ios
-	react-native run-ios --device
+	react-native run-ios --port=$WATCHER_PORT --device
 }
 
 buildIosDeviceQA(){
 	prebuild_ios
-	react-native run-ios --device --scheme "MetaMask-QA"
+	react-native run-ios --port=$WATCHER_PORT --device --scheme "MetaMask-QA"
 }
 
 generateArchivePackages() {
@@ -400,9 +400,9 @@ startWatcher() {
 	if [ "$MODE" == "clean" ]; then
 		watchman watch-del-all
 		rm -rf $TMPDIR/metro-cache
-		react-native start -- --reset-cache
+		react-native start --port=$WATCHER_PORT -- --reset-cache
 	else
-		react-native start
+		react-native start --port=$WATCHER_PORT
 	fi
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,6 @@ PRE_RELEASE=false
 JS_ENV_FILE=".js.env"
 ANDROID_ENV_FILE=".android.env"
 IOS_ENV_FILE=".ios.env"
-WATCHER_PORT=${WATCHER_PORT:-8081}
 
 envFileMissing() {
 	FILE="$1"
@@ -118,6 +117,7 @@ prebuild(){
 			source $JS_ENV_FILE
 		fi
 	fi
+  WATCHER_PORT=${WATCHER_PORT:-8081}
 }
 
 prebuild_ios(){
@@ -396,6 +396,7 @@ buildIos() {
 
 startWatcher() {
 	source $JS_ENV_FILE
+  WATCHER_PORT=${WATCHER_PORT:-8081}
 	yarn --ignore-engines build:static-logos
 	if [ "$MODE" == "clean" ]; then
 		watchman watch-del-all


### PR DESCRIPTION
## **Description**

You may want to run multiple instance of the wallet for debug purposes and to enable this, you will need to configure metro on different port. This PR allows you to run the wallet without conflicting with other react native apps.

```
WATCHER_PORT=8082 yarn start:ios
```

You can also directly edit with `.js.env` with:
```
export WATCHER_PORT=8081
```
## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
