### PR TITLE
chore: updating design tokens to 1.13 includes accessibility updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "@metamask/composable-controller": "^3.0.0",
     "@metamask/contract-metadata": "^2.1.0",
     "@metamask/controller-utils": "^3.4.0",
-    "@metamask/design-tokens": "^1.12.0",
+    "@metamask/design-tokens": "^1.13.0",
     "@metamask/eth-sig-util": "^4.0.1",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/gas-fee-controller": "^5.0.0",
@@ -195,6 +195,7 @@
     "@metamask/post-message-stream": "7.0.0",
     "@metamask/ppom-validator": "0.22.0",
     "@metamask/preferences-controller": "^4.0.0",
+    "@metamask/react-native-button": "^3.0.0",
     "@metamask/scure-bip39": "^2.1.0",
     "@metamask/sdk-communication-layer": "^0.12.0",
     "@metamask/signature-controller": "4.0.1",
@@ -296,7 +297,6 @@
     "react-native-blob-jsi-helper": "^0.3.1",
     "react-native-branch": "^5.6.2",
     "react-native-browser-polyfill": "0.1.2",
-    "@metamask/react-native-button": "^3.0.0",
     "react-native-camera": "^3.36.0",
     "react-native-confetti": "^0.1.0",
     "react-native-confetti-cannon": "^1.5.0",
@@ -373,8 +373,7 @@
     "uuid": "^8.3.2",
     "valid-url": "1.0.9",
     "vm-browserify": "1.1.2",
-    "zxcvbn": "4.4.2",
-    "cockatiel": "^3.1.1"
+    "zxcvbn": "4.4.2"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3605,10 +3605,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.3"
 
-"@metamask/design-tokens@^1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.12.0.tgz#05ad9ba4e91cb62dd2149ac0d026ba1fe2b9d8dd"
-  integrity sha512-hoAnXYjx/NrlcpjsQGHLe383G7K/PHxXKGwGjJq7+iwnqpxjPHvyyai0Xh6hhT88ydq1n6OJRG/pwvD1mkQPug==
+"@metamask/design-tokens@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.13.0.tgz#b91677f2abe014a8ee809f3fd7a865a89aa0294d"
+  integrity sha512-kkQIaoFm8aRypKpwEY+Nz45u56U5Gtc3AlpWyaP8pg3oerjOBBkCePpCpXL9wlPlvKmuGsTGeiVxd3j/TNNnpg==
 
 "@metamask/eslint-config-typescript@^9.0.0":
   version "9.0.1"


### PR DESCRIPTION
## **Description**
This PR updates the design-tokens package to `v1.13.0`, introducing accessibility enhancements to various color categories, including `warning/default`, `success/default`, and inverse colors. Additionally, it incorporates pressed tokens. 

For a detailed overview of the color updates, please refer to [this PR in the design-tokens repository](https://github.com/MetaMask/design-tokens/pull/586). 

The accessibility improvements ensure that:

- Text using the `warning/default` color now meets WCAG AA color contrast requirements.
- Text using the `success/default` color now meets WCAG AA color contrast requirements.
- Text using the `primary/inverse`, `error/inverse`, `success/inverse`, and `info/inverse` colors in dark mode now meets WCAG AA color contrast requirements.

These updates enhance the accessibility and user experience for vision impaired folks in mobile.

## **Related issues**

Related: https://github.com/MetaMask/metamask-extension#workspaces/design-system-61e8a2ae77c3a60012e5003c/issues/zh/329

## **Manual testing steps**
The easiest way to review these accessibility updates is to check storybook

1. Go to the root `index.js`
2. Uncomment storybook 
3. Run storybook 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

TBC

### **After**

TBC

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
