### PR TITLE
fix: Network not updating when changing account connected the first time on a DAPP

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -262,9 +262,9 @@ export class BackgroundBridge extends EventEmitter {
 
     // Check if update already sent
     if (
-      this.chainIdSent !== publicState.chainId &&
-      this.networkVersionSent !== publicState.networkVersion &&
-      publicState.networkVersion !== 'loading'
+      this.chainIdSent !== publicState.chainId ||
+      (this.networkVersionSent !== publicState.networkVersion &&
+        publicState.networkVersion !== 'loading')
     ) {
       this.chainIdSent = publicState.chainId;
       this.networkVersionSent = publicState.networkVersion;

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -5,8 +5,6 @@ import {
   NetworkState,
   NetworkStatus,
 } from '@metamask/network-controller';
-import { getDecimalChainId } from '../util/networks';
-import { Hex } from '@metamask/utils';
 
 const selectNetworkControllerState = (state: RootState) =>
   state?.engine?.backgroundState?.NetworkController;
@@ -68,18 +66,17 @@ export const selectNetworkClientId = createSelector(
  * included in the NetworkController state. It's set to "loading" if the
  * network is loading, but otherwise is set to the network ID.
  *
- * @deprecated Use networkStatus and chainId instead
+ * @deprecated Use networkStatus and networkId instead
  */
 export const selectLegacyNetwork = createSelector(
   selectNetworkControllerState,
-  selectChainId,
-  (networkControllerState: NetworkState, chainId: Hex) => {
-    const { selectedNetworkClientId, networksMetadata } =
+  (networkControllerState: NetworkState) => {
+    const { networkId, selectedNetworkClientId, networksMetadata } =
       networkControllerState;
 
     return networksMetadata?.[selectedNetworkClientId].status !==
       NetworkStatus.Available
       ? 'loading'
-      : getDecimalChainId(chainId);
+      : networkId;
   },
 );

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -6,6 +6,7 @@ import {
   NetworkStatus,
 } from '@metamask/network-controller';
 import { getDecimalChainId } from '../util/networks';
+import { Hex } from '@metamask/utils';
 
 const selectNetworkControllerState = (state: RootState) =>
   state?.engine?.backgroundState?.NetworkController;
@@ -71,13 +72,14 @@ export const selectNetworkClientId = createSelector(
  */
 export const selectLegacyNetwork = createSelector(
   selectNetworkControllerState,
-  (networkControllerState: NetworkState) => {
-    const { selectedNetworkClientId, networksMetadata, providerConfig } =
+  selectChainId,
+  (networkControllerState: NetworkState, chainId: Hex) => {
+    const { selectedNetworkClientId, networksMetadata } =
       networkControllerState;
 
     return networksMetadata?.[selectedNetworkClientId].status !==
       NetworkStatus.Available
       ? 'loading'
-      : getDecimalChainId(providerConfig.chainId);
+      : getDecimalChainId(chainId);
   },
 );

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -5,6 +5,7 @@ import {
   NetworkState,
   NetworkStatus,
 } from '@metamask/network-controller';
+import { getDecimalChainId } from '../util/networks';
 
 const selectNetworkControllerState = (state: RootState) =>
   state?.engine?.backgroundState?.NetworkController;
@@ -66,16 +67,17 @@ export const selectNetworkClientId = createSelector(
  * included in the NetworkController state. It's set to "loading" if the
  * network is loading, but otherwise is set to the network ID.
  *
- * @deprecated Use networkStatus and networkId instead
+ * @deprecated Use networkStatus and chainId instead
  */
 export const selectLegacyNetwork = createSelector(
   selectNetworkControllerState,
   (networkControllerState: NetworkState) => {
-    const { networkId, selectedNetworkClientId, networksMetadata } =
+    const { selectedNetworkClientId, networksMetadata, providerConfig } =
       networkControllerState;
+
     return networksMetadata?.[selectedNetworkClientId].status !==
       NetworkStatus.Available
       ? 'loading'
-      : networkId;
+      : getDecimalChainId(providerConfig.chainId);
   },
 );


### PR DESCRIPTION
## **Description**
Updating the conditional case on `BackgroundBridge` `onStateUpdate` function to trigger notifyChainChanged, when the chainId changes and when the network changes, it will allow for both properties being sent when they are called more than once and they are miss matching. That was happening on the first switch of the network and causing the bug.

This fixes this issue: https://github.com/MetaMask/metamask-mobile/issues/9006
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

https://recordit.co/FEycCcnZ92

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
