### PR TITLE
feat(ramp): order details redirection/analytics tests

### DIFF
--- a/app/components/UI/Ramp/common/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/common/Views/OrderDetails/OrderDetails.test.tsx
@@ -220,6 +220,46 @@ describe('OrderDetails', () => {
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
+  it('sends analytics events when an order is loaded', () => {
+    render(OrderDetails);
+    expect(mockTrackEvent.mock.lastCall).toMatchInlineSnapshot(`
+      Array [
+        "ONRAMP_PURCHASE_DETAILS_VIEWED",
+        Object {
+          "chain_id_destination": "1",
+          "currency_destination": "ETH",
+          "currency_source": "USD",
+          "order_type": "BUY",
+          "payment_method_id": "test-payment-method-id",
+          "provider_onramp": "Test Provider",
+          "status": "PENDING",
+        },
+      ]
+    `);
+
+    mockTrackEvent.mockReset();
+    const testOrder = {
+      ...mockOrder,
+      orderType: OrderOrderTypeEnum.Sell,
+    };
+
+    render(OrderDetails, [testOrder]);
+    expect(mockTrackEvent.mock.lastCall).toMatchInlineSnapshot(`
+      Array [
+        "OFFRAMP_PURCHASE_DETAILS_VIEWED",
+        Object {
+          "chain_id_source": "1",
+          "currency_destination": "USD",
+          "currency_source": "ETH",
+          "order_type": "SELL",
+          "payment_method_id": "test-payment-method-id",
+          "provider_offramp": "Test Provider",
+          "status": "PENDING",
+        },
+      ]
+    `);
+  });
+
   it('navigates to buy flow when the user attempts to make another purchase', async () => {
     const testOrder = {
       ...mockOrder,

--- a/app/components/UI/Ramp/common/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/common/Views/OrderDetails/OrderDetails.test.tsx
@@ -97,6 +97,7 @@ jest.mock('../../../common/sdk', () => ({
 
 const mockUseParamsDefaultValues = {
   orderId: mockOrder.id,
+  redirectToSendTransaction: false,
 };
 
 let mockUseParamsValues = {
@@ -163,10 +164,28 @@ describe('OrderDetails', () => {
 
   it('renders an empty screen layout if there is no order', async () => {
     mockUseParamsValues = {
+      ...mockUseParamsDefaultValues,
       orderId: 'invalid-id',
     };
     render(OrderDetails);
     expect(screen.toJSON()).toMatchSnapshot();
+  });
+
+  it('redirects to send transaction page when user is redirected back from a provider for a sell order', async () => {
+    const testOrder = {
+      ...mockOrder,
+      state: FIAT_ORDER_STATES.CREATED,
+      orderType: OrderOrderTypeEnum.Sell,
+      sellTxHash: undefined,
+    };
+    mockUseParamsValues = {
+      ...mockUseParamsDefaultValues,
+      redirectToSendTransaction: true,
+    };
+    render(OrderDetails, [testOrder]);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.SEND_TRANSACTION, {
+      orderId: testOrder.id,
+    });
   });
 
   it('renders a pending order', async () => {


### PR DESCRIPTION
## **Description**
Adds test to increase coverage of the order details page to 98%

## **Related issues**
n/a

## **Manual testing steps**
n/a

## **Screenshots/Recordings**
n/a

### **Before**
n/a

### **After**
n/a

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
