### PR TITLE
fix: Rename old code fences

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -63,9 +63,9 @@ import OrderDetails from '../../UI/Ramp/common/Views/OrderDetails';
 import SendTransaction from '../../UI/Ramp/common/Views/SendTransaction';
 import TabBar from '../../../component-library/components/Navigation/TabBar';
 import BrowserUrlModal from '../../Views/BrowserUrlModal';
-///: BEGIN:ONLY_INCLUDE_IN(flask)
+///: BEGIN:ONLY_INCLUDE_IF(flask)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
-///: END:ONLY_INCLUDE_IN
+///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
 import AnalyticsV2 from '../../../util/analyticsV2';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -207,7 +207,7 @@ const BrowserFlow = () => (
 
 export const DrawerContext = React.createContext({ drawerRef: null });
 
-///: BEGIN:ONLY_INCLUDE_IN(flask)
+///: BEGIN:ONLY_INCLUDE_IF(flask)
 const SnapsSettingsStack = () => (
   <Stack.Navigator>
     <Stack.Screen
@@ -217,7 +217,7 @@ const SnapsSettingsStack = () => (
     />
   </Stack.Navigator>
 );
-///: END:ONLY_INCLUDE_IN
+///: END:ONLY_INCLUDE_IF
 
 const SettingsFlow = () => (
   <Stack.Navigator initialRouteName={'Settings'}>
@@ -312,7 +312,7 @@ const SettingsFlow = () => (
       options={EnterPasswordSimple.navigationOptions}
     />
     {
-      ///: BEGIN:ONLY_INCLUDE_IN(flask)
+      ///: BEGIN:ONLY_INCLUDE_IF(flask)
     }
     <Stack.Screen
       name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
@@ -320,7 +320,7 @@ const SettingsFlow = () => (
       options={{ headerShown: false }}
     />
     {
-      ///: END:ONLY_INCLUDE_IN
+      ///: END:ONLY_INCLUDE_IF
     }
   </Stack.Navigator>
 );

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -29,9 +29,9 @@ import {
   REQUEST_SETTINGS,
   SECURITY_SETTINGS,
 } from '../../../../wdio/screen-objects/testIDs/Screens/Settings.testIds';
-///: BEGIN:ONLY_INCLUDE_IN(flask)
+///: BEGIN:ONLY_INCLUDE_IF(flask)
 import { createSnapsSettingsListNavDetails } from '../Snaps/SnapsSettingsList/SnapsSettingsList';
-///: END:ONLY_INCLUDE_IN
+///: END:ONLY_INCLUDE_IF
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -117,11 +117,11 @@ const Settings = () => {
     });
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(flask)
   const onPressSnaps = () => {
     navigation.navigate(...createSnapsSettingsListNavDetails());
   };
-  ///: END:ONLY_INCLUDE_IN
+  ///: END:ONLY_INCLUDE_IF
 
   const submitFeedback = () => {
     trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_SEND_FEEDBACK);
@@ -216,7 +216,7 @@ const Settings = () => {
         testID={NETWORKS_SETTINGS}
       />
       {
-        ///: BEGIN:ONLY_INCLUDE_IN(flask)
+        ///: BEGIN:ONLY_INCLUDE_IF(flask)
       }
       <SettingsDrawer
         title={strings('app_settings.snaps.title')}
@@ -224,7 +224,7 @@ const Settings = () => {
         onPress={onPressSnaps}
       />
       {
-        ///: END:ONLY_INCLUDE_IN
+        ///: END:ONLY_INCLUDE_IF
       }
       <SettingsDrawer
         title={strings('app_settings.fiat_on_ramp.title')}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -107,11 +107,11 @@ const Routes = {
   ADD_NETWORK: 'AddNetwork',
   SWAPS: 'Swaps',
   LOCK_SCREEN: 'LockScreen',
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(flask)
   SNAPS: {
     SNAPS_SETTINGS_LIST: 'SnapsSettingsList',
   },
-  ///: END:ONLY_INCLUDE_IN
+  ///: END:ONLY_INCLUDE_IF
 };
 
 export default Routes;


### PR DESCRIPTION
## **Description**

Code fences were recently broken due to the merging of #7972. This PR fixes them.

## **Related issues**

- #7972 

## **Manual testing steps**

1. Observe that CI passes for this PR but not on `main`
2. Confirm that all code fences are named `ONLY_INCLUDE_IF` and not `ONLY_INCLUDE_IN`
