### PR TITLE
fix: Fetch token rates

### DIFF
--- a/patches/@metamask+assets-controllers+7.0.0.patch
+++ b/patches/@metamask+assets-controllers+7.0.0.patch
@@ -517,7 +517,7 @@ index 8bb7c20..f6f43f2 100644
       * Checks if the active network's native currency is supported by the coingecko API.
       * If supported, it fetches and maps contractExchange rates to a format to be consumed by the UI.
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
-index e3f81e9..b8e07f6 100644
+index e3f81e9..69ee17a 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
 @@ -1,4 +1,11 @@
@@ -548,16 +548,50 @@ index e3f81e9..b8e07f6 100644
              this.configure({ chainId });
          });
          this.poll();
-@@ -107,7 +114,7 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -107,7 +114,8 @@ class TokenRatesController extends base_controller_1.BaseController {
          return __awaiter(this, void 0, void 0, function* () {
              interval && this.configure({ interval }, false, false);
              this.handle && clearTimeout(this.handle);
 -            yield (0, controller_utils_1.safelyExecute)(() => this.updateExchangeRates());
++      
 +            yield (0, controller_utils_1.safelyExecute)(() => this.updateExchangeRates(true));
              this.handle = setTimeout(() => {
                  this.poll(this.config.interval);
              }, this.config.interval);
-@@ -201,8 +208,11 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -148,11 +156,27 @@ class TokenRatesController extends base_controller_1.BaseController {
+      * @returns The exchange rates for the given pairs.
+      */
+     fetchExchangeRate(chainSlug, vsCurrency) {
+-        return __awaiter(this, void 0, void 0, function* () {
+-            const tokenPairs = this.tokenList.map((token) => token.address).join(',');
+-            const query = `contract_addresses=${tokenPairs}&vs_currencies=${vsCurrency.toLowerCase()}`;
+-            return (0, controller_utils_1.handleFetch)(CoinGeckoApi.getTokenPriceURL(chainSlug, query));
+-        });
++            const tokenPairs = this.tokenList.map((token) => token.address);
++          
++            const tokenPairsChunks = (chunkSize) =>  tokenPairs.reduce((resultArray, item, index) => {
++
++                const chunkIndex = Math.floor(index/chunkSize);
++                    if(!resultArray[chunkIndex]) {
++                        resultArray[chunkIndex] = []
++                    }
++                
++                resultArray[chunkIndex].push(item);
++                
++                return resultArray
++                
++            }, []);
++                
++            const tokensPairsChunks = tokenPairsChunks(10);
++          
++            return tokensPairsChunks.map((tokenPairsChunk) => {
++                const query = `contract_addresses=${tokenPairsChunk.join(',')}&vs_currencies=${vsCurrency.toLowerCase()}`;
++                return (0, controller_utils_1.handleFetch)(CoinGeckoApi.getTokenPriceURL(chainSlug, query));
++            });
+     }
+     /**
+      * Checks if the current native currency is a supported vs currency to use
+@@ -201,8 +225,11 @@ class TokenRatesController extends base_controller_1.BaseController {
      }
      /**
       * Updates exchange rates for all tokens.
@@ -570,7 +604,7 @@ index e3f81e9..b8e07f6 100644
          return __awaiter(this, void 0, void 0, function* () {
              if (this.tokenList.length === 0 || this.disabled) {
                  return;
-@@ -217,7 +227,13 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -217,7 +244,13 @@ class TokenRatesController extends base_controller_1.BaseController {
              }
              else {
                  const { nativeCurrency } = this.config;
@@ -585,12 +619,10 @@ index e3f81e9..b8e07f6 100644
              }
              this.update({ contractExchangeRates: newContractExchangeRates });
          });
-@@ -236,46 +252,47 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -236,46 +269,45 @@ class TokenRatesController extends base_controller_1.BaseController {
       */
      fetchAndMapExchangeRates(nativeCurrency, slug) {
          return __awaiter(this, void 0, void 0, function* () {
-+            // Clear exchange rates before fetching new ones.
-+            this.update({ contractExchangeRates: {} });
 +            // Set new native currency to prevent this method from being called multiple times
 +            this.configure({ previousNativeCurrency: nativeCurrency });
              const contractExchangeRates = {};
@@ -616,12 +648,14 @@ index e3f81e9..b8e07f6 100644
 -                        tokenExchangeRates,
 -                        { conversionRate: vsCurrencyToNativeCurrencyConversionRate },
 -                    ] = yield Promise.all([
+-                        this.fetchExchangeRate(slug, controller_utils_1.FALL_BACK_VS_CURRENCY),
 +            try {
 +                // check if native currency is supported as a vs_currency by the API
 +                const nativeCurrencySupported = yield this.checkIsSupportedVsCurrency(nativeCurrency);
 +                if (nativeCurrencySupported) {
 +                    // If it is we can do a simple fetch against the CoinGecko API
-+                    const prices = yield this.fetchExchangeRate(slug, nativeCurrency);
++                    const res = yield Promise.all(this.fetchExchangeRate(slug, nativeCurrency));
++                    const prices = Object.assign({}, ...res);
 +                    this.tokenList.forEach((token) => {
 +                        const price = prices[token.address.toLowerCase()];
 +                        contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(token.address)] = price
@@ -632,8 +666,8 @@ index e3f81e9..b8e07f6 100644
 +                else {
 +                    // if native currency is not supported we need to use a fallback vsCurrency, get the exchange rates
 +                    // in token/fallback-currency format and convert them to expected token/nativeCurrency format.
-+                    const [tokenExchangeRates, { conversionRate: vsCurrencyToNativeCurrencyConversionRate = 0 },] = yield Promise.all([
-                         this.fetchExchangeRate(slug, controller_utils_1.FALL_BACK_VS_CURRENCY),
++                    const [res, { conversionRate: vsCurrencyToNativeCurrencyConversionRate = 0 },] = yield Promise.all([
++                       Promise.all(this.fetchExchangeRate(slug, controller_utils_1.FALL_BACK_VS_CURRENCY)),
                          (0, crypto_compare_1.fetchExchangeRate)(nativeCurrency, controller_utils_1.FALL_BACK_VS_CURRENCY, false),
                      ]);
 -                }
@@ -641,6 +675,7 @@ index e3f81e9..b8e07f6 100644
 -                    if (error instanceof Error &&
 -                        error.message.includes('market does not exist for this coin pair')) {
 -                        return {};
++                    const tokenExchangeRates = Object.assign({}, ...res);
 +                    for (const [tokenAddress, conversion] of Object.entries(tokenExchangeRates)) {
 +                        const tokenToVsCurrencyConversionRate = conversion[controller_utils_1.FALL_BACK_VS_CURRENCY.toLowerCase()];
 +                        contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(tokenAddress)] =
@@ -656,8 +691,6 @@ index e3f81e9..b8e07f6 100644
 -                            vsCurrencyToNativeCurrencyConversionRate;
 +            }
 +            catch (error) {
-+                // If there is an error catched we clean the state
-+                this.update({ contractExchangeRates: {} });
 +                if (error instanceof Error &&
 +                    error.message.includes('market does not exist for this coin pair')) {
 +                    return {};

--- a/patches/@metamask+assets-controllers+7.0.0.patch
+++ b/patches/@metamask+assets-controllers+7.0.0.patch
@@ -491,11 +491,48 @@ index 4ed4990..df0524b 100644
                              });
                          }
                      }
+diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.d.ts b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.d.ts
+index 8bb7c20..f6f43f2 100644
+--- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.d.ts
++++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.d.ts
+@@ -57,6 +57,7 @@ export interface TokenRatesConfig extends BaseConfig {
+     chainId: string;
+     tokens: Token[];
+     threshold: number;
++    previousNativeCurrency: string;
+ }
+ interface ContractExchangeRates {
+     [address: string]: number | undefined;
+@@ -148,8 +149,11 @@ export declare class TokenRatesController extends BaseController<TokenRatesConfi
+     getChainSlug(): Promise<string | null>;
+     /**
+      * Updates exchange rates for all tokens.
++     *
++     * @param forceFetch - Force a currency rate update, even when the
++     * native currency has not recently changed.
+      */
+-    updateExchangeRates(): Promise<void>;
++    updateExchangeRates(forceFetch?: boolean): Promise<void>;
+     /**
+      * Checks if the active network's native currency is supported by the coingecko API.
+      * If supported, it fetches and maps contractExchange rates to a format to be consumed by the UI.
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
-index e3f81e9..c7b0a33 100644
+index e3f81e9..b8e07f6 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.js
-@@ -77,6 +77,7 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -1,4 +1,11 @@
+ "use strict";
++// PATCH NOTES:
++// This patch is based upon the core branch `assets-controllers-v7-token-rate-controller-patch`
++// It includes the following changes:
++// - Prevent unnecessary fetch calls
++//  - Fetch calls are currently limited to one per polling cycle, or upon a change in native currency.
++// - Clear conversion rates immediately when an update starts, before waiting for the result
++// - Clear conversion rates upon update failure
+ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+     return new (P || (P = Promise))(function (resolve, reject) {
+@@ -77,6 +84,7 @@ class TokenRatesController extends base_controller_1.BaseController {
              chainId: '',
              tokens: [],
              threshold: 6 * 60 * 60 * 1000,
@@ -503,7 +540,7 @@ index e3f81e9..c7b0a33 100644
          };
          this.defaultState = {
              contractExchangeRates: {},
-@@ -93,7 +94,6 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -93,7 +101,6 @@ class TokenRatesController extends base_controller_1.BaseController {
          });
          onNetworkStateChange(({ providerConfig }) => {
              const { chainId } = providerConfig;
@@ -511,7 +548,7 @@ index e3f81e9..c7b0a33 100644
              this.configure({ chainId });
          });
          this.poll();
-@@ -107,7 +107,7 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -107,7 +114,7 @@ class TokenRatesController extends base_controller_1.BaseController {
          return __awaiter(this, void 0, void 0, function* () {
              interval && this.configure({ interval }, false, false);
              this.handle && clearTimeout(this.handle);
@@ -520,37 +557,35 @@ index e3f81e9..c7b0a33 100644
              this.handle = setTimeout(() => {
                  this.poll(this.config.interval);
              }, this.config.interval);
-@@ -202,7 +202,7 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -201,8 +208,11 @@ class TokenRatesController extends base_controller_1.BaseController {
+     }
      /**
       * Updates exchange rates for all tokens.
++     *
++     * @param forceFetch - Force a currency rate update, even when the
++     * native currency has not recently changed.
       */
 -    updateExchangeRates() {
 +    updateExchangeRates(forceFetch = false) {
          return __awaiter(this, void 0, void 0, function* () {
              if (this.tokenList.length === 0 || this.disabled) {
                  return;
-@@ -214,10 +214,17 @@ class TokenRatesController extends base_controller_1.BaseController {
-                     const address = (0, controller_utils_1.toChecksumHexAddress)(token.address);
-                     newContractExchangeRates[address] = undefined;
-                 });
--            }
--            else {
-+            } else {
+@@ -217,7 +227,13 @@ class TokenRatesController extends base_controller_1.BaseController {
+             }
+             else {
                  const { nativeCurrency } = this.config;
 -                newContractExchangeRates = yield this.fetchAndMapExchangeRates(nativeCurrency, slug);
 +                // Only fetch if native curency is different or when forced (used in polling)
 +                if (this.config.previousNativeCurrency !== nativeCurrency || forceFetch) {
-+                    newContractExchangeRates = yield this.fetchAndMapExchangeRates(
-+                        nativeCurrency,
-+                        slug
-+                    );
-+                } else {
++                    newContractExchangeRates = yield this.fetchAndMapExchangeRates(nativeCurrency, slug);
++                }
++                else {
 +                    newContractExchangeRates = this.state.contractExchangeRates;
 +                }
              }
              this.update({ contractExchangeRates: newContractExchangeRates });
          });
-@@ -236,7 +243,12 @@ class TokenRatesController extends base_controller_1.BaseController {
+@@ -236,46 +252,47 @@ class TokenRatesController extends base_controller_1.BaseController {
       */
      fetchAndMapExchangeRates(nativeCurrency, slug) {
          return __awaiter(this, void 0, void 0, function* () {
@@ -559,20 +594,45 @@ index e3f81e9..c7b0a33 100644
 +            // Set new native currency to prevent this method from being called multiple times
 +            this.configure({ previousNativeCurrency: nativeCurrency });
              const contractExchangeRates = {};
-+            try{
-             // check if native currency is supported as a vs_currency by the API
-             const nativeCurrencySupported = yield this.checkIsSupportedVsCurrency(nativeCurrency);
-             if (nativeCurrencySupported) {
-@@ -254,7 +266,7 @@ class TokenRatesController extends base_controller_1.BaseController {
-                 // in token/fallback-currency format and convert them to expected token/nativeCurrency format.
-                 let tokenExchangeRates;
-                 let vsCurrencyToNativeCurrencyConversionRate = 0;
+-            // check if native currency is supported as a vs_currency by the API
+-            const nativeCurrencySupported = yield this.checkIsSupportedVsCurrency(nativeCurrency);
+-            if (nativeCurrencySupported) {
+-                // If it is we can do a simple fetch against the CoinGecko API
+-                const prices = yield this.fetchExchangeRate(slug, nativeCurrency);
+-                this.tokenList.forEach((token) => {
+-                    const price = prices[token.address.toLowerCase()];
+-                    contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(token.address)] = price
+-                        ? price[nativeCurrency.toLowerCase()]
+-                        : 0;
+-                });
+-            }
+-            else {
+-                // if native currency is not supported we need to use a fallback vsCurrency, get the exchange rates
+-                // in token/fallback-currency format and convert them to expected token/nativeCurrency format.
+-                let tokenExchangeRates;
+-                let vsCurrencyToNativeCurrencyConversionRate = 0;
 -                try {
-+
-                     [
-                         tokenExchangeRates,
-                         { conversionRate: vsCurrencyToNativeCurrencyConversionRate },
-@@ -262,21 +274,24 @@ class TokenRatesController extends base_controller_1.BaseController {
+-                    [
+-                        tokenExchangeRates,
+-                        { conversionRate: vsCurrencyToNativeCurrencyConversionRate },
+-                    ] = yield Promise.all([
++            try {
++                // check if native currency is supported as a vs_currency by the API
++                const nativeCurrencySupported = yield this.checkIsSupportedVsCurrency(nativeCurrency);
++                if (nativeCurrencySupported) {
++                    // If it is we can do a simple fetch against the CoinGecko API
++                    const prices = yield this.fetchExchangeRate(slug, nativeCurrency);
++                    this.tokenList.forEach((token) => {
++                        const price = prices[token.address.toLowerCase()];
++                        contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(token.address)] = price
++                            ? price[nativeCurrency.toLowerCase()]
++                            : 0;
++                    });
++                }
++                else {
++                    // if native currency is not supported we need to use a fallback vsCurrency, get the exchange rates
++                    // in token/fallback-currency format and convert them to expected token/nativeCurrency format.
++                    const [tokenExchangeRates, { conversionRate: vsCurrencyToNativeCurrencyConversionRate = 0 },] = yield Promise.all([
                          this.fetchExchangeRate(slug, controller_utils_1.FALL_BACK_VS_CURRENCY),
                          (0, crypto_compare_1.fetchExchangeRate)(nativeCurrency, controller_utils_1.FALL_BACK_VS_CURRENCY, false),
                      ]);
@@ -581,7 +641,6 @@ index e3f81e9..c7b0a33 100644
 -                    if (error instanceof Error &&
 -                        error.message.includes('market does not exist for this coin pair')) {
 -                        return {};
-+
 +                    for (const [tokenAddress, conversion] of Object.entries(tokenExchangeRates)) {
 +                        const tokenToVsCurrencyConversionRate = conversion[controller_utils_1.FALL_BACK_VS_CURRENCY.toLowerCase()];
 +                        contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(tokenAddress)] =
@@ -595,7 +654,8 @@ index e3f81e9..c7b0a33 100644
 -                    contractExchangeRates[(0, controller_utils_1.toChecksumHexAddress)(tokenAddress)] =
 -                        tokenToVsCurrencyConversionRate *
 -                            vsCurrencyToNativeCurrencyConversionRate;
-+            } catch (error) {
++            }
++            catch (error) {
 +                // If there is an error catched we clean the state
 +                this.update({ contractExchangeRates: {} });
 +                if (error instanceof Error &&
@@ -604,10 +664,8 @@ index e3f81e9..c7b0a33 100644
                  }
 +                throw error;
              }
-+
              return contractExchangeRates;
          });
-     }
 diff --git a/node_modules/@metamask/assets-controllers/dist/TokensController.js b/node_modules/@metamask/assets-controllers/dist/TokensController.js
 index 0e03b88..bd7ddbd 100644
 --- a/node_modules/@metamask/assets-controllers/dist/TokensController.js


### PR DESCRIPTION
## **Description**
Divided the request to coingecko into chunks of 10 tokens since they disabled more than 10 tokens per request on their public api

It's fixed but still there is a lot of flakiness due to the fact that we are exceeding the rate limit (429) a lot of times that we do the request.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**
https://recordit.co/7Qw5lCodfL
![image](https://github.com/MetaMask/metamask-mobile/assets/46944231/174d41d2-992d-4064-97bf-cc680d94f7b0)
![image](https://github.com/MetaMask/metamask-mobile/assets/46944231/0ae9058e-2c3c-4d32-87a0-336bd6de3017)


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
