### PR TITLE
chore: add strings to en.json for smart transactions

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -924,7 +924,10 @@
     "blockaid": "Blockaid",
     "blockaid_desc": "Privacy preserving - no data is shared with third parties. Available on Arbitrum, Avalanche, BNB chain, Ethereum Mainnet, Optimism, Polygon, Sepolia and Base.",
     "security_alerts": "Security alerts",
-    "security_alerts_desc": "This feature alerts you to malicious activity by locally reviewing your transaction and signature requests. Always do your own due diligence before approving any requests. There's no guarantee that this feature will detect all malicious activity. By enabling this feature you agree to the provider's terms of use."
+    "security_alerts_desc": "This feature alerts you to malicious activity by locally reviewing your transaction and signature requests. Always do your own due diligence before approving any requests. There's no guarantee that this feature will detect all malicious activity. By enabling this feature you agree to the provider's terms of use.",
+    "smart_transactions_opt_in_heading": "Smart Transactions",
+    "smart_transactions_opt_in_desc": "Turn on Smart Transactions for more reliable and secure transactions, and adjustable fees on ETH Mainnet.",
+    "smart_transactions_learn_more": "Learn more."
   },
   "sdk": {
     "disconnect_title": "Disconnect all sites?",
@@ -1462,6 +1465,29 @@
     "sign_description_2": "tap on Get Signature",
     "sign_get_signature": "Get Signature",
     "network_fee": "Network Fee"
+  },
+  "smart_transactions": {
+    "status_submitting_header": "Submitting your transaction",
+    "status_submitting_description": "Estimated completion {{timeLeft}}",
+    
+    "status_success_header": "Your transaction is complete",
+
+    "status_submitting_past_estimated_deadline_header": "Sorry for the wait",
+    "status_submitting_past_estimated_deadline_description": "If your transaction is not finalized within {{timeLeft}}, it will be canceled and you will not be charged for gas.",
+    
+    "status_cancelled_header": "Your transaction was canceled",
+    "status_cancelled_description": "Your transaction couldn't be completed, so it was canceled to save you from paying unnecessary gas fees.",
+    
+    "status_failed_header": "Your transaction failed",
+    "status_failed_description": "Sudden market changes can cause failures. If the problem continues, reach out to MetaMask customer support.",
+    
+    "view_transaction": "View transaction",
+    "view_activity": "View activity",
+    "return_to_dapp": "Return to {{dappName}}",
+    "try_again": "Try again",
+    "create_new": "Create new {{txType}}",
+    "swap": "swap",
+    "send": "send"
   },
   "address_book": {
     "recents": "Recents",
@@ -2488,6 +2514,21 @@
       "title": "Cashing out made easy",
       "description": "Sell your crypto directly in MetaMask! We’ll help you find quotes from trusted providers, so you can sell your crypto in an accessible, fast, and secure way, every time.",
       "action_text": "Try it out"
+    },
+    "stx": {
+      "header": "Introducing Smart Transactions",
+      "description_1": "Unlock the safest, most reliable, and easiest transaction experience - a smarter way to navigate web3.",
+      "description_2": "Millions of dollars are lost every month due to failed transactions & frontrunning. Smart transactions fixes this.",
+      "description_3": "Right now, Smart Transactions are only available on ETH Mainnet. You can turn them off at any time in settings.",
+      "secondary_button": "Not right now",
+      "primary_button": "Enable Smart Transactions",
+      "learn_more": "Learn more.",
+      "benefit_1_1": "82% fewer failed",
+      "benefit_1_2": "transactions",
+      "benefit_2_1": "Transaction",
+      "benefit_2_2": "protection",
+      "benefit_3_1": "Real-time",
+      "benefit_3_2": "updates"
     }
   },
   "invalid_network": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds a number of strings to `en.json` for Smart Transactions, which will come out in a separate PR. I've split the much larger PR into smaller pieces to improve reviewer experience and readability.


## **Related issues**

The much larger PR these changes have been picked from: https://github.com/MetaMask/metamask-mobile/pull/9315

Fixes: n/a

## **Manual testing steps**

n/a

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
n/a

### **After**

<!-- [screenshots/recordings] -->
n/a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
