### PR TITLE
chore: Reduce e2e build scenarios

### DIFF
--- a/.github/scripts/check-bitrise-e2e-smoke/check-e2e-smoke-trigger.ts
+++ b/.github/scripts/check-bitrise-e2e-smoke/check-e2e-smoke-trigger.ts
@@ -3,8 +3,6 @@ import { context, getOctokit } from '@actions/github';
 import { GitHub } from '@actions/github/lib/utils';
 
 enum PullRequestTriggerType {
-  Opened = 'opened',
-  Reopened = 'reopened',
   ReadyForReview = 'ready_for_review',
   Labeled = 'labeled',
 }
@@ -34,22 +32,6 @@ async function main(): Promise<void> {
   console.log(`Workflow triggered by the event (${triggerAction})`);
 
   switch (triggerAction) {
-    case PullRequestTriggerType.Opened:
-      shouldTriggerE2E = !context.payload.pull_request?.draft;
-      if (!shouldTriggerE2E) {
-        console.log(`Skipping E2E smoke since opened PR is in draft.`);
-      } else {
-        console.log(`Starting E2E smoke since opened PR is ready for review.`);
-      }
-      break;
-    case PullRequestTriggerType.Reopened:
-      shouldTriggerE2E = !context.payload.pull_request?.draft;
-      if (!shouldTriggerE2E) {
-        console.log(`Skipping E2E smoke since reopened PR is in draft.`);
-      } else {
-        console.log(`Starting E2E smoke since reopened PR is ready for review.`);
-      }
-      break;
     case PullRequestTriggerType.ReadyForReview:
       shouldTriggerE2E = true;
       console.log(
@@ -90,7 +72,7 @@ async function main(): Promise<void> {
         process.exit(1);
       }
     } catch (error) {
-      console.log(`Error occured when applying label: ${error}`);
+      core.setFailed(`Error occured when applying label: ${error}`);
       process.exit(1);
     }
   }

--- a/.github/workflows/check-bitrise-e2e-smoke.yml
+++ b/.github/workflows/check-bitrise-e2e-smoke.yml
@@ -2,7 +2,7 @@ name: Check Bitrise E2E Smoke Tests
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, labeled]
+    types: [ready_for_review, labeled]
 
 env:
   E2E_LABEL: 'Run Smoke E2E'


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Since we're seeing our Bitrise credits drained relatively quickly, this PR removes the `opened` and `reopened` scenarios for triggering e2e smoke tests. The remaining ways to trigger e2e smoke tests are `ready_for_review` and `labeled`.

## **Related issues**

Fixes: #

## **Manual testing steps**

`ready_for_review` - Change this PR to draft and back to ready for review
`labeled` - Apply the `Run E2E Smoke` label

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
