### PR TITLE
fix: Enable disable javascript of the webview when change tab on the navigation tab

### DIFF
--- a/app/actions/browser/index.js
+++ b/app/actions/browser/index.js
@@ -109,3 +109,14 @@ export function storeFavicon({ origin, url }) {
     url,
   };
 }
+/**
+ * Store the value of javascrip enabled on in app browser
+ * @param {Boolean} isJavascriptEnabled - Represents in app browser javascript enabled property
+ * @returns
+ */
+export function setJavascriptEnable(isJavascriptEnabled) {
+  return {
+    type: 'JAVASCRIPT_ENABLED',
+    isJavascriptEnabled,
+  };
+}

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -4,7 +4,7 @@
 import React, { useCallback, useRef } from 'react';
 import { Platform, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 // External dependencies.
 import TabBarItem from '../TabBarItem';
@@ -23,8 +23,10 @@ import { ICON_BY_TAB_BAR_ICON_KEY } from './TabBar.constants';
 import { colors as importedColors } from '../../../../styles/common';
 import { AvatarSize } from '../../Avatars/Avatar';
 import OnboardingWizard from '../../../../components/UI/OnboardingWizard';
+import { setJavascriptEnable } from '../../../../actions/browser';
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
+  const dispatch = useDispatch<any>();
   const { colors } = useTheme();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { bottomInset });
@@ -61,6 +63,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
         callback?.();
         switch (rootScreenName) {
           case Routes.WALLET_VIEW:
+            dispatch(setJavascriptEnable(false));
             navigation.navigate(Routes.WALLET.HOME, {
               screen: Routes.WALLET.TAB_STACK_FLOW,
               params: {
@@ -69,6 +72,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
             });
             break;
           case Routes.MODAL.WALLET_ACTIONS:
+            dispatch(setJavascriptEnable(false));
             navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
               screen: Routes.MODAL.WALLET_ACTIONS,
             });
@@ -81,14 +85,17 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
             );
             break;
           case Routes.BROWSER_VIEW:
+            dispatch(setJavascriptEnable(true));
             navigation.navigate(Routes.BROWSER.HOME, {
               screen: Routes.BROWSER_VIEW,
             });
             break;
           case Routes.TRANSACTIONS_VIEW:
+            dispatch(setJavascriptEnable(false));
             navigation.navigate(Routes.TRANSACTIONS_VIEW);
             break;
           case Routes.SETTINGS_VIEW:
+            dispatch(setJavascriptEnable(false));
             navigation.navigate(Routes.SETTINGS_VIEW, {
               screen: 'Settings',
             });

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -133,7 +133,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
         />
       );
     },
