### PR TITLE
fix: Refactor SDK initialization

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -244,9 +244,7 @@ const App = ({ userLoggedIn }) => {
   const { colors } = useTheme();
   const { toastRef } = useContext(ToastContext);
   const dispatch = useDispatch();
-  const sdkInit = useRef(false);
-  const sdkPostInit = useRef(false);
-  const [postInitReady, setPostInitReady] = useState(false);
+  const sdkInit = useRef();
   const [onboarded, setOnboarded] = useState(false);
   const triggerSetCurrentRoute = (route) => {
     dispatch(setCurrentRoute(route));
@@ -356,7 +354,7 @@ const App = ({ userLoggedIn }) => {
             Logger.error('Error from Branch: ' + error);
           }
 
-          if (sdkPostInit.current === true) {
+          if (sdkInit.current) {
             handleDeeplink(opts);
           } else {
             queueOfHandleDeeplinkFunctions.current =
@@ -391,13 +389,20 @@ const App = ({ userLoggedIn }) => {
   useEffect(() => {
     // Init SDKConnect only if the navigator is ready, user is onboarded, and SDK is not initialized.
     async function initSDKConnect() {
-      if (navigator?.getCurrentRoute && onboarded && !sdkInit.current) {
+      if (
+        navigator?.getCurrentRoute &&
+        onboarded &&
+        sdkInit.current === undefined &&
+        userLoggedIn
+      ) {
+        sdkInit.current = false;
         try {
           const sdkConnect = SDKConnect.getInstance();
           await sdkConnect.init({ navigation: navigator, context: 'Nav/App' });
-          setPostInitReady(true);
+          await SDKConnect.getInstance().postInit();
           sdkInit.current = true;
         } catch (err) {
+          sdkInit.current = undefined;
           console.error(`Cannot initialize SDKConnect`, err);
         }
       }
@@ -405,29 +410,7 @@ const App = ({ userLoggedIn }) => {
     initSDKConnect().catch((err) => {
       Logger.error(err, 'Error initializing SDKConnect');
     });
-  }, [navigator, onboarded]);
-
-  useEffect(() => {
-    // Handle post-init process separately.
-    async function handlePostInit() {
-      if (
-        sdkInit.current &&
-        !sdkPostInit.current &&
-        postInitReady &&
-        userLoggedIn
-      ) {
-        try {
-          await SDKConnect.getInstance().postInit();
-          sdkPostInit.current = true;
-        } catch (err) {
-          console.error(`Cannot postInit SDKConnect`, err);
-        }
-      }
-    }
-    handlePostInit().catch((err) => {
-      Logger.error(err, 'Error postInit SDKConnect');
-    });
-  }, [userLoggedIn, postInitReady, queueOfHandleDeeplinkFunctions]);
+  }, [navigator, onboarded, userLoggedIn]);
 
   useEffect(() => {
     if (isWC2Enabled) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR simplifies SDK initialization logic, which was causing the security modal to re-render, which was breaking both performance and E2E tests

Fixes #1499 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://recordit.co/NcG1KbKuxH

### **After**

<!-- [screenshots/recordings] -->


https://github.com/MetaMask/metamask-mobile/assets/10508597/c50bd819-71e5-42b1-8236-4fe0acb41547



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
