### PR TITLE
refactor: bring back IOS_SIMULATOR var as optional

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -198,7 +198,12 @@ buildAndroidRunFlask(){
 
 buildIosSimulator(){
 	prebuild_ios
-	react-native run-ios --port=$WATCHER_PORT
+	if [ -n "$IOS_SIMULATOR" ]; then
+		SIM_OPTION="--simulator \"$IOS_SIMULATOR\""
+	else
+		SIM_OPTION=""
+	fi
+	react-native run-ios --port=$WATCHER_PORT $SIM_OPTION
 }
 
 buildIosSimulatorQA(){


### PR DESCRIPTION
## **Description**

This PR brings back the `IOS_SIMULATOR` variable for the `yarn start:ios` script, this time the variable will not have a default value.

This will allow users to specify a Simulator if they want. For example running this to select iPhone 15 Pro
```sh
IOS_SIMULATOR="iPhone 15 Pro" yarn start:ios
```

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `IOS_SIMULATOR="iPhone 15 Pro" yarn start:ios`, the build must succeed.
2. Change simulator to another one available and the build must succeed.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
