### PR TITLE
fix: ignore ppom when using yarn format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,5 @@ scripts
 .prettierignore
 locales
 .storybook
+/ppom
+app/lib/ppom/ppom.html.js


### PR DESCRIPTION
## **Description**

When running `yarn format` the `app/lib/ppom/ppom.html.js` is modified.
This file is ignored by `yarn lint` but still generates changes when we format all the project.
Maybe we should make this file comply but given lint ignores it, I suggest we also ignore the formating.

- Add ppom and generated ppom html to prettier ignore file

## **Related issues**

Fixes: NA

## **Manual testing steps**

NA

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
