### PR TITLE
fix: prevent repeated incoming transaction notifications

### DIFF
--- a/patches/@metamask+transaction-controller+8.0.1.patch
+++ b/patches/@metamask+transaction-controller+8.0.1.patch
@@ -4,13 +4,13 @@ index 0000000..550de56
 --- /dev/null
 +++ b/node_modules/@metamask/transaction-controller/dist/.patch.txt
 @@ -0,0 +1,7 @@
-+PATCH GENERATED FROM MetaMask/core branch: refactor/transaction-controller-patch-mobile-5
++PATCH GENERATED FROM MetaMask/core branch: patch/mobile-transaction-controller-8-0-1
 +This patch backports various transaction controller features from the main branch of MetaMask/core
 +Steps to update patch:
-+* Create a new core branch from: patch/mobile-transaction-controller-7-1-0
++* Create a new core branch from: patch/mobile-transaction-controller-8-0-1
 +* Run "yarn build" in the core monorepo
 +* Run "yarn patch:tx <core-directory>" in the mobile repo
-+* Once the new patch is merged, add your changes to: patch/mobile-transaction-controller-6-1-0
++* Once the new patch is merged, add your changes to: patch/mobile-transaction-controller-8-0-1
 diff --git a/node_modules/@metamask/transaction-controller/dist/EtherscanRemoteTransactionSource.d.ts b/node_modules/@metamask/transaction-controller/dist/EtherscanRemoteTransactionSource.d.ts
 index d89ef46..7637754 100644
 --- a/node_modules/@metamask/transaction-controller/dist/EtherscanRemoteTransactionSource.d.ts
@@ -179,7 +179,7 @@ index 048e002..0000000
 -{"version":3,"file":"IncomingTransactionHelper.d.ts","sourceRoot":"","sources":["../src/IncomingTransactionHelper.ts"],"names":[],"mappings":"AACA,OAAO,KAAK,QAAQ,MAAM,qBAAqB,CAAC;AAChD,OAAO,KAAK,EAAE,YAAY,EAAE,MAAM,8BAA8B,CAAC;AAGjE,OAAO,KAAK,EACV,uBAAuB,EAEvB,eAAe,EAEhB,MAAM,SAAS,CAAC;AAQjB,qBAAa,yBAAyB;;gBASxB,EACV,eAAe,EACf,WAAW,EACX,gBAAgB,EAChB,uBAAuB,GACxB,EAAE;QACD,eAAe,EAAE,MAAM,YAAY,CAAC;QACpC,WAAW,EAAE,MAAM,QAAQ,CAAC;QAC5B,gBAAgB,EAAE,MAAM,CAAC;QACzB,uBAAuB,EAAE,uBAAuB,CAAC;KAClD;IAOK,SAAS,CAAC,EACd,OAAO,EACP,iBAAiB,EACjB,SAAS,EACT,MAAM,GACP,EAAE;QACD,OAAO,EAAE,MAAM,CAAC;QAChB,iBAAiB,EAAE,eAAe,EAAE,CAAC;QACrC,SAAS,CAAC,EAAE,MAAM,CAAC;QACnB,MAAM,CAAC,EAAE,MAAM,CAAC;KACjB,GAAG,OAAO,CAAC;QACV,cAAc,EAAE,OAAO,CAAC;QACxB,YAAY,EAAE,eAAe,EAAE,CAAC;QAChC,iBAAiB,CAAC,EAAE,MAAM,CAAC;KAC5B,CAAC;CAmMH"}
 \ No newline at end of file
 diff --git a/node_modules/@metamask/transaction-controller/dist/IncomingTransactionHelper.js b/node_modules/@metamask/transaction-controller/dist/IncomingTransactionHelper.js
-index 6a27aeb..e18a2b7 100644
+index 6a27aeb..5f34686 100644
 --- a/node_modules/@metamask/transaction-controller/dist/IncomingTransactionHelper.js
 +++ b/node_modules/@metamask/transaction-controller/dist/IncomingTransactionHelper.js
 @@ -19,126 +19,173 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
@@ -423,7 +423,7 @@ index 6a27aeb..e18a2b7 100644
 +    const lastFetchedKey = __classPrivateFieldGet(this, _IncomingTransactionHelper_instances, "m", _IncomingTransactionHelper_getBlockNumberKey).call(this);
 +    const lastFetchedBlockNumbers = __classPrivateFieldGet(this, _IncomingTransactionHelper_getLastFetchedBlockNumbers, "f").call(this);
 +    const previousValue = lastFetchedBlockNumbers[lastFetchedKey];
-+    if (previousValue === lastFetchedBlockNumber) {
++    if (previousValue >= lastFetchedBlockNumber) {
 +        return;
 +    }
 +    lastFetchedBlockNumbers[lastFetchedKey] = lastFetchedBlockNumber;


### PR DESCRIPTION
## **Description**

Update the `TransactionController` patch to not update the last fetched block number if the new value is lower than the previous one.

This in turn prevents excess `incomingTransactionBlock` events being emitted which stops the duplicate notifications.

## **Related issues**

Fixes: #8948 

## **Manual testing steps**

1. Use account with previous incoming token transfer.
2. Send native balance to same account.
3. Verify incoming transaction notification is shown only once.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
