### PR TITLE
feat: confirm button color updates when transaction is malicious

### DIFF
--- a/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
@@ -86,8 +86,8 @@ exports[`ActionView should render correctly 1`] = `
             Object {
               "marginLeft": 8,
             },
-            {},
-            {},
+            Object {},
+            Object {},
           ]
         }
         disabled={false}

--- a/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
@@ -86,6 +86,8 @@ exports[`ActionView should render correctly 1`] = `
             Object {
               "marginLeft": 8,
             },
+            {},
+            {},
           ]
         }
         disabled={false}

--- a/app/components/UI/ActionView/index.js
+++ b/app/components/UI/ActionView/index.js
@@ -13,23 +13,38 @@ import { strings } from '../../../../locales/i18n';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { useTheme } from '../../../util/theme';
 
-const styles = StyleSheet.create({
-  actionContainer: {
-    flex: 0,
-    flexDirection: 'row',
-    paddingVertical: 16,
-    paddingHorizontal: 24,
-  },
-  button: {
-    flex: 1,
-  },
-  cancel: {
-    marginRight: 8,
-  },
-  confirm: {
-    marginLeft: 8,
-  },
-});
+export const ConfirmButtonState = {
+  Error: 'error',
+  Warning: 'warning',
+  Normal: 'normal',
+};
+
+const getStyles = (colors) =>
+  StyleSheet.create({
+    actionContainer: {
+      flex: 0,
+      flexDirection: 'row',
+      paddingVertical: 16,
+      paddingHorizontal: 24,
+    },
+    button: {
+      flex: 1,
+    },
+    cancel: {
+      marginRight: 8,
+    },
+    confirm: {
+      marginLeft: 8,
+    },
+    confirmButtonError: {
+      backgroundColor: colors.error.default,
+      borderColor: colors.error.default,
+    },
+    confirmButtonWarning: {
+      backgroundColor: colors.warning.default,
+      borderColor: colors.warning.default,
+    },
+  });
 
 /**
  * PureComponent that renders scrollable content above configurable buttons
@@ -51,10 +66,12 @@ export default function ActionView({
   loading = false,
   keyboardShouldPersistTaps = 'never',
   style = undefined,
+  confirmButtonState = ConfirmButtonState.Normal,
 }) {
   const { colors } = useTheme();
   confirmText = confirmText || strings('action_view.confirm');
   cancelText = cancelText || strings('action_view.cancel');
+  const styles = getStyles(colors);
 
   return (
     <View style={baseStyles.flexGrow}>
@@ -93,7 +110,16 @@ export default function ActionView({
               testID={confirmTestID}
               type={confirmButtonMode}
               onPress={onConfirmPress}
-              containerStyle={[styles.button, styles.confirm]}
+              containerStyle={[
+                styles.button,
+                styles.confirm,
+                confirmButtonState === ConfirmButtonState.Error
+                  ? styles.confirmButtonError
+                  : {},
+                confirmButtonState === ConfirmButtonState.Warning
+                  ? styles.confirmButtonWarning
+                  : {},
+              ]}
               disabled={confirmed || confirmDisabled || loading}
             >
               {confirmed || loading ? (
@@ -189,4 +215,8 @@ ActionView.propTypes = {
    * Optional View styles. Applies to scroll view
    */
   style: PropTypes.object,
+  /**
+   * Optional Confirm button state - this can be Error/Warning/Normal.
+   */
+  confirmButtonState: PropTypes.string,
 };

--- a/app/components/UI/ApproveTransactionReview/index.js
+++ b/app/components/UI/ApproveTransactionReview/index.js
@@ -7,7 +7,7 @@ import {
   ScrollView,
 } from 'react-native';
 import Eth from 'ethjs-query';
-import ActionView from '../../UI/ActionView';
+import ActionView, { ConfirmButtonState } from '../../UI/ActionView';
 import PropTypes from 'prop-types';
 import { getApproveNavbar } from '../Navbar';
 import { connect } from 'react-redux';
@@ -94,6 +94,7 @@ import { isNetworkRampNativeTokenSupported } from '../Ramp/utils';
 import { getRampNetworks } from '../../../reducers/fiatOrders';
 import SkeletonText from '../Ramp/components/SkeletonText';
 import InfoModal from '../../../components/UI/Swaps/components/InfoModal';
+import { ResultType } from '../BlockaidBanner/BlockaidBanner.types';
 import TransactionBlockaidBanner from '../TransactionBlockaidBanner/TransactionBlockaidBanner';
 import { regex } from '../../../util/regex';
 
@@ -699,6 +700,30 @@ class ApproveTransactionReview extends PureComponent {
     );
   };
 
