### PR TITLE
chore: [Force upgrade PROD] bumped minimum app version to 1242 or 7.14.0 in PROD

### DIFF
--- a/AppConfig/test/MockAppConfig.json
+++ b/AppConfig/test/MockAppConfig.json
@@ -1,7 +1,7 @@
 {
   "security":{
     "minimumVersions": {
-      "appMinimumBuild": 1242,
+      "appMinimumBuild": 1224,
       "appleMinimumOS": 6,
       "androidMinimumAPIVersion": 21
     }

--- a/AppConfig/test/MockAppConfig.json
+++ b/AppConfig/test/MockAppConfig.json
@@ -1,7 +1,7 @@
 {
   "security":{
     "minimumVersions": {
-      "appMinimumBuild": 1224,
+      "appMinimumBuild": 1242,
       "appleMinimumOS": 6,
       "androidMinimumAPIVersion": 21
     }

--- a/AppConfig/v1/AppConfig.json
+++ b/AppConfig/v1/AppConfig.json
@@ -1,7 +1,7 @@
 {
   "security":{
     "minimumVersions": {
-      "appMinimumBuild": 1224,
+      "appMinimumBuild": 1242,
       "appleMinimumOS": 6,
       "androidMinimumAPIVersion": 21
     }


### PR DESCRIPTION
## **Description**

This PR bumps the test version for Force Upgrade to 7.14.0

## **Related issues**

Fixes:

## **Manual testing steps**

- [x] Test app version before 7.14.0 (1242). It should display Update modal when using test endpoint: 
- [x] Test app version  7.14.0 (1242). It should not display Update modal when using test endpoint
- [x] Document Minimum app version bump
- [x] 7.14.0 should reach 100% on both platforms Android & iOS

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
