### PR TITLE
fix: Security modal pop up twice

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -232,7 +232,7 @@ const VaultRecoveryFlow = () => (
   </Stack.Navigator>
 );
 
-const App = ({ userLoggedIn }) => {
+const App = ({ userLoggedIn, hasUserSelectedAutomaticSecurityCheckOption }) => {
   const animationRef = useRef(null);
   const animationNameRef = useRef(null);
   const opacity = useRef(new Animated.Value(1)).current;
@@ -391,7 +391,13 @@ const App = ({ userLoggedIn }) => {
   useEffect(() => {
     // Init SDKConnect only if the navigator is ready, user is onboarded, and SDK is not initialized.
     async function initSDKConnect() {
-      if (navigator?.getCurrentRoute && onboarded && !sdkInit.current) {
+      // If we post initialize the sdk before the security modal being seen by the user, the security modal will render twice
+      if (
+        navigator?.getCurrentRoute &&
+        onboarded &&
+        !sdkInit.current &&
+        hasUserSelectedAutomaticSecurityCheckOption
+      ) {
         try {
           const sdkConnect = SDKConnect.getInstance();
           await sdkConnect.init({ navigation: navigator, context: 'Nav/App' });
@@ -405,7 +411,7 @@ const App = ({ userLoggedIn }) => {
     initSDKConnect().catch((err) => {
       Logger.error(err, 'Error initializing SDKConnect');
     });
-  }, [navigator, onboarded]);
+  }, [navigator, onboarded, hasUserSelectedAutomaticSecurityCheckOption]);
 
   useEffect(() => {
     // Handle post-init process separately.
@@ -450,7 +456,6 @@ const App = ({ userLoggedIn }) => {
     checkExisting().catch((error) => {
       Logger.error(error, 'Error checking existing user');
     });
-    /* eslint-disable react-hooks/exhaustive-deps */
   }, []);
 
   useEffect(() => {
@@ -822,6 +827,8 @@ const App = ({ userLoggedIn }) => {
 
 const mapStateToProps = (state) => ({
   userLoggedIn: state.user.userLoggedIn,
+  hasUserSelectedAutomaticSecurityCheckOption:
+    state.security.hasUserSelectedAutomaticSecurityCheckOption,
 });
 
 export default connect(mapStateToProps)(App);


### PR DESCRIPTION
## **Description**
sdk was updating a state variable on the initialization of it to do a post initialization, and that was triggering the modal to render twice, so it was added a condition to only run the post initialization if the security modal was already prompted to the user

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/1499

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**
https://recordit.co/5mJj3NEiY9

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
