### PR TITLE
fix: issue with 'dappIconUrl' in 'AccountConnect.ts'

### DIFF
--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -102,7 +102,8 @@ const AccountConnect = (props: AccountConnectProps) => {
   // Last wallet connect session metadata
   const wc2Metadata = useSelector((state: RootState) => state.sdk.wc2Metadata);
 
-  const dappIconUrl = sdkConnection.originatorInfo?.icon;
+  const dappIconUrl = sdkConnection?.originatorInfo?.icon;
+
   const faviconSource = useFavicon(origin);
 
   const actualIcon = useMemo(


### PR DESCRIPTION
## **Description**

This PR addresses a bug in the `AccountConnect.tsx` file where an unhandled exception occurs if there are no accounts connected to a dApp. 
The issue arises on line 105 due to attempting to access the icon property of originatorInfo on an undefined sdkConnection. 

The proposed fix safely accesses originatorInfo by adding an optional chaining operator before originatorInfo, ensuring that the code gracefully handles scenarios where `sdkConnection` might be undefined.

https://github.com/MetaMask/metamask-mobile/assets/61094771/c71a61e3-cdc9-440f-87e3-ba8867d709db


 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
