### PR TITLE
fix: add warning for optimism and arbitrum goerli

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -69,7 +69,7 @@ import {
   selectProviderType,
 } from '../../../selectors/networkController';
 import { selectShowIncomingTransactionNetworks } from '../../../selectors/preferencesController';
-import { NETWORKS_CHAIN_ID } from '../../../constants/network';
+import { DEPRECATED_NETWORKS } from '../../../constants/network';
 import WarningAlert from '../../../components/UI/WarningAlert';
 import { GOERLI_DEPRECATED_ARTICLE } from '../../../constants/urls';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
@@ -108,6 +108,14 @@ const Main = (props) => {
 
   useEnableAutomaticSecurityChecks();
   useMinimumVersions();
+
+  useEffect(() => {
+    if (DEPRECATED_NETWORKS.includes(props.chainId)) {
+      setShowDeprecatedAlert(true);
+    } else {
+      setShowDeprecatedAlert(false);
+    }
+  }, [props.chainId]);
 
   useEffect(() => {
     const { TransactionController } = Engine.context;
@@ -333,7 +341,7 @@ const Main = (props) => {
   };
 
   const renderDeprecatedNetworkAlert = (chainId, backUpSeedphraseVisible) => {
-    if (chainId === NETWORKS_CHAIN_ID.GOERLI && showDeprecatedAlert) {
+    if (DEPRECATED_NETWORKS.includes(chainId) && showDeprecatedAlert) {
       return (
         <WarningAlert
           text={strings('networks.deprecated_goerli')}

--- a/app/constants/network.js
+++ b/app/constants/network.js
@@ -31,4 +31,13 @@ export const NETWORKS_CHAIN_ID = {
   GOERLI: toHex('5'),
   LINEA_MAINNET: toHex('59144'),
   ZKSYNC_ERA: toHex('324'),
+  ARBITRUM_GOERLI: toHex('421613'),
+  OPTIMISM_GOERLI: toHex('420'),
 };
+
+// To add a deprecation warning to a network, add it to the array
+export const DEPRECATED_NETWORKS = [
+  NETWORKS_CHAIN_ID.GOERLI,
+  NETWORKS_CHAIN_ID.ARBITRUM_GOERLI,
+  NETWORKS_CHAIN_ID.OPTIMISM_GOERLI,
+];


### PR DESCRIPTION
## **Description**

Adds a warning when the user switches to either Arbitrum goerli or OP goerli testnet.

This also fixes the fact that once you switch to goerli network and you close the warning. Then switch to Ethereum. Then switch back to goerli, you wont be able to see the deprecation warning again.

## **Related issues**

Fixes:
Related ticket : https://consensyssoftware.atlassian.net/browse/MMASSETS-155

## **Manual testing steps**

1. Go to home page
2. Either use chainlist to add OP goerli network/Arbitrum Goerli. Or you can click on Add network manually and fill the input boxes
3. Click switch network
4. You should see the network deprecation warning.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/10994169/d1279946-6cbe-42dc-bc8c-53fabec434dd


### **After**


https://github.com/MetaMask/metamask-mobile/assets/10994169/1828b594-0507-41ac-85cc-e41f72703770



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
