### PR TITLE
fix: unmount Settings on blur to hide credential

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -410,6 +410,7 @@ const HomeTabs = () => {
         AnalyticsV2.trackEvent(MetaMetricsEvents.NAVIGATION_TAPS_SETTINGS);
       },
       rootScreenName: Routes.SETTINGS_VIEW,
+      unmountOnBlur: true,
     },
   };
 


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently there's an edge case that displays the seed phrase or private key without the use of password when the user tries to reveal the private key from the wallet view, this is caused by the screen not unmounting when changing tabs. The change in this PR sets a flag to unmount the Settings tab whenever the user navigates from it.

[React Navigation source](https://reactnavigation.org/docs/bottom-tab-navigator/#unmountonblur)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/8210

## **Manual testing steps**

_Same steps as indicated in ticket #8210_

1. Have a wallet configured with SRP backed up and be at wallet view
2. Tap settings gear
3. Tap `Security & Privacy`
4. Tap `Reveal Secret Recovery Phrase`
5. Tap `Get started`
6. Complete the quiz
7. Supply password
8. Tap `Next`
9. Tap and hold `Hold to reveal SRP`
10. When SRP is displayed do **NOT** tap `Done`
11. Tap Wallet on bottom left to return to wallet view
12. Tap 3 dots next to public address
13. Tap `Show private key`
14. See that the screen display the correct texts and the private key is protect by the password

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/17601467/5e9b78da-1f91-4f62-9067-da3c71f5aae2

### **After**

https://github.com/MetaMask/metamask-mobile/assets/17601467/2bc8cf11-198c-4840-9282-602859afa391

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
