### PR TITLE
fix: Fix fullscreen issue with bottomsheet

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.styles.ts
@@ -22,18 +22,13 @@ const styleSheet = (params: {
   const { vars, theme } = params;
   const { colors, shadows } = theme;
   const { maxSheetHeight, screenBottomPadding, isFullscreen } = vars;
-  const positionObject = isFullscreen
-    ? { ...StyleSheet.absoluteFillObject }
-    : {
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
-      };
 
   return StyleSheet.create({
     base: Object.assign({
-      ...positionObject,
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
     } as ViewStyle) as ViewStyle,
     sheet: {
       backgroundColor: colors.background.default,


### PR DESCRIPTION
## **Description**
- BottomSheetDialog's current fullscreen behavior attaches the Dialog to the top of the screen instead of letting the height be dictated by the maxScreenHeight, which factors in the safe area inset. This PR removes the absolute `top:0` position of isFullscreen behavior

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to Metamask Portfolio
2. Connect an account
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/MetaMask/metamask-mobile/assets/14355083/f8dcc940-ea6e-4532-b76d-9dabf03b42a9

<!-- [screenshots/recordings] -->

### **After**
https://github.com/MetaMask/metamask-mobile/assets/14355083/c366f833-7efc-4d2e-b480-8fe0b67fc778

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
