### PR TITLE
fix: Inputting a nonce value messes up the nonce counter setting a totally different number

### DIFF
--- a/app/components/UI/CustomNonceModal/index.js
+++ b/app/components/UI/CustomNonceModal/index.js
@@ -127,7 +127,8 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
   };
 
   const saveAndClose = () => {
-    save(nonce);
+    const numberNonce = Number(nonce);
+    save(numberNonce);
     close();
   };
 

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -934,15 +934,19 @@ class Confirm extends PureComponent {
     this.setState({ hexDataModalVisible: !hexDataModalVisible });
   };
 
+  updateTransactionStateWithUpdatedNonce = (nonceValue) => {
+    this.props.setNonce(nonceValue);
+    this.setState({ preparedTransaction: {} });
+  };
+
   renderCustomNonceModal = () => {
-    const { setNonce } = this.props;
     const { proposedNonce, nonce } = this.props.transaction;
     return (
       <CustomNonceModal
         proposedNonce={proposedNonce}
         nonceValue={nonce}
         close={() => this.toggleConfirmationModal(REVIEW)}
-        save={setNonce}
+        save={this.updateTransactionStateWithUpdatedNonce}
       />
     );
   };


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Observed that inputed nonce value isn't stored as number and this messes the nonce counter.

## **Related issues**

Fixes: #6482 

## **Manual testing steps**

1. Enable Nonce Edit in Advanced Settings
2. Go to test-dapp
3. Initiate a transaction
4. Click to edit nonce
5. Adjust the nonce by manually
6. Save and submit transaction
7. See nonce value submitted

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
http://recordit.co/fh6KDG0R9g

### **After**

http://recordit.co/xwxPU8NjeZ

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
