### PR TITLE
fix: blockaid validations should be done only on mainnet

### DIFF
--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -17,6 +17,11 @@ jest.mock('../../core/Engine', () => ({
       updateTransaction: jest.fn(),
       updateSecurityAlertResponse: jest.fn(),
     },
+    NetworkController: {
+      state: {
+        providerConfig: { chainId: '1' },
+      },
+    },
   },
 }));
 
@@ -54,6 +59,7 @@ const mockSignatureRequest = {
 describe('validateResponse', () => {
   beforeEach(() => {
     Engine.context.PreferencesController.state.securityAlertsEnabled = true;
+    Engine.context.NetworkController.state.providerConfig.chainId = '1';
   });
 
   afterEach(() => {
@@ -67,7 +73,7 @@ describe('validateResponse', () => {
   });
 
   it('should not validate user is not on mainnet', async () => {
-    Engine.context.NetworkController.state.providerConfig.chainId = '0x5';
+    Engine.context.NetworkController.state.providerConfig.chainId = '5';
     await PPOMUtil.validateRequest(mockRequest, '123');
     expect(Engine.context.PPOMController.usePPOM).toBeCalledTimes(0);
   });

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -66,6 +66,12 @@ describe('validateResponse', () => {
     expect(Engine.context.PPOMController.usePPOM).toBeCalledTimes(0);
   });
 
+  it('should not validate user is not on mainnet', async () => {
+    Engine.context.NetworkController.state.providerConfig.chainId = '0x5';
+    await PPOMUtil.validateRequest(mockRequest, '123');
+    expect(Engine.context.PPOMController.usePPOM).toBeCalledTimes(0);
+  });
+
   it('should not validate if requested method is not allowed', async () => {
     Engine.context.PreferencesController.state.securityAlertsEnabled = false;
     await PPOMUtil.validateRequest(

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -1,6 +1,7 @@
 import Logger from '../../util/Logger';
 import Engine from '../../core/Engine';
 import { isBlockaidFeatureEnabled } from '../../util/blockaid';
+import { isMainnetByChainId } from '../../util/networks';
 import {
   Reason,
   ResultType,
@@ -35,12 +36,17 @@ const RequestInProgress = {
 const validateRequest = async (req: any, transactionId?: string) => {
   let securityAlertResponse;
   try {
-    const { PPOMController: ppomController, PreferencesController } =
-      Engine.context;
+    const {
+      PPOMController: ppomController,
+      PreferencesController,
+      NetworkController,
+    } = Engine.context;
+    const currentChainId = NetworkController.state.providerConfig.chainId;
     if (
       !isBlockaidFeatureEnabled() ||
       !PreferencesController.state.securityAlertsEnabled ||
-      !ConfirmationMethods.includes(req.method)
+      !ConfirmationMethods.includes(req.method) ||
+      !isMainnetByChainId(currentChainId)
     ) {
       return;
     }


### PR DESCRIPTION
## **Description**
Blockaid validations on mobile should work on mainnet only.

## **Related issues**

Fixes: #7772

## **Manual testing steps**

1. Go to test test DAPP
2. Submit transaction on Sepolia network
3. Blockaid validation should not work for it

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
