### PR TITLE
fix: Tokens disappearing when updating 

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -518,7 +518,7 @@ class Engine {
       config: {
         provider: networkController.getProviderAndBlockTracker().provider,
         chainId: networkController.state.providerConfig.chainId,
-        selectedAddress: accountsController.getSelectedAccount().address,
+        selectedAddress: preferencesController.state.selectedAddress,
       },
       // @ts-expect-error TODO: Resolve/patch mismatch between base-controller versions. Before: never, never. Now: string, string, which expects 3rd and 4th args to be informed for restrictedControllerMessengers
       messenger: this.controllerMessenger.getRestricted<

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -524,11 +524,10 @@ class Engine {
       messenger: this.controllerMessenger.getRestricted<
         'TokensController',
         'ApprovalController:addRequest',
-        'AccountsController:selectedAccountChange'
+        never
       >({
         name: 'TokensController',
         allowedActions: [`${approvalController.name}:addRequest`],
-        allowedEvents: ['AccountsController:selectedAccountChange'],
       }),
       getERC20TokenName: assetsContractController.getERC20TokenName.bind(
         assetsContractController,
@@ -1033,8 +1032,7 @@ class Engine {
         {
           onTokensStateChange: (listener) =>
             tokensController.subscribe(listener),
-          getSelectedAddress: () =>
-            accountsController.getSelectedAccount().address,
+          getSelectedAddress: () => preferencesController.state.selectedAddress,
           getERC20BalanceOf: assetsContractController.getERC20BalanceOf.bind(
             assetsContractController,
           ),

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1052,7 +1052,7 @@ class Engine {
           preferencesController.subscribe(listener),
         chainId: networkController.state.providerConfig.chainId,
         ticker: networkController.state.providerConfig.ticker,
-        selectedAddress: accountsController.getSelectedAccount().address,
+        selectedAddress: preferencesController.state.selectedAddress,
         tokenPricesService: codefiTokenApiV2,
         interval: 30 * 60 * 1000,
       }),

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -501,7 +501,8 @@ class Engine {
 
     const tokensController = new TokensController({
       // TODO: The tokens controller currently does not support internalAccounts. This is done to match the behavior of the previous tokens controller subscription.
-      onPreferencesStateChange: (listener) =>  preferencesController.subscribe(listener),
+      onPreferencesStateChange: (listener) =>
+        preferencesController.subscribe(listener),
       onNetworkStateChange: (listener) =>
         this.controllerMessenger.subscribe(
           AppConstants.NETWORK_STATE_CHANGE_EVENT,
@@ -1047,7 +1048,8 @@ class Engine {
             AppConstants.NETWORK_STATE_CHANGE_EVENT,
             listener,
           ),
-        onPreferencesStateChange: (listener) =>  preferencesController.subscribe(listener),
+        onPreferencesStateChange: (listener) =>
+          preferencesController.subscribe(listener),
         chainId: networkController.state.providerConfig.chainId,
         ticker: networkController.state.providerConfig.ticker,
         selectedAddress: accountsController.getSelectedAccount().address,

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -501,17 +501,7 @@ class Engine {
 
     const tokensController = new TokensController({
       // TODO: The tokens controller currently does not support internalAccounts. This is done to match the behavior of the previous tokens controller subscription.
-      onPreferencesStateChange: (listener) =>
-        this.controllerMessenger.subscribe(
-          `AccountsController:selectedAccountChange`,
-          (newlySelectedInternalAccount) => {
-            const prevState = preferencesController.state;
-            listener({
-              ...prevState,
-              selectedAddress: newlySelectedInternalAccount.address,
-            });
-          },
-        ),
+      onPreferencesStateChange: (listener) =>  preferencesController.subscribe(listener),
       onNetworkStateChange: (listener) =>
         this.controllerMessenger.subscribe(
           AppConstants.NETWORK_STATE_CHANGE_EVENT,
@@ -1057,17 +1047,7 @@ class Engine {
             AppConstants.NETWORK_STATE_CHANGE_EVENT,
             listener,
           ),
-        onPreferencesStateChange: (listener) =>
-          this.controllerMessenger.subscribe(
-            `AccountsController:selectedAccountChange`,
-            (newlySelectedInternalAccount) => {
-              const prevState = preferencesController.state;
-              listener({
-                ...prevState,
-                selectedAddress: newlySelectedInternalAccount.address,
-              });
-            },
-          ),
+        onPreferencesStateChange: (listener) =>  preferencesController.subscribe(listener),
         chainId: networkController.state.providerConfig.chainId,
         ticker: networkController.state.providerConfig.ticker,
         selectedAddress: accountsController.getSelectedAccount().address,


### PR DESCRIPTION
## **Description**


The variable `newlySelectedInternalAccount.address`, that was being returned by the `AccountsController:selectedAccountChange` event was on a lowercase format. We were duplicating the accounts, so one account was checksummed and another not, which was making the tokens be on storage but not showing because the new selected account was not with tokens imported.


This is a how the data storage was:
```
{"allDetectedTokens": {"0x1": {"0x2990079bcdEe240329a520d2444386FC119da21a": [Array]}, "0xa86a": {"0x2990079bcdEe240329a520d2444386FC119da21a": [Array], "0x2990079bcdee240329a520d2444386fc119da21a": [Array]}}, "allIgnoredTokens": {}, "allTokens": {"0xa86a": {"0x2990079bcdEe240329a520d2444386FC119da21a": [Array]}}, "detectedTokens": [{"address": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7", "aggregators": [Array], "decimals": 6, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7.png", "isERC721": false, "name": "TetherToken", "symbol": "USDT"}, {"address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E", "aggregators": [Array], "decimals": 6, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e.png", "isERC721": false, "name": "USD Coin", "symbol": "USDC"}, {"address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7", "aggregators": [Array], "decimals": 18, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7.png", "isERC721": false, "name": "Wrapped AVAX", "symbol": "WAVAX"}, {"address": "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB", "aggregators": [Array], "decimals": 18, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab.png", "isERC721": false, "name": "Wrapped Ether", "symbol": "WETH.E"}, {"address": "0x50b7545627a5162F82A992c33b87aDc75187B218", "aggregators": [Array], "decimals": 8, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x50b7545627a5162f82a992c33b87adc75187b218.png", "isERC721": false, "name": "Wrapped BTC", "symbol": "WBTC.E"}, {"address": "0x63a72806098Bd3D9520cC43356dD78afe5D386D9", "aggregators": [Array], "decimals": 18, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x63a72806098bd3d9520cc43356dd78afe5d386d9.png", "isERC721": false, "name": "Aave Token", "symbol": "AAVE.E"}, {"address": "0x8b82A291F83ca07Af22120ABa21632088fC92931", "aggregators": [Array], "decimals": 18, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x8b82a291f83ca07af22120aba21632088fc92931.png", "isERC721": false, "name": "Ethereum  Wormhole ", "symbol": "ETH"}, {"address": "0x120AD3e5A7c796349e591F1570D9f7980F4eA9cb", "aggregators": [Array], "decimals": 6, "image": "https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x120ad3e5a7c796349e591f1570d9f7980f4ea9cb.png", "isERC721": false, "name": "Axelar Wrapped LUNA", "symbol": "LUNA"}], "ignoredTokens": [], "tokens": []}
```

This is how it is now:

```
{
   "allDetectedTokens":{
      "0x1":{
         "0x2990079bcdEe240329a520d2444386FC119da21a":[
            "Array"
         ]
      },
      "0xa86a":{
         "0x2990079bcdEe240329a520d2444386FC119da21a":[
            "Array"
         ]
      }
   },
   "allIgnoredTokens":{
      
   },
   "allTokens":{
      "0xa86a":{
         "0x2990079bcdEe240329a520d2444386FC119da21a":[
            "Array"
         ]
      }
   },
   "detectedTokens":[
      
   ],
   "ignoredTokens":[
      
   ],
   "tokens":[
      {
         "address":"0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":6,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7.png",
         "name":"TetherToken",
         "symbol":"USDT"
      },
      {
         "address":"0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":6,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e.png",
         "name":"USD Coin",
         "symbol":"USDC"
      },
      {
         "address":"0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":18,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7.png",
         "name":"Wrapped AVAX",
         "symbol":"WAVAX"
      },
      {
         "address":"0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":18,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab.png",
         "name":"Wrapped Ether",
         "symbol":"WETH.E"
      },
      {
         "address":"0x50b7545627a5162F82A992c33b87aDc75187B218",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":8,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x50b7545627a5162f82a992c33b87adc75187b218.png",
         "name":"Wrapped BTC",
         "symbol":"WBTC.E"
      },
      {
         "address":"0x63a72806098Bd3D9520cC43356dD78afe5D386D9",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":18,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x63a72806098bd3d9520cc43356dd78afe5d386d9.png",
         "name":"Aave Token",
         "symbol":"AAVE.E"
      },
      {
         "address":"0x8b82A291F83ca07Af22120ABa21632088fC92931",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":18,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x8b82a291f83ca07af22120aba21632088fc92931.png",
         "name":"Ethereum  Wormhole ",
         "symbol":"ETH"
      },
      {
         "address":"0x120AD3e5A7c796349e591F1570D9f7980F4eA9cb",
         "aggregators":[
            "Array"
         ],
         "balanceError":null,
         "decimals":6,
         "image":"https://static.metafi.codefi.network/api/v1/tokenIcons/43114/0x120ad3e5a7c796349e591f1570d9f7980f4ea9cb.png",
         "name":"Axelar Wrapped LUNA",
         "symbol":"LUNA"
      }
   ]
}
```

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/9122

## **Manual testing steps**

1. Go to uniswap, pancake swap, open sea
2.  Connect with those dapps
3. Disconnected with those dapps
4. Performed a swap on uniswap on avalanche and binance smart chain

## **Screenshots/Recordings**
Upgrade path recording:


Uploading Screen Recording 2024-04-05 at 13.14.41.mov…




### **Before**

https://github.com/MetaMask/metamask-mobile/assets/22918444/e8b1b1be-87e6-4c4e-956c-7c553517a987




### **After**


https://github.com/MetaMask/metamask-mobile/assets/22918444/0697d9ba-27e8-4cbc-a743-9ab3d6da2bff



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
