### PR TITLE
fix: Revert javascript disabled on the webview

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -15,7 +15,6 @@ import { withNavigation } from '@react-navigation/compat';
 import { WebView } from 'react-native-webview';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useIsFocused } from '@react-navigation/native';
 import BrowserBottomBar from '../../UI/BrowserBottomBar';
 import PropTypes from 'prop-types';
 import Share from 'react-native-share';
@@ -254,8 +253,6 @@ const sessionENSNames = {};
 const ensIgnoreList = [];
 
 export const BrowserTab = (props) => {
-  const isFocused = useIsFocused();
-  const [key, setKey] = useState(1);
   const [backEnabled, setBackEnabled] = useState(false);
   const [forwardEnabled, setForwardEnabled] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -1433,15 +1430,6 @@ export const BrowserTab = (props) => {
     [reload],
   );
 
-  /**
-   * According to Apple docs, it is not possible to update properties such as `javascriptEnabled` dynamically
-   * - https://developer.apple.com/documentation/webkit/wkwebviewconfiguration.
-   * By updating the key prop, we are forcing iOS WebView to reinitialize with the new `javascriptEnabled` value.
-   */
-  useEffect(() => {
-    if (Platform.OS === 'ios') setKey((prevKey) => prevKey + 1);
-  }, [isFocused]);
-
   const renderIpfsBanner = () => (
     <View style={styles.bannerContainer}>
       <Banner
@@ -1490,7 +1478,6 @@ export const BrowserTab = (props) => {
           {!!entryScriptWeb3 && firstUrlLoaded && (
             <>
               <WebView
-                key={key}
                 originWhitelist={['*']}
                 decelerationRate={'normal'}
                 ref={webviewRef}
@@ -1508,12 +1495,12 @@ export const BrowserTab = (props) => {
                 onError={onError}
                 onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
                 sendCookies
+                javascriptEnabled
                 allowsInlineMediaPlayback
                 useWebkit
                 testID={BrowserViewSelectorsIDs.ANDROID_CONTAINER}
                 applicationNameForUserAgent={'WebView MetaMaskMobile'}
                 onFileDownload={handleOnFileDownload}
-                javaScriptEnabled={isFocused}
               />
               {ipfsBannerVisible && renderIpfsBanner()}
             </>


### PR DESCRIPTION
## **Description**
This PR reverts this [PR](https://github.com/MetaMask/metamask-mobile/pull/7809)


This PR needs to be reverted because when the user is on in app browser and needs to switch network, it will disable the javascript and that will make the dapp be misaligned.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
