### PR TITLE
test: migrate MessageSign tests to react testing library

### DIFF
--- a/app/components/UI/MessageSign/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/MessageSign/__snapshots__/index.test.tsx.snap
@@ -1,29 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MessageSign should render correctly 1`] = `
-<MessageSign
+exports[`MessageSign ExpandedMessage should render ExpandedMessage correctly 1`] = `
+<div
   currentPageInformation={
     Object {
       "title": "title",
       "url": "http://localhost:8545",
     }
   }
-  messageParams={
+  renderMessage={[Function]}
+  testID="ExpandedMessage"
+  toggleExpandedMessage={[MockFunction]}
+>
+  <span>
+    ExpandedMessage Component
+  </span>
+</div>
+`;
+
+exports[`MessageSign ExpandedMessage should render Message text correctly 1`] = `
+<Text
+  style={
     Object {
-      "data": "message",
-      "from": "0x0",
-      "metamaskId": "TestMessageId",
-      "origin": "example.com",
+      "color": "#24272A",
+      "fontFamily": "EuclidCircularB-Regular",
+      "fontSize": 14,
+      "fontWeight": "400",
+      "textAlign": "center",
     }
   }
+>
+  message
+</Text>
+`;
+
+exports[`MessageSign SignatureRequest should render correctly 1`] = `
+<div
+  currentPageInformation={
+    Object {
+      "title": "title",
+      "url": "http://localhost:8545",
+    }
+  }
+  fromAddress="0xE413f7dB07f9B93936189867588B1440D823e651"
   navigation={
     Object {
       "navigate": [MockFunction],
     }
   }
-  onConfirm={[MockFunction]}
-  onReject={[MockFunction]}
+  onConfirm={[Function]}
+  onReject={[Function]}
   showExpandedMessage={false}
+  showWarning={true}
+  testID="SignatureRequest"
   toggleExpandedMessage={[MockFunction]}
-/>
+  truncateMessage={false}
+  type="eth_sign"
+>
+  <span>
+    SignatureRequest Component
+  </span>
+  <View
+    style={
+      Object {
+        "marginBottom": 4,
+      }
+    }
+  >
+    <Text
+      onTextLayout={[Function]}
+      style={
+        Object {
+          "color": "#24272A",
+        }
+      }
+    >
+      message
+    </Text>
+  </View>
+</div>
 `;

--- a/app/components/UI/MessageSign/index.test.tsx
+++ b/app/components/UI/MessageSign/index.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import MessageSign from './index';
-import configureMockStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
-import SignatureRequest from '../SignatureRequest';
 import Engine from '../../../core/Engine';
 import NotificationManager from '../../../core/NotificationManager';
 import { InteractionManager } from 'react-native';
@@ -12,6 +8,15 @@ import AppConstants from '../../../core/AppConstants';
 import { strings } from '../../../../locales/i18n';
 import initialBackgroundState from '../../../util/test/initial-background-state.json';
 import analyticsV2 from '../../../util/analyticsV2';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import { act, waitFor } from '@testing-library/react-native';
+import { KEYSTONE_TX_CANCELED } from '../../../constants/error';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+// eslint-disable-next-line import/no-namespace
+import * as addressUtils from '../../../util/address';
+import createExternalSignModelNav from '../../../util/hardwareWallet/signatureUtils';
+
+const fakeAddress = '0xE413f7dB07f9B93936189867588B1440D823e651';
 
 jest.mock('../../../core/Engine', () => ({
   acceptPendingApproval: jest.fn(),
@@ -20,212 +25,365 @@ jest.mock('../../../core/Engine', () => ({
     SignatureController: {
       hub: {
         on: jest.fn(),
+        removeListener: jest.fn(),
       },
     },
     KeyringController: {
       state: {
-        keyrings: [],
+        keyrings: [{ accounts: [fakeAddress] }],
       },
     },
   },
 }));
+
+const EngineMock = Engine as jest.Mocked<typeof Engine>;
 
 jest.mock('../../../core/NotificationManager', () => ({
   showSimpleNotification: jest.fn(),
 }));
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (callback: any) =>
-    callback({
-      signatureRequest: {
-        securityAlertResponse: {
-          description: '',
-          features: [],
-          providerRequestsCount: { eth_chainId: 1 },
-          reason: '',
-          result_type: 'Benign',
-        },
-      },
-    }),
-}));
-
 jest.mock('../../../util/analyticsV2');
 
 jest.mock('../../../util/address', () => ({
-  getAddressAccountType: jest.fn().mockReturnValue('Metamask'),
+  ...jest.requireActual('../../../util/address'),
   isExternalHardwareAccount: jest.fn(),
 }));
 