+  getConfirmButtonState() {
+    const { transaction } = this.props;
+    const { id, currentTransactionSecurityAlertResponse } = transaction;
+    let confirmButtonState = ConfirmButtonState.Normal;
+    if (
+      id &&
+      currentTransactionSecurityAlertResponse?.id &&
+      currentTransactionSecurityAlertResponse.id === id
+    ) {
+      if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Malicious
+      ) {
+        confirmButtonState = ConfirmButtonState.Error;
+      } else if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Warning
+      ) {
+        confirmButtonState = ConfirmButtonState.Warning;
+      }
+    }
+    return confirmButtonState;
+  }
+
   renderDetails = () => {
     const {
       originalApproveAmount,
@@ -812,6 +837,7 @@ class ApproveTransactionReview extends PureComponent {
               onCancelPress={this.onCancelPress}
               onConfirmPress={this.onConfirmPress}
               confirmDisabled={shouldDisableConfirmButton}
+              confirmButtonState={this.getConfirmButtonState()}
             >
               <View style={styles.actionViewChildren}>
                 <ScrollView nestedScrollEnabled>

--- a/app/components/UI/SignatureRequest/index.js
+++ b/app/components/UI/SignatureRequest/index.js
@@ -18,11 +18,12 @@ import Device from '../../../util/device';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import WarningMessage from '../../Views/SendFlow/WarningMessage';
 import AccountInfoCard from '../AccountInfoCard';
-import ActionView from '../ActionView';
+import ActionView, { ConfirmButtonState } from '../ActionView';
 import BlockaidBanner from '../BlockaidBanner/BlockaidBanner';
 import QRSigningDetails from '../QRHardware/QRSigningDetails';
 import withQRHardwareAwareness from '../QRHardware/withQRHardwareAwareness';
 import WebsiteIcon from '../WebsiteIcon';
+import { ResultType } from '../BlockaidBanner/BlockaidBanner.types';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -334,6 +335,14 @@ class SignatureRequest extends PureComponent {
         expandedHeight = styles.expandedHeight1;
       }
     }
+
+    let confirmButtonState = ConfirmButtonState.Normal;
+    if (securityAlertResponse?.result_type === ResultType.Malicious) {
+      confirmButtonState = ConfirmButtonState.Error;
+    } else if (securityAlertResponse?.result_type === ResultType.Warning) {
+      confirmButtonState = ConfirmButtonState.Warning;
+    }
+
     return (
       <View testID={this.props.testID} style={[styles.root, expandedHeight]}>
         <ActionView
@@ -348,6 +357,7 @@ class SignatureRequest extends PureComponent {
           onCancelPress={this.onReject}
           onConfirmPress={this.onConfirm}
           confirmButtonMode="sign"
+          confirmButtonState={confirmButtonState}
         >
           <View>
             <View style={styles.signingInformation}>

--- a/app/components/UI/TransactionReview/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionReview/__snapshots__/index.test.tsx.snap
@@ -1580,6 +1580,8 @@ Array [
                         Object {
                           "marginLeft": 8,
                         },
+                        Object {},
+                        Object {},
                       ],
                     ],
                     null,

--- a/app/components/UI/TransactionReview/index.js
+++ b/app/components/UI/TransactionReview/index.js
@@ -43,7 +43,7 @@ import AnalyticsV2 from '../../../util/analyticsV2';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import TransactionHeader from '../TransactionHeader';
 import AccountFromToInfoCard from '../AccountFromToInfoCard';
-import ActionView from '../ActionView';
+import ActionView, { ConfirmButtonState } from '../ActionView';
 import { WALLET_CONNECT_ORIGIN } from '../../../util/walletconnect';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import withQRHardwareAwareness from '../QRHardware/withQRHardwareAwareness';
@@ -62,6 +62,7 @@ import { selectTokens } from '../../../selectors/tokensController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
 import ApproveTransactionHeader from '../ApproveTransactionHeader';
 import AppConstants from '../../../core/AppConstants';
+import { ResultType } from '../BlockaidBanner/BlockaidBanner.types';
 import TransactionBlockaidBanner from '../TransactionBlockaidBanner/TransactionBlockaidBanner';
 
 const POLLING_INTERVAL_ESTIMATED_L1_FEE = 30000;
@@ -445,6 +446,30 @@ class TransactionReview extends PureComponent {
     return url;
   }
 
+  getConfirmButtonState() {
+    const { transaction } = this.props;
+    const { id, currentTransactionSecurityAlertResponse } = transaction;
+    let confirmButtonState = ConfirmButtonState.Normal;
+    if (
+      id &&
+      currentTransactionSecurityAlertResponse?.id &&
+      currentTransactionSecurityAlertResponse.id === id
+    ) {
+      if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Malicious
+      ) {
+        confirmButtonState = ConfirmButtonState.Error;
+      } else if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Warning
+      ) {
+        confirmButtonState = ConfirmButtonState.Warning;
+      }
+    }
+    return confirmButtonState;
+  }
+
   renderTransactionReview = () => {
     const {
       transactionConfirmed,
@@ -481,6 +506,7 @@ class TransactionReview extends PureComponent {
     } = this.state;
     const url = this.getUrlFromBrowser();
     const styles = this.getStyles();
+
     return (
       <>
         <Animated.View
@@ -508,6 +534,7 @@ class TransactionReview extends PureComponent {
               confirmDisabled={
                 transactionConfirmed || Boolean(error) || isAnimating
               }
+              confirmButtonState={this.getConfirmButtonState()}
             >
               <View style={styles.actionViewChildren}>
                 <ScrollView nestedScrollEnabled>

--- a/app/components/UI/TypedSign/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TypedSign/__snapshots__/index.test.tsx.snap
@@ -611,6 +611,8 @@ exports[`TypedSign onConfirm signs message 1`] = `
                     Object {
                       "marginLeft": 8,
                     },
+                    Object {},
+                    Object {},
                   ],
                 ],
                 null,
@@ -1265,6 +1267,8 @@ exports[`TypedSign onReject rejects message 1`] = `
                     Object {
                       "marginLeft": 8,
                     },
+                    Object {},
+                    Object {},
                   ],
                 ],
                 null,

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -371,6 +371,8 @@ exports[`AddAsset component renders correctly 1`] = `
                       Object {
                         "marginLeft": 8,
                       },
+                      Object {},
+                      Object {},
                     ],
                   ],
                   Object {

--- a/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
@@ -1650,11 +1650,14 @@ exports[`Confirm should render correctly 1`] = `
                                   "backgroundColor": "#0376C9",
                                   "minHeight": 50,
                                 },
-                                Object {
-                                  "alignSelf": "flex-end",
-                                  "flex": 1,
-                                  "marginHorizontal": 24,
-                                },
+                                Array [
+                                  Object {
+                                    "alignSelf": "flex-end",
+                                    "flex": 1,
+                                    "marginHorizontal": 24,
+                                  },
+                                  Object {},
+                                ],
                               ],
                               Object {
                                 "opacity": 0.6,

--- a/app/components/Views/SendFlow/Confirm/index.js
+++ b/app/components/Views/SendFlow/Confirm/index.js
@@ -112,6 +112,7 @@ import {
   isBlockaidFeatureEnabled,
 } from '../../../../util/blockaid';
 import ppomUtil from '../../../../lib/ppom/ppom-util';
+import { ResultType } from '../../../../components/UI/BlockaidBanner/BlockaidBanner.types';
 import TransactionBlockaidBanner from '../../../../components/UI/TransactionBlockaidBanner/TransactionBlockaidBanner';
 
 const EDIT = 'edit';
@@ -1084,6 +1085,34 @@ class Confirm extends PureComponent {
     );
   };
 
+  getConfirmButtonStyles() {
+    const { transactionMeta } = this.state;
+    const { transaction } = this.props;
+    const { currentTransactionSecurityAlertResponse } = transaction;
+    const colors = this.context.colors || mockTheme.colors;
+    const styles = createStyles(colors);
+
+    let confirmButtonStyle = {};
+    if (
+      transactionMeta.id &&
+      currentTransactionSecurityAlertResponse?.id &&
+      currentTransactionSecurityAlertResponse.id === transactionMeta.id
+    ) {
+      if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Malicious
+      ) {
+        confirmButtonStyle = styles.confirmButtonError;
+      } else if (
+        currentTransactionSecurityAlertResponse?.response?.result_type ===
+        ResultType.Warning
+      ) {
+        confirmButtonStyle = styles.confirmButtonWarning;
+      }
+    }
+    return confirmButtonStyle;
+  }
+
   render = () => {
     const { selectedAsset, paymentRequest } = this.props.transactionState;
     const {
@@ -1279,7 +1308,7 @@ class Confirm extends PureComponent {
               Boolean(errorMessage) ||
               isAnimating
             }
-            containerStyle={styles.buttonNext}
+            containerStyle={[styles.buttonNext, this.getConfirmButtonStyles()]}
             onPress={this.onNext}
             testID={ConfirmViewSelectorsIDs.SEND_BUTTON}
           >

--- a/app/components/Views/SendFlow/Confirm/styles.ts
+++ b/app/components/Views/SendFlow/Confirm/styles.ts
@@ -138,6 +138,14 @@ const createStyles = (colors: any) =>
       marginTop: 20,
       marginHorizontal: 10,
     },
+    confirmButtonError: {
+      backgroundColor: colors.error.default,
+      borderColor: colors.error.default,
+    },
+    confirmButtonWarning: {
+      backgroundColor: colors.warning.default,
+      borderColor: colors.warning.default,
+    },
   });
 
 export default createStyles;


### PR DESCRIPTION
## **Description**
Red / Yellow confirm button to be displayed when transaction is reported as Malicious / Warning by blockaid

## **Related issues**

Fixes: MetaMask/MetaMask-planning#1993

## **Manual testing steps**

1. To to test dapp or send flow
2. Submit a malicious transaction
3. Check color of submit button as validation completes

## **Screenshots/Recordings**
<img width="409" alt="Screenshot 2024-02-02 at 4 31 06 PM" src="https://github.com/MetaMask/metamask-mobile/assets/2182307/dbf3964e-f379-4e99-9530-26902319c906">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
