### PR TITLE
feat: set nft auto detection to true for new users

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
+++ b/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
@@ -1945,7 +1945,7 @@ exports[`SecuritySettings should render correctly 1`] = `
               }
               thumbTintColor="#FFFFFF"
               tintColor="#D6D9DC"
-              value={false}
+              value={true}
             />
           </View>
         </View>

--- a/app/core/Engine.test.js
+++ b/app/core/Engine.test.js
@@ -79,4 +79,11 @@ describe('Engine', () => {
       `No account found for address: ${invalidAddress}`,
     );
   });
+
+  it('useNftDetection should be true by default for new users', () => {
+    const engine = Engine.init({});
+    const backgroundState = engine.datamodel.state;
+
+    expect(backgroundState.PreferencesController.useNftDetection).toBe(true);
+  });
 });

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -386,7 +386,8 @@ class Engine {
         useTokenDetection:
           initialState?.PreferencesController?.useTokenDetection ?? true,
         // TODO: Use previous value when preferences UI is available
-        useNftDetection: false,
+        useNftDetection:
+          initialState?.PreferencesController?.useTokenDetection ?? true,
         displayNftMedia: true,
         securityAlertsEnabled: true,
       },

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -18,10 +18,10 @@
     }
   },
   "AccountsController": {
-     "internalAccounts": {
-       "accounts": {},
-       "selectedAccount": ""
-     }
+    "internalAccounts": {
+      "accounts": {},
+      "selectedAccount": ""
+    }
   },
   "AddressBookController": {
     "addressBook": {}
@@ -76,7 +76,7 @@
       "ticker": "ETH"
     },
     "networksMetadata": {
-      "mainnet":{  "EIPS": {},"status": "unknown"}
+      "mainnet": { "EIPS": {}, "status": "unknown" }
     },
     "networkId": null,
     "selectedNetworkClientId": "mainnet"
@@ -94,7 +94,7 @@
     "lostIdentities": {},
     "selectedAddress": "",
     "useTokenDetection": true,
-    "useNftDetection": false,
+    "useNftDetection": true,
     "useSafeChainsListValidation": true,
     "displayNftMedia": true,
     "securityAlertsEnabled": true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

we aim to enable the NFT Auto-Detect features by default for all new users on mobile . This enhancement will automatically populate users' wallets with relevant NFTs without requiring manual setup.

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Install a fresh app
2. go to the NFTs tab
3. you should see the list of your NFTs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
