### PR TITLE
fix: Add paddings to the segmented control and use sentence case

### DIFF
--- a/app/components/Views/AddAsset/AddAsset.styles.ts
+++ b/app/components/Views/AddAsset/AddAsset.styles.ts
@@ -1,6 +1,8 @@
-import { StyleSheet } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 import { fontStyles } from '../../../styles/common';
+
+const screenWidth = Dimensions.get('window').width;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
@@ -15,9 +17,17 @@ const styleSheet = (params: { theme: Theme }) => {
       marginTop: 10,
       paddingHorizontal: 16,
     },
-    tabUnderlineStyle: {
+    tabUnderlineStyleSearch: {
       height: 2,
       backgroundColor: colors.primary.default,
+      marginLeft: 16,
+      width: screenWidth / 2,
+    },
+    tabUnderlineStyleCustomToken: {
+      height: 2,
+      backgroundColor: colors.primary.default,
+      marginLeft: -16,
+      width: screenWidth / 2,
     },
     tabBar: {
       borderColor: colors.border.muted,

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -63,16 +63,34 @@ const AddAsset = () => {
     });
   };
 
-  const renderTabBar = () => (
-    <DefaultTabBar
-      underlineStyle={styles.tabUnderlineStyle}
-      activeTextColor={colors.primary.default}
-      inactiveTextColor={colors.text.alternative}
-      backgroundColor={colors.background.default}
-      tabStyle={styles.tabStyle}
-      textStyle={styles.textStyle}
-      style={styles.tabBar}
-    />
+  const renderTabBar = useCallback(
+    (args) => {
+      if (args.activeTab === 0) {
+        return (
+          <DefaultTabBar
+            underlineStyle={styles.tabUnderlineStyleSearch}
+            activeTextColor={colors.primary.default}
+            inactiveTextColor={colors.text.default}
+            backgroundColor={colors.background.default}
+            tabStyle={styles.tabStyle}
+            textStyle={styles.textStyle}
+            style={styles.tabBar}
+          />
+        );
+      }
+      return (
+        <DefaultTabBar
+          underlineStyle={styles.tabUnderlineStyleCustomToken}
+          activeTextColor={colors.primary.default}
+          inactiveTextColor={colors.text.default}
+          backgroundColor={colors.background.default}
+          tabStyle={styles.tabStyle}
+          textStyle={styles.textStyle}
+          style={styles.tabBar}
+        />
+      );
+    },
+    [styles, colors],
   );
 
   return (

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -8,6 +8,7 @@ import {
   SafeAreaView,
   Linking,
   Platform,
+  Dimensions,
 } from 'react-native';
 import { connect } from 'react-redux';
 import {
@@ -80,6 +81,8 @@ import {
 } from '../../../../../selectors/networkController';
 import { regex } from '../../../../../../app/util/regex';
 import { NetworksViewSelectorsIDs } from '../../../../../../e2e/selectors/Settings/NetworksView.selectors';
+
+const screenWidth = Dimensions.get('window').width;
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -163,9 +166,17 @@ const createStyles = (colors) =>
       justifyContent: 'space-between',
       marginVertical: 12,
     },
-    tabUnderlineStyle: {
+    tabUnderlineStylePopular: {
       height: 2,
       backgroundColor: colors.primary.default,
+      marginLeft: 16,
+      width: screenWidth / 2,
+    },
+    tabUnderlineStyleCustomNetwork: {
+      height: 2,
+      backgroundColor: colors.primary.default,
+      marginLeft: -16,
+      width: screenWidth / 2,
     },
     tabStyle: {
       paddingVertical: 8,
@@ -214,6 +225,7 @@ const createStyles = (colors) =>
 const allNetworks = getAllNetworks();
 const allNetworksblockExplorerUrl = (networkName) =>
   `https://${networkName}.infura.io/v3/`;
+
 /**
  * Main view for app configurations
  */
@@ -1045,17 +1057,31 @@ class NetworkSettings extends PureComponent {
 
   goToLearnMore = () => Linking.openURL(strings('networks.learn_more_url'));
 
-  renderTabBar = () => {
+  renderTabBar = (args) => {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
+    if (args.activeTab === 0) {
+      return (
+        <DefaultTabBar
+          underlineStyle={styles.tabUnderlineStylePopular}
+          activeTextColor={colors.primary.default}
+          inactiveTextColor={colors.text.default}
+          backgroundColor={colors.background.default}
+          tabStyle={styles.tabStyle}
+          textStyle={styles.textStyle}
+          style={styles.tabBar}
+        />
+      );
+    }
     return (
       <DefaultTabBar
-        underlineStyle={styles.tabUnderlineStyle}
+        underlineStyle={styles.tabUnderlineStyleCustomNetwork}
         activeTextColor={colors.primary.default}
-        inactiveTextColor={colors.text.muted}
+        inactiveTextColor={colors.text.default}
         backgroundColor={colors.background.default}
         tabStyle={styles.tabStyle}
         textStyle={styles.textStyle}
+        style={styles.tabBar}
       />
     );
   };

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   View,
   TextStyle,
+  Dimensions,
 } from 'react-native';
 import { Theme } from '@metamask/design-tokens';
 import { useSelector } from 'react-redux';
@@ -45,6 +46,8 @@ import {
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectSelectedAddress } from '../../../selectors/preferencesController';
 
+const screenWidth = Dimensions.get('window').width;
+
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
     wrapper: {
@@ -52,9 +55,17 @@ const createStyles = ({ colors, typography }: Theme) =>
       backgroundColor: colors.background.default,
     },
     walletAccount: { marginTop: 28 },
-    tabUnderlineStyle: {
+    tabUnderlineStyleTokens: {
       height: 2,
       backgroundColor: colors.primary.default,
+      marginLeft: 16,
+      width: screenWidth / 2,
+    },
+    tabUnderlineStyleNfts: {
+      height: 2,
+      backgroundColor: colors.primary.default,
+      marginLeft: -16,
+      width: screenWidth / 2,
     },
     tabStyle: {
       paddingBottom: 0,
@@ -201,17 +212,32 @@ const Wallet = ({ navigation }: any) => {
   }, [navigation, themeColors, networkName, networkImageSource, onTitlePress]);
 
   const renderTabBar = useCallback(
-    () => (
-      <DefaultTabBar
-        underlineStyle={styles.tabUnderlineStyle}
-        activeTextColor={colors.primary.default}
-        inactiveTextColor={colors.text.default}
-        backgroundColor={colors.background.default}
-        tabStyle={styles.tabStyle}
-        textStyle={styles.textStyle}
-        style={styles.tabBar}
-      />
-    ),
+    (args) => {
+      if (args.activeTab === 0) {
+        return (
+          <DefaultTabBar
+            underlineStyle={styles.tabUnderlineStyleTokens}
+            activeTextColor={colors.primary.default}
+            inactiveTextColor={colors.text.default}
+            backgroundColor={colors.background.default}
+            tabStyle={styles.tabStyle}
+            textStyle={styles.textStyle}
+            style={styles.tabBar}
+          />
+        );
+      }
+      return (
+        <DefaultTabBar
+          underlineStyle={styles.tabUnderlineStyleNfts}
+          activeTextColor={colors.primary.default}
+          inactiveTextColor={colors.text.default}
+          backgroundColor={colors.background.default}
+          tabStyle={styles.tabStyle}
+          textStyle={styles.textStyle}
+          style={styles.tabBar}
+        />
+      );
+    },
     [styles, colors],
   );
 


### PR DESCRIPTION
## **Description**

Currently segmented controls on wallet view, import token view, network view have no paddings on the side. Need to match designs and have 16px paddings on each side.
On import token view and network view, copies for segments are in all caps. Should be using normal sentence case (e.g. "Custom networks" instead of "CUSTOM NETWORKS"), font "Body-MD-Medium", and color "text/default" & "primary/default".

## **Related issues**

Fixes: [#8060](https://github.com/MetaMask/metamask-mobile/issues/8060) 

## **Manual testing steps**
1. Wallet view: open the app and you are on the default wallet view.
2. Import token view: click on "Import tokens" on the wallet view
3. Network view: click on the network picker on the top of the wallet view, then click "Add Network"

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/26223211/de19499d-d888-47f9-a5c3-a37fc769a53d

### **After**


https://github.com/MetaMask/metamask-mobile/assets/26223211/9549ab5b-8729-481f-bbac-2b5c6c906858


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
