### PR TITLE
feat: Add `hideSubmitButton` prop to templates

### DIFF
--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
@@ -14,7 +14,7 @@ const CONTENT_MOCK = 'CONTENT_MOCK';
 const CANCEL_TEXT_MOCK = 'CANCEL_TEXT_MOCK';
 const CONFIRM_TEXT_MOCK = 'CONFIRM_TEXT_MOCK';
 
-describe('ApprovalResult', () => {
+describe('TemplateConfirmation', () => {
   const mockProps: TemplateConfirmationProps = {
     approvalRequest: {
       id: 'mocked',

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
@@ -37,8 +37,6 @@ describe('TemplateConfirmation', () => {
       content: [CONTENT_MOCK],
       cancelText: CANCEL_TEXT_MOCK,
       confirmText: CONFIRM_TEXT_MOCK,
-      hideSubmitButton: true,
-      hideCancelButton: true,
     });
     const wrapper = render(<TemplateConfirmation {...mockProps} />);
 

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
@@ -27,8 +27,6 @@ describe('TemplateConfirmation', () => {
       expectsResult: false,
       requestState: null,
       time: 123456,
-      hideSubmitButton: true,
-      hideCancelButton: true,
     },
     onConfirm: jest.fn(),
     onCancel: jest.fn(),
@@ -39,6 +37,8 @@ describe('TemplateConfirmation', () => {
       content: [CONTENT_MOCK],
       cancelText: CANCEL_TEXT_MOCK,
       confirmText: CONFIRM_TEXT_MOCK,
+      hideSubmitButton: true,
+      hideCancelButton: true,
     });
     const wrapper = render(<TemplateConfirmation {...mockProps} />);
 

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import TemplateConfirmation, {
+  TemplateConfirmationProps,
+} from './TemplateConfirmation';
+import { ApprovalTypes } from '../../../../../../core/RPCMethods/RPCMethodMiddleware';
+import { getTemplateValues } from './Templates';
+
+jest.mock('./Templates', () => ({
+  getTemplateValues: jest.fn(),
+}));
+
+const CONTENT_MOCK = 'CONTENT_MOCK';
+const CANCEL_TEXT_MOCK = 'CANCEL_TEXT_MOCK';
+const CONFIRM_TEXT_MOCK = 'CONFIRM_TEXT_MOCK';
+
+describe('ApprovalResult', () => {
+  const mockProps: TemplateConfirmationProps = {
+    approvalRequest: {
+      id: 'mocked',
+      origin: 'metamask',
+      requestData: {
+        data: '123',
+      },
+      // Add props here in order to satisfy the type
+      type: ApprovalTypes.RESULT_SUCCESS,
+      expectsResult: false,
+      requestState: null,
+      time: 123456,
+      hideSubmitButton: true,
+      hideCancelButton: true,
+    },
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  };
+
+  it('renders content and actions', () => {
+    (getTemplateValues as jest.Mock).mockReturnValue({
+      content: [CONTENT_MOCK],
+      cancelText: CANCEL_TEXT_MOCK,
+      confirmText: CONFIRM_TEXT_MOCK,
+    });
+    const wrapper = render(<TemplateConfirmation {...mockProps} />);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.queryByText(CONTENT_MOCK)).toBeDefined();
+    expect(wrapper.queryByText(CANCEL_TEXT_MOCK)).toBeDefined();
+    expect(wrapper.queryByText(CONFIRM_TEXT_MOCK)).toBeDefined();
+  });
+
+  it('renders content without actions', () => {
+    (getTemplateValues as jest.Mock).mockReturnValue({
+      content: [CONTENT_MOCK],
+      cancelText: CANCEL_TEXT_MOCK,
+      confirmText: CONFIRM_TEXT_MOCK,
+      hideSubmitButton: true,
+      hideCancelButton: true,
+    });
+    const wrapper = render(<TemplateConfirmation {...mockProps} />);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.queryByText(CONTENT_MOCK)).toBeDefined();
+    expect(wrapper.queryByText(CANCEL_TEXT_MOCK)).toBeNull();
+    expect(wrapper.queryByText(CONFIRM_TEXT_MOCK)).toBeNull();
+  });
+});

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
@@ -49,15 +49,6 @@ const TemplateConfirmation = ({
     [approvalRequest, onConfirm, onCancel, colors],
   );
 
-  const showActions =
-    !templatedValues.hideSubmitButton &&
-    Boolean(
-      templatedValues.onConfirm ||
-        onConfirm ||
-        templatedValues.onCancel ||
-        onCancel,
-    );
-
   useEffect(() => {
     // Handles the cancellation logic
     const handleOnCancel = () => {
@@ -70,16 +61,18 @@ const TemplateConfirmation = ({
     };
   }, [templatedValues.onCancel, onCancel, templatedValues]);
 
-  const buttons = [
-    {
+  const buttons = [];
+
+  if (!templatedValues.hideSubmitButton) {
+    buttons.push({
       variant: ButtonVariants.Primary,
       label: templatedValues.confirmText ?? strings('template_confirmation.ok'),
       size: ButtonSize.Lg,
       onPress: templatedValues.onConfirm ?? onConfirm,
-    },
-  ];
+    });
+  }
 
-  if (!templatedValues.onlyConfirmButton) {
+  if (!templatedValues.hideCancelButton) {
     buttons.push({
       variant: ButtonVariants.Secondary,
       label:
@@ -92,7 +85,7 @@ const TemplateConfirmation = ({
   return (
     <View style={styles.root}>
       <TemplateRenderer sections={templatedValues.content} />
-      {showActions && (
+      {buttons.length > 0 && (
         <View style={styles.actionContainer}>
           <BottomSheetFooter
             buttonsAlignment={ButtonsAlignment.Horizontal}

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
@@ -49,6 +49,15 @@ const TemplateConfirmation = ({
     [approvalRequest, onConfirm, onCancel, colors],
   );
 
+  const showActions =
+    !templatedValues.hideSubmitButton &&
+    Boolean(
+      templatedValues.onConfirm ||
+        onConfirm ||
+        templatedValues.onCancel ||
+        onCancel,
+    );
+
   useEffect(() => {
     // Handles the cancellation logic
     const handleOnCancel = () => {
@@ -83,12 +92,14 @@ const TemplateConfirmation = ({
   return (
     <View style={styles.root}>
       <TemplateRenderer sections={templatedValues.content} />
-      <View style={styles.actionContainer}>
-        <BottomSheetFooter
-          buttonsAlignment={ButtonsAlignment.Horizontal}
-          buttonPropsArray={buttons}
-        />
-      </View>
+      {showActions && (
+        <View style={styles.actionContainer}>
+          <BottomSheetFooter
+            buttonsAlignment={ButtonsAlignment.Horizontal}
+            buttonPropsArray={buttons}
+          />
+        </View>
+      )}
     </View>
   );
 };

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
@@ -16,7 +16,10 @@ import { useAppThemeFromContext } from '../../../../../../util/theme';
 import { AcceptOptions, ApprovalRequest } from '@metamask/approval-controller';
 
 export interface TemplateConfirmationProps {
-  approvalRequest: ApprovalRequest<any>;
+  approvalRequest: ApprovalRequest<any> & {
+    hideCancelButton?: boolean;
+    hideSubmitButton?: boolean;
+  };
   onConfirm: (opts?: AcceptOptions) => void;
   onCancel: () => void;
 }

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/TemplateConfirmation.tsx
@@ -16,10 +16,7 @@ import { useAppThemeFromContext } from '../../../../../../util/theme';
 import { AcceptOptions, ApprovalRequest } from '@metamask/approval-controller';
 
 export interface TemplateConfirmationProps {
-  approvalRequest: ApprovalRequest<any> & {
-    hideCancelButton?: boolean;
-    hideSubmitButton?: boolean;
-  };
+  approvalRequest: ApprovalRequest<any>;
   onConfirm: (opts?: AcceptOptions) => void;
   onCancel: () => void;
 }

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/ApprovalResult.ts
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/ApprovalResult.ts
@@ -114,7 +114,7 @@ function getValues(
     ],
     confirmText: strings('approval_result.ok'),
     onConfirm: actions.onConfirm,
-    onlyConfirmButton: true,
+    hideCancelButton: true,
   };
 }
 

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/index.ts
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/index.ts
@@ -10,11 +10,11 @@ export interface ConfirmationTemplateValues {
   cancelText?: string;
   confirmText?: string;
   content: TemplateRendererInput;
+  hideCancelButton?: boolean;
+  hideSubmitButton?: boolean;
   onCancel?: () => void;
   onConfirm?: (opts?: AcceptOptions) => void;
-  onlyConfirmButton?: boolean;
   loadingText?: string;
-  hideSubmitButton?: boolean;
 }
 
 export interface ConfirmationTemplate {
@@ -38,11 +38,11 @@ const ALLOWED_TEMPLATE_KEYS: string[] = [
   'cancelText',
   'confirmText',
   'content',
+  'hideCancelButton',
+  'hideSubmitButton',
   'onCancel',
   'onConfirm',
-  'onlyConfirmButton',
   'loadingText',
-  'hideSubmitButton',
 ];
 
 export function getTemplateValues(

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/index.ts
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/index.ts
@@ -14,6 +14,7 @@ export interface ConfirmationTemplateValues {
   onConfirm?: (opts?: AcceptOptions) => void;
   onlyConfirmButton?: boolean;
   loadingText?: string;
+  hideSubmitButton?: boolean;
 }
 
 export interface ConfirmationTemplate {
@@ -41,6 +42,7 @@ const ALLOWED_TEMPLATE_KEYS: string[] = [
   'onConfirm',
   'onlyConfirmButton',
   'loadingText',
+  'hideSubmitButton',
 ];
 
 export function getTemplateValues(

--- a/app/components/Views/confirmations/components/Approval/TemplateConfirmation/__snapshots__/TemplateConfirmation.test.tsx.snap
+++ b/app/components/Views/confirmations/components/Approval/TemplateConfirmation/__snapshots__/TemplateConfirmation.test.tsx.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TemplateConfirmation renders content and actions 1`] = `
+<View
+  collapsable={false}
+  forwardedRef={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
+      "minHeight": 200,
+      "paddingBottom": 20,
+      "paddingTop": 24,
+    }
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Object {
+        "color": "#24272A",
+        "fontFamily": "Euclid Circular B",
+        "fontSize": 14,
+        "fontWeight": "400",
+        "letterSpacing": 0,
+        "lineHeight": 22,
+      }
+    }
+  >
+    CONTENT_MOCK
+  </Text>
+  <View
+    collapsable={false}
+    forwardedRef={[Function]}
+    style={
+      Object {
+        "flex": 0,
+        "justifyContent": "center",
+        "paddingVertical": 16,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#FFFFFF",
+          "flexDirection": "row",
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+        }
+      }
+      testID="bottomsheetfooter"
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[MockFunction]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#0376C9",
+            "borderRadius": 24,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="bottomsheetfooter-button"
+        variant="Primary"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontFamily": "Euclid Circular B",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          CONFIRM_TEXT_MOCK
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[MockFunction]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376C9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "marginLeft": 16,
+            "marginTop": 0,
+            "paddingHorizontal": 16,
+          }
+        }
+        testID="bottomsheetfooter-button-subsequent"
+        variant="Secondary"
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            Object {
+              "color": "#0376C9",
+              "fontFamily": "Euclid Circular B",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          CANCEL_TEXT_MOCK
+        </Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`TemplateConfirmation renders content without actions 1`] = `
+<View
+  collapsable={false}
+  forwardedRef={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
+      "minHeight": 200,
+      "paddingBottom": 20,
+      "paddingTop": 24,
+    }
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Object {
+        "color": "#24272A",
+        "fontFamily": "Euclid Circular B",
+        "fontSize": 14,
+        "fontWeight": "400",
+        "letterSpacing": 0,
+        "lineHeight": 22,
+      }
+    }
+  >
+    CONTENT_MOCK
+  </Text>
+</View>
+`;


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add `hideSubmitButton` property to confirmation templates. Also hiding action buttons will be possible if `onSubmit` and `onCancel` is not provided. 

## **Related issues**

Fixes: https://github.com/orgs/MetaMask/projects/47/views/1?pane=issue&itemId=55391209

Similar task is resolved in extension https://github.com/MetaMask/metamask-extension/pull/23085

## **Manual testing steps**

To manually test this, either you should add `hideSubmitButton` to true in to your approval request (via code) 
Or temporarily set `hideSubmitButton` to true in your local at `app/components/Views/confirmations/components/Approval/TemplateConfirmation/Templates/index.ts` `values` constant. (See the recorded video by doing this)

## **Screenshots/Recordings**

### **After**


https://github.com/MetaMask/metamask-mobile/assets/7644512/ddad90e6-1e15-40a0-9e1c-887bbdc10ebc



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
