### PR TITLE
fix: Fix `eth_signTypedData` signatures containing `0x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/oss-attribution-generator": "^2.0.1",
     "@metamask/providers": "^13.1.0",
-    "@metamask/test-dapp": "^7.2.0",
+    "@metamask/test-dapp": "^8.0.0",
     "@react-native-community/datetimepicker": "^7.5.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "@react-native-community/slider": "^4.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,9 +3650,9 @@
     tweetnacl-util "^0.15.1"
 
 "@metamask/eth-sig-util@^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-6.0.1.tgz#2c5a670c9552ce4d47309d5f5d6569d0518fec23"
-  integrity sha512-Lt2DC4w4Sbtbd4DCsE+vfjdWcnFHSxfSfiJpt66hfLtAbetHsvbZcwKoa46TEA3G/V48ZuS4NWvJmtaA4F8UWA==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-6.0.2.tgz#d81dc87e0cd5a6580010911501976b48821746ad"
+  integrity sha512-D6IIefM2vS+4GUGGtezdBbkwUYQC4bCosYx/JteUuF0zfe6lyxR4cruA8+2QHoUg7F7edNH1xymYpqYq1BeOkw==
   dependencies:
     "@ethereumjs/util" "^8.1.0"
     "@metamask/abi-utils" "^1.2.0"
@@ -3663,15 +3663,14 @@
     tweetnacl-util "^0.15.1"
 
 "@metamask/eth-sig-util@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-7.0.0.tgz#b035a2b826018578a5d463668bb64828271376d8"
-  integrity sha512-8KeXZB4SKx3EfNS5ahbjUMegyGvDQYk6Nk3hmM658sXpfAQR5ZlIXBgj+9RF+ZROqsU6EuNVgKt7Fr10re60PQ==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-7.0.1.tgz#ad3227d6120f15f9293478de7dd9685a5c329586"
+  integrity sha512-59GSrMyFH2fPfu7nKeIQdZ150zxXNNhAQIUaFRUW+MGtVA4w/ONbiQobcRBLi+jQProfIyss51G8pfLPcQ0ylg==
   dependencies:
     "@ethereumjs/util" "^8.1.0"
     "@metamask/abi-utils" "^2.0.2"
     "@metamask/utils" "^8.1.0"
     ethereum-cryptography "^2.1.2"
-    ethjs-util "^0.1.6"
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3944,10 +3944,10 @@
     human-standard-token-abi "^2.0.0"
     web3 "^0.20.7"
 
-"@metamask/test-dapp@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-7.2.0.tgz#2520dbcf578753ff4a82b3545a2a3cf23cc497e8"
-  integrity sha512-WxdaLIUlxJ9Ucdasa2FVhW1D3B8g9kgSsBfXb5RQ6QWjzx2WeEb8YKwfe4u80xtbBdefrgS24UU6+9wfwxK17w==
+"@metamask/test-dapp@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-8.0.0.tgz#72f64b18a6157400ef3a3901c35819883524a048"
+  integrity sha512-yy1eZ9fZfJSEJIUjqcigBehFv6vdPGmDkVnzpBpEJqxiMPZGnbR5dypMfo0XsPdp5Lvmawx47Kamuy4Ocsy+iw==
 
 "@metamask/transaction-controller@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
## **Description**

In v7.10.0, signatures including a `bytes` field with the value `0x` were being encoded differently than before. Previously the string `0x` was interpreted as an "empty" hex number, but as of v7.10.0 they were encoded as the string "0x". This change was not intentional, and it resulted in invalid signatures.

This problem was introduced in `@metamask/eth-sig-util@6.0.1` (see here for details: https://github.com/MetaMask/eth-sig-util/issues/340). This package was introduced to mobile when `@metamask/keyring-controller` was updated to v6 (https://github.com/MetaMask/metamask-mobile/pull/7267). The keyrings themselves still use `@metamask/eth-sig-util@5.0.1`, but the `KeyringController` is signing these messages directly rather than delegating to the keyrings, which is why the newer `@metamask/eth-sig-util` package is used here.

This has been resolved by updating all affected versions of `@metamask/eth-sig-util`.

## **Related issues**

Fixes #7792

## **Manual testing steps**

1. Navigate to https://gudahtt.github.io/test-dapp/ in the in-app browser
2. Sign a message using `eth_signTypedData_v4` 
3. Attempt to verify that message. On production (v7.10.0) this does not work. It should work correctly on this branch, returning the signing account address.

## **Screenshots/Recordings**

**Before**

https://recordit.co/xejXpo4mlh

**After**

https://recordit.co/NnnpxbCVRB

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
