### PR TITLE
feat: add MetaMetrics custom flush vars and log

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -60,3 +60,9 @@ export SEGMENT_WRITE_KEY=""
 export SEGMENT_PROXY_URL=""
 export SEGMENT_DELETE_API_SOURCE_ID=""
 export SEGMENT_REGULATIONS_ENDPOINT=""
+
+# Optional for dev purpose: Segment flush interval in seconds
+# example for 1 second flush interval
+export SEGMENT_FLUSH_INTERVAL="1"
+# example for flush when 1 event is queued
+export SEGMENT_FLUSH_EVENT_LIMIT="1"

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -476,7 +476,22 @@ class MetaMetrics implements IMetaMetrics {
         proxy: process.env.SEGMENT_PROXY_URL as string,
         debug: __DEV__,
         anonymousId: METAMETRICS_ANONYMOUS_ID,
+        // allow custom flush interval and event limit for dev and testing
+        // each is optional and can be set in the .js.env file
+        // if not set, the default values from the Segment SDK will be used
+        flushInterval: process.env.SEGMENT_FLUSH_INTERVAL as unknown as number,
+        flushAt: process.env.SEGMENT_FLUSH_EVENT_LIMIT as unknown as number,
       };
+
+      if (__DEV__)
+        Logger.log(
+          `MetaMetrics client configured with: ${JSON.stringify(
+            config,
+            null,
+            2,
+          )}`,
+        );
+
       this.instance = new MetaMetrics(createClient(config));
     }
     return this.instance;


### PR DESCRIPTION
## **Description**

- add optional custom flush vars and log in MetaMetrics Segment client config
- update example .js.env

> [!NOTE]
> No unit test change as it only affect the log and it's dev feature.
> The behaviour of metrics is unchanged.
> If you feel tests should be added, please suggest how.

## **Related issues**

Fixes #8772 

## **Manual testing steps**

0. With dev environment configured to use Segment (configure `SEGMENT_WRITE_KEY` and `SEGMENT_PROXY_URL`, see contrib doc)
1. Set env vars in `.js.env`:
  ```env
  export SEGMENT_FLUSH_INTERVAL=2
  export SEGMENT_FLUSH_EVENT_LIMIT=4
  ```
2. run app in as a local dev build
3. check logs for:
  ```
  LOG  [MetaMask DEBUG]: MetaMetrics client configured with: {
    "writeKey": "...",
    "proxy": "...",
    "debug": true,
    "anonymousId": "...",
    "flushInterval": "2",
    "flushAt": "4"
  }
  ```
4. Navigate in the app to settings and notice the following two lines in the logs, very close to each other as interval is 2s:
  ```
  INFO  TRACK event saved {"event": "Navigation Drawer", "properties": {"action": "Navigation Drawer", "name": "Settings"}, "type": "track"}
  ...
  INFO  Sent 1 events 
  ```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
