### PR TITLE
fix(deps): replace eth-json-rpc-errors with eth-rpc-errors

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -8,7 +8,7 @@ import {
 } from 'json-rpc-engine';
 import type { Transaction } from '@metamask/transaction-controller';
 import type { ProviderConfig } from '@metamask/network-controller';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import Engine from '../Engine';
 import { store } from '../../store';
 import { getPermittedAccounts } from '../Permissions';
@@ -576,10 +576,12 @@ describe('getRpcMethodMiddleware', () => {
 
         const response = await callMiddleware({ middleware, request });
 
-        expect((response as JsonRpcFailure).error).toStrictEqual({
-          code: expectedError.code,
-          message: expectedError.message,
-        });
+        expect((response as JsonRpcFailure).error.code).toBe(
+          expectedError.code,
+        );
+        expect((response as JsonRpcFailure).error.message).toBe(
+          expectedError.message,
+        );
       });
 
       it('returns a JSON-RPC error if the site does not have permission to use the referenced account', async () => {
@@ -615,10 +617,12 @@ describe('getRpcMethodMiddleware', () => {
 
         const response = await callMiddleware({ middleware, request });
 
-        expect((response as JsonRpcFailure).error).toStrictEqual({
-          code: expectedError.code,
-          message: expectedError.message,
-        });
+        expect((response as JsonRpcFailure).error.code).toBe(
+          expectedError.code,
+        );
+        expect((response as JsonRpcFailure).error.message).toBe(
+          expectedError.message,
+        );
       });
     });
 
@@ -686,10 +690,12 @@ describe('getRpcMethodMiddleware', () => {
 
         const response = await callMiddleware({ middleware, request });
 
-        expect((response as JsonRpcFailure).error).toStrictEqual({
-          code: expectedError.code,
-          message: expectedError.message,
-        });
+        expect((response as JsonRpcFailure).error.code).toBe(
+          expectedError.code,
+        );
+        expect((response as JsonRpcFailure).error.message).toBe(
+          expectedError.message,
+        );
       });
     });
 
@@ -759,10 +765,12 @@ describe('getRpcMethodMiddleware', () => {
 
         const response = await callMiddleware({ middleware, request });
 
-        expect((response as JsonRpcFailure).error).toStrictEqual({
-          code: expectedError.code,
-          message: expectedError.message,
-        });
+        expect((response as JsonRpcFailure).error.code).toBe(
+          expectedError.code,
+        );
+        expect((response as JsonRpcFailure).error.message).toBe(
+          expectedError.message,
+        );
       });
     });
 

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -4,7 +4,7 @@ import {
   createAsyncMiddleware,
   JsonRpcEngineCallbackError,
 } from 'json-rpc-engine';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import {
   EndFlowOptions,
   StartFlowOptions,

--- a/app/core/RPCMethods/eth_sendTransaction.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.ts
@@ -3,7 +3,7 @@ import {
   TransactionController,
   WalletDevice,
 } from '@metamask/transaction-controller';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import ppomUtil from '../../lib/ppom/ppom-util';
 
 /**

--- a/app/core/RPCMethods/wallet_addEthereumChain.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.js
@@ -3,7 +3,7 @@ import validUrl from 'valid-url';
 import { ChainId, isSafeChainId } from '@metamask/controller-utils';
 import { jsonRpcRequest } from '../../util/jsonRpcRequest';
 import Engine from '../Engine';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import {
   getDecimalChainId,
   isPrefixedFormattedHexString,

--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -1,5 +1,5 @@
 import { InteractionManager } from 'react-native';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import wallet_addEthereumChain from './wallet_addEthereumChain';
 import Engine from '../Engine';
 

--- a/app/core/RPCMethods/wallet_switchEthereumChain.js
+++ b/app/core/RPCMethods/wallet_switchEthereumChain.js
@@ -1,5 +1,5 @@
 import Engine from '../Engine';
-import { ethErrors } from 'eth-json-rpc-errors';
+import { ethErrors } from 'eth-rpc-errors';
 import {
   getDecimalChainId,
   getDefaultNetworkByChainId,

--- a/app/declarations.d.ts
+++ b/app/declarations.d.ts
@@ -30,8 +30,6 @@ declare module '*.png' {
   export default content;
 }
 
-// TODO: eth-json-rpc-errors does not contain types. May want to create our own types.
-declare module 'eth-json-rpc-errors';
 declare module '@react-native-community/checkbox' {
   import CheckBoxOriginal from '@react-native-community/checkbox';
 

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "eciesjs": "^0.3.15",
     "eth-block-tracker": "^7.0.1",
     "eth-ens-namehash": "2.0.8",
-    "eth-json-rpc-errors": "^2.0.2",
     "eth-json-rpc-filters": "4.2.2",
     "eth-json-rpc-infura": "5.1.0",
     "eth-json-rpc-middleware": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15570,13 +15570,6 @@ eth-json-rpc-errors@^1.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-errors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
-  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
-  dependencies:
-    fast-safe-stringify "^2.0.6"
-
 eth-json-rpc-filters@4.2.2, eth-json-rpc-filters@^4.2.1:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.2.tgz#eb35e1dfe9357ace8a8908e7daee80b2cd60a10d"


### PR DESCRIPTION

## **Description**

`eth-json-rpc-errors` was renamed to `eth-rpc-errors` in 2020.

metamask-mobile is still pulling in both packages. This removes deprecated `eth-json-rpc-errors` and replaces references with `eth-rpc-errors`.

## **Related issues**


## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
