### PR TITLE
feat: android sdk connection management

### DIFF
--- a/app/components/Views/SDKSessionsManager/SDKSessionItem.tsx
+++ b/app/components/Views/SDKSessionsManager/SDKSessionItem.tsx
@@ -1,15 +1,25 @@
 import { ThemeColors } from '@metamask/design-tokens/dist/js/themes/types';
 import { ThemeTypography } from '@metamask/design-tokens/dist/js/typography';
 import React, { useEffect, useState } from 'react';
-import { Image, StyleSheet, Text, TextStyle, View } from 'react-native';
+import { StyleSheet, TextStyle, View } from 'react-native';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { AvatarSize } from '../../../../app/component-library/components/Avatars/Avatar';
+import AvatarToken from '../../../../app/component-library/components/Avatars/Avatar/variants/AvatarToken';
+import Badge, {
+  BadgeStatusState,
+  BadgeVariant,
+} from '../../../../app/component-library/components/Badges/Badge';
+import BadgeWrapper from '../../../../app/component-library/components/Badges/BadgeWrapper';
+import { ConnectionProps } from '../../../../app/core/SDKConnect/Connection';
 import { strings } from '../../../../locales/i18n';
-import { ConnectionProps } from '../../../core/SDKConnect/SDKConnect';
 import { useTheme } from '../../../util/theme';
 import StyledButton from '../../UI/StyledButton';
+import Text from '../../../../app/component-library/components/Texts/Text';
+import AvatarFavicon from '../../../../app/component-library/components/Avatars/Avatar/variants/AvatarFavicon';
 
 interface SDKSessionViewProps {
   connection: ConnectionProps;
+  connected?: boolean;
   onDisconnect: (channelId: string) => void;
 }
 
