### PR TITLE
fix: Prevent SES errors in iOS dev builds

### DIFF
--- a/patches/react-native+0.71.14.patch
+++ b/patches/react-native+0.71.14.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..340f48d 100644
+index 1379ffd..d1a2b3f 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
 @@ -24,26 +24,51 @@
@@ -8,7 +8,7 @@ index 1379ffd..340f48d 100644
 
 +const Platform = require('../Utilities/Platform');
 +
-+if (Platform.OS === 'ios' && !global?.HermesInternal) {
++if (Platform.OS === 'ios' && !global?.HermesInternal && !__DEV__) {
 +  require('../../../../ses.cjs'); // ses@0.18.8
 +  /**
 +   * Without consoleTaming: 'unsafe' causes:


### PR DESCRIPTION
## **Description**

SES is now disabled in development builds. This was done as a workaround to various incompatibilities between SES and React development libraries, which were causing a SES error whenever a warning or error was triggered in an iOS dev build.

## **Related issues**

Fixes #7923

## **Manual testing steps**

Follow the reproduction steps for this issue: https://github.com/MetaMask/metamask-mobile/issues/7920

## **Screenshots/Recordings**

Before:

<img width="427" alt="Screenshot 2023-11-23 at 7 00 47 PM" src="https://github.com/MetaMask/metamask-mobile/assets/2459287/11143d5c-f2ce-4594-a525-e74d52e96255">


After:

<img width="427" alt="Screenshot 2023-11-23 at 6 54 32 PM" src="https://github.com/MetaMask/metamask-mobile/assets/2459287/3fd72105-28fc-4cdc-af50-61e9da3da780">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
