### PR TITLE
test: Increase E2E test setup time

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -56,7 +56,7 @@ module.exports = {
     'ios.simulator': {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14 Pro',
+        type: 'iPhone 13 Pro',
       },
     },
     'android.bitrise.emulator': {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -6,7 +6,7 @@ module.exports = {
       config: 'e2e/jest.e2e.config.js',
     },
     jest: {
-      setupTimeout: 120000,
+      setupTimeout: 220000,
     },
     retries: 2,
   },
@@ -56,7 +56,7 @@ module.exports = {
     'ios.simulator': {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 13 Pro',
+        type: 'iPhone 14 Pro',
       },
     },
     'android.bitrise.emulator': {


### PR DESCRIPTION
## **Description**

The android E2E tests have encountered failures because the installation of the application on the emulator now takes longer than the current test timeout allows. In order to restore the ability to pass the E2E tests, the purpose of this pull request (PR) is to increase the test setup time, allowing sufficient time for the installation process.  


### **Before**

Failing Bitrise builds: 
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/fa0431b0-3114-4a0f-a511-23d065d4d244
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/10be074e-af5f-4750-8d72-7e61c6102b9d
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/fa0431b0-3114-4a0f-a511-23d065d4d244


### **After**


Passing bitrise smoke Build: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/354f2ad1-121b-4f48-9d7d-479bcb00160d
Passing bitrise regression test build: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/354f2ad1-121b-4f48-9d7d-479bcb00160d

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
