### PR TITLE
fix: Disable javascript when webview is not focused

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1433,10 +1433,9 @@ export const BrowserTab = (props) => {
   );
 
   /**
-   * This is needed to re-render the webview when this compoennt is unfocused.
-   * Since on IOS after the webview is created changing the javaScriptEnabled property
-   * will not stop any script already running.
-   * This way we can inject the property isFocused to turn the JavaScriptEnabled prop to false
+   * According to Apple docs, it is not possible to update properties such as `javascriptEnabled` dynamically
+   * - https://developer.apple.com/documentation/webkit/wkwebviewconfiguration.
+   * By updating the key prop, we are forcing iOS WebView to reinitialize with the new `javascriptEnabled` value.
    */
   useEffect(() => {
     if (Platform.OS === 'ios') setKey((prevKey) => prevKey + 1);

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -15,6 +15,7 @@ import { withNavigation } from '@react-navigation/compat';
 import { WebView } from 'react-native-webview';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { useIsFocused } from '@react-navigation/native';
 import BrowserBottomBar from '../../UI/BrowserBottomBar';
 import PropTypes from 'prop-types';
 import Share from 'react-native-share';
@@ -252,6 +253,8 @@ const sessionENSNames = {};
 const ensIgnoreList = [];
 
 export const BrowserTab = (props) => {
+  const isFocused = useIsFocused();
+  const [key, setKey] = useState(1);
   const [backEnabled, setBackEnabled] = useState(false);
   const [forwardEnabled, setForwardEnabled] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -1429,6 +1432,16 @@ export const BrowserTab = (props) => {
     [reload],
   );
 
+  /**
+   * This is needed to re-render the webview when this compoennt is unfocused.
+   * Since on IOS after the webview is created changing the javaScriptEnabled property
+   * will not stop any script already running.
+   * This way we can inject the property isFocused to turn the JavaScriptEnabled prop to false
+   */
+  useEffect(() => {
+    setKey((prevKey) => prevKey + 1);
+  }, [isFocused]);
+
   const renderIpfsBanner = () => (
     <View style={styles.bannerContainer}>
       <Banner
@@ -1477,6 +1490,7 @@ export const BrowserTab = (props) => {
           {!!entryScriptWeb3 && firstUrlLoaded && (
             <>
               <WebView
+                key={key}
                 originWhitelist={['*']}
                 decelerationRate={'normal'}
                 ref={webviewRef}
@@ -1494,12 +1508,12 @@ export const BrowserTab = (props) => {
                 onError={onError}
                 onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
                 sendCookies
-                javascriptEnabled
                 allowsInlineMediaPlayback
                 useWebkit
                 testID={'browser-webview'}
                 applicationNameForUserAgent={'WebView MetaMaskMobile'}
                 onFileDownload={handleOnFileDownload}
+                javaScriptEnabled={isFocused}
               />
               {ipfsBannerVisible && renderIpfsBanner()}
             </>

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1439,7 +1439,7 @@ export const BrowserTab = (props) => {
    * This way we can inject the property isFocused to turn the JavaScriptEnabled prop to false
    */
   useEffect(() => {
-    setKey((prevKey) => prevKey + 1);
+    if (Platform.OS === 'ios') setKey((prevKey) => prevKey + 1);
   }, [isFocused]);
 
   const renderIpfsBanner = () => (


### PR DESCRIPTION
## **Description**
More info will be find on the [issue](https://github.com/MetaMask/mobile-planning/issues/1247#issuecomment-1810856723). 

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
