### PR TITLE
fix: Fix title color type in settings drawer

### DIFF
--- a/app/components/UI/SettingsDrawer/index.js
+++ b/app/components/UI/SettingsDrawer/index.js
@@ -76,7 +76,7 @@ const propTypes = {
   /**
    * Title color
    */
-  titleColor: TextColor,
+  titleColor: PropTypes.string,
 };
 
 const defaultProps = {


### PR DESCRIPTION
## **Description**
- Through the [replacement work PR](https://github.com/MetaMask/metamask-mobile/pull/8037) where I updated the UI of the settings drawer, I mistakenly updated the type of the title color from `PropTypes.string` to `TextColor`, which causes a warning. This PR reverts the type back from `TextColor` to `PropTypes.string`
- 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/8037/files#r1471909876

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
