### PR TITLE
fix: show only blockaid multichain on whats new 

### DIFF
--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -17,27 +17,6 @@ export const whatsNew: WhatsNew = {
    * Both slide count and slide content will be rendered in the same order as the data set.
    */
   slides: [
-    [
-      {
-        type: 'image',
-        image: require('../../../images/whats_new_sell.png'),
-      },
-      {
-        type: 'title',
-        title: strings('whats_new.sell.title'),
-      },
-      {
-        type: 'description',
-        description: strings('whats_new.sell.description'),
-      },
-      // button to try it out
-      {
-        type: 'button',
-        buttonText: strings('whats_new.sell.action_text'),
-        buttonType: 'blue',
-        onPress: (props) => props.navigation.navigate(Routes.RAMP.SELL),
-      },
-    ],
     ...(isBlockaidFeatureEnabled()
       ? ([
           [

--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -7,8 +7,8 @@ import { WhatsNew } from './types';
 export const whatsNew: WhatsNew = {
   // All users that have <6.4.0 and are updating to >=6.4.0 should see
   onlyUpdates: false, // false: Users who updated the app and new installs will see this. true: only users who update will see it
-  maxLastAppVersion: '7.15.0', // Only users who had a previous version <7.12.0 version will see this
-  minAppVersion: '7.16.0', // Only users who updated to a version >= 7.3.0 will see this
+  maxLastAppVersion: '7.15.0', // Only users who had a previous version <7.15.0 version will see this
+  minAppVersion: '7.15.0', // Only users who updated to a version >= 7.15.0 will see this
   /**
    * Slides utilizes a templating system in the form of a 2D array, which is eventually rendered within app/components/UI/WhatsNewModal/index.js.
    * The root layer determines the number of slides. Ex. To display 3 slides, the root layer should contain 3 arrays.

--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -7,8 +7,8 @@ import { WhatsNew } from './types';
 export const whatsNew: WhatsNew = {
   // All users that have <6.4.0 and are updating to >=6.4.0 should see
   onlyUpdates: false, // false: Users who updated the app and new installs will see this. true: only users who update will see it
-  maxLastAppVersion: '7.12.0', // Only users who had a previous version <7.12.0 version will see this
-  minAppVersion: '7.12.0', // Only users who updated to a version >= 7.3.0 will see this
+  maxLastAppVersion: '7.15.0', // Only users who had a previous version <7.12.0 version will see this
+  minAppVersion: '7.16.0', // Only users who updated to a version >= 7.3.0 will see this
   /**
    * Slides utilizes a templating system in the form of a 2D array, which is eventually rendered within app/components/UI/WhatsNewModal/index.js.
    * The root layer determines the number of slides. Ex. To display 3 slides, the root layer should contain 3 arrays.


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Remove the ramp update on what's new and show only blockaid multi chain update.
## **Related issues**

Fixes:

## **Manual testing steps**

1. Fresh install MM
2. Should see only blockaid multichain in the what's new announcement modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

http://recordit.co/4yXjVyDxpC

### **After**

http://recordit.co/UOuONCcNQq

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
