### PR TITLE
fix: add display warning for mumbai

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -69,7 +69,10 @@ import {
   selectProviderType,
 } from '../../../selectors/networkController';
 import { selectShowIncomingTransactionNetworks } from '../../../selectors/preferencesController';
-import { DEPRECATED_NETWORKS } from '../../../constants/network';
+import {
+  DEPRECATED_NETWORKS,
+  NETWORKS_CHAIN_ID,
+} from '../../../constants/network';
 import WarningAlert from '../../../components/UI/WarningAlert';
 import { GOERLI_DEPRECATED_ARTICLE } from '../../../constants/urls';
 import {
@@ -345,6 +348,15 @@ const Main = (props) => {
 
   const renderDeprecatedNetworkAlert = (chainId, backUpSeedphraseVisible) => {
     if (DEPRECATED_NETWORKS.includes(chainId) && showDeprecatedAlert) {
+      if (NETWORKS_CHAIN_ID.MUMBAI === chainId) {
+        return (
+          <WarningAlert
+            text={strings('networks.network_deprecated_title')}
+            dismissAlert={() => setShowDeprecatedAlert(false)}
+            precedentAlert={backUpSeedphraseVisible}
+          />
+        );
+      }
       return (
         <WarningAlert
           text={strings('networks.deprecated_goerli')}

--- a/app/constants/network.js
+++ b/app/constants/network.js
@@ -35,6 +35,7 @@ export const NETWORKS_CHAIN_ID = {
   ZKSYNC_ERA: toHex('324'),
   ARBITRUM_GOERLI: toHex('421613'),
   OPTIMISM_GOERLI: toHex('420'),
+  MUMBAI: toHex('80001'),
 };
 
 // To add a deprecation warning to a network, add it to the array
@@ -43,6 +44,7 @@ export const DEPRECATED_NETWORKS = [
   NETWORKS_CHAIN_ID.ARBITRUM_GOERLI,
   NETWORKS_CHAIN_ID.OPTIMISM_GOERLI,
   NETWORKS_CHAIN_ID.LINEA_GOERLI,
+  NETWORKS_CHAIN_ID.MUMBAI,
 ];
 export const CHAINLIST_CURRENCY_SYMBOLS_MAP = {
   MAINNET: 'ETH',

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -77,3 +77,6 @@ export const ADD_CUSTOM_NETWORK_ARTCILE =
 
 export const LEDGER_SUPPORT_LINK =
   'https://support.ledger.com/hc/en-us/articles/360009576554-Ethereum-ETH-?docs=true';
+
+export const GOERLI_DEPRECATED_ARTICLE =
+  'https://github.com/eth-clients/goerli#goerli-goerlitzer-testnet';


### PR DESCRIPTION

## **Description**

This PR adds a display of a deprecation warning when a user switches to MUMBAI network

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to settings => network => add network => Custom networks
2. Fill in inputs: Name:Mumbai; RPC_URL:https://80001.rpc.thirdweb.com; chainId: 80001; Symbol: MATIC
3. Switch to this network
4. You should be able to see a deprecation warning "This network is deprecated"

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/10994169/2aac6cf6-b884-4dac-8505-647ce2fabf35




### **After**

https://github.com/MetaMask/metamask-mobile/assets/10994169/1ca57d35-d415-4aa5-b6e8-383973f848cd


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
