### PR TITLE
fix: Remove duplicate declarations and library

### DIFF
--- a/app/declarations.d.ts
+++ b/app/declarations.d.ts
@@ -8,8 +8,6 @@ declare module 'react-native-fade-in-image';
 
 declare module 'react-native-minimizer';
 
-declare module '@react-native-community/checkbox';
-
 declare module 'react-native-scrollable-tab-view/DefaultTabBar' {
   const content: React.FC<any>;
   export default content;

--- a/package.json
+++ b/package.json
@@ -237,7 +237,6 @@
     "base-64": "1.0.0",
     "bignumber.js": "^9.0.1",
     "buffer": "5.2.1",
-    "cockatiel": "^3.1.1",
     "compare-versions": "^3.6.0",
     "content-hash": "2.5.2",
     "crypto-js": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "base-64": "1.0.0",
     "bignumber.js": "^9.0.1",
     "buffer": "5.2.1",
+    "cockatiel": "^3.1.1",
     "compare-versions": "^3.6.0",
     "content-hash": "2.5.2",
     "crypto-js": "^4.2.0",
@@ -368,8 +369,7 @@
     "uuid": "^8.3.2",
     "valid-url": "1.0.9",
     "vm-browserify": "1.1.2",
-    "zxcvbn": "4.4.2",
-    "cockatiel": "^3.1.1"
+    "zxcvbn": "4.4.2"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This small PR removes duplicates from:
- Type declarations
- Library from package.json

## **Related issues**

Fixes:

## **Manual testing steps**

This PR is only reliant on smoke E2E tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
