### PR TITLE
fix: broken WhatsNew

### DIFF
--- a/app/components/UI/WhatsNewModal/types.ts
+++ b/app/components/UI/WhatsNewModal/types.ts
@@ -41,7 +41,7 @@ type SlideContentType =
 
 type WhatsNewSlides = SlideContentType[][];
 
-type VersionString = `${number}.${number}.${number}`;
+type VersionString = `${number}.${number}.${number}` | `${number}.${number}`;
 
 export interface WhatsNew {
   onlyUpdates: boolean;

--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -7,7 +7,7 @@ import { WhatsNew } from './types';
 export const whatsNew: WhatsNew = {
   // All users that have <6.4.0 and are updating to >=6.4.0 should see
   onlyUpdates: false, // false: Users who updated the app and new installs will see this. true: only users who update will see it
-  maxLastAppVersion: '7.19.0', // Only users who had a previous version <7.19.0 version will see this
+  maxLastAppVersion: '7.19', // Only users who had a previous version <7.19.0 version will see this
   minAppVersion: '7.14.0', // Only users who updated to a version >= 7.14.0 will see this
   /**
    * Slides utilizes a templating system in the form of a 2D array, which is eventually rendered within app/components/UI/WhatsNewModal/index.js.

--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -7,8 +7,8 @@ import { WhatsNew } from './types';
 export const whatsNew: WhatsNew = {
   // All users that have <6.4.0 and are updating to >=6.4.0 should see
   onlyUpdates: false, // false: Users who updated the app and new installs will see this. true: only users who update will see it
-  maxLastAppVersion: '7.15.0', // Only users who had a previous version <7.15.0 version will see this
-  minAppVersion: '7.15.0', // Only users who updated to a version >= 7.15.0 will see this
+  maxLastAppVersion: '7.19.0', // Only users who had a previous version <7.19.0 version will see this
+  minAppVersion: '7.14.0', // Only users who updated to a version >= 7.14.0 will see this
   /**
    * Slides utilizes a templating system in the form of a 2D array, which is eventually rendered within app/components/UI/WhatsNewModal/index.js.
    * The root layer determines the number of slides. Ex. To display 3 slides, the root layer should contain 3 arrays.

--- a/app/components/UI/WhatsNewModal/whatsNewList.ts
+++ b/app/components/UI/WhatsNewModal/whatsNewList.ts
@@ -7,8 +7,8 @@ import { WhatsNew } from './types';
 export const whatsNew: WhatsNew = {
   // All users that have <6.4.0 and are updating to >=6.4.0 should see
   onlyUpdates: false, // false: Users who updated the app and new installs will see this. true: only users who update will see it
-  maxLastAppVersion: '7.19', // Only users who had a previous version <7.19.0 version will see this
-  minAppVersion: '7.14.0', // Only users who updated to a version >= 7.14.0 will see this
+  maxLastAppVersion: '7.20', // When updating, only users who had a previous version < '7.20' may see the modal
+  minAppVersion: '7.16.0', // Only users whose current version is >= 7.16.0 may see the modal. This should match the version with the latest copy changes in the modal.
   /**
    * Slides utilizes a templating system in the form of a 2D array, which is eventually rendered within app/components/UI/WhatsNewModal/index.js.
    * The root layer determines the number of slides. Ex. To display 3 slides, the root layer should contain 3 arrays.


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The WhatsNew modal isn't displayed when updating from the v7.15.0 to v7.16.0. We had previously defined the `minAppVersion` to `v7.15.0`. See [comment](https://github.com/MetaMask/metamask-mobile/pull/8453#discussion_r1470139639)

## **Related issues**

Fixes: #8553 

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
