### PR TITLE
feat: Snaps settings

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -65,6 +65,7 @@ import TabBar from '../../../component-library/components/Navigation/TabBar';
 import BrowserUrlModal from '../../Views/BrowserUrlModal';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
+import { SnapSettings } from '../../Views/Snaps/SnapSettings';
 ///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
 import AnalyticsV2 from '../../../util/analyticsV2';
@@ -214,6 +215,11 @@ const SnapsSettingsStack = () => (
       name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
       component={SnapsSettingsList}
       options={SnapsSettingsList.navigationOptions}
+    />
+    <Stack.Screen
+      name={Routes.SNAPS.SNAP_SETTINGS}
+      component={SnapSettings}
+      options={SnapSettings.navigationOptions}
     />
   </Stack.Navigator>
 );

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,2 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export default SNAP_SETTINGS_REMOVE_BUTTON;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,0 +1,2 @@
+const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
+export default SNAP_SETTINGS_REMOVE_BUTTON;

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native';
+
+const styleSheet = () =>
+  StyleSheet.create({
+    snapSettingsContainer: {
+      flex: 1,
+      marginHorizontal: 16,
+    },
+    itemPaddedContainer: {
+      paddingVertical: 16,
+    },
+    removeSection: {
+      paddingTop: 32,
+    },
+    removeButton: {
+      marginVertical: 16,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>
@@ -18,3 +19,4 @@ const styleSheet = () =>
   });
 
 export default styleSheet;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect } from 'react';
