### PR TITLE
fix: catch unfulfilled promise for token fetch

### DIFF
--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -403,7 +403,9 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
         CurrencyRateController.start(),
         TokenRatesController.updateExchangeRates(),
       ];
-      await Promise.all(actions);
+      await Promise.all(actions).catch((error) => {
+        Logger.error(error, 'Error while refreshing tokens');
+      });
       setRefreshing(false);
     });
   };


### PR DESCRIPTION
## **Description**

When a token's price is unavailable, the list of token prices becomes unavailable. On pull to refresh this was resulting with a hung spinner due to an uncaught promise rejection.
This PR adds a catch to the promise to resolve the hanging spinner.

## **Related issues**

Related: [#1518](https://github.com/MetaMask/mobile-planning/issues/1518)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/MetaMask/metamask-mobile/assets/141057783/28505dba-807e-44a0-a379-4a85a15f7010



### **After**


https://github.com/MetaMask/metamask-mobile/assets/141057783/900c733a-d79c-443e-9631-c208694e86f6



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
