### PR TITLE
fix: correct `SubjectType` for origins connecting via the `BackgroundBridge`

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -387,7 +387,8 @@ export class BackgroundBridge extends EventEmitter {
         Engine.context,
         Engine.controllerMessenger,
         origin,
-        SubjectType.Snap,
+        // We assume that origins connecting through the BackgroundBridge are websites
+        SubjectType.Website,
       ),
     );
     ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
## **Description**

The `SubjectType` for origins connecting via the `BackgroundBridge` was incorrectly set to `SubjectType.Snap` for all origins. This PR corrects it to assuming that all origins are of type `SubjectType.Website`. 

This is important in order to enforce that Snap-specific RPC methods don't leak into the possession of dapps.