### PR TITLE
fix: Remove duplicate  i18n, en key: `qr_hardware`

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -541,7 +541,6 @@
   },
   "accounts": {
     "create_new_account": "Create a new account",
-    "qr_hardware": "QR hardware",
     "import_account": "Import an account",
     "connect_hardware": "Connect hardware wallet",
     "imported": "Imported",


### PR DESCRIPTION
## **Description**

Removes duplicate en, i18n key: `qr_hardware`

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="464" alt="Screenshot 2024-03-25 at 3 15 43 PM" src="https://github.com/MetaMask/metamask-mobile/assets/20778143/293e9832-4327-4bdf-838f-497f384a33d2">

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
