### PR TITLE
fix: state initialisation in PPOMController

### DIFF
--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -98,7 +98,7 @@ class EngineService {
     if (isBlockaidFeatureEnabled()) {
       controllers.push({
         name: 'PPOMController',
-        key: AppConstants.PPOM_INITIALISATION_STATE_CHANGE_EVENT,
+        key: `${engine.context.PPOMController.name}:stateChange`,
       });
     }
 

--- a/app/redux/slices/engine/engineReducer.test.tsx
+++ b/app/redux/slices/engine/engineReducer.test.tsx
@@ -22,6 +22,7 @@ const backgroundState = {
   NetworkController: {},
   NftController: {},
   NftDetectionController: {},
+  PPOMController: {},
   PermissionController: {},
   PhishingController: {},
   PreferencesController: {},

--- a/app/redux/slices/engine/index.ts
+++ b/app/redux/slices/engine/index.ts
@@ -70,6 +70,10 @@ const controllerNames = [
     name: 'LoggingController',
     initialState: {},
   },
+  {
+    name: 'PPOMController',
+    initialState: {},
+  },
 ];
 
 const controllerReducer =


### PR DESCRIPTION
## **Description**

PPOMController state initialisation is broken. This is resulting in blockaid files being downloaded each time app is re-opened.

## **Related issues**

Fixes: MetaMask/metamask-mobile#8280

## **Manual testing steps**
The issue is hard to test manually.

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [ ] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
