### PR TITLE
feat: goerli deprecation warning

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -11,6 +11,7 @@ import {
   AppState,
   StyleSheet,
   View,
+  Linking,
   PushNotificationIOS, // eslint-disable-line react-native/split-platform-components
 } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
@@ -69,6 +70,9 @@ import {
 } from '../../../selectors/networkController';
 import { selectShowIncomingTransactionNetworks } from '../../../selectors/preferencesController';
 import { addHexPrefix, toHexadecimal } from '../../../util/number';
+import { NETWORKS_CHAIN_ID } from '../../../constants/network';
+import WarningAlert from '../../../components/UI/WarningAlert';
+import { GOERLI_DEPRECATED_ARTICLE } from '../../../constants/urls';
 
 const Stack = createStackNavigator();
 
@@ -90,6 +94,7 @@ const Main = (props) => {
   const [forceReload, setForceReload] = useState(false);
   const [showRemindLaterModal, setShowRemindLaterModal] = useState(false);
   const [skipCheckbox, setSkipCheckbox] = useState(false);
+  const [showDeprecatedAlert, setShowDeprecatedAlert] = useState(true);
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
@@ -321,6 +326,23 @@ const Main = (props) => {
     termsOfUse();
   }, [termsOfUse]);
 
+  const openDeprecatedNetworksArticle = () => {
+    Linking.openURL(GOERLI_DEPRECATED_ARTICLE);
+  };
+
+  const renderDeprecatedNetworkAlert = (chainId, backUpSeedphraseVisible) => {
+    if (chainId === NETWORKS_CHAIN_ID.GOERLI && showDeprecatedAlert) {
+      return (
+        <WarningAlert
+          text={strings('networks.deprecated_goerli')}
+          dismissAlert={() => setShowDeprecatedAlert(false)}
+          onPressLearnMore={openDeprecatedNetworksArticle}
+          precedentAlert={backUpSeedphraseVisible}
+        />
+      );
+    }
+  };
+
   return (
     <React.Fragment>
       <View style={styles.flex}>
@@ -338,6 +360,10 @@ const Main = (props) => {
           onDismiss={toggleRemindLater}
           navigation={props.navigation}
         />
+        {renderDeprecatedNetworkAlert(
+          props.chainId,
+          props.backUpSeedphraseVisible,
+        )}
         <SkipAccountSecurityModal
           modalVisible={showRemindLaterModal}
           onCancel={skipAccountModalSecureNow}
@@ -400,6 +426,10 @@ Main.propTypes = {
    * Current chain id
    */
   chainId: PropTypes.string,
+  /**
+   * backup seed phrase modal visible
+   */
+  backUpSeedphraseVisible: PropTypes.bool,
 };
 
 const mapStateToProps = (state) => ({
@@ -407,6 +437,7 @@ const mapStateToProps = (state) => ({
     selectShowIncomingTransactionNetworks(state),
   providerType: selectProviderType(state),
   chainId: selectChainId(state),
+  backUpSeedphraseVisible: state.user.backUpSeedphraseVisible,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/UI/WarningAlert/WarningAlert.styles.ts
+++ b/app/components/UI/WarningAlert/WarningAlert.styles.ts
@@ -22,6 +22,7 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 8,
       backgroundColor: colors.background.default,
       borderColor: colors.warning.default,
+      paddingBottom: 16,
     },
     upperAlertContainer: { bottom: 120 },
     alertWrapper: {

--- a/app/components/UI/WarningAlert/__snapshots__/WarningAlert.test.tsx.snap
+++ b/app/components/UI/WarningAlert/__snapshots__/WarningAlert.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`ButtonBase should render correctly 1`] = `
         "borderRadius": 8,
         "bottom": 20,
         "left": 16,
+        "paddingBottom": 16,
         "position": "absolute",
         "right": 16,
       },

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -69,3 +69,6 @@ export const LINEA_FAUCET = 'https://www.infura.io/faucet/linea';
 // Add custom network
 export const ADD_CUSTOM_NETWORK_ARTCILE =
   'https://support.metamask.io/hc/en-us/articles/360057142392-Verifying-custom-network-information';
+
+export const GOERLI_DEPRECATED_ARTICLE =
+  'https://github.com/eth-clients/goerli#goerli-goerlitzer-testnet';


### PR DESCRIPTION
## **Description**
This PR aims to implement the goerli deprecation warning.
It will only show the warning when the user it's on Goerli.
Every time the user kills the app, after hiding the warning, the warning will appear again.


This merge of this PR is blocked by the translations [PR](https://github.com/MetaMask/metamask-mobile/pull/7789), please check if the translations are created to be included on the next release

## **Related issues**

Fixes: #https://github.com/MetaMask/mobile-planning/issues/1369

## **Manual testing steps**

Scenario1:
* Switch network to goerli
* Hide the warning
* Switch network to ethereum network
* no warning should appear
* Switch network back to goerli 
* the warning should not appear (Proposing this since it deviates from the original scenarios proposed, it was accepted here on this [comment](https://github.com/MetaMask/mobile-planning/issues/1369#issuecomment-1812539150))

Scenario2:
* Switch network to goerli
* Hide the warning
* Kill the app
* Open the app
* the warning should appear


## **Screenshots/Recordings**

https://recordit.co/NBZXT6IM4L

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