+import { View, ScrollView, SafeAreaView } from 'react-native';
+
+import Engine from '../../../../core/Engine';
+import Text, {
+  TextVariant,
+} from '../../../../component-library/components/Texts/Text';
+import Button, {
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../component-library/components/Buttons/Button';
+
+import stylesheet from './SnapSettings.styles';
+import {
+  createNavigationDetails,
+  useParams,
+} from '../../../../util/navigation/navUtils';
+import Routes from '../../../../constants/navigation/Routes';
+import { Snap } from '@metamask/snaps-utils';
+import { getNavigationOptionsTitle } from '../../../UI/Navbar';
+import { useNavigation } from '@react-navigation/native';
+import { SnapDetails } from '../components/SnapDetails';
+import { SnapDescription } from '../components/SnapDescription';
+import { SnapPermissions } from '../components/SnapPermissions';
+import { strings } from '../../../../../locales/i18n';
+import { useStyles } from '../../../hooks/useStyles';
+import { useSelector } from 'react-redux';
+import SNAP_SETTINGS_REMOVE_BUTTON from './SnapSettings.constants';
+
+interface SnapSettingsProps {
+  snap: Snap;
+}
+
+export const createSnapSettingsNavDetails =
+  createNavigationDetails<SnapSettingsProps>(Routes.SNAPS.SNAP_SETTINGS);
+
+const SnapSettings = () => {
+  const { styles, theme } = useStyles(stylesheet, {});
+  const { colors } = theme;
+  const navigation = useNavigation();
+
+  const { snap } = useParams<SnapSettingsProps>();
+
+  const permissionsState = useSelector(
+    (state: any) => state.engine.backgroundState.PermissionController,
+  );
+
+  function getPermissionSubjects(state: any) {
+    return state.subjects || {};
+  }
+
+  function getPermissions(state: any, origin: any) {
+    return getPermissionSubjects(state)[origin]?.permissions;
+  }
+
+  const permissionsFromController = getPermissions(permissionsState, snap.id);
+
+  useEffect(() => {
+    navigation.setOptions(
+      getNavigationOptionsTitle(
+        `${snap.manifest.proposedName}`,
+        navigation,
+        false,
+        colors,
+      ),
+    );
+  }, [colors, navigation, snap.manifest.proposedName]);
+
+  const removeSnap = useCallback(async () => {
+    const { SnapController } = Engine.context as any;
+    await SnapController.removeSnap(snap.id);
+    navigation.goBack();
+  }, [navigation, snap.id]);
+
+  return (
+    <SafeAreaView style={styles.snapSettingsContainer}>
+      <ScrollView>
+        <SnapDetails snap={snap} />
+        <View style={styles.itemPaddedContainer}>
+          <SnapDescription
+            snapName={snap.manifest.proposedName}
+            snapDescription={snap.manifest.description}
+          />
+        </View>
+        <View style={styles.itemPaddedContainer}>
+          <SnapPermissions permissions={permissionsFromController} />
+        </View>
+        <View style={styles.removeSection}>
+          <Text variant={TextVariant.HeadingMD}>
+            {strings(
+              'app_settings.snaps.snap_settings.remove_snap_section_title',
+            )}
+          </Text>
+          <Text variant={TextVariant.BodyMD}>
+            {strings(
+              'app_settings.snaps.snap_settings.remove_snap_section_description',
+            )}
+          </Text>
+          <Button
+            testID={SNAP_SETTINGS_REMOVE_BUTTON}
+            style={styles.removeButton}
+            variant={ButtonVariants.Secondary}
+            label={strings(
+              'app_settings.snaps.snap_settings.remove_button_label',
+              { snapName: snap.manifest.proposedName },
+            )}
+            isDanger
+            width={ButtonWidthTypes.Full}
+            onPress={removeSnap}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default React.memo(SnapSettings);

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useEffect } from 'react';
 import { View, ScrollView, SafeAreaView } from 'react-native';
 
@@ -115,3 +116,4 @@ const SnapSettings = () => {
 };
 
 export default React.memo(SnapSettings);
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/index.ts
+++ b/app/components/Views/Snaps/SnapSettings/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import SnapSettings from './SnapSettings';
+
+export { SnapSettings };

--- a/app/components/Views/Snaps/SnapSettings/index.ts
+++ b/app/components/Views/Snaps/SnapSettings/index.ts
@@ -1,4 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import/prefer-default-export */
 import SnapSettings from './SnapSettings';
 
 export { SnapSettings };
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { Status } from '@metamask/snaps-utils';
@@ -222,4 +221,3 @@ describe('SnapSettings', () => {
     });
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { Status } from '@metamask/snaps-utils';
@@ -221,3 +222,4 @@ describe('SnapSettings', () => {
     });
   });
 });
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { SemVerVersion, Status } from '@metamask/snaps-utils';
+import SnapSettings from '../SnapSettings';
+import {
+  SNAP_DETAILS_CELL,
+  SNAP_PERMISSIONS,
+  SNAP_PERMISSION_CELL,
+  SNAP_SETTINGS_REMOVE_BUTTON,
+} from '../../../../../constants/test-ids';
+import Engine from '../../../../../core/Engine';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import {
+  PermissionConstraint,
+  SubjectPermissions,
+} from '@metamask/permission-controller';
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    SnapController: {
+      removeSnap: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: () => ({
+    snap: {
+      blocked: false,
+      enabled: true,
+      permissionName: 'wallet_snap_npm:@chainsafe/filsnap',
+      id: 'npm:@chainsafe/filsnap',
+      initialPermissions: {
+        'endowment:network-access': {},
+        'endowment:rpc': {
+          dapps: true,
+          snaps: true,
+        },
+        snap_confirm: {},
+        snap_getBip44Entropy: [
+          {
+            coinType: 1,
+          },
+          {
+            coinType: 461,
+          },
+        ],
+        snap_manageState: {},
+      },
+      manifest: {
+        version: '2.3.13' as SemVerVersion,
+        proposedName: 'Filsnap',
+        description: 'The Filecoin snap.',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/Chainsafe/filsnap.git',
+        },
+        source: {
+          shasum: 'Z7lh6iD1yjfKES/WutUyxepg5Dgp8Xjo3kivsz9vpwc=',
+          location: {
+            npm: {
+              filePath: 'dist/bundle.js',
+              packageName: '@chainsafe/filsnap',
+              registry: 'https://registry.npmjs.org/',
+            },
+          },
+        },
+        initialPermissions: {
+          'endowment:network-access': {},
+          'endowment:rpc': {
+            dapps: true,
+            snaps: true,
+          },
+          snap_confirm: {},
+          snap_getBip44Entropy: [
+            {
+              coinType: 1,
+            },
+            {
+              coinType: 461,
+            },
+          ],
+          snap_manageState: {},
+        },
+        manifestVersion: '0.1',
+      },
+      status: 'runing' as Status,
+      version: '2.3.13' as SemVerVersion,
+      versionHistory: [
+        {
+          version: '2.3.13',
+          date: 1684964145490,
+          origin: 'metamask-mobile',
+        },
+      ],
+    },
+  }),
+  createNavigationDetails: jest.fn(),
+}));
+
+const mockDate = 1684964145490;
+const mockDate2 = 1686081721987;
+
+const mockPermissions: SubjectPermissions<PermissionConstraint> = {
+  'endowment:network-access': {
+    id: 'Bjj3InYtb6U4ak-uja0f_',
+    parentCapability: 'endowment:network-access',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate,
+  },
+  'endowment:rpc': {
+    id: 'Zma-vejrSvLtHmLrbSBAX',
+    parentCapability: 'endowment:rpc',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: [
+      {
+        type: 'rpcOrigin',
+        value: {
+          dapps: true,
+          snaps: true,
+        },
+      },
+    ],
+    date: mockDate2,
+  },
+  snap_confirm: {
+    id: 'tVtSEUjc48Ab-gF6UI7X3',
+    parentCapability: 'snap_confirm',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate2,
+  },
+  snap_manageState: {
+    id: 'BKbg3uDSHHu0D1fCUTOmS',
+    parentCapability: 'snap_manageState',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: null,
+    date: mockDate2,
+  },
+  snap_getBip44Entropy: {
+    id: 'MuqnOW-7BRg94sRDmVnDK',
+    parentCapability: 'snap_getBip44Entropy',
+    invoker: 'npm:@chainsafe/filsnap',
+    caveats: [
+      {
+        type: 'permittedCoinTypes',
+        value: [
+          {
+            coinType: 1,
+          },
+          {
+            coinType: 461,
+          },
+        ],
+      },
+    ],
+    date: mockDate2,
+  },
+};
+
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      setOptions: jest.fn(),
+      goBack: mockGoBack,
+    }),
+  };
+});
+
+const engineState = {
+  engine: {
+    backgroundState: {
+      PermissionController: {
+        subjects: {
+          'npm:@chainsafe/filsnap': {
+            permissions: mockPermissions,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('SnapSettings', () => {
+  it('renders correctly', () => {
+    const { getAllByTestId, getByTestId } = renderWithProvider(
+      <SnapSettings />,
+      {
+        state: engineState,
+      },
+    );
+
+    const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
+    const description = getByTestId(SNAP_DETAILS_CELL);
+    const permissionContainer = getByTestId(SNAP_PERMISSIONS);
+    const permissions = getAllByTestId(SNAP_PERMISSION_CELL);
+    expect(removeButton).toBeTruthy();
+    expect(description).toBeTruthy();
+    expect(permissionContainer).toBeTruthy();
+    expect(permissions.length).toBe(7);
+    expect(removeButton.props.children[1].props.children).toBe(
+      'Remove Filsnap',
+    );
+  });
+
+  it('remove snap and goes back when Remove button is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<SnapSettings />, {
+      state: engineState,
+    });
+
+    const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
+    fireEvent(removeButton, 'onPress');
+    expect(Engine.context.SnapController.removeSnap).toHaveBeenCalledWith(
+      'npm:@chainsafe/filsnap',
+    );
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
-import { SemVerVersion, Status } from '@metamask/snaps-utils';
+import { Status } from '@metamask/snaps-utils';
 import SnapSettings from '../SnapSettings';
-import {
-  SNAP_DETAILS_CELL,
-  SNAP_PERMISSIONS,
-  SNAP_PERMISSION_CELL,
-  SNAP_SETTINGS_REMOVE_BUTTON,
-} from '../../../../../constants/test-ids';
 import Engine from '../../../../../core/Engine';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import {
   PermissionConstraint,
   SubjectPermissions,
 } from '@metamask/permission-controller';
+import { SemVerVersion } from '@metamask/utils';
+import SNAP_SETTINGS_REMOVE_BUTTON from '../SnapSettings.constants';
+import { SNAP_DETAILS_CELL } from '../../components/SnapDetails/SnapDetails.constants';
+import SNAP_PERMISSIONS from '../../components/SnapPermissions/SnapPermissions.contants';
+import { SNAP_PERMISSION_CELL } from '../../components/SnapPermissionCell/SnapPermissionCell.constants';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
@@ -1,2 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DESCRIPTION_TITLE = 'snap-description-title';
 export const SNAP_DESCRIPTION = 'snap-description';
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
@@ -1,0 +1,2 @@
+export const SNAP_DESCRIPTION_TITLE = 'snap-description-title';
+export const SNAP_DESCRIPTION = 'snap-description';

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
@@ -1,0 +1,44 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+/**
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    snapInfoContainer: {
+      backgroundColor: colors.background.default,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: colors.border.default,
+    },
+    titleContainer: {
+      alignItems: 'center',
+      padding: 4,
+      flexDirection: 'row',
+    },
+    iconContainer: {
+      paddingHorizontal: 8,
+      flexDirection: 'row',
+    },
+    snapCell: {
+      borderRadius: 8,
+      borderWidth: 0,
+    },
+    detailsContainerWithBorder: {
+      padding: 16,
+      borderColor: colors.border.default,
+      borderTopWidth: 1,
+      alignItems: 'center',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -42,3 +43,4 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View } from 'react-native';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import stylesheet from './SnapDescription.styles';
+import { useStyles } from '../../../../../component-library/hooks';
+import {
+  SNAP_DESCRIPTION,
+  SNAP_DESCRIPTION_TITLE,
+} from './SnapDescription.constants';
+
+interface SnapDescriptionProps {
+  snapName: string;
+  snapDescription: string;
+}
+
+const SnapDescription = ({
+  snapName,
+  snapDescription,
+}: SnapDescriptionProps) => {
+  const { styles } = useStyles(stylesheet, {});
+
+  return (
+    <View style={styles.snapInfoContainer}>
+      <View style={styles.titleContainer}>
+        <View style={styles.iconContainer}>
+          <Icon
+            name={IconName.SnapsMobile}
+            size={IconSize.Sm}
+            color={IconColor.Primary}
+          />
+        </View>
+        <Text
+          testID={SNAP_DESCRIPTION_TITLE}
+          style={styles.snapCell}
+          variant={TextVariant.BodyMD}
+        >
+          {snapName}
+        </Text>
+      </View>
+      <View style={styles.detailsContainerWithBorder}>
+        <Text testID={SNAP_DESCRIPTION} variant={TextVariant.BodyMD}>
+          {snapDescription}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default React.memo(SnapDescription);

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {
@@ -54,3 +55,4 @@ const SnapDescription = ({
 };
 
 export default React.memo(SnapDescription);
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/index.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import SnapDescription from './SnapDescription';
+
+export { SnapDescription };

--- a/app/components/Views/Snaps/components/SnapDescription/index.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/index.ts
@@ -1,4 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import/prefer-default-export */
 import SnapDescription from './SnapDescription';
 
 export { SnapDescription };
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapDescription from '../SnapDescription';
@@ -20,3 +21,4 @@ describe('SnapDescription', () => {
     expect(description.props.children).toBe('Test snap description');
   });
 });
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import SnapDescription from '../SnapDescription';
+import {
+  SNAP_DESCRIPTION,
+  SNAP_DESCRIPTION_TITLE,
+} from '../SnapDescription.constants';
+
+describe('SnapDescription', () => {
+  it('renders correctly', async () => {
+    const { getByTestId } = render(
+      <SnapDescription
+        snapName="test snap"
+        snapDescription="Test snap description"
+      />,
+    );
+    const title = await getByTestId(SNAP_DESCRIPTION_TITLE);
+    const description = await getByTestId(SNAP_DESCRIPTION);
+    expect(title.props.children).toBe('test snap');
+    expect(description.props.children).toBe('Test snap description');
+  });
+});

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
@@ -1,4 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DETAILS_CELL = 'snap-details-cell';
 export const SNAP_DETAILS_SWITCH = 'snap-details-switch';
 export const SNAP_DETAILS_INSTALL_ORIGIN = 'snap-details-install-origin';
 export const SNAP_DETAILS_INSTALL_DATE = 'snap-details-install-date';
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
@@ -1,0 +1,4 @@
+export const SNAP_DETAILS_CELL = 'snap-details-cell';
+export const SNAP_DETAILS_SWITCH = 'snap-details-switch';
+export const SNAP_DETAILS_INSTALL_ORIGIN = 'snap-details-install-origin';
+export const SNAP_DETAILS_INSTALL_DATE = 'snap-details-install-date';

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
@@ -1,0 +1,43 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+/**
+ *
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    snapInfoContainer: {
+      backgroundColor: colors.background.default,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border.default,
+    },
+    snapCell: {
+      borderRadius: 8,
+      borderWidth: 0,
+    },
+    detailsContainerWithBorder: {
+      padding: 16,
+      borderColor: colors.border.default,
+      borderTopWidth: 1,
+      borderBottomWidth: 1,
+      alignItems: 'center',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    detailsContainer: {
+      padding: 16,
+      alignItems: 'center',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -41,3 +42,4 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useMemo, useState } from 'react';
 import { View, Switch } from 'react-native';
 
@@ -120,3 +121,4 @@ const SnapDetails = ({ snap }: SnapDetailsProps) => {
 };
 
 export default React.memo(SnapDetails);
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
@@ -35,28 +35,19 @@ const SnapDetails = ({ snap }: SnapDetailsProps) => {
   const { colors } = theme;
   const [enabled, setEnabled] = useState<boolean>(snap.enabled);
 
-  const enableSnap = useCallback(async () => {
-    const { SnapController } = Engine.context;
-    await SnapController.enableSnap(snap.id);
-  }, [snap.id]);
+  const toggleSnap = useCallback(
+    (enable) => {
+      const { SnapController } = Engine.context;
 
-  const disableSnap = useCallback(async () => {
-    const { SnapController } = Engine.context;
-    await SnapController.disableSnap(snap.id);
-  }, [snap.id]);
+      if (!SnapController) return;
 
-  const handleOnValueChange = useCallback(
-    (newValue) => {
-      setEnabled(newValue);
-      if (newValue) {
-        enableSnap();
-      } else {
-        disableSnap();
-      }
+      enable
+        ? SnapController.enableSnap(snap.id)
+        : SnapController.disableSnap(snap.id);
+      setEnabled(enable);
     },
-    [disableSnap, enableSnap],
+    [snap.id],
   );
-
   const snapInstalledDate: string = useMemo(
     () =>
       strings('app_settings.snaps.snap_details.install_date', {
@@ -87,7 +78,7 @@ const SnapDetails = ({ snap }: SnapDetailsProps) => {
             true: colors.primary.default,
             false: colors.border.muted,
           }}
-          onValueChange={handleOnValueChange}
+          onValueChange={toggleSnap}
           ios_backgroundColor={colors.border.muted}
         />
       </View>

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Switch } from 'react-native';
+
+import Engine from '../../../../../core/Engine';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Cell, {
+  CellVariant,
+} from '../../../../../component-library/components/Cells/Cell';
+import { AvatarVariant } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import { Snap } from '@metamask/snaps-utils';
+import stylesheet from './SnapDetails.styles';
+import { SnapVersionBadge } from '../SnapVersionTag';
+import { toDateFormat } from '../../../../../util/date';
+import { strings } from '../../../../../../locales/i18n';
+import { useStyles } from '../../../../../component-library/hooks';
+import Label from '../../../../../component-library/components/Form/Label';
+import {
+  SNAP_DETAILS_CELL,
+  SNAP_DETAILS_INSTALL_DATE,
+  SNAP_DETAILS_INSTALL_ORIGIN,
+  SNAP_DETAILS_SWITCH,
+} from './SnapDetails.constants';
+
+interface SnapDetailsProps {
+  snap: Snap;
+}
+
+const SnapDetails = ({ snap }: SnapDetailsProps) => {
+  const { styles, theme } = useStyles(stylesheet, {});
+  const { colors } = theme;
+  const [enabled, setEnabled] = useState<boolean>(snap.enabled);
+
+  const enableSnap = useCallback(async () => {
+    const { SnapController } = Engine.context;
+    await SnapController.enableSnap(snap.id);
+  }, [snap.id]);
+
+  const disableSnap = useCallback(async () => {
+    const { SnapController } = Engine.context;
+    await SnapController.disableSnap(snap.id);
+  }, [snap.id]);
+
+  const handleOnValueChange = useCallback(
+    (newValue) => {
+      setEnabled(newValue);
+      if (newValue) {
+        enableSnap();
+      } else {
+        disableSnap();
+      }
+    },
+    [disableSnap, enableSnap],
+  );
+
+  const snapInstalledDate: string = useMemo(
+    () =>
+      strings('app_settings.snaps.snap_details.install_date', {
+        date: toDateFormat(snap.versionHistory[0].date),
+      }),
+    [snap.versionHistory],
+  );
+
+  return (
+    <View style={styles.snapInfoContainer}>
+      <Cell
+        testID={SNAP_DETAILS_CELL}
+        style={styles.snapCell}
+        variant={CellVariant.Display}
+        title={snap.manifest.proposedName}
+        secondaryText={snap.id}
+        avatarProps={{
+          variant: AvatarVariant.Icon,
+          name: IconName.Snaps,
+        }}
+      />
+      <View style={styles.detailsContainerWithBorder}>
+        <Label>{strings('app_settings.snaps.snap_details.enabled')}</Label>
+        <Switch
+          testID={SNAP_DETAILS_SWITCH}
+          value={enabled}
+          trackColor={{
+            true: colors.primary.default,
+            false: colors.border.muted,
+          }}
+          onValueChange={handleOnValueChange}
+          ios_backgroundColor={colors.border.muted}
+        />
+      </View>
+      <View style={styles.detailsContainer}>
+        <Label>
+          {strings('app_settings.snaps.snap_details.install_origin')}
+        </Label>
+        <View>
+          <Text
+            testID={SNAP_DETAILS_INSTALL_ORIGIN}
+            variant={TextVariant.BodyMD}
+            color={TextColor.Primary}
+          >
+            {snap.versionHistory[0].origin}
+          </Text>
+          <Text
+            testID={SNAP_DETAILS_INSTALL_DATE}
+            variant={TextVariant.BodyMD}
+            color={TextColor.Muted}
+          >
+            {snapInstalledDate}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.detailsContainer}>
+        <Label>{strings('app_settings.snaps.snap_details.version')}</Label>
+        <SnapVersionBadge version={snap.version} />
+      </View>
+    </View>
+  );
+};
+
+export default React.memo(SnapDetails);

--- a/app/components/Views/Snaps/components/SnapDetails/index.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import SnapDetails from './SnapDetails';
+
+export { SnapDetails };

--- a/app/components/Views/Snaps/components/SnapDetails/index.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/index.ts
@@ -1,4 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import/prefer-default-export */
 import SnapDetails from './SnapDetails';
 
 export { SnapDetails };
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Snap, Status } from '@metamask/snaps-utils';
+import SnapDetails from '../SnapDetails';
+import Engine from '../../../../../../core/Engine';
+import { SemVerVersion } from '@metamask/utils';
+import {
+  SNAP_DETAILS_CELL,
+  SNAP_DETAILS_INSTALL_DATE,
+  SNAP_DETAILS_INSTALL_ORIGIN,
+  SNAP_DETAILS_SWITCH,
+} from '../SnapDetails.constants';
+import { SNAP_VERSION_BADGE } from '../../SnapVersionTag/SnapVersionTag.constants';
+
+jest.mock('../../../../../../core/Engine', () => ({
+  context: {
+    SnapController: {
+      enableSnap: jest.fn(),
+      disableSnap: jest.fn(),
+    },
+  },
+}));
+
+describe('SnapDetails', () => {
+  const mockSnap: Snap = {
+    blocked: false,
+    enabled: true,
+    permissionName: 'wallet_snap_npm:@chainsafe/filsnap',
+    id: 'npm:@chainsafe/filsnap',
+    initialPermissions: {
+      'endowment:network-access': {},
+      'endowment:rpc': {
+        dapps: true,
+        snaps: true,
+      },
+      snap_confirm: {},
+      snap_getBip44Entropy: [
+        {
+          coinType: 1,
+        },
+        {
+          coinType: 461,
+        },
+      ],
+      snap_manageState: {},
+    },
+    manifest: {
+      version: '2.3.13' as SemVerVersion,
+      proposedName: 'Filsnap',
+      description: 'The Filecoin snap.',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/Chainsafe/filsnap.git',
+      },
+      source: {
+        shasum: 'Z7lh6iD1yjfKES/WutUyxepg5Dgp8Xjo3kivsz9vpwc=',
+        location: {
+          npm: {
+            filePath: 'dist/bundle.js',
+            packageName: '@chainsafe/filsnap',
+            registry: 'https://registry.npmjs.org/',
+          },
+        },
+      },
+      initialPermissions: {
+        'endowment:network-access': {},
+        'endowment:rpc': {
+          dapps: true,
+          snaps: true,
+        },
+        snap_confirm: {},
+        snap_getBip44Entropy: [
+          {
+            coinType: 1,
+          },
+          {
+            coinType: 461,
+          },
+        ],
+        snap_manageState: {},
+      },
+      manifestVersion: '0.1',
+    },
+    status: 'runing' as Status,
+    version: '2.3.13' as SemVerVersion,
+    versionHistory: [
+      {
+        version: '2.3.13',
+        date: 1684964145490,
+        origin: 'metamask-mobile',
+      },
+    ],
+  };
+
+  const installDateString = 'Installed on May 24 at 5:35 pm';
+
+  it('renders the correct snap details', async () => {
+    const { getByTestId } = render(<SnapDetails snap={mockSnap} />);
+
+    const cell = await getByTestId(SNAP_DETAILS_CELL);
+    const switchElement = await getByTestId(SNAP_DETAILS_SWITCH);
+    const installOrigin = await getByTestId(SNAP_DETAILS_INSTALL_ORIGIN);
+    const installDate = await getByTestId(SNAP_DETAILS_INSTALL_DATE);
+    const versionBadge = await getByTestId(SNAP_VERSION_BADGE);
+
+    expect(cell).toBeTruthy();
+    expect(switchElement).toBeTruthy();
+    expect(installOrigin).toBeTruthy();
+    expect(installDate).toBeTruthy();
+    expect(versionBadge).toBeTruthy();
+
+    expect(cell.props.children.props.title).toEqual(
+      mockSnap.manifest.proposedName,
+    );
+    expect(cell.props.children.props.secondaryText).toEqual(mockSnap.id);
+
+    expect(switchElement.props.value).toEqual(true);
+
+    expect(installOrigin.props.children).toEqual('metamask-mobile');
+
+    expect(installDate.props.children).toEqual(installDateString);
+  });
+
+  it('handles snap enable and disable', async () => {
+    const { getByTestId } = render(<SnapDetails snap={mockSnap} />);
+
+    const switchElement = await getByTestId(SNAP_DETAILS_SWITCH);
+
+    fireEvent(switchElement, 'onValueChange', false);
+
+    expect(Engine.context.SnapController.disableSnap).toHaveBeenCalledWith(
+      mockSnap.id,
+    );
+
+    expect(switchElement.props.value).toEqual(false);
+
+    fireEvent(switchElement, 'onValueChange', true);
+
+    expect(Engine.context.SnapController.enableSnap).toHaveBeenCalledWith(
+      mockSnap.id,
+    );
+
+    expect(switchElement.props.value).toEqual(true);
+  });
+});

--- a/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Snap, Status } from '@metamask/snaps-utils';
@@ -143,3 +144,4 @@ describe('SnapDetails', () => {
     expect(switchElement.props.value).toEqual(true);
   });
 });
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/test/SnapDetails.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Snap, Status } from '@metamask/snaps-utils';
@@ -144,4 +143,3 @@ describe('SnapDetails', () => {
     expect(switchElement.props.value).toEqual(true);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
@@ -13,9 +13,16 @@ import { Snap } from '@metamask/snaps-utils';
 import stylesheet from './SnapElement.styles';
 import { useStyles } from '../../../../../component-library/hooks';
 import SNAP_ElEMENT from './SnapElement.constants';
+import { useNavigation } from '@react-navigation/native';
+import { createSnapSettingsNavDetails } from '../../SnapSettings/SnapSettings';
 
 const SnapElement = (snap: Snap) => {
   const { styles } = useStyles(stylesheet, {});
+  const { navigate } = useNavigation();
+
+  const onPress = () => {
+    navigate(...createSnapSettingsNavDetails({ snap }));
+  };
 
   return (
     <Cell
@@ -24,6 +31,7 @@ const SnapElement = (snap: Snap) => {
       variant={CellVariant.Display}
       title={snap.manifest.proposedName}
       secondaryText={snap.id}
+      onPress={onPress}
       avatarProps={{
         variant: AvatarVariant.Icon,
         name: IconName.Snaps,

--- a/app/components/Views/Snaps/components/SnapElement/test/SnapElement.test.tsx
+++ b/app/components/Views/Snaps/components/SnapElement/test/SnapElement.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapElement from '../SnapElement';
@@ -98,4 +97,3 @@ describe('SnapElement', () => {
     expect(cell.props.children.props.secondaryText).toEqual(mockSnap.id);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/test/SnapPermissionCell.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapPermissionCell, {
@@ -64,4 +63,3 @@ describe('SnapPermissionCell', () => {
     expect(permissionDate.props.children).toEqual(expectedDate);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermissions.test.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/test/SnapPermissions.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import SnapPermissions from '../SnapPermissions';
 import { SnapPermissions as SnapPermissionsType } from '@metamask/snaps-utils';
@@ -1115,4 +1114,3 @@ describe('SnapPermissions', () => {
     expect(permissionCellDates[2].props.children).toBe(expectedDate);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
@@ -1,2 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_VERSION_BADGE = 'snap-version-badge';
 export const SNAP_VERSION_BADGE_VALUE = 'snap-version-badge-value';
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
@@ -1,0 +1,2 @@
+export const SNAP_VERSION_BADGE = 'snap-version-badge';
+export const SNAP_VERSION_BADGE_VALUE = 'snap-version-badge-value';

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+/**
+ *
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    versionBadgeContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      backgroundColor: colors.background.alternative,
+      paddingVertical: 2,
+      paddingHorizontal: 8,
+      borderRadius: 16,
+    },
+    versionBadgeItem: {
+      padding: 2,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -28,3 +29,4 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {
@@ -44,3 +45,4 @@ const SnapVersionTag: React.FC<SnapVersionTagProps> = ({
 };
 
 export default React.memo(SnapVersionTag);
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import stylesheet from './SnapVersionTag.styles';
+import { useStyles } from '../../../../../component-library/hooks';
+import { SemVerVersion } from '@metamask/utils';
+import {
+  SNAP_VERSION_BADGE,
+  SNAP_VERSION_BADGE_VALUE,
+} from './SnapVersionTag.constants';
+
+interface SnapVersionTagProps extends React.ComponentProps<typeof View> {
+  version: SemVerVersion;
+}
+
+const SnapVersionTag: React.FC<SnapVersionTagProps> = ({
+  version,
+}: SnapVersionTagProps) => {
+  const { styles } = useStyles(stylesheet, {});
+  return (
+    <View testID={SNAP_VERSION_BADGE} style={styles.versionBadgeContainer}>
+      <Text
+        testID={SNAP_VERSION_BADGE_VALUE}
+        variant={TextVariant.HeadingSMRegular}
+        color={TextColor.Default}
+        style={styles.versionBadgeItem}
+      >
+        {`v${version}`}
+      </Text>
+      <Icon
+        name={IconName.Export}
+        size={IconSize.Sm}
+        style={styles.versionBadgeItem}
+      />
+    </View>
+  );
+};
+
+export default React.memo(SnapVersionTag);

--- a/app/components/Views/Snaps/components/SnapVersionTag/index.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import SnapVersionBadge from './SnapVersionTag';
+
+export { SnapVersionBadge };

--- a/app/components/Views/Snaps/components/SnapVersionTag/index.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/index.ts
@@ -1,4 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import/prefer-default-export */
 import SnapVersionBadge from './SnapVersionTag';
 
 export { SnapVersionBadge };
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import SnapVersionBadge from '../SnapVersionTag';
+import { SemVerVersion } from '@metamask/utils';
+import {
+  SNAP_VERSION_BADGE,
+  SNAP_VERSION_BADGE_VALUE,
+} from '../SnapVersionTag.constants';
+
+describe('SnapVersionBadge', () => {
+  it('renders the version in the correct format', async () => {
+    const { getByTestId } = render(
+      <SnapVersionBadge version={'2.3.13' as SemVerVersion} />,
+    );
+    const versionBadge = await getByTestId(SNAP_VERSION_BADGE);
+    const versionBadgeValue = await getByTestId(SNAP_VERSION_BADGE_VALUE);
+    expect(versionBadge).toBeTruthy();
+    expect(versionBadgeValue.props.children).toBe('v2.3.13');
+  });
+});

--- a/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapVersionBadge from '../SnapVersionTag';
@@ -19,4 +18,3 @@ describe('SnapVersionBadge', () => {
     expect(versionBadgeValue.props.children).toBe('v2.3.13');
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/test/SnapVersionTag.test.tsx
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapVersionBadge from '../SnapVersionTag';
@@ -18,3 +19,4 @@ describe('SnapVersionBadge', () => {
     expect(versionBadgeValue.props.children).toBe('v2.3.13');
   });
 });
+///: END:ONLY_INCLUDE_IF

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -111,6 +111,7 @@ const Routes = {
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SNAPS: {
     SNAPS_SETTINGS_LIST: 'SnapsSettingsList',
+    SNAP_SETTINGS: 'SnapSettings',
   },
   ///: END:ONLY_INCLUDE_IF
 };

--- a/app/core/Snaps/index.ts
+++ b/app/core/Snaps/index.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import SnapBridge from './SnapBridge';
 import SnapDuplex from './SnapDuplex';
 import WebviewExecutionService from './WebviewExecutionService';
@@ -27,3 +28,4 @@ export {
   detectSnapLocation,
 };
 export type { DetectSnapLocationOptions };
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/fetch.ts
+++ b/app/core/Snaps/location/fetch.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import/prefer-default-export */
 import RNFetchBlob, { FetchBlobResponse } from 'rn-fetch-blob';
 import Logger from '../../../util/Logger';
@@ -49,3 +50,4 @@ export const fetchFunction: FetchFN = async (
   );
   return await convertFetchBlobResponseToResponse(response);
 };
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/index.ts
+++ b/app/core/Snaps/location/index.ts
@@ -1,2 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export * from './location';
 export * from './fetch';
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/location.ts
+++ b/app/core/Snaps/location/location.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { NpmLocation, NpmOptions } from './npm';
 import {
   HttpLocation,
@@ -42,3 +43,4 @@ export function detectSnapLocation(
       );
   }
 }
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,3 +1,4 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   createSnapManifest,
   DEFAULT_REQUESTED_SNAP_VERSION,
@@ -427,3 +428,4 @@ async function fetchNpmTarball(
     npmPackageDataLocation,
   ];
 }
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/permissions/permissions.ts
+++ b/app/core/Snaps/permissions/permissions.ts
@@ -1,3 +1,5 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // TODO: Figure out which permissions should be disabled at this point
 export const ExcludedSnapPermissions = Object.freeze([]);
 export const ExcludedSnapEndowments = Object.freeze([]);
+///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- This PR adds a settings page for each snap that allows users to read the granted permissions, remove the snap, read the description and title.

- The designs for this feature can be found [here](https://www.figma.com/file/f4i6WJ1rbxtD5TUk7mypnF/Mobile-Flask-Flows?type=design&node-id=15-21756)

This PR does not...
- Render specific snap icons
- Show the connected sites and allow the user to disconnect from them
- install origin and snap version are not clickable
- There are also small UX differences between the designs and my version due to limitations of the existing designs system components

_2. What is the improvement/solution?_
- Create a stack navigator for the snaps settings and put it inside the `app/components/Nav/Main/MainNavigator.js`. This stack will then live in the `SettingsFlow` stack navigator
- Removes the old placement for the snaps workflows inside the DrawerView.
- Add the entry point to the SnapsSettingsList inside the settings screen under the Networks section
- Renamed the old SnapsDev screen to `SnapsSettingsList.tsx` and had it render a list of SnapElements. This is the component that shows the snap name and id. When clicked it takes the user to the Settings page for a specific snap.
- Modified the `SnapElement` component to render a a [Cell](https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Cells/Cell). This cell contains the snap name, snap id, a default icon for all snaps. I did not render the specific snap icon in this PR.
- Clicking on the SnapElement is brings you to a specific [SnapSettings](https://github.com/MetaMask/metamask-mobile/pull/6443/files#diff-c872c20c6374fcb89bc3df8e8a9005267cbbd0100349ffae01883cf7b3345892R36) screen. This screen contains
    - A [SnapDetails](https://github.com/MetaMask/metamask-mobile/pull/6443/files#diff-1b6464779ba1da8411a27bd2f4eb241f9edbbb7453483ce4d5e012458adfa581R31)
    - A [SnapDescription](https://github.com/MetaMask/metamask-mobile/pull/6443/files)
    - A [SnapPermissions](https://github.com/MetaMask/metamask-mobile/pull/6443/files#diff-a3d4e8960662bb24b7c2c431b6a938f6a8b4ba1878461d2a50806137f3cd32b2R37) which renders the list of permissions in a human readable way. More on this later.
    - And lastly this screen renders a Remove Snap section that contains a red button that when pressed calls `SnapController.removeSnap(snap.id);` and `navigation.goBack();`
    <img width="433" alt="Screenshot 2023-05-30 at 4 49 25 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/6403383b-dd0d-45cc-81bc-67e90be5b877">

- The `app/components/Views/Snaps` contains all of these screens and components and matches the desired file structure for components of this nature. Each component lives within its own folder, each of which have a `styles.ts` file. `index.ts` file, the component itself and a test folder. 
    - Every component and screen are thoroughly tested.
  
<img width="232" alt="Screenshot 2023-12-13 at 10 22 43 AM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/7bc2d170-5624-4a6a-b7bf-0ce40b75260f">
4/d43f23bd-b14f-4130-9c58-ae36489b8652">

## New Components
#### [SnapDescription](https://github.com/MetaMask/metamask-mobile/blob/55d96c51e009df9bb6dc468720bc4c9c1ca34a8a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx#L23) (Low Complexity)
- a trivial component that takes in the name and description of a snap and renders it in a nice box with a border
The designs:
<img width="324" alt="Screenshot 2023-05-30 at 5 28 26 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/a229d783-d5da-43d6-bdac-ac35872a70ee">

My Version:
<img width="369" alt="Screenshot 2023-05-30 at 5 28 35 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/281ec17f-0791-4e36-9ba1-423eabb943b5">


#### [SnapElement](https://github.com/MetaMask/metamask-mobile/blob/55d96c51e009df9bb6dc468720bc4c9c1ca34a8a/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx#L18) (Low Complexity)
- A list element that renders a [Cell](https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Cells/Cell) with the Snap name and id, a placeholder icon and navigates to the SnapSettings screen of that specific snap when clicked.
The designs:
<img width="333" alt="Screenshot 2023-05-30 at 5 30 57 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/3bd857e4-a353-4029-86ee-c414d433ac59">

My version:
<img width="395" alt="Screenshot 2023-05-30 at 5 30 43 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/4e9c70cb-c796-4bf1-a061-b38787989bd7">


#### [SnapVersionBadge](https://github.com/MetaMask/metamask-mobile/blob/4e7d2ec33bfc8d0d99e027a50c89b43a6d0a51b1/app/components/Views/Snaps/components/SnapVersionBadge/SnapVersionBadge.tsx#L23) (Low Complexity)
- A trivial component that renders the snap version with a `v` prefix and has an icon beside it. As of now clicking this button does nothing but in the future it will most likely link to other versions of that snap.
The designs:
<img width="73" alt="Screenshot 2023-05-30 at 5 29 52 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/700d9f34-4c49-4e6c-bfa4-3b2409b75c71">

My version:
<img width="111" alt="Screenshot 2023-05-30 at 5 29 44 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/cc2df282-c9ad-446c-90e9-49bbef29f603">


#### [SnapDetails](https://github.com/MetaMask/metamask-mobile/blob/ada6f09eee19ce4971d117132e58bbb0077cdccd/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx#L30-L31) (Medium Complexity)
- A component that renders the Snap name/id, a toggle button to enable/disable the snap, the install origin and date as well as the version badge mentioned below. 
The designs:
<img width="333" alt="Screenshot 2023-05-30 at 5 26 33 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/96430b2a-00bc-4a89-bcbf-e78c95c6889e">

My Version:
<img width="377" alt="Screenshot 2023-05-30 at 5 26 47 PM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/beac5900-2353-4407-9b45-d87dc962f9f2">


## **Related issues**

Progresses: https://github.com/MetaMask/accounts-planning/issues/143

## **Manual testing steps**

1. checkout this branch
8. run `yarn setup`
9. open the `.js.env`
10. modify the `METAMASK_BUILD_TYPE` to  `export METAMASK_BUILD_TYPE="flask"`
11. in your terminal run `source .js.env` and then run `yarn watch:clean`
12. in xcode select the flask variant  and press play
13. open http://metamask.github.io/snaps/test-snaps/1.1.0 in the browser

<img width="318" alt="Screenshot 2023-12-08 at 12 04 41 AM" src="https://github.com/MetaMask/metamask-mobile/assets/22918444/1a4a9cda-de34-4257-92a2-8705e5253720">

14. create a wallet
15. navigate to the browser
16. open this url: https://metamask.github.io/snaps/test-snaps/1.1.0/
17. install a snap, I usually install the bip32/bip44 snap
18. the install flow should appear with 3 steps including the a success screen
19. click the `Get Public key` button on the snap site, you should get a result
20. navigate to `settings/snaps`
21. you should see a list of all your installed snaps
22. clicking on an installed snap should bring you to the settings page for that snap
23. from this page you should see...
    - the description and name of the snap
    - all of the permissions it uses and when they were granted
    - the ability to disable the snap
    - the ability to remove the snap
24. Clicking remove snap should remove it from the list


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
- Only the list of snaps was available. 
- There was no way to delete a snap or view more details about it

![Simulator Screenshot - iPhone 13 Pro - 2023-12-13 at 10 02 11](https://github.com/MetaMask/metamask-mobile/assets/22918444/09e087b8-c862-4313-841f-9a78f0096680)

### **After**


https://github.com/MetaMask/metamask-mobile/assets/22918444/0738506e-aa9b-45ab-ad42-f1de52d55b46



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
