### PR TITLE
feat: add env vars mapping in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -124,12 +124,28 @@ remapEnvVariable() {
     echo "Successfully remapped $old_var_name to $new_var_name."
 }
 
-remapFlaskEnvVariables() {
-	# remap flask env variables to match what the app expects
+remapEnvVariableQA() {
+  	echo "Remapping QA env variable names to match QA values"
+  	remapEnvVariable "SEGMENT_WRITE_KEY_QA" "SEGMENT_WRITE_KEY"
+  	remapEnvVariable "SEGMENT_PROXY_URL_QA" "SEGMENT_PROXY_URL"
+  	remapEnvVariable "SEGMENT_DELETE_API_SOURCE_ID_QA" "SEGMENT_DELETE_API_SOURCE_ID"
+  	remapEnvVariable "SEGMENT_REGULATIONS_ENDPOINT_QA" "SEGMENT_REGULATIONS_ENDPOINT"
+}
 
-	echo "Remapping flask env variable names to match production"
-	# ios.env/android.env variables
-	remapEnvVariable "MM_FLASK_MIXPANEL_TOKEN" "MM_MIXPANEL_TOKEN"
+remapEnvVariableRelease() {
+  	echo "Remapping release env variable names to match production values"
+  	remapEnvVariable "SEGMENT_WRITE_KEY_PROD" "SEGMENT_WRITE_KEY"
+  	remapEnvVariable "SEGMENT_PROXY_URL_PROD" "SEGMENT_PROXY_URL"
+  	remapEnvVariable "SEGMENT_DELETE_API_SOURCE_ID_PROD" "SEGMENT_DELETE_API_SOURCE_ID"
+  	remapEnvVariable "SEGMENT_REGULATIONS_ENDPOINT_PROD" "SEGMENT_REGULATIONS_ENDPOINT"
+}
+
+remapFlaskEnvVariables() {
+  	echo "Remapping Flask env variable names to match Flask values"
+  	remapEnvVariable "SEGMENT_WRITE_KEY_FLASK" "SEGMENT_WRITE_KEY"
+  	remapEnvVariable "SEGMENT_PROXY_URL_FLASK" "SEGMENT_PROXY_URL"
+  	remapEnvVariable "SEGMENT_DELETE_API_SOURCE_ID_FLASK" "SEGMENT_DELETE_API_SOURCE_ID"
+  	remapEnvVariable "SEGMENT_REGULATIONS_ENDPOINT_FLASK" "SEGMENT_REGULATIONS_ENDPOINT"
 }
 
 loadJSEnv(){
@@ -266,6 +282,9 @@ generateArchivePackages() {
 }
 
 buildIosRelease(){
+
+  remapEnvVariableRelease
+
 	# Enable Sentry to auto upload source maps and debug symbols
 	export SENTRY_DISABLE_AUTO_UPLOAD="false"
 	prebuild_ios
@@ -329,6 +348,7 @@ buildIosReleaseE2E(){
 }
 
 buildIosQA(){
+  remapEnvVariableQA
 	prebuild_ios
 
   	echo "Start QA build..."
@@ -352,6 +372,8 @@ buildIosQA(){
 
 
 buildAndroidQA(){
+  remapEnvVariableQA
+  
 	if [ "$PRE_RELEASE" = false ] ; then
 		adb uninstall io.metamask.qa
 	fi
@@ -377,6 +399,9 @@ buildAndroidQA(){
 }
 
 buildAndroidRelease(){
+
+  remapEnvVariableRelease
+
 	if [ "$PRE_RELEASE" = false ] ; then
 		adb uninstall io.metamask || true
 	fi


### PR DESCRIPTION
## **Description**

- add env vars mapping in build script
- add calls to qa and release steps
- update flask function

For QA, envs are suffixed by the Segment source suffix: for QA by `QA`, for release by `PROD` and for flask by `FLASK`.
example: `SEGMENT_WRITE_KEY_QA` remaps to the app `SEGMENT_WRITE_KEY`

## **Related issues**

Fixes #8769 

## **Manual testing steps**

1. [Go to bitrise QA build](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/f59b8b65-a044-4762-bc7e-e15d8c7209d4?tab=artifacts)
2. Run the built dapp and check that events are landing on [the correct source](https://app.segment.com/consensys-analytics/sources?search=mobile) (use Segment source debugger)

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
