### PR TITLE
fix: Update MixPanel proxy URL

### DIFF
--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -31,7 +31,7 @@ export const KEYSTONE_SUPPORT_VIDEO = 'https://keyst.one/mmmvideo';
 
 // MixPanel
 export const MIXPANEL_PROXY_ENDPOINT_BASE_URL =
-  'https://proxy.metafi-dev.codefi.network/mixpanel/v1/api/app';
+  'https://proxy.metafi.codefi.network/mixpanel/v1/api/app';
 
 // Network
 export const CHAINLIST_URL = 'https://chainlist.wtf';


### PR DESCRIPTION
## **Description**

This PR updates the MixPanel proxy URL to use the updated production server domain instead. We should no longer be using the `dev` server.

## **Related issues**

No related issues.

## **Manual testing steps**

1. You can test the proxy server is up by running the following command in your terminal (project token in invalid)

```bash
curl -i -s -k -X $'POST' \
    -H $'Host: proxy.api.cx.metamask.io' -H $'Accept: application/json' -H $'Content-Type: application/json' -H $'Content-Length: 30' \
    --data-binary $'{\"distinct_ids\": [\"12312312\"]}' \
    $'https://proxy.api.cx.metamask.io/mixpanel/v1/api/app/data-deletions/v3.0/?token=abcdefg'
```

2. In the MetaMask application, navigate `Settings` -> `Security & Privacy` -> `Delete MetaMetrics Data`. Upon clicking you should see a request made.

## **Screenshots/Recordings**


### **Before**

Not applicable 

### **After**

Not applicable 

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've included manual testing steps
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
