### PR TITLE
fix(labeling guidelines): Add definition of regression-develop label

### DIFF
--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -21,6 +21,9 @@ Every PR shall include one the QA labels below:
 Once PR has been tested by QA (only if the PR was labeled with `needs-qa`):
 - **QA Passed**: If the PR was labeled with `needs-qa`, this label must be added once QA has signed off
 
+### Optional labels:
+- **regression-develop**: This label can manually be added to a bug report issue at the time of its creation if the bug is present on development branch (i.e. `main`), but is not yet released in production.
+
 ### Labels prohibited when PR needs to be merged:
 Any PR that includes one of the following labels can not be merged:
 


### PR DESCRIPTION
## **Description**

- New  definition added to labelling guidelines: `regression-develop`.
- Same PR on Extension reop: https://github.com/MetaMask/metamask-extension/pull/23855

## **Related issues**

- Fixes: None

## **Manual testing steps**

- None

## **Screenshots/Recordings**

- Preview available here: https://github.com/MetaMask/metamask-mobile/blob/efaf3bb3fe2d36219f67345dd921cd9e890944fd/.github/guidelines/LABELING_GUIDELINES.md

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.