### PR TITLE
fix(ramp): loading fox position

### DIFF
--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1247,6 +1247,7 @@ exports[`Quotes renders animation on first fetching 1`] = `
                                 pointerEvents="none"
                                 style={
                                   Object {
+                                    "alignSelf": "center",
                                     "height": 260,
                                     "width": 260,
                                   }

--- a/app/components/UI/Ramp/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/components/LoadingAnimation/index.tsx
@@ -61,6 +61,7 @@ const createStyles = (
     foxContainer: {
       width: STAGE_SIZE,
       height: STAGE_SIZE,
+      alignSelf: 'center',
     },
   });
 
@@ -161,9 +162,7 @@ function LoadingAnimation({
   return (
     <View style={styles.screen}>
       <View style={styles.content}>
-        <>
-          <Title centered>{title}</Title>
-        </>
+        <Title centered>{title}</Title>
 
         <View style={styles.progressWrapper}>
           <Animated.View style={[styles.progressBar, progressStyle]} />


### PR DESCRIPTION
## **Description**

The initial loading animation of the fox face must be centered. This PR fixes the position in bigger screens.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RAMPS-1428

## **Manual testing steps**

1. Go through Buy or Sell flow
2. Get quotes
3. Fox animation must be centered

## **Screenshots/Recordings**


### **Before**

<img width="250" src="https://github.com/MetaMask/metamask-mobile/assets/1024246/f4fb8cf1-e84a-4e31-917d-df4b900effb2" />


### **After**

<img width="250" src="https://github.com/MetaMask/metamask-mobile/assets/1024246/e6415a39-bed9-43f4-8026-99589f7dfe59" /> 


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
