### PR TITLE
chore: Sentry reduce traceSample rate to 0.04

### DIFF
--- a/app/util/sentry/utils.js
+++ b/app/util/sentry/utils.js
@@ -225,7 +225,7 @@ export function setupSentry() {
               }),
             ]
           : integrations,
-      tracesSampleRate: 0.05,
+      tracesSampleRate: 0.04,
       beforeSend: (report) => rewriteReport(report),
       beforeBreadcrumb: (breadcrumb) => rewriteBreadcrumb(breadcrumb),
       beforeSendTransaction: (event) => excludeEvents(event),


### PR DESCRIPTION
## **Description**

This PR reduces the Sentry Performance sample rate by 20% since we are meeting our 30-day cap. There are enough events to root cause current performance issues.

## **Related issues**

Fixes:

## **Manual testing steps**

NA - non-functional change

## **Screenshots/Recordings**

NA - non-functional change

### **Before**

NA - non-functional change

### **After**

NA - non-functional change

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
