### PR TITLE
chore: Update dependabot.yml to use new team label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-      - "team-mobile-client"
+      - "team-mobile-platform"


### PR DESCRIPTION
## **Description**

Update dependabot.yml to use new [team-mobile-platform](https://github.com/MetaMask/metamask-mobile/labels/team-mobile-platform) label

## **Related issues**

Fixes wrong team label in Dependabot PRs

## **Manual testing steps**

1. Run dependabot
2. check the correct `team-mobile-platform` label is assigned to PR

## **Screenshots/Recordings**
NA
### **Before**

<img width="919" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/4677568/0e996716-3d19-42f0-a7fb-73ca84ca450d">

### **After**

<img width="319" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/4677568/58a4ba74-3248-4fd5-9ca3-b243399bceb1">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
