### PR TITLE
chore: Added deprecation notice to non-ds icons

### DIFF
--- a/app/declarations.d.ts
+++ b/app/declarations.d.ts
@@ -49,3 +49,227 @@ declare module '@react-native-community/checkbox' {
    */
   export default class CheckBox extends CheckBoxType {}
 }
+
+declare module 'react-native-vector-icons/Ionicons' {
+  import IonicIconOriginal from 'react-native-vector-icons/Ionicons';
+
+  type IonicIconType = typeof IonicIconOriginal;
+
+  /**
+   * @deprecated The `<IonicIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the IonicIcon component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8110}
+   */
+  export default class IonicIcon extends IonicIconType {}
+}
+
+declare module 'react-native-vector-icons/FontAwesome' {
+  import FontAwesomeIconOriginal from 'react-native-vector-icons/FontAwesome';
+
+  type FontAwesomeIconType = typeof FontAwesomeIconOriginal;
+
+  /**
+   * @deprecated The `<FontAwesomeIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the FontAwesomeIcon component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8111}
+   */
+  export default class FontAwesomeIcon extends FontAwesomeIconType {}
+}
+
+declare module 'react-native-vector-icons/AntDesign' {
+  import AntDesignIconOriginal from 'react-native-vector-icons/AntDesign';
+
+  type AntDesignIconType = typeof AntDesignIconOriginal;
+
+  /**
+   * @deprecated The `<AntDesignIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the AntDesignIcon component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8112}
+   */
+  export default class AntDesignIcon extends AntDesignIconType {}
+}
+
+declare module 'react-native-vector-icons/MaterialCommunityIcons' {
+  import MaterialCommunityIconsOriginal from 'react-native-vector-icons/MaterialCommunityIcons';
+
+  type MaterialCommunityIconsType = typeof MaterialCommunityIconsOriginal;
+
+  /**
+   * @deprecated The `<MaterialCommunityIconsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the MaterialCommunityIcons component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8113}
+   */
+  export default class MaterialCommunityIcons extends MaterialCommunityIconsIconType {}
+}
+
+declare module 'react-native-vector-icons/Feather' {
+  import FeatherIconOriginal from 'react-native-vector-icons/Feather';
+
+  type FeatherIconType = typeof FeatherIconOriginal;
+
+  /**
+   * @deprecated The `<FeatherIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the FeatherIcon component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8114}
+   */
+  export default class FeatherIcon extends FeatherIconType {}
+}
+
+declare module 'react-native-vector-icons/EvilIcons' {
+  import EvilIconsOriginal from 'react-native-vector-icons/EvilIcons';
+
+  type EvilIconsType = typeof EvilIconsOriginal;
+
+  /**
+   * @deprecated The `<EvilIconsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the EvilIcons component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8115}
+   */
+  export default class EvilIcons extends EvilIconsType {}
+}
+
+declare module 'react-native-vector-icons/SimpleLineIcons' {
+  import SimpleLineIconsOriginal from 'react-native-vector-icons/SimpleLineIcons';
+
+  type SimpleLineIconsType = typeof SimpleLineIconsOriginal;
+
+  /**
+   * @deprecated The `<SimpleLineIconsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the SimpleLineIcons component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8116}
+   */
+  export default class SimpleLineIcons extends SimpleLineIconsType {}
+}
+
+declare module 'react-native-vector-icons/MaterialIcons' {
+  import MaterialIconsOriginal from 'react-native-vector-icons/MaterialIcons';
+
+  type MaterialIconsType = typeof MaterialIconsOriginal;
+
+  /**
+   * @deprecated The `<MaterialIconsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the MaterialIcons component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8117}
+   */
+  export default class MaterialIcons extends MaterialIconsType {}
+}
+
+declare module 'react-native-vector-icons/FontAwesome5' {
+  import FontAwesome5IconOriginal from 'react-native-vector-icons/FontAwesome5';
+
+  type FontAwesome5IconType = typeof FontAwesome5IconOriginal;
+
+  /**
+   * @deprecated The `<FontAwesome5Icon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the FontAwesome5 component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8118}
+   */
+  export default class FontAwesome5 extends FontAwesome5IconType {}
+}
+
+declare module 'react-native-vector-icons/Octicons' {
+  import OcticonsIconOriginal from 'react-native-vector-icons/Octicons';
+
+  type OcticonsIconType = typeof OcticonsIconOriginal;
+
+  /**
+   * @deprecated The `<OcticonsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the Octicons component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8119}
+   */
+  export default class Octicons extends OcticonsIconType {}
+}
+
+declare module 'react-native-vector-icons/Entypo' {
+  import EntypoIconOriginal from 'react-native-vector-icons/Entypo';
+
+  type EntypoIconType = typeof EntypoIconOriginal;
+
+  /**
+   * @deprecated The `<EntypoIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the Entypo component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8120}
+   */
+  export default class Entypo extends EntypoIconType {}
+}
+
+declare module 'react-native-vector-icons/Foundation' {
+  import FoundationIconOriginal from 'react-native-vector-icons/Foundation';
+
+  type FoundationIconType = typeof FoundationIconOriginal;
+
+  /**
+   * @deprecated The `<FoundationIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the Foundation component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8121}
+   */
+  export default class Foundation extends FoundationIconType {}
+}
+
+declare module 'react-native-vector-icons/Fontisto' {
+  import FontistoIconOriginal from 'react-native-vector-icons/Fontisto';
+
+  type FontistoIconType = typeof FontistoIconOriginal;
+
+  /**
+   * @deprecated The `<FontistoIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the Fontisto component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8122}
+   */
+  export default class Fontisto extends FontistoIconType {}
+}
+
+declare module 'react-native-vector-icons/Zocial' {
+  import ZocialIconOriginal from 'react-native-vector-icons/Zocial';
+
+  type ZocialIconType = typeof ZocialIconOriginal;
+
+  /**
+   * @deprecated The `<ZocialIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
+   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
+   * You can find documentation for the new Icon component in the README:
+   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
+   * If you would like to help with the replacement of the usage of the Zocial component, please submit a pull request against this GitHub issue:
+   * {@link https://github.com/MetaMask/metamask-mobile/issues/8123}
+   */
+  export default class Zocial extends ZocialIconType {}
+}


### PR DESCRIPTION
## **Description**
- Added deprecation notice to non-ds icons, which includes Ionicons, FontAwesome, FontAwesome5, AntDesign, MaterialCommunityIcons, Feather, EvilIcons, SimpleLineIcons, MaterialIcons, Octicons, Entypo, Foundation, Fontisto, and Zocial

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull this branch and open VS Code
2. Search `<IonicIcon`
3. Find instance and hover mouse over tag
4. See deprecation notice
5. Repeat for: `<FontAwesomeIcon`, `<AntDesignIcon`, `<MaterialCommunityIcons`, `<MaterialIcons`,  `<SimpleLineIcons`, `FontAwesome5`, `OcticonsIcon`, `Entypo`, `FoundationIcon`

## **Screenshots/Recordings**
N/A
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

![Screenshot 2023-12-18 at 3 27 58 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/84f596c7-f0e6-454f-8ba4-e25de63e3d88)
![Screenshot 2023-12-18 at 3 28 23 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/193192b6-24a9-4eff-9e39-85d6fa8a2f49)
![Screenshot 2023-12-18 at 3 30 17 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/f336c294-b1cc-40ae-8732-ca1fa1650659)
![Screenshot 2023-12-18 at 3 30 52 PM](https://github.com/MetaMask/metamask-mobile/assets/8112138/67df1bcd-c757-4cb7-9259-2376692462a4)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
