### PR TITLE
fix: temp disable SES

### DIFF
--- a/patches/react-native+0.71.14.patch
+++ b/patches/react-native+0.71.14.patch
@@ -1,8 +1,33 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..7438dad 100644
+index 1379ffd..e59f511 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
-@@ -27,23 +27,28 @@
+@@ -24,26 +24,53 @@
+
+ 'use strict';
+
++const Platform = require('../Utilities/Platform');
++
++const IS_LOCKDOWN_ENABLED = false; // Temporarily false until CI issues investigated and resolved
++
++if (IS_LOCKDOWN_ENABLED && Platform.OS === 'ios' && !global?.HermesInternal && !__DEV__) {
++  require('../../../../ses.cjs'); // ses@0.18.8
++  /**
++   * Without consoleTaming: 'unsafe' causes:
++   * - Attempting to define property on object that is not extensible.
++   * Without errorTrapping 'none' causes:
++   * - TypeError: undefined is not a function (near '...globalThis.process.on...')
++   * Without unhandledRejectionTrapping 'none' causes:
++   * - TypeError: globalThis.process.on is not a function. (In 'globalThis.process.on('unhandledRejection', h.unhandledRejectionHandler)', 'globalThis.process.on' is undefined)
++   * overrideTaming 'severe' is ideal (default override?)
++   * Nb: global.process is only partially shimmed, which confuses SES
++   * Nb: All are Unhandled JS Exceptions, since we call lockdown before setUpErrorHandling
++  */
++  repairIntrinsics({ consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe' });
++  require('reflect-metadata'); // Vetted shim required to fix: https://github.com/LavaMoat/docs/issues/26
++  hardenIntrinsics();
++}
++
  const start = Date.now();
 
  require('./setUpGlobals');

--- a/patches/react-native+0.71.14.patch
+++ b/patches/react-native+0.71.14.patch
@@ -1,33 +1,8 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..e59f511 100644
+index 1379ffd..7438dad 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
-@@ -24,26 +24,53 @@
-
- 'use strict';
-
-+const Platform = require('../Utilities/Platform');
-+
-+const IS_LOCKDOWN_ENABLED = false; // Temporarily false until CI issues investigated and resolved
-+
-+if (IS_LOCKDOWN_ENABLED && Platform.OS === 'ios' && !global?.HermesInternal && !__DEV__) {
-+  require('../../../../ses.cjs'); // ses@0.18.8
-+  /**
-+   * Without consoleTaming: 'unsafe' causes:
-+   * - Attempting to define property on object that is not extensible.
-+   * Without errorTrapping 'none' causes:
-+   * - TypeError: undefined is not a function (near '...globalThis.process.on...')
-+   * Without unhandledRejectionTrapping 'none' causes:
-+   * - TypeError: globalThis.process.on is not a function. (In 'globalThis.process.on('unhandledRejection', h.unhandledRejectionHandler)', 'globalThis.process.on' is undefined)
-+   * overrideTaming 'severe' is ideal (default override?)
-+   * Nb: global.process is only partially shimmed, which confuses SES
-+   * Nb: All are Unhandled JS Exceptions, since we call lockdown before setUpErrorHandling
-+  */
-+  repairIntrinsics({ consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe' });
-+  require('reflect-metadata'); // Vetted shim required to fix: https://github.com/LavaMoat/docs/issues/26
-+  hardenIntrinsics();
-+}
-+
+@@ -27,23 +27,28 @@
  const start = Date.now();
 
  require('./setUpGlobals');

--- a/patches/react-native+0.71.14.patch
+++ b/patches/react-native+0.71.14.patch
@@ -1,14 +1,16 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..d1a2b3f 100644
+index 1379ffd..e59f511 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
-@@ -24,26 +24,51 @@
+@@ -24,26 +24,53 @@
 
  'use strict';
 
 +const Platform = require('../Utilities/Platform');
 +
-+if (Platform.OS === 'ios' && !global?.HermesInternal && !__DEV__) {
++const IS_LOCKDOWN_ENABLED = false; // Temporarily false until CI issues investigated and resolved
++
++if (IS_LOCKDOWN_ENABLED && Platform.OS === 'ios' && !global?.HermesInternal && !__DEV__) {
 +  require('../../../../ses.cjs'); // ses@0.18.8
 +  /**
 +   * Without consoleTaming: 'unsafe' causes:
@@ -77,7 +79,7 @@ index 155cb59..053550c 100644
      defaultConfig {
          minSdkVersion(21)
 diff --git a/node_modules/react-native/ReactAndroid/hermes-engine/build.gradle b/node_modules/react-native/ReactAndroid/hermes-engine/build.gradle
-index c714f87..dca2750 100644
+index c714f87..65f9ba3 100644
 --- a/node_modules/react-native/ReactAndroid/hermes-engine/build.gradle
 +++ b/node_modules/react-native/ReactAndroid/hermes-engine/build.gradle
 @@ -43,11 +43,11 @@ def overrideHermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") != nul


### PR DESCRIPTION
## **Description**

<s>Temporarily disable lockdown to unbreak CI
after investigation the CI unit test failures are unrelated to SES https://github.com/MetaMask/metamask-mobile/pull/8046 </s>

Temporarily disable lockdown to fix recent spike in iOS crashes.
The fix is here: https://github.com/MetaMask/metamask-mobile/pull/8033
<s>But CI is currently down to verify the fix, so we may want to merge this now instead</s>

## **Related issues**

Fixes: 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
