### PR TITLE
fix: Update account name in PreferencesController AND AccountsController

### DIFF
--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -244,9 +244,8 @@ class AccountOverview extends PureComponent {
       this.doENSLookup();
     });
 
-    const { PreferencesController } = Engine.context;
     if (!this.isAccountLabelDefined(accountLabel)) {
-      PreferencesController.setAccountLabel(selectedAddress, 'Account');
+      Engine.setAccountLabel(selectedAddress, 'Account');
     }
   };
 
@@ -262,13 +261,12 @@ class AccountOverview extends PureComponent {
   }
 
   setAccountLabel = () => {
-    const { PreferencesController } = Engine.context;
     const { selectedAddress, identities } = this.props;
     const { accountLabel } = this.state;
 
     const lastAccountLabel = identities[selectedAddress].name;
 
-    PreferencesController.setAccountLabel(
+    Engine.setAccountLabel(
       selectedAddress,
       this.isAccountLabelDefined(accountLabel)
         ? accountLabel

--- a/app/components/Views/EditAccountName/EditAccountName.test.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.test.tsx
@@ -7,12 +7,18 @@ import EditAccountName from './EditAccountName';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import initialBackgroundState from '../../../util/test/initial-background-state.json';
 
-const mockSetAccountLabel = jest.fn();
+const mockPreferencesSetAccountLabel = jest.fn();
+const mockEngineSetAccountLabel = jest.fn();
+const mockAccountsControllerSetAccountName = jest.fn();
 
 jest.mock('../../../core/Engine', () => ({
+  setAccountLabel: () => mockEngineSetAccountLabel,
   context: {
     PreferencesController: {
-      setAccountLabel: () => mockSetAccountLabel,
+      setAccountLabel: () => mockPreferencesSetAccountLabel,
+    },
+    AccountsController: {
+      setAccountName: () => mockAccountsControllerSetAccountName,
     },
   },
 }));
@@ -28,10 +34,37 @@ const mockInitialState = {
   engine: {
     backgroundState: {
       ...initialBackgroundState,
+      AccountsController: {
+        internalAccounts: {
+          accounts: {
+            '30313233-3435-4637-b839-383736353430': {
+              address: '0x0',
+              id: '30313233-3435-4637-b839-383736353430',
+              options: {},
+              metadata: {
+                name: 'Account 1',
+                keyring: {
+                  type: 'HD Key Tree',
+                },
+              },
+              methods: [
+                'personal_sign',
+                'eth_sign',
+                'eth_signTransaction',
+                'eth_signTypedData_v1',
+                'eth_signTypedData_v3',
+                'eth_signTypedData_v4',
+              ],
+              type: 'eip155:eoa',
+            },
+          },
+        },
+        selectedAccount: '30313233-3435-4637-b839-383736353430',
+      },
       PreferencesController: {
-        selectedAddress: '0x',
+        selectedAddress: '0x0',
         identities: {
-          '0x': { name: 'Account 1', address: '0x' },
+          '0x0': { name: 'Account 1', address: '0x0' },
         },
       },
     },
@@ -69,6 +102,9 @@ describe('EditAccountName', () => {
     mockNavigate.mockClear();
     mockGoBack.mockClear();
     mockSetOptions.mockClear();
+    mockPreferencesSetAccountLabel.mockClear();
+    mockEngineSetAccountLabel.mockClear();
+    mockAccountsControllerSetAccountName.mockClear();
   });
   it('should render correctly', () => {
     const { getByText, toJSON } = renderComponent(mockInitialState);

--- a/app/components/Views/EditAccountName/EditAccountName.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.tsx
@@ -83,20 +83,21 @@ const EditAccountName = () => {
   };
 
   const saveAccountName = async () => {
-    const { PreferencesController } = Engine.context;
-    PreferencesController.setAccountLabel(selectedAddress, accountName);
-    navigate('WalletView');
+    if (accountName && accountName.length > 0) {
+      Engine.setAccountLabel(selectedAddress, accountName);
+      navigate('WalletView');
 
-    try {
-      const analyticsProperties = async () => {
-        const accountType = getAddressAccountType(selectedAddress);
-        const account_type = accountType === 'QR' ? 'hardware' : accountType;
-        return { account_type, chain_id: getDecimalChainId(chainId) };
-      };
-      const analyticsProps = await analyticsProperties();
-      trackEvent(MetaMetricsEvents.ACCOUNT_RENAMED, analyticsProps);
-    } catch {
-      return {};
+      try {
+        const analyticsProperties = async () => {
+          const accountType = getAddressAccountType(selectedAddress);
+          const account_type = accountType === 'QR' ? 'hardware' : accountType;
+          return { account_type, chain_id: getDecimalChainId(chainId) };
+        };
+        const analyticsProps = await analyticsProperties();
+        trackEvent(MetaMetricsEvents.ACCOUNT_RENAMED, analyticsProps);
+      } catch {
+        return {};
+      }
     }
   };
 

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`EditAccountName should render correctly 1`] = `
             editable={false}
             onBlur={[Function]}
             onFocus={[Function]}
-            placeholder="0x"
+            placeholder="0x0"
             style={
               Object {
                 "backgroundColor": "#FFFFFF",

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1597,6 +1597,21 @@ class Engine {
       throw new Error(`No account found for address: ${address}`);
     }
   }
+
+  /**
+   * This should be used instead of directly calling PreferencesController.setAccountLabel or AccountsController.setAccountName in order to keep the names in sync
+   * We are currently incrementally migrating the accounts data to the AccountsController so we must keep these values
+   * in sync until the migration is complete.
+   */
+  setAccountLabel(address: string, label: string) {
+    const { AccountsController, PreferencesController } = this.context;
+    const accountToBeNamed = AccountsController.getAccountByAddress(address);
+    if (accountToBeNamed === undefined) {
+      throw new Error(`No account found for address: ${address}`);
+    }
+    AccountsController.setAccountName(accountToBeNamed.id, label);
+    PreferencesController.setAccountLabel(address, label);
+  }
 }
 
 /**
@@ -1736,5 +1751,9 @@ export default {
   setSelectedAddress: (address: string) => {
     assertEngineExists(instance);
     instance.setSelectedAccount(address);
+  },
+  setAccountLabel: (address: string, label: string) => {
+    assertEngineExists(instance);
+    instance.setAccountLabel(address, label);
   },
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


1. What is the reason for the change?
- the internal state of the accounts controller and the preferences controller was getting out of sync when editing the account names in the UI
- this meant that the users preferred name was not reflected in the AccountsController
- although there is currently no user impact because of this issue, it will lead to problems in the future and will require a new migration to be written in coming releases. 
2. What is the improvement/solution?
- Created a new Engine utility method called `setAccountLabel` (similar to what we are doing for `setSelectedAccount`) that changes both the PreferencesController and the AccountsController label.
- Updated the use of `PreferencesController.setAccountLabel` in the UI to be `Engine.setAccountLabel`
- added tests


## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Create or import a wallet
2. add the following code block to the `useAccounts.ts` hook

```ts
  // TODO remove this useEffect before merging
  useEffect(() => {
    // eslint-disable-next-line no-console
    console.log(
      'Accounts/ AccountController',
      JSON.stringify(Engine.context.AccountsController.state, null, 2),
    );
    // eslint-disable-next-line no-console
    console.log(
      'Accounts/ PreferencesController',
      JSON.stringify(
        Engine.context.PreferencesController.state.identities,
        null,
        2,
      ),
    );
  }, [
    Engine.context.AccountsController.state,
    Engine.context.PreferencesController.identities,
    Engine.context.PreferencesController.state.identities,
  ]);
```
3. reload the app and inspect the logs. the names and addresses should match 1:1
4. add an account via the account picker from the main wallet view
5. change the names of your accounts
6. refresh the wallet
7. all the account names should match along with the selected account
8. the state logged in the console should still match 1:1

**- Double check that there are NO other direct calls to other preferences controller methods like `PreferencesController.setAccountLabel`**

### **Before**

- Notice different account names in each controller
```json
 Accounts/ AccountController {
  "internalAccounts": {
    "accounts": {
      "6ffaed06-b348-4fc1-a227-972de373effd": {
        "id": "6ffaed06-b348-4fc1-a227-972de373effd",
        "address": "0x4a29682b2636147f608cf7554f47bd9877117bdd",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Account 1",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712528808432
        }
      },
      "59e23a68-b6b7-43a8-90f8-7236f748fe00": {
        "id": "59e23a68-b6b7-43a8-90f8-7236f748fe00",
        "address": "0x769dde14f7d7d48ed431d727801620f46d7ae29e",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Account 2",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712528808551
        }
      },
      "04cc2134-f9f6-4a42-b07b-3ebc40078f4f": {
        "id": "04cc2134-f9f6-4a42-b07b-3ebc40078f4f",
        "address": "0x9351164ed35ace26f345f749b9cb85b5c699e2b7",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Account 3",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712528808747
        }
      }
    },
    "selectedAccount": "04cc2134-f9f6-4a42-b07b-3ebc40078f4f"
  }
}
 LOG  Accounts/ PreferencesController {
  "0x4A29682b2636147F608CF7554F47bd9877117bDd": {
    "address": "0x4A29682b2636147F608CF7554F47bd9877117bDd",
    "name": "Account 1",
    "importTime": 1712527955387
  },
  "0x769ddE14f7D7D48eD431d727801620F46d7aE29e": {
    "address": "0x769ddE14f7D7D48eD431d727801620F46d7aE29e",
    "name": "Cool 2",
    "importTime": 1712528157517
  },
  "0x9351164ED35aCe26F345F749B9Cb85b5C699E2b7": {
    "address": "0x9351164ED35aCe26F345F749B9Cb85b5C699E2b7",
    "name": "Gyro 3",
    "importTime": 1712528160433
  }
}
```

### **After**

- Notice that the account names in both controllers match

```json
Accounts/ AccountController {
  "internalAccounts": {
    "accounts": {
      "6ffaed06-b348-4fc1-a227-972de373effd": {
        "id": "6ffaed06-b348-4fc1-a227-972de373effd",
        "address": "0x4a29682b2636147f608cf7554f47bd9877117bdd",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Cool Account 1",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712575526370
        }
      },
      "59e23a68-b6b7-43a8-90f8-7236f748fe00": {
        "id": "59e23a68-b6b7-43a8-90f8-7236f748fe00",
        "address": "0x769dde14f7d7d48ed431d727801620f46d7ae29e",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Cool Account 2",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712575539858
        }
      },
      "04cc2134-f9f6-4a42-b07b-3ebc40078f4f": {
        "id": "04cc2134-f9f6-4a42-b07b-3ebc40078f4f",
        "address": "0x9351164ed35ace26f345f749b9cb85b5c699e2b7",
        "options": {},
        "methods": [
          "personal_sign",
          "eth_sign",
          "eth_signTransaction",
          "eth_signTypedData_v1",
          "eth_signTypedData_v3",
          "eth_signTypedData_v4"
        ],
        "type": "eip155:eoa",
        "metadata": {
          "name": "Cool Account 3",
          "keyring": {
            "type": "HD Key Tree"
          },
          "lastSelected": 1712575552843
        }
      }
    },
    "selectedAccount": "04cc2134-f9f6-4a42-b07b-3ebc40078f4f"
  }
}
 LOG  Accounts/ PreferencesController {
  "0x4A29682b2636147F608CF7554F47bd9877117bDd": {
    "address": "0x4A29682b2636147F608CF7554F47bd9877117bDd",
    "name": "Cool Account 1",
    "importTime": 1712527955387
  },
  "0x769ddE14f7D7D48eD431d727801620F46d7aE29e": {
    "address": "0x769ddE14f7D7D48eD431d727801620F46d7aE29e",
    "name": "Cool Account 2",
    "importTime": 1712528157517
  },
  "0x9351164ED35aCe26F345F749B9Cb85b5C699E2b7": {
    "address": "0x9351164ED35aCe26F345F749B9Cb85b5C699E2b7",
    "name": "Cool Account 3",
    "importTime": 1712528160433
  }
}
```

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