-jest.mock('@react-navigation/native');
+const addressUtilsMock = addressUtils as jest.Mocked<typeof addressUtils>;
+
+jest.mock('../../../util/hardwareWallet/signatureUtils', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation((...args) => [args]),
+}));
+
+const createExternalSignModelNavMock =
+  createExternalSignModelNav as jest.MockedFunction<
+    typeof createExternalSignModelNav
+  >;
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../SignatureRequest', () => (props: any) => (
+  <div {...{ ...props, testID: 'SignatureRequest' }}>
+    <span>SignatureRequest Component</span>
+    {props.children}
+  </div>
+));
+
+jest.mock('../SignatureRequest/ExpandedMessage', () => (props: any) => (
+  <div {...{ ...props, testID: 'ExpandedMessage' }}>
+    <span>ExpandedMessage Component</span>
+    {props.children}
+  </div>
+));
 
 const messageParamsMock = {
   data: 'message',
   origin: 'example.com',
   metamaskId: 'TestMessageId',
-  from: '0x0',
+  from: '0xE413f7dB07f9B93936189867588B1440D823e651',
 };
-
-const navigation = {
-  navigate: jest.fn(),
-};
-
-const mockStore = configureMockStore();
 
 const initialState = {
   engine: {
     backgroundState: initialBackgroundState,
   },
+  signatureRequest: {
+    securityAlertResponse: {
+      description: '',
+      features: [],
+      providerRequestsCount: { eth_chainId: 1 },
+      reason: '',
+      result_type: 'Benign',
+    },
+  },
 };
 
