### PR TITLE
fix: Updated ButtonLink to use text when size is auto

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
@@ -88,25 +88,19 @@ exports[`CustomSpendCap should match snapshot 1`] = `
         />
       </View>
     </View>
-    <TouchableOpacity
-      activeOpacity={1}
+    <Text
+      accessibilityRole="text"
       onPress={[Function]}
       onPressIn={[Function]}
       onPressOut={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
-          "borderRadius": 0,
-          "flexDirection": "row",
-          "height": "auto",
-          "justifyContent": "center",
-          "paddingHorizontal": 0,
+          "color": "#24272A",
         }
       }
+      suppressHighlighting={true}
       textVariant="sBodyMD"
-      variant="Link"
     >
       <Text
         accessibilityRole="text"
@@ -123,7 +117,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
       >
         Use site suggestion
       </Text>
-    </TouchableOpacity>
+    </Text>
   </View>
   <View
     style={
@@ -225,24 +219,18 @@ exports[`CustomSpendCap should match snapshot 1`] = `
     >
       This allows the third party to spend all your token balance until it reaches the cap or you revoke the spending cap. If this is not intended, consider setting a lower spending cap.
        
-      <TouchableOpacity
-        activeOpacity={1}
+      <Text
+        accessibilityRole="text"
         onPress={[Function]}
         onPressIn={[Function]}
         onPressOut={[Function]}
         style={
           Object {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
             "backgroundColor": "transparent",
-            "borderRadius": 0,
-            "flexDirection": "row",
-            "height": "auto",
-            "justifyContent": "center",
-            "paddingHorizontal": 0,
+            "color": "#24272A",
           }
         }
-        variant="Link"
+        suppressHighlighting={true}
       >
         <Text
           accessibilityRole="text"
@@ -259,7 +247,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
         >
           Learn more
         </Text>
-      </TouchableOpacity>
+      </Text>
     </Text>
   </View>
 </View>

--- a/app/component-library/components/Banners/Banner/variants/BannerAlert/__snapshots__/BannerAlert.test.tsx.snap
+++ b/app/component-library/components/Banners/Banner/variants/BannerAlert/__snapshots__/BannerAlert.test.tsx.snap
@@ -72,24 +72,18 @@ exports[`BannerAlert should render BannerAlert 1`] = `
     >
       Sample Banner Alert Description
     </Text>
-    <TouchableOpacity
-      activeOpacity={1}
+    <Text
+      accessibilityRole="text"
       onPress={[Function]}
       onPressIn={[Function]}
       onPressOut={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
-          "borderRadius": 0,
-          "flexDirection": "row",
-          "height": "auto",
-          "justifyContent": "center",
-          "paddingHorizontal": 0,
+          "color": "#24272A",
         }
       }
-      variant="Link"
+      suppressHighlighting={true}
     >
       <Text
         accessibilityRole="text"
@@ -106,7 +100,7 @@ exports[`BannerAlert should render BannerAlert 1`] = `
       >
         Sample Action Button Label
       </Text>
-    </TouchableOpacity>
+    </Text>
   </View>
   <View
     style={

--- a/app/component-library/components/Banners/Banner/variants/BannerTip/__snapshots__/BannerTip.test.tsx.snap
+++ b/app/component-library/components/Banners/Banner/variants/BannerTip/__snapshots__/BannerTip.test.tsx.snap
@@ -82,24 +82,18 @@ exports[`BannerTip should render default settings correctly 1`] = `
     >
       Sample Banner Tip Description
     </Text>
-    <TouchableOpacity
-      activeOpacity={1}
+    <Text
+      accessibilityRole="text"
       onPress={[Function]}
       onPressIn={[Function]}
       onPressOut={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
-          "borderRadius": 0,
-          "flexDirection": "row",
-          "height": "auto",
-          "justifyContent": "center",
-          "paddingHorizontal": 0,
+          "color": "#24272A",
         }
       }
-      variant="Link"
+      suppressHighlighting={true}
     >
       <Text
         accessibilityRole="text"
@@ -116,7 +110,7 @@ exports[`BannerTip should render default settings correctly 1`] = `
       >
         Sample Action Button Label
       </Text>
-    </TouchableOpacity>
+    </Text>
   </View>
   <View
     style={

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
@@ -7,6 +7,7 @@ import { GestureResponderEvent } from 'react-native';
 import Text from '../../../../Texts/Text';
 import { useStyles } from '../../../../../hooks';
 import Button from '../../foundation/ButtonBase';
+import { ButtonSize } from '../../Button.types';
 
 // Internal dependencies.
 import { ButtonLinkProps } from './ButtonLink.types';
@@ -71,15 +72,30 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
     );
 
   return (
-    <Button
-      style={styles.base}
-      label={renderLabel()}
-      labelColor={getLabelColor()}
-      onPressIn={triggerOnPressedIn}
-      onPressOut={triggerOnPressedOut}
-      size={size}
-      {...props}
-    />
+    <>
+      {size === ButtonSize.Auto ? (
+        <Text
+          style={styles.base}
+          suppressHighlighting
+          onPressIn={triggerOnPressedIn}
+          onPressOut={triggerOnPressedOut}
+          accessibilityRole="link"
+          {...props}
+        >
+          {renderLabel()}
+        </Text>
+      ) : (
+        <Button
+          style={styles.base}
+          label={renderLabel()}
+          labelColor={getLabelColor()}
+          onPressIn={triggerOnPressedIn}
+          onPressOut={triggerOnPressedOut}
+          size={size}
+          {...props}
+        />
+      )}
+    </>
   );
 };
 

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/__snapshots__/ButtonLink.test.tsx.snap
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/__snapshots__/ButtonLink.test.tsx.snap
@@ -1,8 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Link should render correctly 1`] = `
-<ButtonBase
-  label={
+<Fragment>
+  <Text
+    accessibilityRole="link"
+    onPress={[Function]}
+    onPressIn={[Function]}
+    onPressOut={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+      }
+    }
+    suppressHighlighting={true}
+  >
     <Text
       color="Primary"
       style={false}
@@ -10,16 +21,6 @@ exports[`Link should render correctly 1`] = `
     >
       I'm a Link!
     </Text>
-  }
-  labelColor="Primary"
-  onPress={[Function]}
-  onPressIn={[Function]}
-  onPressOut={[Function]}
-  size="auto"
-  style={
-    Object {
-      "backgroundColor": "transparent",
-    }
-  }
-/>
+  </Text>
+</Fragment>
 `;


### PR DESCRIPTION
## **Description**
- Updated ButtonLink to use text when size is auto. This also fixes the ButtonLink misalignment in TagUrl

## **Related issues**

Fixes:  https://github.com/MetaMask/mobile-planning/issues/1374
https://github.com/MetaMask/mobile-planning/issues/1258

## **Screenshots/Recordings**
https://github.com/MetaMask/metamask-mobile/assets/14355083/31bab240-c50b-40f6-94d3-f82077a370bf

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
