### PR TITLE
Cherrypick blockaid fixes

### DIFF
--- a/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.styles.ts
+++ b/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.styles.ts
@@ -15,6 +15,11 @@ const createStyles = () =>
       flexDirection: 'row',
       justifyContent: 'center',
       alignItems: 'center',
+      marginTop: 10,
+    },
+    successIconContainer: {
+      flex: 1,
+      marginLeft: 25,
     },
     iconContainer: {
       flex: 1,
@@ -22,7 +27,6 @@ const createStyles = () =>
     },
     iconStyle: {
       alignSelf: 'center',
-      marginTop: 10,
     },
     goBackIcon: {
       alignItems: 'flex-end',

--- a/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.tsx
@@ -100,7 +100,7 @@ const BlockaidIndicator = ({ navigation }: Props) => {
 
           <SheetHeader title={strings('blockaid_banner.before_you_proceed')} />
           <Text variant={TextVariant.BodyMD}>
-            {strings('blockaid_banner.enable_blockaid_alerts')}
+            {strings('blockaid_banner.enable_blockaid_alerts_description')}
           </Text>
           <View style={styles.buttonWrapper}>
             <Button
@@ -148,7 +148,7 @@ const BlockaidIndicator = ({ navigation }: Props) => {
       {ppomInitialisationStatus === PPOMInitialisationStatus.SUCCESS && (
         <View style={styles.blockaidWrapper}>
           <View style={styles.iconWrapper}>
-            <View style={styles.iconContainer}>
+            <View style={styles.successIconContainer}>
               <Icon
                 name={IconName.Confirmation}
                 size={IconSize.Xl}

--- a/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/BlockaidIndicator.tsx
@@ -84,7 +84,11 @@ const BlockaidIndicator = ({ navigation }: Props) => {
   const multiFailures = failureCount >= 3;
 
   return (
-    <BottomSheet ref={sheetRef} isInteractable={sheetInteractable}>
+    <BottomSheet
+      ref={sheetRef}
+      isInteractable={sheetInteractable}
+      onClose={goBackToExperimentalScreen}
+    >
       {status === Status.Idle && (
         <View style={styles.blockaidWrapper}>
           <View style={styles.iconWrapper}>

--- a/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/__snapshots__/BlockaidIndicator.test.tsx.snap
+++ b/app/components/Views/Settings/ExperimentalSettings/BlockaidIndicator/__snapshots__/BlockaidIndicator.test.tsx.snap
@@ -21,6 +21,7 @@ Array [
             "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "center",
+            "marginTop": 10,
           }
         }
       >
@@ -40,7 +41,6 @@ Array [
               Object {
                 "alignSelf": "center",
                 "height": 32,
-                "marginTop": 10,
                 "width": 32,
               }
             }
@@ -104,7 +104,7 @@ Array [
           }
         }
       >
-        To enable this feature we need to set up some security alert. This page will need to stay open while its being set up. This will take less than a minute to complete.
+        This page will need to stay open while security alerts are being set up. This process will take less than a minute to complete.
       </Text>
       <View
         style={
@@ -217,6 +217,7 @@ Array [
             "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "center",
+            "marginTop": 10,
           }
         }
       >
@@ -236,7 +237,6 @@ Array [
               Object {
                 "alignSelf": "center",
                 "height": 32,
-                "marginTop": 10,
                 "width": 32,
               }
             }
@@ -300,7 +300,7 @@ Array [
           }
         }
       >
-        To enable this feature we need to set up some security alert. This page will need to stay open while its being set up. This will take less than a minute to complete.
+        This page will need to stay open while security alerts are being set up. This process will take less than a minute to complete.
       </Text>
       <View
         style={
@@ -401,6 +401,7 @@ Array [
             "alignItems": "center",
             "flexDirection": "row",
             "justifyContent": "center",
+            "marginTop": 10,
           }
         }
       >
@@ -420,7 +421,6 @@ Array [
               Object {
                 "alignSelf": "center",
                 "height": 32,
-                "marginTop": 10,
                 "width": 32,
               }
             }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -20,6 +20,7 @@
     "transfer_farming_description": "If you approve this request, a third party known for scams will take all your assets.",
     "before_you_proceed": "Before you proceed",
     "enable_blockaid_alerts": "To enable this feature we need to set up some security alert. This page will need to stay open while its being set up. This will take less than a minute to complete.",
+    "enable_blockaid_alerts_description": "This page will need to stay open while security alerts are being set up. This process will take less than a minute to complete.",
     "setting_up_alerts": "Setting up security alerts",
     "setting_up_alerts_description": "We are going as fast as we can to set up security alerts. Hang in there, we are almost done.",
     "setup_complete": "Set up complete",


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Cherry picks https://github.com/MetaMask/metamask-mobile/pull/8394 and https://github.com/MetaMask/metamask-mobile/pull/8393

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
