### PR TITLE
refactor: Remove isFlexible prop from BottomSheet

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.tsx
@@ -37,7 +37,7 @@ const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
       onClose,
       isInteractable = true,
       shouldNavigateBack = true,
-      isFlexible = false,
+      isFullscreen = false,
       ...props
     },
     ref,
@@ -95,7 +95,7 @@ const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
           isInteractable={isInteractable}
           onDismissed={onHidden}
           ref={bottomSheetDialogRef}
-          isFlexible={isFlexible}
+          isFullscreen={isFullscreen}
         >
           {children}
         </BottomSheetDialog>

--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.types.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.types.ts
@@ -23,9 +23,10 @@ export interface BottomSheetProps extends ViewProps {
    */
   shouldNavigateBack?: boolean;
   /**
-   * Optional boolean that allow the bottomsheet to grow until the top.
+   * Optional prop to toggle full screen state of BottomSheetDialog.
+   * @default false
    */
-  isFlexible?: boolean;
+  isFullscreen?: boolean;
 }
 
 export type BottomSheetPostCallback = () => void;

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
@@ -50,7 +50,6 @@ const BottomSheetDialog = forwardRef<
       isFullscreen = false,
       isInteractable = true,
       onDismissed,
-      isFlexible = false,
       ...props
     },
     ref,
@@ -58,10 +57,9 @@ const BottomSheetDialog = forwardRef<
     const { top: screenTopPadding, bottom: screenBottomPadding } =
       useSafeAreaInsets();
     const { height: screenHeight } = useWindowDimensions();
-    const marginTop = isFlexible ? 0 : DEFAULT_BOTTOMSHEETDIALOG_MARGINTOP;
     const maxSheetHeight = isFullscreen
       ? screenHeight - screenTopPadding
-      : screenHeight - screenTopPadding - marginTop;
+      : screenHeight - screenTopPadding - DEFAULT_BOTTOMSHEETDIALOG_MARGINTOP;
     const { styles } = useStyles(styleSheet, {
       maxSheetHeight,
       screenBottomPadding,

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types.ts
@@ -23,10 +23,6 @@ export interface BottomSheetDialogProps extends ViewProps {
    * Optional callback that gets triggered when sheet is dismissed.
    */
   onDismissed?: () => void;
-  /**
-   * Optional boolean that allow the bottomsheet to grow until the top.
-   */
-  isFlexible?: boolean;
 }
 
 export interface BottomSheetDialogRef {

--- a/app/components/Approvals/AddChainApproval/AddChainApproval.tsx
+++ b/app/components/Approvals/AddChainApproval/AddChainApproval.tsx
@@ -23,7 +23,7 @@ const AddChainApproval = () => {
   if (approvalRequest?.type !== ApprovalTypes.ADD_ETHEREUM_CHAIN) return null;
 
   return (
-    <BottomSheet onClose={onReject} shouldNavigateBack={false} isFlexible>
+    <BottomSheet onClose={onReject} shouldNavigateBack={false} isFullscreen>
       <BottomSheetHeader>
         <Text variant={TextVariant.HeadingMD}>
           {strings('add_custom_network.title')}

--- a/app/components/Approvals/AddChainApproval/__snapshots__/AddChainApproval.test.tsx.snap
+++ b/app/components/Approvals/AddChainApproval/__snapshots__/AddChainApproval.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AddChainApproval renders 1`] = `
 <ForwardRef
-  isFlexible={true}
+  isFullscreen={true}
   shouldNavigateBack={false}
 >
   <BottomSheetHeader>


### PR DESCRIPTION
## **Description**
- Currently the `isFlexible` prop and `isFullscreen` prop are functioning the same way. `isFlexible` will be removed in favor of `isFullscreen`
<img width="651" alt="Screenshot 2024-01-28 at 6 51 55 PM" src="https://github.com/MetaMask/metamask-mobile/assets/14355083/4710aee9-ff48-4caa-8b62-f54120595f47">

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
