### PR TITLE
fix: correct asset type in the incoming transaction notification

### DIFF
--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -14,7 +14,7 @@ import {
 } from '../constants/storage';
 import { safeToChecksumAddress } from '../util/address';
 import ReviewManager from './ReviewManager';
-import { selectChainId } from '../selectors/networkController';
+import { selectChainId, selectTicker } from '../selectors/networkController';
 import { store } from '../store';
 
 const constructTitleAndMessage = (data) => {
@@ -404,6 +404,7 @@ class NotificationManager {
     } = Engine.context;
     const { selectedAddress } = PreferencesController.state;
     const chainId = selectChainId(store.getState());
+    const ticker = selectTicker(store.getState());
 
     /// Find the incoming TX
     const { transactions } = TransactionController.state;
@@ -430,7 +431,7 @@ class NotificationManager {
             nonce: `${hexToBN(txs[0].transaction.nonce).toString()}`,
             amount: `${renderFromWei(hexToBN(txs[0].transaction.value))}`,
             id: txs[0]?.id,
-            assetType: strings('unit.eth'),
+            assetType: txs[0]?.transferInformation?.symbol || ticker,
           },
           autoHide: true,
           duration: 5000,


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently, the notifications for the new incoming transactions always show the ticker (asset type) as ETH.
This PR fixes the issue, supporting both the ERC20 token and the native token.

## **Related issues**

Fixes: #8832 #7669 

## **Manual testing steps**

1. Send token to the wallet address
2. Check the notification

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
![IMG_3242](https://github.com/MetaMask/metamask-mobile/assets/30585557/976c0f53-fd09-49fb-be1a-6b9dd84d0835)
* Actually this's a ERC20 transfering transaction

### **After**

<!-- [screenshots/recordings] -->
![Screenshot 2024-02-23 at 16 46 10](https://github.com/MetaMask/metamask-mobile/assets/30585557/26aee6b5-4fff-497b-9088-0029befd9507)
![Screenshot 2024-02-23 at 16 44 49](https://github.com/MetaMask/metamask-mobile/assets/30585557/897bdb48-dd44-4a65-999a-0f2cd54c6a3a)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
