### PR TITLE
fix: Fix image import related type errors

### DIFF
--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   // TODO: Fix type errors and uncomment all directories
   "include": [
+    "app/declarations.d.ts",
     // "app/**/*",
     "app/__mocks__/**/*",
     "app/actions/**/*",
@@ -17,8 +18,7 @@
     "app/reducers/**/*",
     "app/selectors/**/*",
     "app/store/**/*",
-    "app/styles/**/*",
+    "app/styles/**/*"
     // "app/util/**/*",
-    "app/declarations.d.ts"
   ]
 }


### PR DESCRIPTION
## **Description**

There have been type errors showing up on some PRs relating to image imports; TypeScript interprets them as strings, but we have them typed as `ImageSourcePropType`. The mismatch is there because these image imports are modified later in the build system.

Normally this is handled by our type declarations, which declare upfront which types these imports should have. But on some PRs, it seems that TypeScript will evaluate these declarations too late, after files including image imports.

I had trouble reproducing this problem on `main`, but it can be seen in the PR #8828 (commit b027cfa86ba6489009c983082f2207f8bb1728e3). If you include this change on that branch, it resolves the problem.

## **Related issues**

Resolves lint error on #8828

## **Manual testing steps**

Patch this change onto #8828 and see that the `yarn lint:tsc` command succeeds

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
