### PR TITLE
fix: adjust the apiLogoUrl logic to handles cases when icon is an object with uri key

### DIFF
--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -98,8 +98,9 @@ class WebsiteIcon extends PureComponent {
     // apiLogoUrl is the url of the icon to be rendered, but it's populated
     // from the icon prop, if it exists, or from the faviconSource prop
     // that is provided by the withFaviconAwareness HOC for useFavicon hook.
+
     const apiLogoUrl = {
-      uri: icon || faviconSource,
+      uri: (typeof icon === 'string' ? icon : icon?.uri) || faviconSource,
     };
 
     let title = this.props.title;

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -62,7 +62,7 @@ class WebsiteIcon extends PureComponent {
     /**
      * Icon image to use, this substitutes getting the icon from the url
      */
-    icon: PropTypes.string,
+    icon: PropTypes.string | PropTypes.object,
 
     /**
      * Favicon source to use, this substitutes getting the icon from the url

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -62,7 +62,7 @@ class WebsiteIcon extends PureComponent {
     /**
      * Icon image to use, this substitutes getting the icon from the url
      */
-    icon: PropTypes.string | PropTypes.object,
+    icon: PropTypes.oneOfType([PropTypes.string | PropTypes.object]),
 
     /**
      * Favicon source to use, this substitutes getting the icon from the url


### PR DESCRIPTION
## **Description**

Adjust the `apiLogoUrl` logic to handles cases when `icon` is an object with `uri` key

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Tested using the https://metamask.github.io/test-dapp/ with connect and personal sign operation


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-mobile/assets/61094771/c8ee8a80-e1f3-43c1-a509-943d7cedd159


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
