### PR TITLE
chore(revert): revert "chore: Split the Swap test into two parts so that transaction activity is checked at the end"

### DIFF
--- a/app/components/Base/DetailsModal.js
+++ b/app/components/Base/DetailsModal.js
@@ -5,7 +5,10 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import { fontStyles } from '../../styles/common';
 import Text from './Text';
 import { useTheme } from '../../util/theme';
-import { DetailsModalSelectorsIDs } from '../../../e2e/selectors/Modals/DetailsModal.selectors';
+import {
+  DETAILS_MODAL_TITLE,
+  DETAILS_MODAL_CLOSE_ICON,
+} from '../../../wdio/screen-objects/testIDs/Components/DetailsModal.js';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -82,7 +85,7 @@ const DetailsModalTitle = ({ style, ...props }) => {
 
   return (
     <Text
-      testID={DetailsModalSelectorsIDs.TITLE}
+      testID={DETAILS_MODAL_TITLE}
       style={[styles.title, style]}
       {...props}
     />
@@ -96,7 +99,7 @@ const DetailsModalCloseIcon = ({ style, ...props }) => {
     <TouchableOpacity
       style={[styles.closeIcon, style]}
       {...props}
-      testID={DetailsModalSelectorsIDs.CLOSE_ICON}
+      testID={DETAILS_MODAL_CLOSE_ICON}
     >
       <Ionicons color={colors.text.default} name={'ios-close'} size={38} />
     </TouchableOpacity>

--- a/app/components/Base/ListItem.js
+++ b/app/components/Base/ListItem.js
@@ -4,7 +4,6 @@ import { StyleSheet, View } from 'react-native';
 import { fontStyles } from '../../styles/common';
 import Text from './Text';
 import { useTheme } from '../../util/theme';
-import { ActivityViewSelectorsIDs } from '../../../e2e/selectors/ActivityView.selectors';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -89,13 +88,7 @@ const ListItemBody = ({ style, ...props }) => {
 const ListItemTitle = ({ style, ...props }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
-  return (
-    <Text
-      style={[styles.title, style]}
-      {...props}
-      testID={ActivityViewSelectorsIDs.TITLE}
-    />
-  );
+  return <Text style={[styles.title, style]} {...props} />;
 };
 const ListItemAmounts = ({ style, ...props }) => {
   const { colors } = useTheme();

--- a/app/components/Base/StatusText.js
+++ b/app/components/Base/StatusText.js
@@ -5,7 +5,7 @@ import { StyleSheet } from 'react-native';
 import { FIAT_ORDER_STATES } from '../../constants/on-ramp';
 import { strings } from '../../../locales/i18n';
 import { useTheme } from '../../util/theme';
-import { ActivityViewSelectorsIDs } from '../../../e2e/selectors/ActivityView.selectors';
+import { DETAILS_MODAL_TITLE } from '../../../wdio/screen-objects/testIDs/Components/DetailsModal.js';
 
 const styles = StyleSheet.create({
   status: {
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 
 export const ConfirmedText = (props) => (
   <Text
-    testID={ActivityViewSelectorsIDs.STATUS}
+    testID={DETAILS_MODAL_TITLE}
     bold
     green
     style={styles.status}
@@ -28,7 +28,6 @@ export const PendingText = (props) => {
   const { colors } = useTheme();
   return (
     <Text
-      testID={ActivityViewSelectorsIDs.STATUS}
       bold
       style={[styles.status, { color: colors.secondary.default }]}
       {...props}
@@ -39,7 +38,6 @@ export const FailedText = (props) => {
   const { colors } = useTheme();
   return (
     <Text
-      testID={ActivityViewSelectorsIDs.STATUS}
       bold
       style={[styles.status, { color: colors.error.default }]}
       {...props}

--- a/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
@@ -623,7 +623,6 @@ exports[`PaymentMethods View renders correctly 1`] = `
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -1106,7 +1105,6 @@ exports[`PaymentMethods View renders correctly 1`] = `
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -1610,7 +1608,6 @@ exports[`PaymentMethods View renders correctly 1`] = `
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -2656,7 +2653,6 @@ exports[`PaymentMethods View renders correctly while loading 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -2970,7 +2966,6 @@ exports[`PaymentMethods View renders correctly while loading 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -3286,7 +3281,6 @@ exports[`PaymentMethods View renders correctly while loading 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -5502,7 +5496,6 @@ exports[`PaymentMethods View renders correctly with null data 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -5816,7 +5809,6 @@ exports[`PaymentMethods View renders correctly with null data 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -6132,7 +6124,6 @@ exports[`PaymentMethods View renders correctly with null data 1`] = `
                                             ],
                                           ]
                                         }
-                                        testID="list-item-title"
                                       >
                                         <View
                                           style={
@@ -6966,7 +6957,6 @@ exports[`PaymentMethods View renders correctly with payment method with disclaim
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -7449,7 +7439,6 @@ exports[`PaymentMethods View renders correctly with payment method with disclaim
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -7953,7 +7942,6 @@ exports[`PaymentMethods View renders correctly with payment method with disclaim
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -9769,7 +9757,6 @@ exports[`PaymentMethods View renders correctly with show back button false 1`] =
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -10252,7 +10239,6 @@ exports[`PaymentMethods View renders correctly with show back button false 1`] =
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={
@@ -10756,7 +10742,6 @@ exports[`PaymentMethods View renders correctly with show back button false 1`] =
                                                 ],
                                               ]
                                             }
-                                            testID="list-item-title"
                                           >
                                             <Text
                                               style={

--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -98,7 +98,6 @@ Array [
                   ],
                 ]
               }
-              testID="list-item-title"
             >
               <View
                 style={
@@ -359,7 +358,6 @@ Array [
                   ],
                 ]
               }
-              testID="list-item-title"
             >
               <View
                 style={
@@ -527,7 +525,6 @@ Array [
                   ],
                 ]
               }
-              testID="list-item-title"
             >
               <View
                 style={

--- a/e2e/pages/ActivitiesView.js
+++ b/e2e/pages/ActivitiesView.js
@@ -1,27 +1,18 @@
 import TestHelpers from '../helpers';
 import messages from '../../locales/languages/en.json';
-import { ActivityViewSelectorsIDs } from '../selectors/ActivityView.selectors';
 
 export default class ActivitiesView {
   static async isVisible() {
-    await TestHelpers.checkIfElementByTextIsVisible(
+    await TestHelpers.checkIfElementWithTextIsVisible(
       messages.transactions_view.title,
     );
   }
 
-  static async tapActivity(title) {
+  static async tapOnSwapActivity(sourceToken, destinationToken) {
+    let title = messages.swaps.transaction_label.swap;
+    title = title.replace('{{sourceToken}}', sourceToken);
+    title = title.replace('{{destinationToken}}', destinationToken);
+
     await TestHelpers.waitAndTapText(title);
-  }
-
-  static async checkActivityTitle(title, index) {
-    return expect(
-      element(by.id(ActivityViewSelectorsIDs.TITLE)).atIndex(index),
-    ).toHaveText(title);
-  }
-
-  static async checkActivityStatus(status, index) {
-    return expect(
-      element(by.id(ActivityViewSelectorsIDs.STATUS)).atIndex(index),
-    ).toHaveText(status);
   }
 }

--- a/e2e/pages/modals/DetailsModal.js
+++ b/e2e/pages/modals/DetailsModal.js
@@ -1,21 +1,29 @@
 import TestHelpers from '../../helpers';
-import { DetailsModalSelectorsIDs } from '../../selectors/Modals/DetailsModal.selectors';
+import {
+  DETAILS_MODAL_TITLE,
+  DETAILS_MODAL_STATUS_CONFIRMED,
+  DETAILS_MODAL_CLOSE_ICON,
+} from '../../../wdio/screen-objects/testIDs/Components/DetailsModal.js';
+import { TransactionDetailsModalSelectorsText } from '../../selectors/Modals/TransactionDetailsModal.selectors';
 
 export default class DetailsModal {
-  static async isTitleVisible(title) {
-    await TestHelpers.checkIfHasText(DetailsModalSelectorsIDs.TITLE, title);
+  static async isTitleVisible(sourceToken, destinationToken) {
+    let title = TransactionDetailsModalSelectorsText.TITLE;
+    title = title.replace('{{sourceToken}}', sourceToken);
+    title = title.replace('{{destinationToken}}', destinationToken);
+    await TestHelpers.checkIfElementHasString(DETAILS_MODAL_TITLE, title);
   }
 
   static async isStatusCorrect(status) {
-    await TestHelpers.checkIfHasText(
-      DetailsModalSelectorsIDs.TRANSACTION_STATUS,
+    await TestHelpers.checkIfElementHasString(
+      DETAILS_MODAL_STATUS_CONFIRMED,
       status,
     );
   }
 
   static async tapOnCloseIcon() {
     try {
-      await TestHelpers.waitAndTap(DetailsModalSelectorsIDs.CLOSE_ICON);
+      await TestHelpers.waitAndTap(DETAILS_MODAL_CLOSE_ICON);
       await TestHelpers.delay(1000);
     } catch {
       //

--- a/e2e/selectors/ActivityView.selectors.js
+++ b/e2e/selectors/ActivityView.selectors.js
@@ -1,5 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const ActivityViewSelectorsIDs = {
-  TITLE: 'list-item-title',
-  STATUS: 'transaction-status',
-};

--- a/e2e/selectors/Modals/DetailsModal.selectors.js
+++ b/e2e/selectors/Modals/DetailsModal.selectors.js
@@ -1,6 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const DetailsModalSelectorsIDs = {
-  TITLE: 'details-modal-title',
-  TRANSACTION_STATUS: 'transaction-status',
-  CLOSE_ICON: 'details-modal-close-ico',
-};

--- a/e2e/specs/swaps/swap-action-regression.spec.js
+++ b/e2e/specs/swaps/swap-action-regression.spec.js
@@ -5,6 +5,7 @@ import QuoteView from '../../pages/swaps/QuoteView';
 import SwapView from '../../pages/swaps/SwapView';
 import TabBarComponent from '../../pages/TabBarComponent';
 import ActivitiesView from '../../pages/ActivitiesView';
+import DetailsModal from '../../pages/modals/DetailsModal';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
@@ -17,13 +18,11 @@ import TestHelpers from '../../helpers';
 import FixtureServer from '../../fixtures/fixture-server';
 import { getFixturesServerPort } from '../../fixtures/utils';
 import { Regression } from '../../tags';
-import { TransactionDetailsModalSelectorsText } from '../../selectors/Modals/TransactionDetailsModal.selectors';
 
 const fixtureServer = new FixtureServer();
 
 describe(Regression('Multiple Swaps from Actions'), () => {
   let swapOnboarded = false;
-  const transactionList = [];
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
     const fixture = new FixtureBuilder()
@@ -83,31 +82,15 @@ describe(Regression('Multiple Swaps from Actions'), () => {
       await SwapView.tapIUnderstandPriceWarning();
       await SwapView.swipeToSwap();
       await SwapView.waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol);
-
-      let transactionTitle = TransactionDetailsModalSelectorsText.TITLE;
-      transactionTitle = transactionTitle.replace(
-        '{{sourceToken}}',
+      await TabBarComponent.tapActivity();
+      await ActivitiesView.isVisible();
+      await ActivitiesView.tapOnSwapActivity(
         sourceTokenSymbol,
-      );
-      transactionTitle = transactionTitle.replace(
-        '{{destinationToken}}',
         destTokenSymbol,
       );
-
-      transactionList.push(transactionTitle);
+      await DetailsModal.isTitleVisible(sourceTokenSymbol, destTokenSymbol);
+      await DetailsModal.isStatusCorrect('Confirmed');
+      await DetailsModal.tapOnCloseIcon();
     },
   );
-
-  it('check that all the transcations appear as confirmed in the activity list', async () => {
-    let transactionIndex = 0;
-
-    await TabBarComponent.tapActivity();
-    await ActivitiesView.isVisible();
-
-    while (transactionList.length) {
-      const transaction = transactionList.pop();
-      await ActivitiesView.checkActivityTitle(transaction, transactionIndex);
-      await ActivitiesView.checkActivityStatus('Confirmed', transactionIndex++);
-    }
-  });
 });

--- a/e2e/specs/swaps/swap-action-smoke.spec.js
+++ b/e2e/specs/swaps/swap-action-smoke.spec.js
@@ -5,6 +5,7 @@ import QuoteView from '../../pages/swaps/QuoteView';
 import SwapView from '../../pages/swaps/SwapView';
 import TabBarComponent from '../../pages/TabBarComponent';
 import ActivitiesView from '../../pages/ActivitiesView';
+import DetailsModal from '../../pages/modals/DetailsModal';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
@@ -17,13 +18,11 @@ import TestHelpers from '../../helpers';
 import FixtureServer from '../../fixtures/fixture-server';
 import { getFixturesServerPort } from '../../fixtures/utils';
 import { Smoke } from '../../tags';
-import { TransactionDetailsModalSelectorsText } from '../../selectors/Modals/TransactionDetailsModal.selectors';
 
 const fixtureServer = new FixtureServer();
 
 describe(Smoke('Swap from Actions'), () => {
   let swapOnboarded = false;
-  const transactionList = [];
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
     const fixture = new FixtureBuilder()
@@ -82,31 +81,15 @@ describe(Smoke('Swap from Actions'), () => {
       await SwapView.tapIUnderstandPriceWarning();
       await SwapView.swipeToSwap();
       await SwapView.waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol);
-
-      let transactionTitle = TransactionDetailsModalSelectorsText.TITLE;
-      transactionTitle = transactionTitle.replace(
-        '{{sourceToken}}',
+      await TabBarComponent.tapActivity();
+      await ActivitiesView.isVisible();
+      await ActivitiesView.tapOnSwapActivity(
         sourceTokenSymbol,
-      );
-      transactionTitle = transactionTitle.replace(
-        '{{destinationToken}}',
         destTokenSymbol,
       );
-
-      transactionList.push(transactionTitle);
+      await DetailsModal.isTitleVisible(sourceTokenSymbol, destTokenSymbol);
+      await DetailsModal.isStatusCorrect('Confirmed');
+      await DetailsModal.tapOnCloseIcon();
     },
   );
-
-  it('check that all the transcations appear as confirmed in the activity list', async () => {
-    let transactionIndex = 0;
-
-    await TabBarComponent.tapActivity();
-    await ActivitiesView.isVisible();
-
-    while (transactionList.length) {
-      const transaction = transactionList.pop();
-      await ActivitiesView.checkActivityTitle(transaction, transactionIndex);
-      await ActivitiesView.checkActivityStatus('Confirmed', transactionIndex++);
-    }
-  });
 });

--- a/e2e/specs/swaps/swap-token-chart.spec.js
+++ b/e2e/specs/swaps/swap-token-chart.spec.js
@@ -61,7 +61,6 @@ describe(Regression('Swap from Token view'), () => {
     await SwapView.isVisible();
     await SwapView.tapIUnderstandPriceWarning();
     await SwapView.swipeToSwap();
-    await TestHelpers.delay(5000);
     await SwapView.waitForSwapToComplete('USDC', 'DAI');
   });
 });

--- a/wdio/screen-objects/testIDs/Components/DetailsModal.js
+++ b/wdio/screen-objects/testIDs/Components/DetailsModal.js
@@ -1,0 +1,3 @@
+export const DETAILS_MODAL_TITLE = 'details-modal-title';
+export const DETAILS_MODAL_STATUS_CONFIRMED = 'status-confirmed-text';
+export const DETAILS_MODAL_CLOSE_ICON = 'details-modal-close-icon';


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#7726

Consider reverting this PR because of the changes introduced to the `Base` folder components related to adding testID props. These testIDs are impacting `Ramp` snapshots instead of only `Swap` views.

I suggest these testIDs to be added to the Swaps views components instead of the Base ones. In case the Base components do not pass those props down, to just modify them by passing `testID` or all the `{...props}` down, so it does not impact the other Views that use them.