-const store = mockStore(initialState);
-
-function createWrapper({
+function createContainer({
   origin = messageParamsMock.origin,
   mockConfirm = jest.fn(),
   mockReject = jest.fn(),
+  showExpandedMessage = false,
 } = {}) {
-  return shallow(
-    <Provider store={store}>
-      <MessageSign
-        currentPageInformation={{
-          title: 'title',
-          url: 'http://localhost:8545',
-        }}
-        messageParams={{ ...messageParamsMock, origin }}
-        onConfirm={mockConfirm}
-        onReject={mockReject}
-        toggleExpandedMessage={jest.fn()}
-        showExpandedMessage={false}
-        navigation={navigation}
-      />
-    </Provider>,
-  ).find(MessageSign);
+  return renderWithProvider(
+    <MessageSign
+      currentPageInformation={{
+        title: 'title',
+        url: 'http://localhost:8545',
+      }}
+      messageParams={{ ...messageParamsMock, origin }}
+      onConfirm={mockConfirm}
+      onReject={mockReject}
+      toggleExpandedMessage={jest.fn()}
+      showExpandedMessage={showExpandedMessage}
+    />,
+    { state: initialState },
+  );
 }
 
 describe('MessageSign', () => {
-  it('should render correctly', () => {
-    const wrapper = createWrapper();
-    expect(wrapper).toMatchSnapshot();
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe('onConfirm', () => {
-    it('signs message', async () => {
-      const onConfirmMock = jest.fn();
-      const wrapper = createWrapper({ mockConfirm: onConfirmMock }).dive();
-      await (wrapper.find(SignatureRequest).props() as any).onConfirm();
+  describe('SignatureRequest', () => {
+    it('should render correctly', () => {
+      const container = createContainer();
 
-      expect(onConfirmMock).toHaveBeenCalledTimes(1);
-    });
-
-    it.each([
-      ['wallet connect', WALLET_CONNECT_ORIGIN],
-      ['SDK remote', AppConstants.MM_SDK.SDK_REMOTE_ORIGIN],
-    ])('shows notification if origin is %s', async (_title, origin) => {
-      jest
-        .spyOn(InteractionManager, 'runAfterInteractions')
-        .mockImplementation((callback: any) => callback());
-
-      (NotificationManager.showSimpleNotification as any).mockReset();
-
-      const wrapper = createWrapper({ origin }).dive();
-      await (wrapper.find(SignatureRequest).props() as any).onConfirm();
-
-      expect(NotificationManager.showSimpleNotification).toHaveBeenCalledTimes(
+      expect(Engine.context.SignatureController.hub.on).toHaveBeenCalledTimes(
         1,
       );
-      expect(NotificationManager.showSimpleNotification).toHaveBeenCalledWith({
-        status: `simple_notification`,
-        duration: 5000,
-        title: strings('notifications.wc_signed_title'),
-        description: strings('notifications.wc_description'),
+      expect(Engine.context.SignatureController.hub.on).toHaveBeenCalledWith(
+        'TestMessageId:signError',
+        expect.any(Function),
+      );
+      expect(analyticsV2.trackEvent).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.SignatureController.hub.removeListener,
+      ).toHaveBeenCalledTimes(0);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    describe('onConfirm', () => {
+      it('signs message', async () => {
+        const onConfirmMock = jest.fn();
+        const container = createContainer({ mockConfirm: onConfirmMock });
+        await container.getByTestId('SignatureRequest').props.onConfirm();
+        expect(onConfirmMock).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        ['wallet connect', WALLET_CONNECT_ORIGIN],
+        ['SDK remote', AppConstants.MM_SDK.SDK_REMOTE_ORIGIN],
+      ])('shows notification if origin is %s', async (_title, origin) => {
+        jest
+          .spyOn(InteractionManager, 'runAfterInteractions')
+          .mockImplementation((callback: any) => callback());
+
+        (NotificationManager.showSimpleNotification as any).mockReset();
+
+        const container = createContainer({ origin });
+        await container.getByTestId('SignatureRequest').props.onConfirm();
+
+        await waitFor(() => {
+          expect(
+            NotificationManager.showSimpleNotification,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            NotificationManager.showSimpleNotification,
+          ).toHaveBeenCalledWith({
+            status: `simple_notification`,
+            duration: 5000,
+            title: strings('notifications.wc_signed_title'),
+            description: strings('notifications.wc_description'),
+          });
+        });
+      });
+
+      it('harware wallet navigates to external signature modal', async () => {
+        addressUtilsMock.isExternalHardwareAccount.mockReturnValueOnce(true);
+        const container = createContainer();
+        await container.getByTestId('SignatureRequest').props.onConfirm();
+
+        expect(createExternalSignModelNavMock).toHaveBeenCalledTimes(1);
+        expect(createExternalSignModelNavMock).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Function),
+          messageParamsMock,
+          'eth_sign',
+        );
+      });
+    });
+
+    describe('onReject', () => {
+      it('rejects message', async () => {
+        const onRejectMock = jest.fn();
+        const container = createContainer({ mockReject: onRejectMock });
+        await container.getByTestId('SignatureRequest').props.onReject();
+
+        expect(onRejectMock).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        ['wallet connect', WALLET_CONNECT_ORIGIN],
+        ['SDK remote', AppConstants.MM_SDK.SDK_REMOTE_ORIGIN],
+      ])('shows notification if origin is %s', async (_title, origin) => {
+        jest
+          .spyOn(InteractionManager, 'runAfterInteractions')
+          .mockImplementation((callback: any) => callback());
+
+        (NotificationManager.showSimpleNotification as any).mockReset();
+        (Engine.context.SignatureController.hub.on as any).mockReset();
+
+        const container = createContainer({ origin });
+        await container.getByTestId('SignatureRequest').props.onReject();
+
+        await waitFor(() => {
+          expect(
+            NotificationManager.showSimpleNotification,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            NotificationManager.showSimpleNotification,
+          ).toHaveBeenCalledWith({
+            status: `simple_notification_rejected`,
+            duration: 5000,
+            title: strings('notifications.wc_signed_rejected_title'),
+            description: strings('notifications.wc_description'),
+          });
+        });
+      });
+    });
+
+    describe('trackEvent', () => {
+      it('tracks event for rejected requests', async () => {
+        const container = createContainer();
+        await container.getByTestId('SignatureRequest').props.onReject();
+
+        expect((analyticsV2.trackEvent as jest.Mock).mock.calls[1][0]).toEqual({
+          category: 'Signature Rejected',
+        });
+        expect((analyticsV2.trackEvent as jest.Mock).mock.calls[1][1]).toEqual({
+          account_type: 'MetaMask',
+          dapp_host_name: undefined,
+          chain_id: undefined,
+          signature_type: 'eth_sign',
+          security_alert_response: 'Benign',
+          security_alert_reason: '',
+          ppom_eth_chainId_count: 1,
+          version: undefined,
+        });
+      });
+
+      it('tracks event for approved requests', async () => {
+        const container = createContainer();
+        await container.getByTestId('SignatureRequest').props.onConfirm();
+
+        expect((analyticsV2.trackEvent as jest.Mock).mock.calls[1][0]).toEqual({
+          category: 'Signature Approved',
+        });
+        expect((analyticsV2.trackEvent as jest.Mock).mock.calls[1][1]).toEqual({
+          account_type: 'MetaMask',
+          dapp_host_name: undefined,
+          chain_id: undefined,
+          signature_type: 'eth_sign',
+          security_alert_response: 'Benign',
+          security_alert_reason: '',
+          ppom_eth_chainId_count: 1,
+          version: undefined,
+        });
+      });
+    });
+
+    describe('shouldTruncateMessage', () => {
+      it('sets truncateMessage to true if message is more then 5 characters', async () => {
+        const container = createContainer();
+
+        expect(
+          container.getByTestId('SignatureRequest').props.truncateMessage,
+        ).toBe(false);
+
+        await act(() => {
+          container.getByText(messageParamsMock.data).props.onTextLayout({
+            nativeEvent: { lines: 'teste123' },
+          });
+        });
+
+        expect(
+          container.getByTestId('SignatureRequest').props.truncateMessage,
+        ).toBe(true);
+      });
+
+      it('sets truncateMessage to false if message is less then 5 characters', async () => {
+        const container = createContainer();
+
+        expect(
+          container.getByTestId('SignatureRequest').props.truncateMessage,
+        ).toBe(false);
+
+        await act(() => {
+          container.getByText(messageParamsMock.data).props.onTextLayout({
+            nativeEvent: { lines: 'test' },
+          });
+        });
+
+        expect(
+          container.getByTestId('SignatureRequest').props.truncateMessage,
+        ).toBe(false);
       });
     });
   });
 
-  describe('onReject', () => {
-    it('rejects message', async () => {
-      const onRejectMock = jest.fn();
-      const wrapper = createWrapper({ mockReject: onRejectMock }).dive();
-      await (wrapper.find(SignatureRequest).props() as any).onReject();
+  describe('ExpandedMessage', () => {
+    it('should render ExpandedMessage correctly', () => {
+      const container = createContainer({ showExpandedMessage: true });
 
-      expect(onRejectMock).toHaveBeenCalledTimes(1);
-    });
-
-    it.each([
-      ['wallet connect', WALLET_CONNECT_ORIGIN],
-      ['SDK remote', AppConstants.MM_SDK.SDK_REMOTE_ORIGIN],
-    ])('shows notification if origin is %s', async (_title, origin) => {
-      jest
-        .spyOn(InteractionManager, 'runAfterInteractions')
-        .mockImplementation((callback: any) => callback());
-
-      (NotificationManager.showSimpleNotification as any).mockReset();
-      (Engine.context.SignatureController.hub.on as any).mockReset();
-
-      const wrapper = createWrapper({ origin }).dive();
-      await (wrapper.find(SignatureRequest).props() as any).onReject();
-
-      expect(NotificationManager.showSimpleNotification).toHaveBeenCalledTimes(
+      expect(Engine.context.SignatureController.hub.on).toHaveBeenCalledTimes(
         1,
       );
-      expect(NotificationManager.showSimpleNotification).toHaveBeenCalledWith({
-        status: `simple_notification_rejected`,
-        duration: 5000,
-        title: strings('notifications.wc_signed_rejected_title'),
-        description: strings('notifications.wc_description'),
-      });
+      expect(Engine.context.SignatureController.hub.on).toHaveBeenCalledWith(
+        'TestMessageId:signError',
+        expect.any(Function),
+      );
+      expect(analyticsV2.trackEvent).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.SignatureController.hub.removeListener,
+      ).toHaveBeenCalledTimes(0);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render Message text correctly', () => {
+      const container = createContainer({ showExpandedMessage: true });
+      expect(
+        container.getByTestId('ExpandedMessage').props.renderMessage(),
+      ).toMatchSnapshot();
     });
   });
 
-  describe('trackEvent', () => {
-    it('tracks event for rejected requests', async () => {
-      const wrapper = createWrapper().dive();
-      await (wrapper.find(SignatureRequest).props() as any).onReject();
+  describe('unmount', () => {
+    it('removes listeners', () => {
+      const container = createContainer();
+      container.unmount();
+      expect(
+        Engine.context.SignatureController.hub.removeListener,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.SignatureController.hub.removeListener,
+      ).toHaveBeenCalledWith('TestMessageId:signError', expect.any(Function));
+    });
+  });
 
-      const rejectedMocks = (
-        analyticsV2.trackEvent as jest.Mock
-      ).mock.calls.filter((call) => call[0].category === 'Signature Rejected');
+  describe('onSignatureError', () => {
+    let events: any;
+    beforeEach(() => {
+      events = {};
 
-      const mockCallsLength = rejectedMocks.length;
-
-      const lastMockCall = rejectedMocks[mockCallsLength - 1];
-
-      expect(lastMockCall[0]).toEqual({ category: 'Signature Rejected' });
-      expect(lastMockCall[1]).toEqual({
-        account_type: 'Metamask',
-        dapp_host_name: undefined,
-        chain_id: undefined,
-        signature_type: 'eth_sign',
-        security_alert_response: 'Benign',
-        security_alert_reason: '',
-        ppom_eth_chainId_count: 1,
-        version: undefined,
-      });
+      EngineMock.context.SignatureController.hub.on.mockImplementationOnce(
+        (event: any, callback: any) => {
+          events[event] = callback;
+        },
+      );
     });
 
-    it('tracks event for approved requests', async () => {
-      const wrapper = createWrapper().dive();
-      await (wrapper.find(SignatureRequest).props() as any).onConfirm();
-
-      const signedMocks = (
-        analyticsV2.trackEvent as jest.Mock
-      ).mock.calls.filter((call) => call[0].category === 'Signature Approved');
-
-      const mockCallsLength = signedMocks.length;
-
-      const lastMockCall = signedMocks[mockCallsLength - 1];
-
-      expect(lastMockCall[0]).toEqual({ category: 'Signature Approved' });
-      expect(lastMockCall[1]).toEqual({
-        account_type: 'Metamask',
-        dapp_host_name: undefined,
-        chain_id: undefined,
-        signature_type: 'eth_sign',
-        security_alert_response: 'Benign',
-        security_alert_reason: '',
-        ppom_eth_chainId_count: 1,
-        version: undefined,
+    it('track has been called when error message starts with KeystoneError#Tx_canceled', async () => {
+      createContainer();
+      events['TestMessageId:signError']({
+        error: new Error(KEYSTONE_TX_CANCELED),
+      });
+      await waitFor(() => {
+        expect(analyticsV2.trackEvent).toHaveBeenCalledTimes(2);
+        expect((analyticsV2.trackEvent as jest.Mock).mock.calls[1][0]).toEqual(
+          MetaMetricsEvents.QR_HARDWARE_TRANSACTION_CANCELED,
+        );
       });
     });
   });


### PR DESCRIPTION
## **Description**

To complement this [PR](https://github.com/MetaMask/metamask-mobile/pull/7822), we are moving MessageSign tests to testing react testing library.
I have also increased the test coverage. MessageSign test coverage now sits at 100%.

![Screenshot 2023-12-06 at 19 37 10](https://github.com/MetaMask/metamask-mobile/assets/15957235/a2b03412-5812-4c3e-9f1c-631263f84b80)

## **Related issues**
None

## **Manual testing steps**

No manual testing required. We are only adding unit tests.

## **Screenshots/Recordings**

Nothing changed.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
