### PR TITLE
fix: Remove prefix from origin before sending request to ppom

### DIFF
--- a/app/core/WalletConnect/WalletConnect.js
+++ b/app/core/WalletConnect/WalletConnect.js
@@ -193,6 +193,7 @@ class WalletConnect {
                 id: payload.id,
                 jsonrpc: '2.0',
                 method: payload.method,
+                origin: this.url.current,
                 params: [
                   {
                     from: payload.params[0].from,

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -183,4 +183,34 @@ describe('validateResponse', () => {
       params: [normalizedTransactionParamsMock],
     });
   });
+
+  it('normalizes transaction request origin before validation', async () => {
+    const validateMock = jest.fn();
+
+    const ppomMock = {
+      validateJsonRpc: validateMock,
+    };
+
+    Engine.context.PPOMController.usePPOM.mockImplementation((callback: any) =>
+      callback(ppomMock),
+    );
+
+    await PPOMUtil.validateRequest(
+      {
+        ...mockRequest,
+        origin: 'wc::metamask.github.io',
+      },
+      '123',
+    );
+
+    expect(normalizeTransactionParamsMock).toBeCalledTimes(1);
+    expect(normalizeTransactionParamsMock).toBeCalledWith(
+      mockRequest.params[0],
+    );
+
+    expect(validateMock).toBeCalledTimes(1);
+    expect(validateMock).toBeCalledWith({
+      ...mockRequest,
+    });
+  });
 });

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -11,6 +11,8 @@ import { isBlockaidFeatureEnabled } from '../../util/blockaid';
 import Logger from '../../util/Logger';
 import { updateSecurityAlertResponse } from '../../util/transaction-controller';
 import { normalizeTransactionParams } from '@metamask/transaction-controller';
+import { WALLET_CONNECT_ORIGIN } from '../../util/walletconnect';
+import AppConstants from '../../core/AppConstants';
 
 const TRANSACTION_METHOD = 'eth_sendTransaction';
 
@@ -115,6 +117,12 @@ const validateRequest = async (req: any, transactionId?: string) => {
 };
 
 function normalizeRequest(request: any) {
+  // normalize origin
+
+  request.origin = request.origin
+    ?.replace(WALLET_CONNECT_ORIGIN, '')
+    ?.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, '');
+
   if (request.method !== TRANSACTION_METHOD) {
     return request;
   }

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -117,15 +117,13 @@ const validateRequest = async (req: any, transactionId?: string) => {
 };
 
 function normalizeRequest(request: any) {
-  // normalize origin
+  if (request.method !== TRANSACTION_METHOD) {
+    return request;
+  }
 
   request.origin = request.origin
     ?.replace(WALLET_CONNECT_ORIGIN, '')
     ?.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, '');
-
-  if (request.method !== TRANSACTION_METHOD) {
-    return request;
-  }
 
   const transactionParams = request.params?.[0] || {};
   const normalizedParams = normalizeTransactionParams(transactionParams);


### PR DESCRIPTION
## **Description**

Domains from wallet connect - are being passed to ppom with a wc:: preffix (example: wc::https://furrevertoken.com/). This is causing url parsing to fail inside PPOM and needs to be fixed on MM side.

## **Related issues**

Fixes: [#2221](https://github.com/MetaMask/MetaMask-planning/issues/2221)

## **Manual testing steps**

1. Connect to testdapp from real device
2. Perform a malicious transaction
3. Click Report an issue
4. Expand the details drop down
5. See that domain is not prefixed with wc::


## **Screenshots/Recordings**

### **Before**

![image](https://github.com/MetaMask/metamask-mobile/assets/44811/52769d39-ea9c-4afc-85f5-a3edf20144ce)

### **After**

![image](https://github.com/MetaMask/metamask-mobile/assets/44811/0c4fd3b4-58e5-4f4e-90e9-ae44a4dea3b2)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
