### PR TITLE
test: Change instances of messages to enContent while importing from locales

### DIFF
--- a/e2e/pages/TestDApp.js
+++ b/e2e/pages/TestDApp.js
@@ -2,7 +2,7 @@ import TestHelpers from '../helpers';
 import { testDappConnectButtonCooridinates } from '../viewHelper';
 import ConnectModal from './modals/ConnectModal';
 import Browser from './Browser';
-import root from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 import { getLocalTestDappPort } from '../fixtures/utils';
 import { BrowserViewSelectorsIDs } from '../selectors/BrowserView.selectors';
 import Assertions from '../utils/Assertions';
@@ -10,7 +10,7 @@ import Assertions from '../utils/Assertions';
 export const TEST_DAPP_LOCAL_URL = `http://localhost:${getLocalTestDappPort()}`;
 
 const BUTTON_RELATIVE_PONT = { x: 200, y: 5 };
-const CONFIRM_BUTTON_TEXT = root.confirmation_modal.confirm_cta;
+const CONFIRM_BUTTON_TEXT = enContent.confirmation_modal.confirm_cta;
 
 export class TestDApp {
   static async connect() {

--- a/e2e/pages/TokenOverview.js
+++ b/e2e/pages/TokenOverview.js
@@ -8,15 +8,15 @@ import {
   TOKEN_OVERVIEW_SWAP_BUTTON,
   ASSET_BACK_BUTTON,
 } from '../../wdio/screen-objects/testIDs/Screens/TokenOverviewScreen.testIds';
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 const chartTimePeriod = [
-  messages.asset_overview.chart_time_period_navigation['1d'],
-  messages.asset_overview.chart_time_period_navigation['1w'],
-  messages.asset_overview.chart_time_period_navigation['1m'],
-  messages.asset_overview.chart_time_period_navigation['3m'],
-  messages.asset_overview.chart_time_period_navigation['1y'],
-  messages.asset_overview.chart_time_period_navigation['3y'],
+  enContent.asset_overview.chart_time_period_navigation['1d'],
+  enContent.asset_overview.chart_time_period_navigation['1w'],
+  enContent.asset_overview.chart_time_period_navigation['1m'],
+  enContent.asset_overview.chart_time_period_navigation['3m'],
+  enContent.asset_overview.chart_time_period_navigation['1y'],
+  enContent.asset_overview.chart_time_period_navigation['3y'],
 ];
 
 export default class TokenOverview {
@@ -48,7 +48,7 @@ export default class TokenOverview {
     for (const period of chartTimePeriod) {
       await this.selectChart(period);
       await TestHelpers.checkIfElementWithTextIsNotVisible(
-        messages.asset_overview.no_chart_data.title,
+        enContent.asset_overview.no_chart_data.title,
       );
     }
   }
@@ -59,7 +59,7 @@ export default class TokenOverview {
 
   static async ChartNotVisible() {
     await TestHelpers.checkIfElementWithTextIsVisible(
-      messages.asset_overview.no_chart_data.title,
+      enContent.asset_overview.no_chart_data.title,
     );
   }
   static async isReceiveButtonVisible() {

--- a/e2e/pages/swaps/OnBoarding.js
+++ b/e2e/pages/swaps/OnBoarding.js
@@ -1,8 +1,8 @@
 import TestHelpers from '../../helpers';
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export default class Onboarding {
   static async tapStartSwapping() {
-    await TestHelpers.waitAndTapText(messages.swaps.onboarding.start_swapping);
+    await TestHelpers.waitAndTapText(enContent.swaps.onboarding.start_swapping);
   }
 }

--- a/e2e/pages/swaps/QuoteView.js
+++ b/e2e/pages/swaps/QuoteView.js
@@ -5,11 +5,11 @@ import {
   SWAP_MAX_SLIPPAGE,
   SWAP_SEARCH_TOKEN,
 } from '../../../wdio/screen-objects/testIDs/Screens/QuoteView.js';
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export default class QuoteView {
   static async isVisible() {
-    await TestHelpers.checkIfElementByTextIsVisible(messages.swaps.get_quotes);
+    await TestHelpers.checkIfElementByTextIsVisible(enContent.swaps.get_quotes);
   }
 
   static async findKeypadButton(digit) {
@@ -38,7 +38,7 @@ export default class QuoteView {
 
   static async tapOnGetQuotes() {
     await device.disableSynchronization();
-    await TestHelpers.waitAndTapText(messages.swaps.get_quotes);
+    await TestHelpers.waitAndTapText(enContent.swaps.get_quotes);
   }
 
   static async checkMaxSlippage(text) {

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -1,13 +1,13 @@
 import TestHelpers from '../../helpers';
 import { SwapsViewSelectors } from '../../selectors/swaps/SwapsView.selectors.js';
 
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import { waitFor } from 'detox';
 
 export default class SwapView {
   static async isVisible() {
     await TestHelpers.checkIfElementByTextIsVisible(
-      messages.swaps.fetching_quotes,
+      enContent.swaps.fetching_quotes,
     );
     await TestHelpers.checkIfVisible(SwapsViewSelectors.SWAP_QUOTE_SUMMARY);
     await TestHelpers.checkIfVisible(SwapsViewSelectors.SWAP_GAS_FEE);

--- a/e2e/selectors/AccountListView.selectors.js
+++ b/e2e/selectors/AccountListView.selectors.js
@@ -1,8 +1,8 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const AccountListViewSelectorsText = {
-  REMOVE_IMPORTED_ACCOUNT: messages.accounts.yes_remove_it,
-  IMPORT_ACCOUNT: messages.account_actions.import_account,
-  CREATE_ACCOUNT: messages.account_actions.add_new_account,
+  REMOVE_IMPORTED_ACCOUNT: enContent.accounts.yes_remove_it,
+  IMPORT_ACCOUNT: enContent.account_actions.import_account,
+  CREATE_ACCOUNT: enContent.account_actions.add_new_account,
 };

--- a/e2e/selectors/ActivitiesView.selectors.js
+++ b/e2e/selectors/ActivitiesView.selectors.js
@@ -1,7 +1,7 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const ActivitiesViewSelectorsText = {
-  TITLE: messages.transactions_view.title,
-  SWAP: messages.swaps.transaction_label.swap,
+  TITLE: enContent.transactions_view.title,
+  SWAP: enContent.swaps.transaction_label.swap,
 };

--- a/e2e/selectors/AddCustomTokenView.selectors.js
+++ b/e2e/selectors/AddCustomTokenView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 export const AddCustomTokenViewSelectorsIDs = {
   CANCEL_BUTTON: 'add-custom-asset-cancel-button',
@@ -6,6 +6,6 @@ export const AddCustomTokenViewSelectorsIDs = {
 };
 
 export const AddCustomTokenViewSelectorsText = {
-  TOKEN_SYMBOL: messages.token.token_symbol,
-  IMPORT_BUTTON: messages.add_asset.tokens.add_token,
+  TOKEN_SYMBOL: enContent.token.token_symbol,
+  IMPORT_BUTTON: enContent.add_asset.tokens.add_token,
 };

--- a/e2e/selectors/BrowserView.selectors.js
+++ b/e2e/selectors/BrowserView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 export const BrowserViewSelectorsIDs = {
   ANDROID_CONTAINER: 'browser-webview',
@@ -9,9 +9,9 @@ export const BrowserViewSelectorsIDs = {
 };
 
 export const BrowserViewSelectorsText = {
-  ADD_FAVORITES_BUTTON: messages.browser.add_to_favorites,
-  BACK_TO_SAFETY_BUTTON: messages.phishing.back_to_safety,
-  CONFIRM_BUTTON: messages.confirmation_modal.confirm_cta,
-  RETURN_HOME: messages.webview_error.return_home,
+  ADD_FAVORITES_BUTTON: enContent.browser.add_to_favorites,
+  BACK_TO_SAFETY_BUTTON: enContent.phishing.back_to_safety,
+  CONFIRM_BUTTON: enContent.confirmation_modal.confirm_cta,
+  RETURN_HOME: enContent.webview_error.return_home,
   METAMASK_TEST_DAPP_URL: 'metamask.github.io',
 };

--- a/e2e/selectors/Common.selectors.js
+++ b/e2e/selectors/Common.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 export const CommonSelectorsIDs = {
   ERROR_MESSAGE: 'error-message-warning',
@@ -18,9 +18,9 @@ export const CommonSelectorsIDs = {
 };
 
 export const CommonSelectorsText = {
-  OK_ALERT_BUTTON: messages.template_confirmation.ok,
-  CANCEL_BUTTON: messages.template_confirmation.cancel,
-  TOAST_REVOKE_ACCOUNTS: messages.toast.revoked_all,
-  TOAST_CONNECTED_ACCOUNTS: messages.toast.connected_and_active,
-  YES_ALERT_BUTTON: messages.drawer.lock_ok,
+  OK_ALERT_BUTTON: enContent.template_confirmation.ok,
+  CANCEL_BUTTON: enContent.template_confirmation.cancel,
+  TOAST_REVOKE_ACCOUNTS: enContent.toast.revoked_all,
+  TOAST_CONNECTED_ACCOUNTS: enContent.toast.connected_and_active,
+  YES_ALERT_BUTTON: enContent.drawer.lock_ok,
 };

--- a/e2e/selectors/EditGasView.selectors.js
+++ b/e2e/selectors/EditGasView.selectors.js
@@ -1,10 +1,10 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const EditGasViewSelectorsText = {
-  AGGRESSIVE: messages.edit_gas_fee_eip1559.aggressive,
-  ADVANCE_OPTIONS: messages.edit_gas_fee_eip1559.advanced_options,
-  SAVE_BUTTON: messages.edit_gas_fee_eip1559.save,
-  MARKET: messages.edit_gas_fee_eip1559.market,
-  LOW: messages.edit_gas_fee_eip1559.low,
+  AGGRESSIVE: enContent.edit_gas_fee_eip1559.aggressive,
+  ADVANCE_OPTIONS: enContent.edit_gas_fee_eip1559.advanced_options,
+  SAVE_BUTTON: enContent.edit_gas_fee_eip1559.save,
+  MARKET: enContent.edit_gas_fee_eip1559.market,
+  LOW: enContent.edit_gas_fee_eip1559.low,
 };

--- a/e2e/selectors/ImportTokenView.selectors.js
+++ b/e2e/selectors/ImportTokenView.selectors.js
@@ -1,10 +1,10 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 export const ImportTokenViewSelectorsIDs = {
   CONTAINER: 'searched-token-result',
 };
 
 export const ImportTokenViewSelectorsText = {
-  IMPORT_BUTTON: messages.add_asset.tokens.add_token,
-  CANCEL_BUTTON: messages.add_asset.tokens.cancel_add_token,
+  IMPORT_BUTTON: enContent.add_asset.tokens.add_token,
+  CANCEL_BUTTON: enContent.add_asset.tokens.cancel_add_token,
 };

--- a/e2e/selectors/Modals/ConnectAccountModal.selectors.js
+++ b/e2e/selectors/Modals/ConnectAccountModal.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const ConnectAccountModalSelectorsIDs = {
   CONTAINER: 'connect-account-modal',
@@ -6,7 +6,7 @@ export const ConnectAccountModalSelectorsIDs = {
 };
 
 export const ConnectAccountModalSelectorsText = {
-  CONNECT_ACCOUNTS: messages.accounts.connect_multiple_accounts,
-  IMPORT_ACCOUNT: messages.account_actions.add_account_or_hardware_wallet,
-  SELECT_ALL: messages.accounts.select_all,
+  CONNECT_ACCOUNTS: enContent.accounts.connect_multiple_accounts,
+  IMPORT_ACCOUNT: enContent.account_actions.add_account_or_hardware_wallet,
+  SELECT_ALL: enContent.accounts.select_all,
 };

--- a/e2e/selectors/Modals/ConnectedAccountModal.selectors.js
+++ b/e2e/selectors/Modals/ConnectedAccountModal.selectors.js
@@ -1,11 +1,10 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
-// eslint-disable-next-line import/prefer-default-export
 export const ConnectedAccountModalSelectorsText = {
-  PERMISSION_LINK: messages.accounts.permissions,
-  DISCONNECT_ALL: messages.accounts.disconnect_all_accounts,
-  IMPORTED: messages.accounts.imported,
-  TITLE: messages.accounts.connected_accounts_title,
+  PERMISSION_LINK: enContent.accounts.permissions,
+  DISCONNECT_ALL: enContent.accounts.disconnect_all_accounts,
+  IMPORTED: enContent.accounts.imported,
+  TITLE: enContent.accounts.connected_accounts_title,
 };
 
 export const ConnectedAccountsSelectorsIDs = {

--- a/e2e/selectors/Modals/ContractApprovalModal.selectors.js
+++ b/e2e/selectors/Modals/ContractApprovalModal.selectors.js
@@ -1,11 +1,11 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const ContractApprovalModalSelectorsText = {
-  ADD_NICKNAME: messages.nickname.add_nickname,
-  EDIT_NICKNAME: messages.nickname.edit_nickname,
-  APPROVE: messages.transactions.tx_review_approve,
-  REJECT: messages.transaction.reject,
-  NEXT: messages.transaction.next,
+  ADD_NICKNAME: enContent.nickname.add_nickname,
+  EDIT_NICKNAME: enContent.nickname.edit_nickname,
+  APPROVE: enContent.transactions.tx_review_approve,
+  REJECT: enContent.transaction.reject,
+  NEXT: enContent.transaction.next,
 };
 
 export const ContractApprovalModalSelectorsIDs = {

--- a/e2e/selectors/Modals/DeleteContactModal.selectors.js
+++ b/e2e/selectors/Modals/DeleteContactModal.selectors.js
@@ -1,8 +1,8 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const DeleteContactModalSelectorsText = {
-  MODAL_TITLE: messages.address_book.delete_contact,
-  DELETE_BUTTON: messages.address_book.delete,
-  CANCEL_BUTTON: messages.address_book.cancel,
+  MODAL_TITLE: enContent.address_book.delete_contact,
+  DELETE_BUTTON: enContent.address_book.delete,
+  CANCEL_BUTTON: enContent.address_book.cancel,
 };

--- a/e2e/selectors/Modals/DeleteWalletModal.selectors.js
+++ b/e2e/selectors/Modals/DeleteWalletModal.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const DeleteWalletModalSelectorsIDs = {
   CONTAINER: 'delete-wallet-modal-container',
@@ -11,6 +11,6 @@ export const DeleteWalletModalSelectorsIDs = {
 };
 
 export const DeleteWalletModalSelectorsText = {
-  UNDERSTAND_BUTTON: messages.login.i_understand,
-  DELETE_MY: messages.login.delete_my,
+  UNDERSTAND_BUTTON: enContent.login.i_understand,
+  DELETE_MY: enContent.login.delete_my,
 };

--- a/e2e/selectors/Modals/NetworkAddedModal.selectors.js
+++ b/e2e/selectors/Modals/NetworkAddedModal.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const NetworkAddedModalSelectorsIDs = {
   CLOSE_NETWORK_BUTTON: 'close-network-button',
@@ -6,5 +6,5 @@ export const NetworkAddedModalSelectorsIDs = {
 };
 
 export const NetworkAddedModalSelectorsText = {
-  SWITCH_NETWORK: messages.networks.new_network,
+  SWITCH_NETWORK: enContent.networks.new_network,
 };

--- a/e2e/selectors/Modals/NetworkEducationModal.selectors.js
+++ b/e2e/selectors/Modals/NetworkEducationModal.selectors.js
@@ -1,6 +1,6 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const NetworkEducationModalSelectorsText = {
-  ADD_TOKEN: messages.network_information.add_token,
+  ADD_TOKEN: enContent.network_information.add_token,
 };

--- a/e2e/selectors/Modals/NetworkListModal.selectors.js
+++ b/e2e/selectors/Modals/NetworkListModal.selectors.js
@@ -1,6 +1,6 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const NetworkListModalSelectorsText = {
-  SELECT_NETWORK: messages.networks.select_network,
+  SELECT_NETWORK: enContent.networks.select_network,
 };

--- a/e2e/selectors/Modals/TransactionDetailsModal.selectors.js
+++ b/e2e/selectors/Modals/TransactionDetailsModal.selectors.js
@@ -1,8 +1,8 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const TransactionDetailsModalSelectorsText = {
-  TITLE: messages.swaps.transaction_label.swap,
-  CONFIRMED: messages.transaction.confirmed,
+  TITLE: enContent.swaps.transaction_label.swap,
+  CONFIRMED: enContent.transaction.confirmed,
 };
 
 export const TransactionDetailsModalSelectorsIDs = {

--- a/e2e/selectors/Onboarding/CustomDefaultNetwork.selectors.js
+++ b/e2e/selectors/Onboarding/CustomDefaultNetwork.selectors.js
@@ -1,9 +1,9 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const CustomDefaultNetworkIDs = {
   USE_THIS_NETWORK_BUTTON_ID: 'use-this-network',
 };
 
 export const CustomDefaultNetworkTexts = {
-  USE_THIS_NETWORK_BUTTON_TEXT: messages.app_settings.networks_default_cta,
+  USE_THIS_NETWORK_BUTTON_TEXT: enContent.app_settings.networks_default_cta,
 };

--- a/e2e/selectors/Onboarding/OnboardingCarousel.selectors.js
+++ b/e2e/selectors/Onboarding/OnboardingCarousel.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const OnboardingCarouselSelectorIDs = {
   CONTAINER_ID: 'onboarding-carousel-screen',
@@ -10,7 +10,7 @@ export const OnboardingCarouselSelectorIDs = {
 };
 
 export const OnboardingCarouselSelectorText = {
-  TITLE_ONE: messages.onboarding_carousel.title1,
-  TITLE_TWO: messages.onboarding_carousel.title2,
-  TITLE_THREE: messages.onboarding_carousel.title3,
+  TITLE_ONE: enContent.onboarding_carousel.title1,
+  TITLE_TWO: enContent.onboarding_carousel.title2,
+  TITLE_THREE: enContent.onboarding_carousel.title3,
 };

--- a/e2e/selectors/SendFlow/AmountView.selectors.js
+++ b/e2e/selectors/SendFlow/AmountView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 export const AmountViewSelectorsIDs = {
   CONTAINER: 'amount-screen',
@@ -8,5 +8,5 @@ export const AmountViewSelectorsIDs = {
 };
 
 export const AmountViewSelectorsText = {
-  SCREEN_TITLE: messages.transaction.amount,
+  SCREEN_TITLE: enContent.transaction.amount,
 };

--- a/e2e/selectors/Settings/Contacts/AddContactView.selectors.js
+++ b/e2e/selectors/Settings/Contacts/AddContactView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../../locales/languages/en.json';
+import enContent from '../../../../locales/languages/en.json';
 
 export const AddContactViewSelectorsIDs = {
   ADD_BUTTON: 'add-contact-add-contact-button',
@@ -11,6 +11,6 @@ export const AddContactViewSelectorsIDs = {
 };
 
 export const AddContactViewSelectorsText = {
-  EDIT_BUTTON: messages.address_book.edit,
-  EDIT_CONTACT: messages.address_book.edit_contact,
+  EDIT_BUTTON: enContent.address_book.edit,
+  EDIT_CONTACT: enContent.address_book.edit_contact,
 };

--- a/e2e/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.js
+++ b/e2e/selectors/Settings/SecurityAndPrivacy/ChangePasswordView.selectors.js
@@ -1,6 +1,6 @@
-import messages from '../../../../locales/languages/en.json';
+import enContent from '../../../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const ChangePasswordViewSelectorsText = {
-  CHANGE_PASSWORD: messages.manual_backup_step_1.confirm_password,
+  CHANGE_PASSWORD: enContent.manual_backup_step_1.confirm_password,
 };

--- a/e2e/selectors/Settings/SecurityAndPrivacy/RevealSeedView.selectors.js
+++ b/e2e/selectors/Settings/SecurityAndPrivacy/RevealSeedView.selectors.js
@@ -1,5 +1,4 @@
-import messages from '../../../../locales/languages/en.json';
-
+// eslint-disable-next-line import/prefer-default-export
 export const RevealSeedViewSelectorsIDs = {
   SECRET_RECOVERY_PHRASE_CONTAINER_ID: 'reveal-private-credential-screen',
   PASSWORD_INPUT: 'login-password-input',
@@ -14,8 +13,4 @@ export const RevealSeedViewSelectorsIDs = {
   SECRET_RECOVERY_PHRASE_LONG_PRESS_BUTTON_ID:
     'reveal-private-long-press-button',
   PASSWORD_INPUT_BOX_ID: 'private-credential-password-text-input',
-};
-
-export const RevealSeedViewSelectorsText = {
-  PASSWORD_WARNING: messages.reveal_credential.unknown_error,
 };

--- a/e2e/selectors/Settings/SecurityAndPrivacy/SecurityPrivacyView.selectors.js
+++ b/e2e/selectors/Settings/SecurityAndPrivacy/SecurityPrivacyView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../../../locales/languages/en.json';
+import enContent from '../../../../locales/languages/en.json';
 
 export const SecurityPrivacyViewSelectorsIDs = {
   CHANGE_PASSWORD_CONTAINER: 'change-password-section',
@@ -12,7 +12,7 @@ export const SecurityPrivacyViewSelectorsIDs = {
 };
 
 export const SecurityPrivacyViewSelectorsText = {
-  CLEAR_BROWSER_COOKIES: messages.app_settings.clear_browser_cookies_desc,
-  PRIVACY_HEADING: messages.app_settings.privacy_heading,
-  BACK_UP_NOW: messages.app_settings.back_up_now,
+  CLEAR_BROWSER_COOKIES: enContent.app_settings.clear_browser_cookies_desc,
+  PRIVACY_HEADING: enContent.app_settings.privacy_heading,
+  BACK_UP_NOW: enContent.app_settings.back_up_now,
 };

--- a/e2e/selectors/Settings/SettingsView.selectors.js
+++ b/e2e/selectors/Settings/SettingsView.selectors.js
@@ -1,9 +1,8 @@
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
-// eslint-disable-next-line import/prefer-default-export
 export const SettingsViewSelectorsText = {
-  ADVANCE_TITLE_TEXT: messages.app_settings.advanced_title,
-  CONTACT_SUPPORT_TITLE: messages.app_settings.contact_support,
+  ADVANCE_TITLE_TEXT: enContent.app_settings.advanced_title,
+  CONTACT_SUPPORT_TITLE: enContent.app_settings.contact_support,
 };
 
 export const SettingsViewSelectorsIDs = {

--- a/e2e/selectors/TransactionConfirmView.selectors.js
+++ b/e2e/selectors/TransactionConfirmView.selectors.js
@@ -1,6 +1,6 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 // eslint-disable-next-line import/prefer-default-export
 export const TransactionConfirmViewSelectorsText = {
-  CANCEL_BUTTON: messages.transaction.cancel,
+  CANCEL_BUTTON: enContent.transaction.cancel,
 };

--- a/e2e/selectors/WalletView.selectors.js
+++ b/e2e/selectors/WalletView.selectors.js
@@ -1,4 +1,4 @@
-import messages from '../../locales/languages/en.json';
+import enContent from '../../locales/languages/en.json';
 
 export const WalletViewSelectorsIDs = {
   WALLET_CONTAINER: 'wallet-screen',
@@ -8,9 +8,9 @@ export const WalletViewSelectorsIDs = {
 };
 
 export const WalletViewSelectorsText = {
-  IMPORT_TOKENS: `${messages.wallet.no_available_tokens} ${messages.wallet.add_tokens}`,
-  NFTS_TAB: messages.wallet.collectibles,
-  TOKENS_TAB: messages.wallet.tokens,
-  HIDE_TOKENS: messages.wallet.remove,
+  IMPORT_TOKENS: `${enContent.wallet.no_available_tokens} ${enContent.wallet.add_tokens}`,
+  NFTS_TAB: enContent.wallet.collectibles,
+  TOKENS_TAB: enContent.wallet.tokens,
+  HIDE_TOKENS: enContent.wallet.remove,
   DEFAULT_TOKEN: 'Ethereum',
 };

--- a/e2e/specs/confirmations/approve-custom-erc20.spec.js
+++ b/e2e/specs/confirmations/approve-custom-erc20.spec.js
@@ -10,7 +10,7 @@ import {
 import TabBarComponent from '../../pages/TabBarComponent';
 import { TestDApp } from '../../pages/TestDApp';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import root from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import ContractApprovalModal from '../../pages/modals/ContractApprovalModal';
 import Assertions from '../../utils/Assertions';
 
@@ -72,7 +72,7 @@ describe(SmokeConfirmations('ERC20 tokens'), () => {
 
         // Assert erc20 is approved
         await TestHelpers.checkIfElementByTextIsVisible(
-          root.transaction.confirmed,
+          enContent.transaction.confirmed,
         );
       },
     );

--- a/e2e/specs/confirmations/approve-default-erc20.spec.js
+++ b/e2e/specs/confirmations/approve-default-erc20.spec.js
@@ -10,7 +10,7 @@ import {
 import TabBarComponent from '../../pages/TabBarComponent';
 import { TestDApp } from '../../pages/TestDApp';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import root from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import { ContractApprovalModalSelectorsIDs } from '../../selectors/Modals/ContractApprovalModal.selectors';
 
 const HST_CONTRACT = SMART_CONTRACTS.HST;
@@ -64,22 +64,22 @@ describe(SmokeConfirmations('ERC20 tokens'), () => {
 
         // Tap next button
         await TestHelpers.checkIfElementWithTextIsVisible(
-          root.transaction.next,
+          enContent.transaction.next,
         );
-        await TestHelpers.tapByText(root.transaction.next);
+        await TestHelpers.tapByText(enContent.transaction.next);
 
         // Tap approve button
         await TestHelpers.checkIfElementWithTextIsVisible(
-          root.transactions.tx_review_approve,
+          enContent.transactions.tx_review_approve,
         );
-        await TestHelpers.tapByText(root.transactions.tx_review_approve);
+        await TestHelpers.tapByText(enContent.transactions.tx_review_approve);
 
         // Navigate to the activity screen
         await TabBarComponent.tapActivity();
 
         // Assert erc20 is approved
         await TestHelpers.checkIfElementByTextIsVisible(
-          root.transaction.confirmed,
+          enContent.transaction.confirmed,
         );
       },
     );

--- a/e2e/specs/confirmations/send-erc20-with-dapp.spec.js
+++ b/e2e/specs/confirmations/send-erc20-with-dapp.spec.js
@@ -10,10 +10,10 @@ import {
 import TabBarComponent from '../../pages/TabBarComponent';
 import { TestDApp } from '../../pages/TestDApp';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
-import root from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 
 const HST_CONTRACT = SMART_CONTRACTS.HST;
-const SENT_TOKENS_MESSAGE_TEXT = root.transactions.sent_tokens;
+const SENT_TOKENS_MESSAGE_TEXT = enContent.transactions.sent_tokens;
 const WEBVIEW_TEST_DAPP_TRANSFER_TOKENS_BUTTON_ID = 'transferTokens';
 
 describe(SmokeConfirmations('ERC20 tokens'), () => {

--- a/e2e/specs/confirmations/send-erc721.spec.js
+++ b/e2e/specs/confirmations/send-erc721.spec.js
@@ -10,12 +10,12 @@ import {
   withFixtures,
   defaultGanacheOptions,
 } from '../../fixtures/fixture-helper';
-import root from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(SmokeConfirmations('ERC721 tokens'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
-  const SENT_COLLECTIBLE_MESSAGE_TEXT = root.transactions.sent_collectible;
+  const SENT_COLLECTIBLE_MESSAGE_TEXT = enContent.transactions.sent_collectible;
   const WEBVIEW_TEST_DAPP_TRANSFER_FROM_BUTTON_ID = 'transferFromButton';
 
   beforeAll(async () => {

--- a/e2e/specs/confirmations/send-eth.spec.js
+++ b/e2e/specs/confirmations/send-eth.spec.js
@@ -9,7 +9,7 @@ import TransactionConfirmationView from '../../pages/TransactionConfirmView';
 import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
-import root from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
   withFixtures,
@@ -18,7 +18,7 @@ import {
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 
 describe(SmokeConfirmations('Send ETH'), () => {
-  const TOKEN_NAME = root.unit.eth;
+  const TOKEN_NAME = enContent.unit.eth;
   const AMOUNT = '0.12345';
 
   beforeAll(async () => {

--- a/e2e/specs/settings/addressbook-tests.spec.js
+++ b/e2e/specs/settings/addressbook-tests.spec.js
@@ -18,7 +18,7 @@ import TestHelpers from '../../helpers';
 import FixtureServer from '../../fixtures/fixture-server';
 import { getFixturesServerPort } from '../../fixtures/utils';
 import CommonView from '../../pages/CommonView';
-import messages from '../../../locales/languages/en.json';
+import enContent from '../../../locales/languages/en.json';
 import DeleteContactModal from '../../pages/modals/DeleteContactModal';
 import Assertions from '../../utils/Assertions';
 
@@ -93,7 +93,7 @@ describe(SmokeCore('Addressbook Tests'), () => {
     await Assertions.checkIfVisible(CommonView.errorMessage);
     await Assertions.checkIfElementToHaveText(
       CommonView.errorMessage,
-      messages.transaction.invalid_address,
+      enContent.transaction.invalid_address,
     );
     await AddContactView.clearAddressInputBox();
     await AddContactView.typeInAddress('ibrahim.team.mask.eth');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We want to improve the variable name we use while importing from the locales folder. "Messages" is a bit unclear and can cause confusion. The purpose here is to rename to "enContent".

## **Related issues**

Fixes: 1510

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
