### PR TITLE
refactor(ds): make onPressClearButton required when showClearButton

### DIFF
--- a/app/component-library/components/Form/TextFieldSearch/TextFieldSearch.types.ts
+++ b/app/component-library/components/Form/TextFieldSearch/TextFieldSearch.types.ts
@@ -2,21 +2,39 @@
 import { TextFieldProps } from '../TextField/TextField.types';
 import { ButtonIconProps } from '../../Buttons/ButtonIcon/ButtonIcon.types';
 
-/**
- * TextFieldSearch component props.
- */
-export interface TextFieldSearchProps extends TextFieldProps {
-  /**
-   * Optional boolean to show the Clear button.
-   * @default false
-   */
-  showClearButton?: boolean;
-  /**
-   * Function to trigger when pressing the clear button.
-   */
-  onPressClearButton?: () => void;
+interface BaseTextFieldSearchProps extends TextFieldProps {
   /**
    * Optional prop to pass any additional props to the clear button.
    */
   clearButtonProps?: ButtonIconProps;
 }
+
+interface HideClearButtonTextFieldSearchProps extends BaseTextFieldSearchProps {
+  /**
+   * Optional boolean to show the Clear button.
+   * @default false
+   */
+  showClearButton?: false;
+  /**
+   * Function to trigger when pressing the clear button.
+   */
+  onPressClearButton?: () => void;
+}
+
+interface ShowClearButtonTextFieldSearchProps extends BaseTextFieldSearchProps {
+  /**
+   * Show the Clear button.
+   */
+  showClearButton: true;
+  /**
+   * Function to trigger when pressing the clear button.
+   */
+  onPressClearButton: () => void;
+}
+
+/**
+ * TextFieldSearch component props.
+ */
+export type TextFieldSearchProps =
+  | HideClearButtonTextFieldSearchProps
+  | ShowClearButtonTextFieldSearchProps;


### PR DESCRIPTION
## **Description**

This PR enforces `TextFieldSearch` prop `onPressClearButton` to be defined when `showClearButton` is not `false`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
