### PR TITLE
ci: Simplify PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,3 +1,8 @@
+<!--
+Please submit this PR as a draft initially.
+Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
+-->
+
 ## **Description**
 
 <!--
@@ -31,16 +36,10 @@ Fixes:
 ## **Pre-merge author checklist**
 
 - [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
-- [ ] I've clearly explained what problem this PR is solving and how it is solved.
-- [ ] I've linked related issues
-- [ ] I've included manual testing steps
-- [ ] I've included screenshots/recordings if applicable
+- [ ] I've completed the PR template to the best of my ability
 - [ ] I’ve included tests if applicable
 - [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
 - [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
-- [ ] I’ve properly set the pull request status:
-  - [ ] In case it's not yet "ready for review", I've set it to "draft".
-  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".
 
 ## **Pre-merge reviewer checklist**
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->
(this text was added to test PR preview)

## **Description**

The PR template checklist has been simplified. The changes are as follows:

* The checkbox about using a draft has been replaced by a comment at the top of the template
* The checkboxes about using the template properly have been consolidated into a "I have completed the template" checkbox

This should streamline the process of creating a PR for contributors, while preserving all the same requirements.

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
