### PR TITLE
chore: fix: scanning dapp QR code does not open in-app browser and navigate …

### DIFF
--- a/app/components/Views/QRScanner/index.tsx
+++ b/app/components/Views/QRScanner/index.tsx
@@ -2,42 +2,42 @@
 /* eslint @typescript-eslint/no-require-imports: "off" */
 
 'use strict';
-import React, { useRef, useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { parse } from 'eth-url-parser';
+import { isValidAddress } from 'ethereumjs-util';
+import React, { useCallback, useRef } from 'react';
 import {
+  Alert,
+  Image,
   InteractionManager,
   SafeAreaView,
-  Image,
   Text,
   TouchableOpacity,
   View,
-  Alert,
 } from 'react-native';
-import { useSelector } from 'react-redux';
-import { useNavigation } from '@react-navigation/native';
 import { RNCamera } from 'react-native-camera';
 import Icon from 'react-native-vector-icons/Ionicons';
-import { parse } from 'eth-url-parser';
-import { colors as importedColors } from '../../../styles/common';
-import { isValidAddress } from 'ethereumjs-util';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
-import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
+import { PROTOCOLS } from '../../../constants/deeplinks';
+import Routes from '../../../constants/navigation/Routes';
+import { MM_SDK_DEEPLINK } from '../../../constants/urls';
 import AppConstants from '../../../core/AppConstants';
-import {
-  failedSeedPhraseRequirements,
-  isValidMnemonic,
-} from '../../../util/validators';
+import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
+import Engine from '../../../core/Engine';
+import { selectChainId } from '../../../selectors/networkController';
+import { colors as importedColors } from '../../../styles/common';
 import { isValidAddressInputViaQRCode } from '../../../util/address';
 import { getURLProtocol } from '../../../util/general';
-import Engine from '../../../core/Engine';
-import Routes from '../../../constants/navigation/Routes';
-import { PROTOCOLS } from '../../../constants/deeplinks';
-import { MM_SDK_DEEPLINK } from '../../../constants/urls';
-import styles from './styles';
 import {
   createNavigationDetails,
   useParams,
 } from '../../../util/navigation/navUtils';
-import { selectChainId } from '../../../selectors/networkController';
+import {
+  failedSeedPhraseRequirements,
+  isValidMnemonic,
+} from '../../../util/validators';
+import styles from './styles';
 
 const frameImage = require('../../../images/frame.png'); // eslint-disable-line import/no-commonjs
 
@@ -210,7 +210,6 @@ const QRScanner = () => {
           origin: AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
           // TODO: Check is pop is still valid.
           onHandled: () => (navigation as any).pop(2),
-          browserCallBack: () => null,
         });
 
         if (handledByDeeplink) {

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -59,7 +59,7 @@ class DeeplinkManager {
     });
   }
 
-  _handleBrowserUrl(url: string, callback: (url: string) => void) {
+  _handleBrowserUrl(url: string, callback?: (url: string) => void) {
     return handleBrowserUrl({
       deeplinkManager: this,
       url,
@@ -82,7 +82,7 @@ class DeeplinkManager {
       origin,
       onHandled,
     }: {
-      browserCallBack: (url: string) => void;
+      browserCallBack?: (url: string) => void;
       origin: string;
       onHandled?: () => void;
     },

--- a/app/core/DeeplinkManager/Handlers/handleBrowserUrl.ts
+++ b/app/core/DeeplinkManager/Handlers/handleBrowserUrl.ts
@@ -9,7 +9,7 @@ function handleBrowserUrl({
 }: {
   deeplinkManager: DeeplinkManager;
   url: string;
-  callback: (url: string) => void;
+  callback?: (url: string) => void;
 }) {
   const handle = InteractionManager.runAfterInteractions(() => {
     if (callback) {

--- a/app/core/DeeplinkManager/ParseManager/handleDappUrl.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleDappUrl.ts
@@ -10,7 +10,7 @@ export function handleDappUrl({
   instance: DeeplinkManager;
   handled: () => void;
   urlObj: ReturnType<typeof extractURLParams>['urlObj'];
-  browserCallBack: (url: string) => void;
+  browserCallBack?: (url: string) => void;
 }) {
   // Enforce https
   handled();

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
@@ -23,7 +23,7 @@ function handleUniversalLink({
   handled: () => void;
   urlObj: ReturnType<typeof extractURLParams>['urlObj'];
   params: ReturnType<typeof extractURLParams>['params'];
-  browserCallBack: (url: string) => void;
+  browserCallBack?: (url: string) => void;
   origin: string;
   wcURL: string;
   url: string;

--- a/app/core/DeeplinkManager/ParseManager/parseDeeplink.ts
+++ b/app/core/DeeplinkManager/ParseManager/parseDeeplink.ts
@@ -19,7 +19,7 @@ function parseDeeplink({
   deeplinkManager: DeeplinkManager;
   url: string;
   origin: string;
-  browserCallBack: (url: string) => void;
+  browserCallBack?: (url: string) => void;
   onHandled?: () => void;
 }) {
   const { urlObj, params } = extractURLParams(url);

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.ts
@@ -26,7 +26,7 @@ const SharedDeeplinkManager = {
   parse: (
     url: string,
     args: {
-      browserCallBack: (url: string) => void;
+      browserCallBack?: (url: string) => void;
       origin: string;
       onHandled?: () => void;
     },


### PR DESCRIPTION
…to dapp #8277 (#8278)

## **Description**

This PR addresses a specific issue where scanning a Dapp QR code did not correctly open the in-app browser to navigate to the Dapp website.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

## **Related issues**

Fixes: #https://github.com/MetaMask/mobile-planning/issues/1481

## **Manual testing steps**

1. Go to this page... 2.
3.

## **Screenshots/Recordings**


https://github.com/MetaMask/metamask-mobile/assets/61094771/d26b12f2-880d-479c-90f1-fe0461b55df9


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
- [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
