### PR TITLE
fix: Send ppom metrics when transaction is cancelled.

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -51,6 +51,7 @@ import { CommonSelectorsIDs } from '../../../../e2e/selectors/Common.selectors';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/WalletView.selectors';
 import { NetworksViewSelectorsIDs } from '../../../../e2e/selectors/Settings/NetworksView.selectors';
 import { SendLinkViewSelectorsIDs } from '../../../../e2e/selectors/SendLinkView.selectors';
+import { withBlockaidMetricsParams } from '../../../util/blockaid';
 
 const trackEvent = (event, params = {}) => {
   MetaMetrics.getInstance().trackEvent(event, params);
@@ -513,6 +514,7 @@ export function getSendFlowTitle(
   route,
   themeColors,
   resetTransaction,
+  transaction,
 ) {
   const innerStyles = StyleSheet.create({
     headerButtonText: {
@@ -528,9 +530,13 @@ export function getSendFlowTitle(
   });
   const rightAction = () => {
     const providerType = route?.params?.providerType ?? '';
+    const additionalTransactionMetricsParams = transaction
+      ? withBlockaidMetricsParams(transaction)
+      : {};
     trackEvent(MetaMetricsEvents.SEND_FLOW_CANCEL, {
       view: title.split('.')[1],
       network: providerType,
+      ...additionalTransactionMetricsParams,
     });
     resetTransaction();
     navigation.dangerouslyGetParent()?.pop();

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -51,7 +51,7 @@ import { CommonSelectorsIDs } from '../../../../e2e/selectors/Common.selectors';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/WalletView.selectors';
 import { NetworksViewSelectorsIDs } from '../../../../e2e/selectors/Settings/NetworksView.selectors';
 import { SendLinkViewSelectorsIDs } from '../../../../e2e/selectors/SendLinkView.selectors';
-import { withBlockaidMetricsParams } from '../../../util/blockaid';
+import { getBlockaidTransactionMetricsParams } from '../../../util/blockaid';
 
 const trackEvent = (event, params = {}) => {
   MetaMetrics.getInstance().trackEvent(event, params);
@@ -530,9 +530,8 @@ export function getSendFlowTitle(
   });
   const rightAction = () => {
     const providerType = route?.params?.providerType ?? '';
-    const additionalTransactionMetricsParams = transaction
-      ? withBlockaidMetricsParams(transaction)
-      : {};
+    const additionalTransactionMetricsParams =
+      getBlockaidTransactionMetricsParams(transaction);
     trackEvent(MetaMetricsEvents.SEND_FLOW_CANCEL, {
       view: title.split('.')[1],
       network: providerType,

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -107,7 +107,7 @@ import { ConfirmViewSelectorsIDs } from '../../../../../../e2e/selectors/SendFlo
 import ExtendedKeyringTypes from '../../../../../constants/keyringTypes';
 import { getLedgerKeyring } from '../../../../../core/Ledger/Ledger';
 import {
-  withBlockaidMetricsParams,
+  getBlockaidTransactionMetricsParams,
   isBlockaidFeatureEnabled,
 } from '../../../../../util/blockaid';
 import ppomUtil from '../../../../../lib/ppom/ppom-util';
@@ -844,7 +844,7 @@ class Confirm extends PureComponent {
                 assetType,
                 {
                   ...this.getAnalyticsParams(),
-                  ...withBlockaidMetricsParams(transaction),
+                  ...getBlockaidTransactionMetricsParams(transaction),
                 },
               ),
             type: 'signTransaction',
@@ -873,7 +873,7 @@ class Confirm extends PureComponent {
           MetaMetricsEvents.SEND_TRANSACTION_COMPLETED,
           {
             ...this.getAnalyticsParams(),
-            ...withBlockaidMetricsParams(transaction),
+            ...getBlockaidTransactionMetricsParams(transaction),
           },
         );
         stopGasPolling();
@@ -1087,7 +1087,7 @@ class Confirm extends PureComponent {
     const { transaction } = this.props;
     const analyticsParams = {
       ...this.getAnalyticsParams(),
-      ...withBlockaidMetricsParams(transaction),
+      ...getBlockaidTransactionMetricsParams(transaction),
       external_link_clicked: 'security_alert_support_link',
     };
     this.props.metrics.trackEvent(

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -107,7 +107,7 @@ import { ConfirmViewSelectorsIDs } from '../../../../../../e2e/selectors/SendFlo
 import ExtendedKeyringTypes from '../../../../../constants/keyringTypes';
 import { getLedgerKeyring } from '../../../../../core/Ledger/Ledger';
 import {
-  getBlockaidMetricsParams,
+  withBlockaidMetricsParams,
   isBlockaidFeatureEnabled,
 } from '../../../../../util/blockaid';
 import ppomUtil from '../../../../../lib/ppom/ppom-util';
@@ -302,23 +302,8 @@ class Confirm extends PureComponent {
     }
   };
 
-  withBlockaidMetricsParams = () => {
-    let blockaidParams = {};
-
-    const { transaction } = this.props;
-    if (
-      transaction.id === transaction.currentTransactionSecurityAlertResponse?.id
-    ) {
-      blockaidParams = getBlockaidMetricsParams(
-        transaction.currentTransactionSecurityAlertResponse?.response,
-      );
-    }
-
-    return blockaidParams;
-  };
-
   updateNavBar = () => {
-    const { navigation, route, resetTransaction } = this.props;
+    const { navigation, route, resetTransaction, transaction } = this.props;
     const colors = this.context.colors || mockTheme.colors;
     navigation.setOptions(
       getSendFlowTitle(
@@ -327,6 +312,7 @@ class Confirm extends PureComponent {
         route,
         colors,
         resetTransaction,
+        transaction,
       ),
     );
   };
@@ -858,7 +844,7 @@ class Confirm extends PureComponent {
                 assetType,
                 {
                   ...this.getAnalyticsParams(),
-                  ...this.withBlockaidMetricsParams(),
+                  ...withBlockaidMetricsParams(transaction),
                 },
               ),
             type: 'signTransaction',
@@ -887,7 +873,7 @@ class Confirm extends PureComponent {
           MetaMetricsEvents.SEND_TRANSACTION_COMPLETED,
           {
             ...this.getAnalyticsParams(),
-            ...this.withBlockaidMetricsParams(),
+            ...withBlockaidMetricsParams(transaction),
           },
         );
         stopGasPolling();
@@ -1101,7 +1087,7 @@ class Confirm extends PureComponent {
     const { transaction } = this.props;
     const analyticsParams = {
       ...this.getAnalyticsParams(),
-      ...this.withBlockaidMetricsParams(transaction),
+      ...withBlockaidMetricsParams(transaction),
       external_link_clicked: 'security_alert_support_link',
     };
     this.props.metrics.trackEvent(

--- a/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
@@ -51,7 +51,7 @@ import TransactionReviewDetailsCard from '../TransactionReview/TransactionReview
 import AppConstants from '../../../../../core/AppConstants';
 import { UINT256_HEX_MAX_VALUE } from '../../../../../constants/transaction';
 import { WALLET_CONNECT_ORIGIN } from '../../../../../util/walletconnect';
-import { withBlockaidMetricsParams } from '../../../../../util/blockaid';
+import { getBlockaidTransactionMetricsParams } from '../../../../../util/blockaid';
 import { withNavigation } from '@react-navigation/compat';
 import {
   isTestNet,
@@ -685,7 +685,7 @@ class ApproveTransactionReview extends PureComponent {
     const { transaction } = this.props;
     const analyticsParams = {
       ...this.getAnalyticsParams(),
-      ...withBlockaidMetricsParams(transaction),
+      ...getBlockaidTransactionMetricsParams(transaction),
       external_link_clicked: 'security_alert_support_link',
     };
     this.props.metrics.trackEvent(
@@ -1169,7 +1169,7 @@ class ApproveTransactionReview extends PureComponent {
       MetaMetricsEvents.APPROVAL_PERMISSION_UPDATED,
       {
         ...this.getAnalyticsParams(),
-        ...withBlockaidMetricsParams(transaction),
+        ...getBlockaidTransactionMetricsParams(transaction),
       },
     );
   };
@@ -1186,7 +1186,7 @@ class ApproveTransactionReview extends PureComponent {
         MetaMetricsEvents.APPROVAL_PERMISSION_UPDATED,
         {
           ...this.getAnalyticsParams(),
-          ...withBlockaidMetricsParams(this.props.transaction),
+          ...getBlockaidTransactionMetricsParams(this.props.transaction),
         },
       );
       return this.setState({ isReadyToApprove: true });

--- a/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
@@ -51,7 +51,7 @@ import TransactionReviewDetailsCard from '../TransactionReview/TransactionReview
 import AppConstants from '../../../../../core/AppConstants';
 import { UINT256_HEX_MAX_VALUE } from '../../../../../constants/transaction';
 import { WALLET_CONNECT_ORIGIN } from '../../../../../util/walletconnect';
-import { getBlockaidMetricsParams } from '../../../../../util/blockaid';
+import { withBlockaidMetricsParams } from '../../../../../util/blockaid';
 import { withNavigation } from '@react-navigation/compat';
 import {
   isTestNet,
@@ -510,21 +510,6 @@ class ApproveTransactionReview extends PureComponent {
     clearInterval(intervalIdForEstimatedL1Fee);
   };
 
-  withBlockaidMetricsParams = () => {
-    let blockaidParams = {};
-
-    const { transaction } = this.props;
-    if (
-      transaction.id === transaction.currentTransactionSecurityAlertResponse?.id
-    ) {
-      blockaidParams = getBlockaidMetricsParams(
-        transaction.currentTransactionSecurityAlertResponse?.response,
-      );
-    }
-
-    return blockaidParams;
-  };
-
   getAnalyticsParams = () => {
     try {
       const { chainId, transaction, onSetAnalyticsParams } = this.props;
@@ -697,9 +682,10 @@ class ApproveTransactionReview extends PureComponent {
   };
 
   onContactUsClicked = () => {
+    const { transaction } = this.props;
     const analyticsParams = {
       ...this.getAnalyticsParams(),
-      ...this.withBlockaidMetricsParams(),
+      ...withBlockaidMetricsParams(transaction),
       external_link_clicked: 'security_alert_support_link',
     };
     this.props.metrics.trackEvent(
@@ -1177,13 +1163,13 @@ class ApproveTransactionReview extends PureComponent {
   };
 
   onCancelPress = () => {
-    const { onCancel } = this.props;
+    const { onCancel, transaction } = this.props;
     onCancel && onCancel();
     this.props.metrics.trackEvent(
       MetaMetricsEvents.APPROVAL_PERMISSION_UPDATED,
       {
         ...this.getAnalyticsParams(),
-        ...this.withBlockaidMetricsParams(),
+        ...withBlockaidMetricsParams(transaction),
       },
     );
   };
@@ -1200,7 +1186,7 @@ class ApproveTransactionReview extends PureComponent {
         MetaMetricsEvents.APPROVAL_PERMISSION_UPDATED,
         {
           ...this.getAnalyticsParams(),
-          ...this.withBlockaidMetricsParams(),
+          ...withBlockaidMetricsParams(this.props.transaction),
         },
       );
       return this.setState({ isReadyToApprove: true });

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -10,11 +10,11 @@ import { NETWORKS_CHAIN_ID } from '../../constants/network';
 import {
   getBlockaidMetricsParams,
   isBlockaidSupportedOnCurrentChain,
-  withBlockaidMetricsParams,
+  getBlockaidTransactionMetricsParams,
 } from '.';
 
 describe('Blockaid util', () => {
-  describe('withBlockaidMetricsParams', () => {
+  describe('getBlockaidTransactionMetricsParams', () => {
     beforeEach(() => {
       jest
         .spyOn(NetworkControllerMock, 'selectChainId')
@@ -41,7 +41,7 @@ describe('Blockaid util', () => {
           },
         },
       };
-      const result = withBlockaidMetricsParams(transaction);
+      const result = getBlockaidTransactionMetricsParams(transaction);
       expect(result).toStrictEqual({});
     });
 
@@ -62,7 +62,7 @@ describe('Blockaid util', () => {
         },
       };
 
-      const result = withBlockaidMetricsParams(transaction);
+      const result = getBlockaidTransactionMetricsParams(transaction);
       expect(result).toEqual({
         ui_customizations: ['flagged_as_malicious'],
         security_alert_response: ResultType.Malicious,

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -84,8 +84,12 @@ export const getBlockaidTransactionMetricsParams = (
 ) => {
   let blockaidParams = {};
 
+  if (!transaction) {
+    return blockaidParams;
+  }
+
   if (
-    transaction?.id === transaction?.currentTransactionSecurityAlertResponse?.id
+    transaction.id === transaction?.currentTransactionSecurityAlertResponse?.id
   ) {
     blockaidParams = getBlockaidMetricsParams(
       transaction.currentTransactionSecurityAlertResponse?.response,

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -5,6 +5,17 @@ import {
 import { BLOCKAID_SUPPORTED_CHAIN_IDS, getDecimalChainId } from '../networks';
 import { store } from '../../store';
 import { selectChainId } from '../../selectors/networkController';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+
+interface TransactionSecurityAlertResponseType {
+  currentTransactionSecurityAlertResponse: {
+    id: string;
+    response: SecurityAlertResponse;
+  };
+}
+
+export type TransactionType = TransactionMeta &
+  TransactionSecurityAlertResponseType;
 
 export const isSupportedChainId = (chainId: string) => {
   /**
@@ -68,11 +79,13 @@ export const getBlockaidMetricsParams = (
   return additionalParams;
 };
 
-export const withBlockaidMetricsParams = (transaction: any) => {
+export const getBlockaidTransactionMetricsParams = (
+  transaction: TransactionType,
+) => {
   let blockaidParams = {};
 
   if (
-    transaction.id === transaction.currentTransactionSecurityAlertResponse?.id
+    transaction?.id === transaction?.currentTransactionSecurityAlertResponse?.id
   ) {
     blockaidParams = getBlockaidMetricsParams(
       transaction.currentTransactionSecurityAlertResponse?.response,

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -67,3 +67,17 @@ export const getBlockaidMetricsParams = (
 
   return additionalParams;
 };
+
+export const withBlockaidMetricsParams = (transaction: any) => {
+  let blockaidParams = {};
+
+  if (
+    transaction.id === transaction.currentTransactionSecurityAlertResponse?.id
+  ) {
+    blockaidParams = getBlockaidMetricsParams(
+      transaction.currentTransactionSecurityAlertResponse?.response,
+    );
+  }
+
+  return blockaidParams;
+};


### PR DESCRIPTION
## **Description**

We should send PPOM/Blockaid metrics parameters when a transaction from wallet is rejected. Right now we only send the metrics when the transaction is approved.

## **Related issues**

Fixes: [#8824](https://github.com/MetaMask/metamask-mobile/issues/8824)

## **Manual testing steps**

1. Enable Blockiad
2. Enable metrics
3. Initiate a malicious tx from inside the wallet
4. Cancel/Reject the transaction
5. See that PPOM Metrics is sent in the logs

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-mobile/assets/54408225/12153f52-baeb-4344-b6f6-0c00c2a1d1fc

### **After**

https://github.com/MetaMask/metamask-mobile/assets/44811/efea6aa9-96f7-4b57-915c-5fe946daabdf

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
