### PR TITLE
fix: fix hex to BN conversion

### DIFF
--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -10,7 +10,6 @@ import {
   balanceToFiatNumber,
   weiToFiatNumber,
   addCurrencySymbol,
-  toBN,
   BNToHex,
   limitToMaximumDecimalPlaces,
 } from '../../../util/number';
@@ -34,7 +33,6 @@ import { isSwapsNativeAsset } from '../Swaps/utils';
 import { toLowerCaseEquals } from '../../../util/general';
 import Engine from '../../../core/Engine';
 import { isEIP1559Transaction } from '@metamask/transaction-controller';
-import { convertHexToDecimal } from '@metamask/controller-utils';
 
 const { getSwapsContractAddress } = swapsUtils;
 
@@ -282,8 +280,7 @@ export function decodeIncomingTransfer(args) {
     selectedAddress,
   } = args;
 
-  const decimalAmount = convertHexToDecimal(value);
-  const amount = toBN(decimalAmount);
+  const amount = hexToBN(value);
   const token = { symbol, decimals, address: contractAddress };
 
   const renderTokenAmount = token

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -7,7 +7,7 @@ describe('decodeIncomingTransfer', () => {
         transaction: {
           to: '0x77648f1407986479fb1fa5cc3597084b5dbdb057',
           from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
-          value: '0x52daf0',
+          value: '52daf0',
         },
         transferInformation: {
           symbol: 'USDT',
@@ -51,6 +51,61 @@ describe('decodeIncomingTransfer', () => {
       summaryAmount: '5.43 USDT',
       summaryFee: '< 0.00001 ETH',
       summaryTotalAmount: '5.43 USDT / < 0.00001 ETH',
+      summarySecondaryTotalAmount: undefined,
+    });
+  });
+
+  it('should decode an incoming transfer with big number with 6 digits', () => {
+    // Arrange
+    const args = {
+      tx: {
+        transaction: {
+          to: '0x77648f1407986479fb1fa5cc3597084b5dbdb057',
+          from: '0x1440ec793ae50fa046b95bfeca5af475b6003f9e',
+          value: '3B9ACA00', // 1000000000 in decimal
+        },
+        transferInformation: {
+          symbol: 'USDT',
+          decimals: 6,
+          contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        },
+        transactionHash:
+          '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+      },
+      currentCurrency: 'usd',
+      contractExchangeRates: {},
+      totalGas: '0x64',
+      actionKey: 'key',
+      primaryCurrency: 'ETH',
+      selectedAddress: '0x77648f1407986479fb1fa5cc3597084b5dbdb057',
+      ticker: 'ETH',
+    };
+
+    // Act
+    const [transactionElement, transactionDetails] =
+      decodeIncomingTransfer(args);
+
+    // Assert
+    expect(transactionElement).toEqual({
+      actionKey: 'key',
+      renderFrom: '0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e',
+      renderTo: '0x77648F1407986479fb1fA5Cc3597084B5dbDB057',
+      value: '1000 USDT',
+      fiatValue: undefined,
+      isIncomingTransfer: true,
+      transactionType: 'transaction_received_token',
+    });
+    expect(transactionDetails).toEqual({
+      renderTotalGas: '< 0.00001 ETH',
+      renderValue: '1000 USDT',
+      renderFrom: '0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e',
+      renderTo: '0x77648F1407986479fb1fA5Cc3597084B5dbDB057',
+      transactionHash:
+        '0x942d7843454266b81bf631022aa5f3f944691731b62d67c4e80c4bb5740058bb',
+      transactionType: 'transaction_received_token',
+      summaryAmount: '1000 USDT',
+      summaryFee: '< 0.00001 ETH',
+      summaryTotalAmount: '1000 USDT / < 0.00001 ETH',
       summarySecondaryTotalAmount: undefined,
     });
   });

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -55,7 +55,7 @@ describe('decodeIncomingTransfer', () => {
     });
   });
 
-  it('should decode an incoming transfer with big number with 6 digits', () => {
+  it('should decode an incoming transfer with big number with 10 digits', () => {
     // Arrange
     const args = {
       tx: {


### PR DESCRIPTION
## **Description**

conversion from hex to BN doesn't work for very large numbers, because the convertHexToDecimal function uses parseInt to convert from hex to decimal, but for numbers greater than 54 digits this may send an incorrect result.

the fix was to use `toHexBN` function

## **Related issues**

Fixes: #8703 

## **Manual testing steps**

1. Click on any token where you hold a large amount
2.Go to the received/sen activity

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
