### PR TITLE
feat: change the yellow loading banner to gray color

### DIFF
--- a/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
+++ b/app/components/UI/BlockaidBanner/BlockaidBanner.tsx
@@ -151,7 +151,7 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
     return (
       <View style={styles.bannerWrapperMargined}>
         <BannerAlert
-          severity={BannerAlertSeverity.Warning}
+          severity={BannerAlertSeverity.Info}
           title={strings('blockaid_banner.loading_title')}
           startAccessory={
             <ActivityIndicator


### PR DESCRIPTION
## **Description**

We need to change the yellow loading blockaid banner to *gray*. But right now we don't have a gray color in our design systems, so pending when this is clarified with DS team (ahem @SayaGT) we don't want this to block release, so we will use the info (blue) banner for now.

## **Related issues**

Fixes: [#1997](https://github.com/MetaMask/MetaMask-planning/issues/1997)

## **Manual testing steps**

1. Launch MM
2. Perform a PPOM flaggable transaction from testdapp
3. See the yellow banner saying `This request is still being simulated......`
4. Checkout this branch
5. Repeat 2-4
6. Now see that the same banner is blue

## **Screenshots/Recordings**


### **Before**

https://github.com/MetaMask/metamask-mobile/assets/44811/d6e1643d-fb8d-4d7c-8d62-e34c9b181584

### **After**

https://github.com/MetaMask/metamask-mobile/assets/44811/cbef0ba8-54f1-424c-8d3b-446209197b5e


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