-    [state, descriptors, navigation, colors, chainId],
+    [state, descriptors, navigation, colors, chainId, dispatch],
   );
 
   const renderTabBarItems = useCallback(

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1437,7 +1437,7 @@ export const BrowserTab = (props) => {
    */
   useEffect(() => {
     if (Platform.OS === 'ios') setKey((prevKey) => prevKey + 1);
-  }, [props.isJavascriptEnabled]);
+  }, [props.isJavascriptEnabled, isTabActive]);
 
   const renderIpfsBanner = () => (
     <View style={styles.bannerContainer}>
@@ -1520,7 +1520,6 @@ export const BrowserTab = (props) => {
         {renderProgressBar()}
         {isTabActive && renderPhishingModal()}
         {isTabActive && renderOptions()}
-
         {isTabActive && renderBottomBar()}
         {isTabActive && renderOnboardingWizard()}
       </View>

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -1510,7 +1510,7 @@ export const BrowserTab = (props) => {
                 testID={'browser-webview'}
                 applicationNameForUserAgent={'WebView MetaMaskMobile'}
                 onFileDownload={handleOnFileDownload}
-                javaScriptEnabled={props.isJavascriptEnabled}
+                javaScriptEnabled={props.isJavascriptEnabled && isTabActive}
               />
               {ipfsBannerVisible && renderIpfsBanner()}
             </>

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -711,6 +711,7 @@ export const BrowserTab = (props) => {
   const changeUrl = async (siteInfo) => {
     url.current = siteInfo.url;
     title.current = siteInfo.title;
+    setInitialUrl(siteInfo.url);
     if (siteInfo.icon) icon.current = siteInfo.icon;
   };
 
@@ -1043,7 +1044,7 @@ export const BrowserTab = (props) => {
 
     setError(false);
 
-    changeUrl(nativeEvent);
+    changeUrl({ ...nativeEvent });
     sendActiveAccount();
 
     icon.current = null;
@@ -1473,6 +1474,17 @@ export const BrowserTab = (props) => {
       />
     </View>
   );
+
+  useEffect(() => {
+    console.log(
+      'ENTER javascipt enabled',
+      props.isJavascriptEnabled,
+      'is tab active',
+      isTabActive,
+      'url',
+      url.current,
+    );
+  }, [props.isJavascriptEnabled, isTabActive, url]);
 
   /**
    * Main render

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -15,7 +15,6 @@ import { withNavigation } from '@react-navigation/compat';
 import { WebView } from 'react-native-webview';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useIsFocused } from '@react-navigation/native';
 import BrowserBottomBar from '../../UI/BrowserBottomBar';
 import PropTypes from 'prop-types';
 import Share from 'react-native-share';
@@ -253,7 +252,6 @@ const sessionENSNames = {};
 const ensIgnoreList = [];
 
 export const BrowserTab = (props) => {
-  const isFocused = useIsFocused();
   const [key, setKey] = useState(1);
   const [backEnabled, setBackEnabled] = useState(false);
   const [forwardEnabled, setForwardEnabled] = useState(false);
@@ -1439,7 +1437,7 @@ export const BrowserTab = (props) => {
    */
   useEffect(() => {
     if (Platform.OS === 'ios') setKey((prevKey) => prevKey + 1);
-  }, [isFocused]);
+  }, [props.isJavascriptEnabled]);
 
   const renderIpfsBanner = () => (
     <View style={styles.bannerContainer}>
@@ -1512,7 +1510,7 @@ export const BrowserTab = (props) => {
                 testID={'browser-webview'}
                 applicationNameForUserAgent={'WebView MetaMaskMobile'}
                 onFileDownload={handleOnFileDownload}
-                javaScriptEnabled={isFocused}
+                javaScriptEnabled={props.isJavascriptEnabled}
               />
               {ipfsBannerVisible && renderIpfsBanner()}
             </>
@@ -1624,6 +1622,10 @@ BrowserTab.propTypes = {
    * Represents the current chain id
    */
   chainId: PropTypes.string,
+  /**
+   * Represents if javascript should be enable on the webview
+   */
+  isJavascriptEnabled: PropTypes.bool,
 };
 
 BrowserTab.defaultProps = {
@@ -1639,6 +1641,7 @@ const mapStateToProps = (state) => ({
   whitelist: state.browser.whitelist,
   wizardStep: state.wizard.step,
   chainId: selectChainId(state),
+  isJavascriptEnabled: state.browser.javascriptEnabled,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/core/DeeplinkManager.js
+++ b/app/core/DeeplinkManager.js
@@ -29,6 +29,7 @@ import DevLogger from './SDKConnect/utils/DevLogger';
 import WC2Manager from './WalletConnect/WalletConnectV2';
 import handleDeeplink from './SDKConnect/handleDeeplink';
 import Logger from '../../app/util/Logger';
+import { setJavascriptEnable } from '../actions/browser';
 
 class DeeplinkManager {
   constructor({ navigation, dispatch }) {
@@ -173,6 +174,7 @@ class DeeplinkManager {
       if (callback) {
         callback(url);
       } else {
+        this.dispatch(setJavascriptEnable(true));
         this.navigation.navigate(Routes.BROWSER.HOME, {
           screen: Routes.BROWSER.VIEW,
           params: {

--- a/app/reducers/browser/index.js
+++ b/app/reducers/browser/index.js
@@ -68,6 +68,12 @@ const browserReducer = (state = initialState, action) => {
           ...state.favicons,
         ].slice(0, AppConstants.FAVICON_CACHE_MAX_SIZE),
       };
+    case 'JAVASCRIPT_ENABLED': {
+      return {
+        ...state,
+        javascriptEnabled: action.isJavascriptEnabled,
+      };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## **Description**
This PR addresses the enablement and disablement of javascript of the webview when change tab on our tab bar.
This enable ledger pop up to work on in app browser.

You are on the webview -> javascript is enabled
You are not on the webview -> javascript is disabled


Currently with a bug
When switching tab
if one tab is on open sea
And we switch to other tab
And back to open sea
It will navigate back to the duck duck go search

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
