### PR TITLE
chore: Added deprecation notices to button-related components

### DIFF
--- a/app/components/UI/Button/index.js
+++ b/app/components/UI/Button/index.js
@@ -19,8 +19,12 @@ const createStyles = (colors) =>
   });
 
 /**
- * UI component that wraps GenericButton
- * which renders the appropiate UI elements for each platform (android & iOS)
+ * @deprecated This `<Button>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8108}
  */
 const Button = (props) => {
   const { colors } = useTheme();

--- a/app/components/UI/GenericButton/index.android.js
+++ b/app/components/UI/GenericButton/index.android.js
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import { View, ViewPropTypes, TouchableNativeFeedback } from 'react-native';
 
 /**
- * UI component that renders a button
- * specifically for android
+ * @deprecated The `<GenericButton>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8107}
  */
 const GenericButton = (props) => (
   <TouchableNativeFeedback

--- a/app/components/UI/GenericButton/index.ios.js
+++ b/app/components/UI/GenericButton/index.ios.js
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import { ViewPropTypes, TouchableOpacity } from 'react-native';
 
 /**
- * UI component that renders a button
- * specifically for iOS
+ * @deprecated The `<GenericButton>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8107}
  */
 const GenericButton = (props) => (
   <TouchableOpacity

--- a/app/components/UI/StyledButton/index.android.js
+++ b/app/components/UI/StyledButton/index.android.js
@@ -11,9 +11,12 @@ import getStyles from './styledButtonStyles';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 
 /**
- * UI component that wraps StyledButton
- * for Android devices
- * see styledButtonStyles.js for available styles
+ * @deprecated The `<StyledButton>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8106}
  */
 export default class StyledButton extends PureComponent {
   static propTypes = {

--- a/app/components/UI/StyledButton/index.ios.js
+++ b/app/components/UI/StyledButton/index.ios.js
@@ -6,9 +6,12 @@ import getStyles from './styledButtonStyles';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 
 /**
- * UI component that renders a styled button
- * for iOS devices
- * see styledButtonStyles.js for available styles
+ * @deprecated The `<StyledButton>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8106}
  */
 export default class StyledButton extends PureComponent {
   static propTypes = {

--- a/app/components/UI/StyledButton/index.js
+++ b/app/components/UI/StyledButton/index.js
@@ -1,3 +1,10 @@
 import StyledButton from './StyledButton'; // eslint-disable-line import/no-unresolved
-
+/**
+ * @deprecated The `<StyledButton>` component has been deprecated in favor of the new `<Button>` component from the component-library.
+ * Please update your code to use the new `<Button>` component instead, which can be found at app/component-library/components/Buttons/Button/Button.tsx.
+ * You can find documentation for the new Button component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Buttons/Button/README.md}
+ * If you would like to help with the replacement of the old `Button` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/8106}
+ */
 export default StyledButton;


### PR DESCRIPTION
## **Description**
- Added deprecation notices to `GenericButton`, `StyledButton`, and `UI/Button`

## **Related issues**

Fixes:
N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**
N/A
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
