### PR TITLE
fix: Lock yarn to 1.22.19

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -138,7 +138,7 @@ workflows:
                 asdf global nodejs 18.18
                 asdf plugin add yarn
                 asdf list all yarn
-                asdf install yarn latest
+                asdf install yarn 1.22.19
                 asdf global yarn 1.22.19
           title: Install node and yarn
       - yarn@0:

--- a/package.json
+++ b/package.json
@@ -524,7 +524,7 @@
   },
   "engines": {
     "node": "^18.17.1",
-    "yarn": "^1.22.0"
+    "yarn": "1.22.17"
   },
   "lavamoat": {
     "allowScripts": {

--- a/package.json
+++ b/package.json
@@ -524,7 +524,7 @@
   },
   "engines": {
     "node": "^18.17.1",
-    "yarn": "1.22.19"
+    "yarn": "^1.22.0"
   },
   "lavamoat": {
     "allowScripts": {

--- a/package.json
+++ b/package.json
@@ -524,7 +524,7 @@
   },
   "engines": {
     "node": "^18.17.1",
-    "yarn": "1.22.17"
+    "yarn": "1.22.19"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Bitrise is experiencing issues where yarn is attempting to install the latest version of yarn (1.22.21). That release version is currently experiencing issues, so we're locking the resolved version to 1.22.19 for now.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
