### PR TITLE
test(ramp): add test for stateHasOrder util

### DIFF
--- a/app/components/UI/Ramp/common/utils/index.test.ts
+++ b/app/components/UI/Ramp/common/utils/index.test.ts
@@ -19,9 +19,12 @@ import {
   isSellOrder,
   isSellFiatOrder,
   getNotificationDetails,
+  stateHasOrder,
 } from '.';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
 import { FiatOrder, RampType } from '../../../../../reducers/fiatOrders/types';
+import { getOrders } from '../../../../../reducers/fiatOrders';
+import type { RootState } from '../../../../../reducers';
 
 describe('timeToDescription', () => {
   it('should return a function', () => {
@@ -450,5 +453,31 @@ describe('getNotificationDetails', () => {
       state: FIAT_ORDER_STATES.CREATED,
     });
     expect(createdDetails).toMatchInlineSnapshot(`null`);
+  });
+});
+
+jest.mock('../../../../../reducers/fiatOrders', () => ({
+  getOrders: jest.fn(),
+}));
+
+describe('stateHasOrder', () => {
+  it('should return true if state has order', () => {
+    (getOrders as jest.MockedFunction<typeof getOrders>).mockReturnValueOnce([
+      { id: '1' },
+      { id: '2' },
+      { id: '3' },
+    ] as FiatOrder[]);
+    expect(stateHasOrder({} as RootState, { id: '1' } as FiatOrder)).toBe(true);
+  });
+
+  it('should return false if state does not have the order', () => {
+    (getOrders as jest.MockedFunction<typeof getOrders>).mockReturnValueOnce([
+      { id: '1' },
+      { id: '2' },
+      { id: '3' },
+    ] as FiatOrder[]);
+    expect(stateHasOrder({} as RootState, { id: '4' } as FiatOrder)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## **Description**

This PR adds a simple missing test in the Ramp utils, for `stateHasOrder` function.
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
