### PR TITLE
fix: Transaction Details view shows inaccurate balance on Mobile

### DIFF
--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -34,6 +34,7 @@ import { isSwapsNativeAsset } from '../Swaps/utils';
 import { toLowerCaseEquals } from '../../../util/general';
 import Engine from '../../../core/Engine';
 import { isEIP1559Transaction } from '@metamask/transaction-controller';
+import { convertHexToDecimal } from '@metamask/controller-utils';
 
 const { getSwapsContractAddress } = swapsUtils;
 
@@ -281,7 +282,7 @@ export function decodeIncomingTransfer(args) {
     selectedAddress,
   } = args;
 
-  const decimalAmount = parseInt(value, 16).toString();
+  const decimalAmount = convertHexToDecimal(value);
   const amount = toBN(decimalAmount);
   const token = { symbol, decimals, address: contractAddress };
 

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -265,7 +265,7 @@ function getCollectibleTransfer(args) {
   return [transactionElement, transactionDetails];
 }
 
-function decodeIncomingTransfer(args) {
+export function decodeIncomingTransfer(args) {
   const {
     tx: {
       transaction: { to, from, value },
@@ -281,7 +281,8 @@ function decodeIncomingTransfer(args) {
     selectedAddress,
   } = args;
 
-  const amount = toBN(value);
+  const decimalAmount = parseInt(value, 16).toString();
+  const amount = toBN(decimalAmount);
   const token = { symbol, decimals, address: contractAddress };
 
   const renderTokenAmount = token
@@ -299,6 +300,7 @@ function decodeIncomingTransfer(args) {
       exchangeRate,
       currentCurrency,
     );
+
     renderTokenFiatNumber = balanceToFiatNumber(
       fromTokenMinimalUnit(amount, token.decimals) || 0,
       conversionRate,

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -1,0 +1,57 @@
+import { decodeIncomingTransfer } from './utils';
+describe('decodeIncomingTransfer', () => {
+  it('should decode an incoming transfer', () => {
+    // Arrange
+    const args = {
+      tx: {
+        transaction: {
+          to: '0x77648f1407986479fb1fa5cc3597084b5dbdb057',
+          from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+          value: '0x52daf0',
+        },
+        transferInformation: {
+          symbol: 'USDT',
+          decimals: 6,
+          contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        },
+        transactionHash:
+          '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+      },
+      currentCurrency: 'usd',
+      contractExchangeRates: {},
+      totalGas: '0x64',
+      actionKey: 'key',
+      primaryCurrency: 'ETH',
+      selectedAddress: '0x77648f1407986479fb1fa5cc3597084b5dbdb057',
+      ticker: 'ETH',
+    };
+
+    // Act
+    const [transactionElement, transactionDetails] =
+      decodeIncomingTransfer(args);
+
+    // Assert
+    expect(transactionElement).toEqual({
+      actionKey: 'key',
+      renderFrom: '0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e',
+      renderTo: '0x77648F1407986479fb1fA5Cc3597084B5dbDB057',
+      value: '5.43 USDT',
+      fiatValue: undefined,
+      isIncomingTransfer: true,
+      transactionType: 'transaction_received_token',
+    });
+    expect(transactionDetails).toEqual({
+      renderTotalGas: '< 0.00001 ETH',
+      renderValue: '5.43 USDT',
+      renderFrom: '0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e',
+      renderTo: '0x77648F1407986479fb1fA5Cc3597084B5dbDB057',
+      transactionHash:
+        '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+      transactionType: 'transaction_received_token',
+      summaryAmount: '5.43 USDT',
+      summaryFee: '< 0.00001 ETH',
+      summaryTotalAmount: '5.43 USDT / < 0.00001 ETH',
+      summarySecondaryTotalAmount: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## **Description**
users have discrepancy in the USDT token balance on his tx insight page in the MM app, they are seeing 33.22 USDT but it should be 5.43 USDT ( see the pictures below ) 

**the problem is due to the fact that we use a hexadecimal value to create a big number object, whereas the function balanceToFiat expects a decimal value. to calculate the conversion fiat**

## **Related issues**

Fixes: #7787 

## **Manual testing steps**

1. Go to the main page of the app and click on your USDT token.
2. scroll down and click on "Received USDT"
3. check the amount section

## **Screenshots/Recordings**

### **Before**

https://drive.google.com/file/d/1766q37UBdndVqk0cNG8eVCBf-mCsCm2j/view?usp=sharing

### **After**

https://drive.google.com/file/d/1l_sC7CK67WbjQmtLpbFUqiqj4iie2Fqv/view?usp=sharing

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
