### PR TITLE
test: fixed Swap smoke and regression test failures

### DIFF
--- a/e2e/pages/TokenOverview.js
+++ b/e2e/pages/TokenOverview.js
@@ -30,7 +30,7 @@ export default class TokenOverview {
   }
 
   static async scrollOnScreen() {
-    await TestHelpers.swipe(TOKEN_OVERVIEW_TXN_SCREEN, 'up', 'slow', 0.3);
+    await TestHelpers.swipe(TOKEN_PRICE, 'up', 'fast', 0.6);
   }
 
   static async tapBackButton() {

--- a/e2e/pages/TokenOverview.js
+++ b/e2e/pages/TokenOverview.js
@@ -6,7 +6,6 @@ import {
   TOKEN_OVERVIEW_RECEIVE_BUTTON,
   TOKEN_OVERVIEW_BUY_BUTTON,
   TOKEN_OVERVIEW_SWAP_BUTTON,
-  TOKEN_OVERVIEW_TXN_SCREEN,
   ASSET_BACK_BUTTON,
 } from '../../wdio/screen-objects/testIDs/Screens/TokenOverviewScreen.testIds';
 import messages from '../../locales/languages/en.json';

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -34,6 +34,7 @@ export default class SwapView {
   }
 
   static async waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol) {
+    await TestHelpers.delay(5000);
     await TestHelpers.checkIfElementByTextIsVisible(
       `Swap complete (${sourceTokenSymbol} to ${destTokenSymbol})`,
     );

--- a/e2e/specs/swaps/swap-token-chart.spec.js
+++ b/e2e/specs/swaps/swap-token-chart.spec.js
@@ -61,7 +61,6 @@ describe(SmokeSwaps('Swap from Token view'), () => {
     await SwapView.isVisible();
     await SwapView.tapIUnderstandPriceWarning();
     await SwapView.swipeToSwap();
-    await TestHelpers.delay(5000);
     await SwapView.waitForSwapToComplete('USDC', 'DAI');
   });
 });


### PR DESCRIPTION
## **Description**

Fixed Swap smoke and regression test failures when running on Android.

Please check the runs I did on Bitrise with the fixes
Smoke: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/1b22e161-3732-4748-9193-771a3a7ad5a5
Regression: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/0e0e0ebf-e127-406d-b350-1c535b0ecf29

## **Related issues**



## **Manual testing steps**

Run this script `yarn test:e2e:android:debug:single e2e/specs/swaps`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
