### PR TITLE
fix: add patch for controller-utils

### DIFF
--- a/patches/@metamask+assets-controllers++@metamask+controller-utils+4.3.2.patch
+++ b/patches/@metamask+assets-controllers++@metamask+controller-utils+4.3.2.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.d.ts b/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.d.ts
+index dd0be20..b6dc625 100644
+--- a/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.d.ts
++++ b/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.d.ts
+@@ -74,7 +74,7 @@ export declare const BUILT_IN_NETWORKS: {
+         readonly rpcPrefs: undefined;
+     };
+ };
+-export declare const OPENSEA_PROXY_URL = "https://proxy.metafi.codefi.network/opensea/v1/api/v1";
++export declare const OPENSEA_PROXY_URL = "https://proxy.metafi.codefi.network/opensea/v1/api/v2";
+ export declare const OPENSEA_API_URL = "https://api.opensea.io/api/v1";
+ export declare const OPENSEA_TEST_API_URL = "https://testnets-api.opensea.io/api/v1";
+ export declare const ORIGIN_METAMASK = "metamask";
+diff --git a/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.js b/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.js
+index 90ede0b..1e99924 100644
+--- a/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.js
++++ b/node_modules/@metamask/assets-controllers/node_modules/@metamask/controller-utils/dist/constants.js
+@@ -85,7 +85,7 @@ exports.BUILT_IN_NETWORKS = {
+     },
+ };
+ // APIs
+-exports.OPENSEA_PROXY_URL = 'https://proxy.metafi.codefi.network/opensea/v1/api/v1';
++exports.OPENSEA_PROXY_URL = 'https://proxy.metafi.codefi.network/opensea/v1/api/v2';
+ exports.OPENSEA_API_URL = 'https://api.opensea.io/api/v1';
+ exports.OPENSEA_TEST_API_URL = 'https://testnets-api.opensea.io/api/v1';
+ // Default origin for controllers


### PR DESCRIPTION

## **Description**

This PR fixes nft auto detection issue.
Adds a patch for assets-controllers dependency (controller-utils v4.3.2)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/9128

## **Manual testing steps**

1. Go to nft tab
2. enable nft auto-detection
3. go back to home page, you should see your detected nfts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
