### PR TITLE
[Force upgrade] bump minimum version 1224 (version 7.12.2)

### DIFF
--- a/AppConfig/v1/AppConfig.json
+++ b/AppConfig/v1/AppConfig.json
@@ -1,7 +1,7 @@
 {
   "security":{
     "minimumVersions": {
-      "appMinimumBuild": 1187,
+      "appMinimumBuild": 1224,
       "appleMinimumOS": 6,
       "androidMinimumAPIVersion": 21
     }


### PR DESCRIPTION
## Description
7.12.2 release notes: https://github.com/MetaMask/metamask-mobile/releases/tag/v7.12.2

## Acceptance Criteria

- [x] Test app version before 7.12.2 (1124). It should display Update modal when using test endpoint: https://recordit.co/Hi1FfzlqJT
- [x] Test app version 7.12.2 (1224). It should not display Update modal when using test endpoint
https://recordit.co/alH5gKos5c
- [x] Document Minimum app version bump
- [x] 7.12.2 should reach 100% on both platforms Android & iOS

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
- [x] In case it's not yet "ready for review", I've set it to "draft".
- [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
