### PR TITLE
fix:  e2e test permission problem

### DIFF
--- a/e2e/init.js
+++ b/e2e/init.js
@@ -7,5 +7,6 @@ import Utilities from './utils/Utilities';
 beforeAll(async () => {
   device.appLaunchArgs.modify({
     detoxURLBlacklistRegex: Utilities.BlacklistURLs,
+    permissions: { notifications: 'YES' },
   });
 });


### PR DESCRIPTION
## **Description**

This PR adds a permission flag on e2e init file so that Notification native dialog don't shows up.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
