### PR TITLE
feat: Update SES lockdown options

### DIFF
--- a/patches/react-native+0.71.15.patch
+++ b/patches/react-native+0.71.15.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..a991485 100644
+index 1379ffd..35cfe3f 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
 @@ -24,26 +24,53 @@
@@ -23,7 +23,7 @@ index 1379ffd..a991485 100644
 +   * Nb: global.process is only partially shimmed, which confuses SES
 +   * Nb: All are Unhandled JS Exceptions, since we call lockdown before setUpErrorHandling
 +  */
-+  repairIntrinsics({ consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe' });
++  repairIntrinsics({ errorTaming: 'unsafe', consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe' });
 +  require('reflect-metadata'); // Vetted shim required to fix: https://github.com/LavaMoat/docs/issues/26
 +  hardenIntrinsics();
 +}

--- a/patches/react-native+0.71.15.patch
+++ b/patches/react-native+0.71.15.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/Libraries/Core/InitializeCore.js b/node_modules/react-native/Libraries/Core/InitializeCore.js
-index 1379ffd..35cfe3f 100644
+index 1379ffd..8b198a9 100644
 --- a/node_modules/react-native/Libraries/Core/InitializeCore.js
 +++ b/node_modules/react-native/Libraries/Core/InitializeCore.js
 @@ -24,26 +24,53 @@
@@ -23,7 +23,7 @@ index 1379ffd..35cfe3f 100644
 +   * Nb: global.process is only partially shimmed, which confuses SES
 +   * Nb: All are Unhandled JS Exceptions, since we call lockdown before setUpErrorHandling
 +  */
-+  repairIntrinsics({ errorTaming: 'unsafe', consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe' });
++  repairIntrinsics({ errorTaming: 'unsafe', consoleTaming: 'unsafe', errorTrapping: 'none', unhandledRejectionTrapping: 'none', overrideTaming: 'severe', stackFiltering: 'verbose' });
 +  require('reflect-metadata'); // Vetted shim required to fix: https://github.com/LavaMoat/docs/issues/26
 +  hardenIntrinsics();
 +}


### PR DESCRIPTION
## **Description**

Update SES lockdown options to improve error stacks

Set error taming to unsafe
- make error stacks also available by the error instance stack
- preserve error stack filtered content
- like we [do](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/lockdown-run.js#L6) in metamask-extension

Set stack filtering to verbose
- show full raw error info for each deep stack level
- preserve _noise_ that the (default) `concise` option was removing

Follow-up to
- https://github.com/MetaMask/metamask-mobile/pull/8033

Ref: https://github.com/endojs/endo/blob/master/packages/ses/docs/reference.md#options-quick-reference

Nb: we're looking into a lockdown/repairIntrinsics option to disable touching errors entirely (for cases like ours involving React Native surfacing JS/Android/iOS errors, then later newer engine Hermes)

## **Related issues**

- note: https://github.com/MetaMask/metamask-mobile/issues/8352

## **Manual testing steps**

Local testing in debug-mode:
- Update [InitializeCore](https://github.com/MetaMask/metamask-mobile/blob/main/patches/react-native%2B0.71.15.patch#L13) to enable SES in debug/dev mode
- Trigger an error somewhere in the app
  - `new Error('test')`
  - `Sentry.captureException(new Error('test'))`
- Check simulator
  - ensure original error preserved in call stack
  - ensure tapping error redirects to source code
- Check Sentry event
  - ensure original error preserved in call stack

But note above we're looking into a better lockdown option for React Native debug-mode,
since we disabled SES in debug-mode [earlier](https://github.com/MetaMask/metamask-mobile/pull/7924) from React Devtools interfering

Production testing:
After we merge https://github.com/MetaMask/metamask-mobile/pull/8373, we'll be able to ft toggle lockdown via our in-app settings menu, which will persist the choice and apply after the app has been rebooted

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
