### PR TITLE
fix: fix metrics trackEvent compatibility with legacy events

### DIFF
--- a/app/core/Analytics/MetaMetrics.test.ts
+++ b/app/core/Analytics/MetaMetrics.test.ts
@@ -284,7 +284,7 @@ describe('MetaMetrics', () => {
         const event = undefined;
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore: Testing untyped legacy JS call with undefined event
+        // @ts-expect-error: Testing untyped legacy JS call with undefined event
         metaMetrics.trackEvent(event);
 
         const { segmentMockClient } = global as any;

--- a/app/core/Analytics/MetaMetrics.test.ts
+++ b/app/core/Analytics/MetaMetrics.test.ts
@@ -275,6 +275,24 @@ describe('MetaMetrics', () => {
           ...properties,
         });
       });
+
+      it('does not break on JS legacy call', async () => {
+        const metaMetrics = TestMetaMetrics.getInstance();
+        expect(await metaMetrics.configure()).toBeTruthy();
+        await metaMetrics.enable();
+
+        const event = undefined;
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: Testing untyped legacy JS call with undefined event
+        metaMetrics.trackEvent(event);
+
+        const { segmentMockClient } = global as any;
+        expect(segmentMockClient.track).toHaveBeenCalledWith(undefined, {
+          anonymous: false,
+          undefined,
+        });
+      });
     });
   });
 

--- a/app/core/Analytics/MetaMetrics.test.ts
+++ b/app/core/Analytics/MetaMetrics.test.ts
@@ -237,6 +237,45 @@ describe('MetaMetrics', () => {
       });
       expect(metaMetrics.isDataRecorded()).toBeFalsy();
     });
+
+    describe('Legacy events', () => {
+      it('tracks legacy properties', async () => {
+        const metaMetrics = TestMetaMetrics.getInstance();
+        expect(await metaMetrics.configure()).toBeTruthy();
+        await metaMetrics.enable();
+        const event: IMetaMetricsEvent = {
+          category: 'event1',
+          properties: { action: 'action1', name: 'description1' },
+        };
+
+        metaMetrics.trackEvent(event);
+
+        const { segmentMockClient } = global as any;
+        expect(segmentMockClient.track).toHaveBeenCalledWith(event.category, {
+          anonymous: false,
+          ...event.properties,
+        });
+      });
+
+      it('overrides legacy properties', async () => {
+        const metaMetrics = TestMetaMetrics.getInstance();
+        expect(await metaMetrics.configure()).toBeTruthy();
+        await metaMetrics.enable();
+        const event: IMetaMetricsEvent = {
+          category: 'event1',
+          properties: { action: 'action1', name: 'description1' },
+        };
+        const properties = { action: 'action2', name: 'description2' };
+
+        metaMetrics.trackEvent(event, properties);
+
+        const { segmentMockClient } = global as any;
+        expect(segmentMockClient.track).toHaveBeenCalledWith(event.category, {
+          anonymous: false,
+          ...properties,
+        });
+      });
+    });
   });
 
   describe('Grouping', () => {

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -601,7 +601,7 @@ class MetaMetrics implements IMetaMetrics {
     if (this.enabled) {
       this.#trackEvent(
         event.category,
-        { anonymous: false, ...event.properties, ...properties },
+        { anonymous: false, ...event?.properties, ...properties },
         saveDataRecording,
       );
     }

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -601,7 +601,7 @@ class MetaMetrics implements IMetaMetrics {
     if (this.enabled) {
       this.#trackEvent(
         event.category,
-        { anonymous: false, ...properties },
+        { anonymous: false, ...event.properties, ...properties },
         saveDataRecording,
       );
     }

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -600,7 +600,8 @@ class MetaMetrics implements IMetaMetrics {
   ): void => {
     if (this.enabled) {
       this.#trackEvent(
-        event.category,
+        // NOTE: we use optional event to avoid undefined error in case of legacy untyped call form JS
+        event?.category,
         { anonymous: false, ...event?.properties, ...properties },
         saveDataRecording,
       );


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Add handling of legacy events that have properties inside the event

## **Related issues**

Realted to https://github.com/MetaMask/mobile-planning/issues/1129

## **Manual testing steps**

NA - see unit tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
NA

### **After**

<!-- [screenshots/recordings] -->
NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
