### PR TITLE
fix: change CUSTOM_TOKEN_IMPORTED tracking mode

### DIFF
--- a/app/components/UI/Swaps/components/TokenSelectModal.js
+++ b/app/components/UI/Swaps/components/TokenSelectModal.js
@@ -157,7 +157,7 @@ function TokenSelectModal({
   balances,
 }) {
   const navigation = useNavigation();
-  const { trackEvent } = useMetrics();
+  const { trackAnonymousEvent } = useMetrics();
 
   const searchInput = useRef(null);
   const list = useRef();
@@ -303,7 +303,7 @@ function TokenSelectModal({
   const handlePressImportToken = useCallback(
     (item) => {
       const { address, symbol } = item;
-      trackEvent(MetaMetricsEvents.CUSTOM_TOKEN_IMPORTED, {
+      trackAnonymousEvent(MetaMetricsEvents.CUSTOM_TOKEN_IMPORTED, {
         address,
         symbol,
         chain_id: getDecimalChainId(chainId),
@@ -311,7 +311,7 @@ function TokenSelectModal({
       hideTokenImportModal();
       onItemPress(item);
     },
-    [chainId, hideTokenImportModal, onItemPress, trackEvent],
+    [chainId, hideTokenImportModal, onItemPress, trackAnonymousEvent],
   );
 
   const handleBlockExplorerPress = useCallback(() => {


### PR DESCRIPTION
## **Description**

change tracking mode to anonymous for CUSTOM_TOKEN_IMPORTED

## **Related issues**

Fixes #9163

## **Manual testing steps**

```gherkin
Feature: Import custom token for swap
  Scenario: Import is tracked anonymously
    GIVEN user has the wallet installed and configured
    AND user is on wallet view
    AND user touches the action button
    AND user touches swap
    AND user touches "select a token"
    AND user pastes "0x72c9Fb7ED19D3ce51cea5C56B3e023cd918baaDf" in the search field
    AND user touches "import" for the suggested AGLT token
    WHEN user confirms import on the bottom sheet
    THEN 2 tracking event (one anonymous one identified) should be received on Mixpanel
    AND identified event has only the event name
    AND anonymous event has event name, token symbol and address
```

## **Screenshots/Recordings**

https://github.com/MetaMask/metamask-mobile/assets/4677568/a14ad235-7bf6-4468-ad47-7ae2b06c7b37

![image](https://github.com/MetaMask/metamask-mobile/assets/4677568/eadd0b1b-60a5-4407-a440-bbeccebd1987)
![image](https://github.com/MetaMask/metamask-mobile/assets/4677568/b33cb75b-4795-4f16-be69-b88ddfb40978)


### **Before**

One identified event with event name, token symbol and address.
<img width="500" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/4677568/ead6f5e3-65fe-4ae0-a867-155d363134bc">

### **After**

Two events, one identified with only event name, one anonymous with token symbol and address.
<img width="500" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/4677568/a2cba1ca-7523-49d7-9e4c-2969a5418dc4">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
