### PR TITLE
chore: Update Network Settings Actionable Buttons to use DS buttons

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -26,7 +26,6 @@ import { getEtherscanBaseUrl } from '../../../../../util/etherscan';
 import Engine from '../../../../../core/Engine';
 import { isWebUri } from 'valid-url';
 import URL from 'url-parse';
-import CustomText from '../../../../Base/Text';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import BigNumber from 'bignumber.js';
 import { jsonRpcRequest } from '../../../../../util/jsonRpcRequest';

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -23,7 +23,6 @@ import Networks, {
   getIsNetworkOnboarded,
 } from '../../../../../util/networks';
 import { getEtherscanBaseUrl } from '../../../../../util/etherscan';
-import StyledButton from '../../../../UI/StyledButton';
 import Engine from '../../../../../core/Engine';
 import { isWebUri } from 'valid-url';
 import URL from 'url-parse';
@@ -201,12 +200,7 @@ const createStyles = (colors) =>
       backgroundColor: colors.primary.muted,
     },
     cancel: {
-      marginRight: 8,
-      backgroundColor: colors.white,
-      borderWidth: 1,
-    },
-    confirm: {
-      marginLeft: 8,
+      marginRight: 16,
     },
     blueText: {
       color: colors.primary.default,
@@ -987,39 +981,38 @@ class NetworkSettings extends PureComponent {
               <View style={styles.buttonsWrapper}>
                 {editable ? (
                   <View style={styles.editableButtonsContainer}>
-                    <StyledButton
-                      type="danger"
+                    <Button
+                      size={ButtonSize.Lg}
+                      variant={ButtonVariants.Secondary}
+                      isDanger
                       onPress={this.removeRpcUrl}
                       testID={REMOVE_NETWORK_BUTTON}
-                      containerStyle={[styles.button, styles.cancel]}
-                    >
-                      <CustomText centered red>
-                        {strings('app_settings.delete')}
-                      </CustomText>
-                    </StyledButton>
-                    <StyledButton
-                      type="confirm"
+                      style={{ ...styles.button, ...styles.cancel }}
+                      label={strings('app_settings.delete')}
+                    />
+                    <Button
+                      size={ButtonSize.Lg}
+                      variant={ButtonVariants.Primary}
                       onPress={this.addRpcUrl}
                       testID={NetworksViewSelectorsIDs.ADD_NETWORKS_BUTTON}
-                      containerStyle={[styles.button, styles.confirm]}
-                      disabled={isActionDisabled}
-                    >
-                      {strings('app_settings.network_save')}
-                    </StyledButton>
+                      style={styles.button}
+                      label={strings('app_settings.network_save')}
+                    />
                   </View>
                 ) : (
                   <View style={styles.buttonsContainer}>
-                    <StyledButton
-                      type="confirm"
+                    <Button
+                      size={ButtonSize.Lg}
+                      variant={ButtonVariants.Primary}
                       onPress={this.addRpcUrl}
                       testID={
                         NetworksViewSelectorsIDs.ADD_CUSTOM_NETWORK_BUTTON
                       }
-                      containerStyle={styles.syncConfirm}
-                      disabled={isActionDisabled}
-                    >
-                      {strings('app_settings.network_add')}
-                    </StyledButton>
+                      style={styles.button}
+                      label={strings('app_settings.network_add')}
+                      isDisabled={isActionDisabled}
+                      width={ButtonWidthTypes.Full}
+                    />
                   </View>
                 )}
               </View>

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -997,6 +997,7 @@ class NetworkSettings extends PureComponent {
                       testID={NetworksViewSelectorsIDs.ADD_NETWORKS_BUTTON}
                       style={styles.button}
                       label={strings('app_settings.network_save')}
+                      isDisabled={isActionDisabled}
                     />
                   </View>
                 ) : (


### PR DESCRIPTION
## **Description**
- Update Network Settings Actionable Buttons to use DS buttons

## **Related issues**

Fixes: #8336 

## **Manual testing steps**

1. Go to Settings
2. Click on Network
3. Click on Add Network
4. Click on Custom

## **Screenshots/Recordings**

### **Before**
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 16 20 01](https://github.com/MetaMask/metamask-mobile/assets/14355083/08391741-023d-4467-bff0-0063698f7272)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 16 28 07](https://github.com/MetaMask/metamask-mobile/assets/14355083/a6cedd91-d931-4410-8088-b40683edea37)


### **After**
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 16 28 24](https://github.com/MetaMask/metamask-mobile/assets/14355083/dad6b221-6f96-428e-a6c8-1f4c12c4d551)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 16 28 39](https://github.com/MetaMask/metamask-mobile/assets/14355083/a68e3be7-b4ea-4cdf-a696-3ea9c4113055)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
