### PR TITLE
fix: blockaid banner should not break if feature is an object

### DIFF
--- a/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
@@ -166,7 +166,7 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
         <View style={styles.details}>
           {features?.map((feature, i) => (
             <Text key={`feature-${i}`} style={styles.detailsItem}>
-              • {feature}
+              • {JSON.stringify(feature)}
             </Text>
           ))}
         </View>

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
@@ -156,7 +156,7 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
   }
 
   const renderDetails = () =>
-    features?.length <= 0 ? null : (
+    features?.length && features?.length <= 0 ? null : (
       <Accordion
         title={strings('blockaid_banner.see_details')}
         onPress={onToggleShowDetails}

--- a/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.types.ts
@@ -32,7 +32,7 @@ export enum ResultType {
 
 export interface SecurityAlertResponse {
   reason: Reason;
-  features?: string[];
+  features?: (string | Record<string, string>)[];
   result_type: ResultType;
   providerRequestsCount?: Record<string, number>;
 }


### PR DESCRIPTION
## **Description**
Blockaid banner should not throw error if feature is an object.

## **Related issues**

Fixes: #7819

## **Manual testing steps**
1. Change the ppom response on the ppom-utils.js file
securityAlertResponse = {
        "result_type": "Malicious",
        "reason": "test",
        "features": [
          {"slkjd": "sjdfsa", "ksdf": "skhdjfska"},
          "blablabla",
          "blablabla",
        ]
    }
2. Go to test dapp
3. Trigger any tx
4. Click Details on the blockaid banner

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
