### PR TITLE
fix: Added inherited to build settings library search paths

### DIFF
--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1372,7 +1372,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift$(inherited)",
+					"${inherited}",
+				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 7.15.0;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1434,7 +1437,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift$(inherited)",
+					"${inherited}",
+				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 7.15.0;
 				ONLY_ACTIVE_ARCH = NO;


### PR DESCRIPTION
## **Description**
Currently when running simulator, this issue arises
<img width="388" alt="Screenshot 2024-02-05 at 7 16 56 PM" src="https://github.com/MetaMask/metamask-mobile/assets/14355083/ed7cb89c-35af-46d7-878f-8843f8f27001">

Per @vivek-consensys 's suggestion, this PR adds `${inherited}` to the Library Search Paths
![image](https://github.com/MetaMask/metamask-mobile/assets/14355083/686aeb29-4e92-4747-ae9e-b45871493c79)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Start the ios simulator
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
