### PR TITLE
fix: fix typo on PPOM modal text

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -23,7 +23,7 @@
     "setting_up_alerts": "Setting up security alerts",
     "setting_up_alerts_description": "We are going as fast as we can to set up security alerts. Hang in there, we are almost done.",
     "setup_complete": "Set up complete",
-    "setup_complete_description": "Security alerts are ready to go. You can close this pageand start exploring your wallet",
+    "setup_complete_description": "Security alerts are ready to go. You can close this page and start exploring your wallet",
     "continue": "Continue",
     "cancel": "Cancel"
   },


### PR DESCRIPTION
## **Description**
This PR fixes a typo on the Setup Completed modal text for Blockaid.
`Security alerts are ready to go. You can close this pageand start exploring your wallet`

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/8062

## **Manual testing steps**

1. Enable Blockaid
2. See Setup Completed modal text


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-mobile/assets/54408225/ad39d32d-a675-42a1-8186-035aa25ba9d3)


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
