### PR TITLE
fix: correct proptypes array in WebsiteIcon component

### DIFF
--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -62,7 +62,7 @@ class WebsiteIcon extends PureComponent {
     /**
      * Icon image to use, this substitutes getting the icon from the url
      */
-    icon: PropTypes.oneOfType([PropTypes.string | PropTypes.object]),
+    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
     /**
      * Favicon source to use, this substitutes getting the icon from the url


### PR DESCRIPTION
## **Description**

This PR fixes an incorrect value being passed to a `PropTypes.oneOfType` function in `WebsiteIcon` component:  https://github.com/MetaMask/metamask-mobile/pull/7917#pullrequestreview-1755887662

## **Related issues**

Fixes: #

## **Manual testing steps**

n/a

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
