### PR TITLE
fix: update nft metadata on page refresh

### DIFF
--- a/app/components/UI/CollectibleContractElement/index.js
+++ b/app/components/UI/CollectibleContractElement/index.js
@@ -92,6 +92,7 @@ function CollectibleContractElement({
   chainId,
   selectedAddress,
   removeFavoriteCollectible,
+  toggleRemovingProgress,
 }) {
   const [collectiblesGrid, setCollectiblesGrid] = useState([]);
   const [collectiblesVisible, setCollectiblesVisible] = useState(
@@ -149,7 +150,11 @@ function CollectibleContractElement({
 
   const handleMenuAction = (index) => {
     if (index === 1) {
+      // set toggle to true
+      toggleRemovingProgress();
       removeNft();
+      // set toggle to false to indicate that removing the NFT has finished
+      toggleRemovingProgress();
     } else if (index === 0) {
       refreshMetadata();
     }
@@ -301,6 +306,7 @@ CollectibleContractElement.propTypes = {
    * Dispatch remove collectible from favorites action
    */
   removeFavoriteCollectible: PropTypes.func,
+  toggleRemovingProgress: PropTypes.func,
 };
 
 const mapStateToProps = (state) => ({

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -172,13 +172,11 @@ const CollectibleContracts = ({
 
       const isIgnored = isCollectibleIgnored(collectible);
 
-      if (!isRemovingNftInProgress) {
-        if (!isIgnored) {
-          if (String(tokenId).includes('e+')) {
-            removeFavoriteCollectible(selectedAddress, chainId, collectible);
-          } else {
-            await NftController.addNft(address, String(tokenId));
-          }
+      if (!isRemovingNftInProgress && !isIgnored) {
+        if (String(tokenId).includes('e+')) {
+          removeFavoriteCollectible(selectedAddress, chainId, collectible);
+        } else {
+          await NftController.addNft(address, String(tokenId));
         }
       }
     },

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -133,7 +133,7 @@ const CollectibleContracts = ({
    * @returns Boolean indicating if the collectible should be updated.
    */
   const shouldUpdateCollectibleMetadata = (collectible) =>
-    typeof collectible.tokenId === 'number';
+    typeof collectible.tokenId === 'number' || typeof collectible.tokenId === "string" && !isNaN(collectible.tokenId);
 
   /**
    * Method to updated collectible and avoid backwards compatibility issues.
@@ -144,7 +144,6 @@ const CollectibleContracts = ({
     async (collectible) => {
       const { NftController } = Engine.context;
       const { address, tokenId } = collectible;
-      NftController.removeNft(address, tokenId);
       if (String(tokenId).includes('e+')) {
         removeFavoriteCollectible(selectedAddress, chainId, collectible);
       } else {

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -133,7 +133,8 @@ const CollectibleContracts = ({
    * @returns Boolean indicating if the collectible should be updated.
    */
   const shouldUpdateCollectibleMetadata = (collectible) =>
-    typeof collectible.tokenId === 'number' || typeof collectible.tokenId === "string" && !isNaN(collectible.tokenId);
+    typeof collectible.tokenId === 'number' ||
+    (typeof collectible.tokenId === 'string' && !isNaN(collectible.tokenId));
 
   /**
    * Method to updated collectible and avoid backwards compatibility issues.

--- a/app/components/UI/CollectibleContracts/index.test.tsx
+++ b/app/components/UI/CollectibleContracts/index.test.tsx
@@ -149,7 +149,7 @@ describe('CollectibleContracts', () => {
     expect(nonOwnedNft).toBeNull();
   });
 
-  it('should test refresh behavior when metadata is updated', async () => {
+  it('UI refresh changes NFT image when metadata image changes', async () => {
     const CURRENT_ACCOUNT = '0x1a';
     const collectibleData = [
       {
@@ -234,16 +234,13 @@ describe('CollectibleContracts', () => {
       },
     };
 
-    jest
+    const spyOnCollectibles = jest
       .spyOn(allSelectors, 'collectiblesSelector')
-      .mockReturnValueOnce(nftItemData);
-    jest
+      .mockReturnValueOnce(nftItemData)
+      .mockReturnValueOnce(nftItemDataUpdated);
+    const spyOnContracts = jest
       .spyOn(allSelectors, 'collectibleContractsSelector')
       .mockReturnValue(collectibleData);
-    jest
-      .spyOn(allSelectors, 'collectiblesSelector')
-      .mockReturnValueOnce(nftItemDataUpdated);
-
     const spyOnAddNft = jest
       .spyOn(Engine.context.NftController, 'addNft')
       .mockImplementation(async () => undefined);
@@ -265,5 +262,9 @@ describe('CollectibleContracts', () => {
         nftItemDataUpdated[0].image,
       );
     });
+
+    spyOnCollectibles.mockRestore();
+    spyOnContracts.mockRestore();
+    spyOnAddNft.mockRestore();
   });
 });

--- a/app/components/UI/CollectibleContracts/index.test.tsx
+++ b/app/components/UI/CollectibleContracts/index.test.tsx
@@ -22,6 +22,14 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    NftController: {
+      addNft: jest.fn(),
+    },
+  },
+}));
+
 const mockStore = configureMockStore();
 const initialState = {
   collectibles: {


### PR DESCRIPTION
## **Description**

This PR fixes nft metadata refresh when the user refreshes the page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMASSETS-105

## **Manual testing steps**

1. Mint an NFT. (I used REMIX)
2. Go to NFT tab and import the NFT
3. You should be able to see the NFT image
4. Update the NFT image
5. Pull down the page to refresh and notice that the image is updated

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/10994169/c067c15a-1525-4cfc-98d6-492ec2cca4c8

### **After**

https://github.com/MetaMask/metamask-mobile/assets/10994169/78ca98b2-f071-4a7e-a73a-f9db390cf0ad



https://github.com/MetaMask/metamask-mobile/assets/10994169/7872d505-cb81-4f95-b99f-297f56b27f32



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