@@ -58,6 +68,7 @@ const createStyles = (
 
 export const SDKSessionItem = ({
   connection,
+  connected = false,
   onDisconnect,
 }: SDKSessionViewProps) => {
   const safeAreaInsets = useSafeAreaInsets();
@@ -94,14 +105,22 @@ export const SDKSessionItem = ({
 
   return (
     <View style={styles.container}>
-      {icon ? (
-        <Image style={styles.icon} source={{ uri: icon }} />
-      ) : (
-        <Text style={[styles.icon, styles.iconText]}>
-          {sessionName.charAt(0).toUpperCase()}
-        </Text>
-      )}
-
+      <BadgeWrapper
+        badgeElement={
+          connected ? (
+            <Badge
+              variant={BadgeVariant.Status}
+              state={BadgeStatusState.Active}
+            />
+          ) : undefined
+        }
+      >
+        {icon ? (
+          <AvatarFavicon imageSource={{ uri: icon }} />
+        ) : (
+          <AvatarToken name={sessionName} isHaloEnabled size={AvatarSize.Md} />
+        )}
+      </BadgeWrapper>
       <Text style={styles.dappName}>{sessionName}</Text>
       <StyledButton
         type="normal"

--- a/app/components/Views/SDKSessionsManager/SDKSessionItem.tsx
+++ b/app/components/Views/SDKSessionsManager/SDKSessionItem.tsx
@@ -18,7 +18,10 @@ import Text from '../../../../app/component-library/components/Texts/Text';
 import AvatarFavicon from '../../../../app/component-library/components/Avatars/Avatar/variants/AvatarFavicon';
 
 interface SDKSessionViewProps {
-  connection: ConnectionProps;
+  connection: {
+    id: ConnectionProps['id'];
+    originatorInfo?: ConnectionProps['originatorInfo'];
+  };
   connected?: boolean;
   onDisconnect: (channelId: string) => void;
 }

--- a/app/components/Views/SDKSessionsManager/SDKSessionsManager.tsx
+++ b/app/components/Views/SDKSessionsManager/SDKSessionsManager.tsx
@@ -6,16 +6,15 @@ import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 
 import { ThemeColors } from '@metamask/design-tokens/dist/js/themes/types';
+import { ThemeTypography } from '@metamask/design-tokens/dist/js/typography';
+import { SDKSelectorsIDs } from '../../../../e2e/selectors/Settings/SDK.selectors';
 import ActionModal from '../../../components/UI/ActionModal';
 import { getNavigationOptionsTitle } from '../../../components/UI/Navbar';
+import { AndroidClient } from '../../../core/SDKConnect/AndroidSDK/android-sdk-types';
+import { ConnectionProps } from '../../../core/SDKConnect/Connection';
 import { SDKConnect } from '../../../core/SDKConnect/SDKConnect';
 import StyledButton from '../../UI/StyledButton';
 import SDKSessionItem from './SDKSessionItem';
-import { ThemeTypography } from '@metamask/design-tokens/dist/js/typography';
-import { SDKSelectorsIDs } from '../../../../e2e/selectors/Settings/SDK.selectors';
-import { ConnectionProps } from '../../../core/SDKConnect/Connection';
-import { AndroidClient } from '../../../core/SDKConnect/AndroidSDK/android-sdk-types';
-import DevLogger from '../../../core/SDKConnect/utils/DevLogger';
 
 interface Props {
   navigation: StackNavigationProp<{
@@ -100,9 +99,6 @@ const SDKSessionsManager = (props: Props) => {
 
       try {
         const _androidConnections = sdk.getAndroidConnections() ?? [];
-        DevLogger.log(
-          `found ${_androidConnections.length} android connections`,
-        );
         setAndroidConnections(_androidConnections);
       } catch (error) {
         console.error('Failed to load Android connections:', error);

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -431,7 +431,7 @@ export const getRpcMethodMiddleware = ({
           res.result = [selectedAddress];
         } else if (isMMSDK) {
           try {
-            const approved = getApprovedHosts()[hostname];
+            const approved = getApprovedHosts(hostname)[hostname];
 
             if (!approved) {
               // Prompts user approval UI in RootRPCMethodsUI.js.

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -45,7 +45,7 @@ import { AndroidClient } from './android-sdk-types';
 
 export default class AndroidService extends EventEmitter2 {
   private communicationClient = NativeModules.CommunicationClient;
-  private connectedClients: { [clientId: string]: AndroidClient } = {};
+  private connections: { [clientId: string]: AndroidClient } = {};
   private rpcQueueManager = new RPCQueueManager();
   private bridgeByClientId: { [clientId: string]: BackgroundBridge } = {};
   private eventHandler: AndroidSDKEventHandler;
@@ -88,9 +88,11 @@ export default class AndroidService extends EventEmitter2 {
           DevLogger.log(
             `AndroidService::setupEventListeners recover client: ${connection.id}`,
           );
-          this.connectedClients[connection.id] = {
+          this.connections[connection.id] = {
+            connected: false,
             clientId: connection.id,
             originatorInfo: connection.originatorInfo as OriginatorInfo,
+            validUntil: connection.validUntil,
           };
         });
       } else {
@@ -111,16 +113,32 @@ export default class AndroidService extends EventEmitter2 {
     await SDKConnect.getInstance().bindAndroidSDK();
   }
 
+  public getConnections() {
+    DevLogger.log(
+      `AndroidService::getConnections`,
+      JSON.stringify(this.connections, null, 2),
+    );
+    return Object.values(this.connections).filter(
+      (connection) => connection?.clientId?.length > 0,
+    );
+  }
+
   private setupOnClientsConnectedListener() {
     this.eventHandler.onClientsConnected((sClientInfo: string) => {
       const clientInfo: AndroidClient = JSON.parse(sClientInfo);
 
       DevLogger.log(`AndroidService::clients_connected`, clientInfo);
-      if (this.connectedClients?.[clientInfo.clientId]) {
+      if (this.connections?.[clientInfo.clientId]) {
         // Skip existing client -- bridge has been setup
         Logger.log(
           `AndroidService::clients_connected - existing client, sending ready`,
         );
+
+        // Update connected state
+        this.connections[clientInfo.clientId] = {
+          ...this.connections[clientInfo.clientId],
+          connected: true,
+        };
 
         this.sendMessage(
           {
@@ -150,10 +168,10 @@ export default class AndroidService extends EventEmitter2 {
         });
 
         try {
-          if (!this.connectedClients?.[clientInfo.clientId]) {
+          if (!this.connections?.[clientInfo.clientId]) {
             DevLogger.log(
               `AndroidService::clients_connected - new client ${clientInfo.clientId}}`,
-              this.connectedClients,
+              this.connections,
             );
             // Ask for account permissions
             await this.checkPermission({
@@ -163,6 +181,13 @@ export default class AndroidService extends EventEmitter2 {
 
             this.setupBridge(clientInfo);
             // Save session to SDKConnect
+            // Save to local connections
+            this.connections[clientInfo.clientId] = {
+              connected: true,
+              clientId: clientInfo.clientId,
+              originatorInfo: clientInfo.originatorInfo,
+              validUntil: clientInfo.validUntil,
+            };
             await SDKConnect.getInstance().addAndroidConnection({
               id: clientInfo.clientId,
               lastAuthorized: Date.now(),
@@ -288,6 +313,12 @@ export default class AndroidService extends EventEmitter2 {
           sessionId = parsedMsg.id;
           message = parsedMsg.message;
           data = JSON.parse(message);
+
+          // Update connected state
+          this.connections[sessionId] = {
+            ...this.connections[sessionId],
+            connected: true,
+          };
         } catch (error) {
           Logger.log(
             error,
@@ -308,14 +339,31 @@ export default class AndroidService extends EventEmitter2 {
           return;
         }
 
-        const bridge = this.bridgeByClientId[sessionId];
+        let bridge = this.bridgeByClientId[sessionId];
 
         if (!bridge) {
           console.warn(
             `AndroidService:: Bridge not found for client`,
             `sessionId=${sessionId} data.id=${data.id}`,
           );
-          return;
+
+          try {
+            // Ask users permissions again - it probably means the channel was removed
+            await this.checkPermission({
+              originatorInfo: this.connections[sessionId].originatorInfo,
+              channelId: sessionId,
+            });
+
+            // Create new bridge
+            this.setupBridge(this.connections[sessionId]);
+            bridge = this.bridgeByClientId[sessionId];
+          } catch (err) {
+            Logger.log(
+              err,
+              `AndroidService::onMessageReceived error checking permissions`,
+            );
+            return;
+          }
         }
 
         const preferencesController = (
@@ -363,8 +411,8 @@ export default class AndroidService extends EventEmitter2 {
   }
 
   private restorePreviousConnections() {
-    if (Object.keys(this.connectedClients ?? {}).length) {
-      Object.values(this.connectedClients).forEach((clientInfo) => {
+    if (Object.keys(this.connections ?? {}).length) {
+      Object.values(this.connections).forEach((clientInfo) => {
         try {
           this.setupBridge(clientInfo);
           this.sendMessage(
@@ -466,13 +514,13 @@ export default class AndroidService extends EventEmitter2 {
 
   async removeConnection(channelId: string) {
     try {
-      if (this.connectedClients[channelId]) {
+      if (this.connections[channelId]) {
         DevLogger.log(
           `AndroidService::remove client ${channelId} exists --- remove bridge`,
         );
         delete this.bridgeByClientId[channelId];
       }
-      delete this.connectedClients[channelId];
+      delete this.connections[channelId];
     } catch (err) {
       Logger.log(err, `AndroidService::remove error`);
     }

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -350,7 +350,7 @@ export default class AndroidService extends EventEmitter2 {
           try {
             // Ask users permissions again - it probably means the channel was removed
             await this.checkPermission({
-              originatorInfo: this.connections[sessionId].originatorInfo,
+              originatorInfo: this.connections[sessionId]?.originatorInfo ?? {},
               channelId: sessionId,
             });
 

--- a/app/core/SDKConnect/AndroidSDK/addAndroidConnection.ts
+++ b/app/core/SDKConnect/AndroidSDK/addAndroidConnection.ts
@@ -8,13 +8,13 @@ async function addAndroidConnection(
   connection: ConnectionProps,
   instance: SDKConnect,
 ) {
-  instance.state.connections[connection.id] = connection;
+  instance.state.androidConnections[connection.id] = connection;
 
   DevLogger.log(`SDKConnect::addAndroidConnection`, connection);
 
   await DefaultPreference.set(
     AppConstants.MM_SDK.ANDROID_CONNECTIONS,
-    JSON.stringify(instance.state.connections),
+    JSON.stringify(instance.state.androidConnections),
   ).catch((err) => {
     throw err;
   });

--- a/app/core/SDKConnect/AndroidSDK/android-sdk-types.ts
+++ b/app/core/SDKConnect/AndroidSDK/android-sdk-types.ts
@@ -3,4 +3,6 @@ import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 export interface AndroidClient {
   originatorInfo: OriginatorInfo;
   clientId: string;
+  connected: boolean;
+  validUntil?: number;
 }

--- a/app/core/SDKConnect/AndroidSDK/loadAndroidConnections.ts
+++ b/app/core/SDKConnect/AndroidSDK/loadAndroidConnections.ts
@@ -15,6 +15,7 @@ async function loadAndroidConnections(): Promise<{
   const parsed = JSON.parse(rawConnections);
   DevLogger.log(
     `SDKConnect::loadAndroidConnections found ${Object.keys(parsed).length}`,
+    parsed,
   );
   return parsed;
 }

--- a/app/core/SDKConnect/Connection/Connection.ts
+++ b/app/core/SDKConnect/Connection/Connection.ts
@@ -27,6 +27,7 @@ import {
   handleClientsReady,
   handleReceivedMessage,
 } from './EventListenersHandlers';
+import handleClientsWaiting from './EventListenersHandlers/handleClientsWaiting';
 
 export interface ConnectionProps {
   id: string;
@@ -210,6 +211,13 @@ export class Connection extends EventEmitter2 {
       handleClientsDisconnected({
         instance: this,
         disapprove,
+      }),
+    );
+
+    this.remote.on(
+      EventType.CLIENTS_WAITING,
+      handleClientsWaiting({
+        instance: this,
       }),
     );
 

--- a/app/core/SDKConnect/Connection/EventListenersHandlers/handleClientsWaiting.ts
+++ b/app/core/SDKConnect/Connection/EventListenersHandlers/handleClientsWaiting.ts
@@ -1,0 +1,15 @@
+import DevLogger from '../../utils/DevLogger';
+import { Connection } from '../Connection';
+
+function handleClientsWaiting({ instance }: { instance: Connection }) {
+  return () => {
+    DevLogger.log(
+      `handleClientsWaiting:: dapp not connected`,
+      instance.channelId,
+    );
+    // TODO - validate connection behavior if disconnect or maintain. Keeping it for now
+    // instance.disconnect({ terminate: false, context: 'CLIENTS_WAITING' });
+  };
+}
+
+export default handleClientsWaiting;

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.test.ts
@@ -181,7 +181,7 @@ describe('connectToChannel', () => {
             channelId: string;
             sendTerminate?: boolean;
           }) => {
-            mockInstance.removeChannel(channelId, sendTerminate);
+            mockInstance.removeChannel({ channelId, sendTerminate });
           },
         }),
       );

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
@@ -87,7 +87,7 @@ async function connectToChannel({
       channelId: string;
       sendTerminate?: boolean;
     }) => {
-      instance.removeChannel(channelId, sendTerminate);
+      instance.removeChannel({ channelId, sendTerminate });
     },
   });
   // Make sure to watch event before you connect

--- a/app/core/SDKConnect/ConnectionManagement/reconnect.ts
+++ b/app/core/SDKConnect/ConnectionManagement/reconnect.ts
@@ -89,7 +89,7 @@ async function reconnect({
 
     // instance condition should not happen keeping it for debug purpose.
     console.warn(`Priotity to deeplink - overwrite previous connection`);
-    instance.removeChannel(channelId, true);
+    instance.removeChannel({ channelId, sendTerminate: true });
   }
 
   if (!instance.state.connections[channelId]) {
@@ -145,7 +145,7 @@ async function reconnect({
     updateOriginatorInfos: instance.updateOriginatorInfos.bind(instance),
     // eslint-disable-next-line @typescript-eslint/no-shadow
     onTerminate: ({ channelId }) => {
-      instance.removeChannel(channelId);
+      instance.removeChannel({ channelId });
     },
   });
   instance.state.connected[channelId].connect({

--- a/app/core/SDKConnect/ConnectionManagement/reconnectAll.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/reconnectAll.test.ts
@@ -21,6 +21,7 @@ describe('reconnectAll', () => {
         connections: {},
       },
       reconnect: mockReconnect,
+      emit: jest.fn(),
     } as unknown as SDKConnect;
   });
 
@@ -39,6 +40,7 @@ describe('reconnectAll', () => {
 
       mockInstance.state.connections[mockChannelId] = {
         otherPublicKey: mockOtherPublicKey,
+        origin: 'qr-code',
       } as unknown as SDKConnect['state']['connections'][string];
 
       reconnectAll(mockInstance);

--- a/app/core/SDKConnect/ConnectionManagement/reconnectAll.ts
+++ b/app/core/SDKConnect/ConnectionManagement/reconnectAll.ts
@@ -1,3 +1,4 @@
+import AppConstants from '../../../../app/core/AppConstants';
 import Logger from '../../../util/Logger';
 import SDKConnect from '../SDKConnect';
 import DevLogger from '../utils/DevLogger';
@@ -14,7 +15,9 @@ async function reconnectAll(instance: SDKConnect) {
 
   const channelIds = Object.keys(instance.state.connections);
   channelIds.forEach((channelId) => {
-    if (channelId) {
+    // Only reconnects to type 'qrcode' connections.
+    const connection = instance.state.connections[channelId];
+    if (connection.origin === AppConstants.DEEPLINKS.ORIGIN_QR_CODE) {
       instance
         .reconnect({
           channelId,

--- a/app/core/SDKConnect/ConnectionManagement/removeAll.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/removeAll.test.ts
@@ -28,6 +28,7 @@ describe('removeAll', () => {
         paused: true,
       },
       removeChannel: mockRemoveChannel,
+      loadAndroidConnections: jest.fn().mockResolvedValue({}),
     } as unknown as SDKConnect;
   });
 
@@ -40,7 +41,11 @@ describe('removeAll', () => {
 
     await removeAll(mockInstance);
 
-    expect(mockRemoveChannel).toHaveBeenCalledWith(mockChannelId, true);
+    expect(mockRemoveChannel).toHaveBeenCalledWith({
+      channelId: mockChannelId,
+      emitRefresh: false,
+      sendTerminate: true,
+    });
   });
 
   it('should clear all android connections from DefaultPreference', async () => {

--- a/app/core/SDKConnect/ConnectionManagement/removeAll.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/removeAll.test.ts
@@ -29,6 +29,7 @@ describe('removeAll', () => {
       },
       removeChannel: mockRemoveChannel,
       loadAndroidConnections: jest.fn().mockResolvedValue({}),
+      emit: jest.fn(),
     } as unknown as SDKConnect;
   });
 

--- a/app/core/SDKConnect/ConnectionManagement/removeAll.ts
+++ b/app/core/SDKConnect/ConnectionManagement/removeAll.ts
@@ -4,7 +4,19 @@ import SDKConnect from '../SDKConnect';
 
 async function removeAll(instance: SDKConnect) {
   for (const id in instance.state.connections) {
-    instance.removeChannel(id, true);
+    instance.removeChannel({
+      channelId: id,
+      sendTerminate: true,
+      emitRefresh: false,
+    });
+  }
+
+  for (const id in await instance.loadAndroidConnections()) {
+    instance.removeChannel({
+      channelId: id,
+      sendTerminate: true,
+      emitRefresh: false,
+    });
   }
 
   // Remove all android connections
@@ -20,6 +32,9 @@ async function removeAll(instance: SDKConnect) {
 
   await DefaultPreference.clear(AppConstants.MM_SDK.SDK_CONNECTIONS);
   await DefaultPreference.clear(AppConstants.MM_SDK.SDK_APPROVEDHOSTS);
+
+  // Delayed ui refresh
+  setTimeout(() => instance.emit('refresh'), 100);
 }
 
 export default removeAll;

--- a/app/core/SDKConnect/ConnectionManagement/watchConnection.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/watchConnection.test.ts
@@ -39,6 +39,7 @@ describe('watchConnection', () => {
         disabledHosts: {},
       },
       removeChannel: mockRemoveChannel,
+      emit: jest.fn(),
       updateSDKLoadingState: mockUpdateSDKLoadingState,
     } as unknown as SDKConnect;
   });
@@ -62,7 +63,11 @@ describe('watchConnection', () => {
 
       mockConnectionStatusListener(mockConnectionStatus);
 
-      expect(mockRemoveChannel).toHaveBeenCalledWith(mockConnection.channelId);
+      expect(mockRemoveChannel).toHaveBeenCalledWith({
+        channelId: mockConnection.channelId,
+        emitRefresh: true,
+        sendTerminate: false,
+      });
     });
   });
 
@@ -80,10 +85,7 @@ describe('watchConnection', () => {
 
       mockClientsDisconnectedListener();
 
-      expect(mockUpdateSDKLoadingState).toHaveBeenCalledWith({
-        channelId: mockConnection.channelId,
-        loading: false,
-      });
+      expect(mockUpdateSDKLoadingState).toHaveBeenCalled();
     });
 
     it('should remove the channel if it is disabled on CLIENTS_DISCONNECTED', () => {
@@ -93,10 +95,10 @@ describe('watchConnection', () => {
 
       mockClientsDisconnectedListener();
 
-      expect(mockRemoveChannel).toHaveBeenCalledWith(
-        mockConnection.channelId,
-        true,
-      );
+      expect(mockRemoveChannel).toHaveBeenCalledWith({
+        channelId: mockConnection.channelId,
+        sendTerminate: true,
+      });
     });
   });
 

--- a/app/core/SDKConnect/ConnectionManagement/watchConnection.ts
+++ b/app/core/SDKConnect/ConnectionManagement/watchConnection.ts
@@ -11,8 +11,17 @@ function watchConnection(connection: Connection, instance: SDKConnect) {
     EventType.CONNECTION_STATUS,
     (connectionStatus: ConnectionStatus) => {
       if (connectionStatus === ConnectionStatus.TERMINATED) {
-        instance.removeChannel(connection.channelId);
+        instance.removeChannel({
+          channelId: connection.channelId,
+          emitRefresh: true,
+          sendTerminate: false,
+        });
       }
+      DevLogger.log(
+        `SDKConnect::watchConnection CONNECTION_STATUS ${connection.channelId} ${connectionStatus}`,
+      );
+      // Inform ui about connection status change
+      instance.emit('refresh');
     },
   );
 

--- a/app/core/SDKConnect/ConnectionManagement/watchConnection.ts
+++ b/app/core/SDKConnect/ConnectionManagement/watchConnection.ts
@@ -45,7 +45,10 @@ function watchConnection(connection: Connection, instance: SDKConnect) {
           );
         });
       // Force terminate connection since it was disabled (do not remember)
-      instance.removeChannel(connection.channelId, true);
+      instance.removeChannel({
+        channelId: connection.channelId,
+        sendTerminate: true,
+      });
     }
   });
 

--- a/app/core/SDKConnect/SDKConnect.test.ts
+++ b/app/core/SDKConnect/SDKConnect.test.ts
@@ -247,7 +247,7 @@ describe('SDKConnect', () => {
       it('should remove a specified channel', async () => {
         const channelId = 'testChannelId';
 
-        await sdkConnect.removeChannel(channelId);
+        await sdkConnect.removeChannel({ channelId });
 
         expect(mockRemoveChannel).toHaveBeenCalledTimes(1);
         expect(mockRemoveChannel).toHaveBeenCalledWith({

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -9,7 +9,6 @@ import AndroidService from './AndroidSDK/AndroidService';
 import addAndroidConnection from './AndroidSDK/addAndroidConnection';
 import bindAndroidSDK from './AndroidSDK/bindAndroidSDK';
 import loadAndroidConnections from './AndroidSDK/loadAndroidConnections';
-import removeAndroidConnection from './AndroidSDK/removeAndroidConnection';
 import { Connection, ConnectionProps } from './Connection';
 import {
   approveHost,
@@ -70,6 +69,7 @@ export interface SDKConnectState {
   androidSDKStarted: boolean;
   androidSDKBound: boolean;
   androidService?: AndroidService;
+  androidConnections: SDKSessions;
   connecting: { [channelId: string]: boolean };
   approvedHosts: ApprovedHosts;
   sdkLoadingState: { [channelId: string]: boolean };
@@ -99,6 +99,7 @@ export class SDKConnect extends EventEmitter2 {
     appState: undefined,
     connected: {},
     connections: {},
+    androidConnections: {},
     androidSDKStarted: false,
     androidSDKBound: false,
     androidService: undefined,
@@ -216,12 +217,16 @@ export class SDKConnect extends EventEmitter2 {
     return loadAndroidConnections();
   }
 
+  getAndroidConnections() {
+    return this.state.androidService?.getConnections();
+  }
+
   async addAndroidConnection(connection: ConnectionProps) {
     return addAndroidConnection(connection, this);
   }
 
   removeAndroidConnection(id: string) {
-    return removeAndroidConnection(id, this);
+    return removeChannel({ channelId: id, instance: this, emitRefresh: true });
   }
 
   /**

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -235,8 +235,21 @@ export class SDKConnect extends EventEmitter2 {
     return invalidateChannel({ channelId, instance: this });
   }
 
-  public removeChannel(channelId: string, sendTerminate?: boolean) {
-    return removeChannel({ channelId, sendTerminate, instance: this });
+  public removeChannel({
+    channelId,
+    sendTerminate,
+    emitRefresh,
+  }: {
+    channelId: string;
+    sendTerminate?: boolean;
+    emitRefresh?: boolean;
+  }) {
+    return removeChannel({
+      channelId,
+      sendTerminate,
+      instance: this,
+      emitRefresh,
+    });
   }
 
   public async removeAll() {


### PR DESCRIPTION
## **Description**

Improvement in android sdk connection management to restore session persistence behavior.
Prevent flickering when cleaning connection with android sessions and add an online status over connected sessions.

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="272" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/107169956/458f96c9-568a-4186-9f4a-47113cd86c76">

### **After**

<img width="273" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/107169956/87c5edb6-f44f-4ba6-a850-828324a261b5">
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
