### PR TITLE
chore: Enable verbose logs for restore-cache

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -517,6 +517,7 @@ workflows:
           title: Restore CCache
           inputs:
             - key: '{{ getenv "CCACHE_KEY" }}'
+            - verbose: true
       - script@1:
           title: Set skip ccache upload
           run_if: '{{ enveq "BITRISE_CACHE_HIT" "exact" }}'
@@ -528,6 +529,7 @@ workflows:
           title: Restore build from cache
           inputs:
             - key: apk-cache-{{ .CommitHash }}
+            - verbose: true
       - script@1:
           title: Run detox build
           run_if: '{{ not (enveq "BITRISE_CACHE_HIT" "exact") }}'
@@ -551,17 +553,20 @@ workflows:
           run_if: '{{not (enveq "SKIP_CCACHE_UPLOAD" "true")}}'
           inputs:
             - key: '{{ getenv "CCACHE_KEY" }}'
+            - verbose: true
             - paths: |-
                 ccache
       - save-cache@1:
           title: Save build
           inputs:
             - key: apk-cache-{{ .CommitHash }}
+            - verbose: true
             - paths: android/app/build/outputs
       - save-cache@1:
           title: Save node_modules
           inputs:
             - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ .CommitHash }}
+            - verbose: true
             - paths: node_modules
     meta:
       bitrise.io:
@@ -579,10 +584,12 @@ workflows:
           title: Restore cache build
           inputs:
             - key: apk-cache-{{ .CommitHash }}
+            - verbose: true
       - restore-cache@2:
           title: Restore cache node_modules
           inputs:
             - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ .CommitHash }}
+            - verbose: true
       - script@1:
           title: Download cmake 3.22.1 with sdkmanager
           is_always_run: false
@@ -692,6 +699,7 @@ workflows:
           title: Restore CCache
           inputs:
             - key: '{{ getenv "CCACHE_KEY" }}'
+            - verbose: true
       - script@1:
           title: Set skip ccache upload
           run_if: '{{ enveq "BITRISE_CACHE_HIT" "exact" }}'
@@ -703,6 +711,7 @@ workflows:
           title: Restore build from cache
           inputs:
             - key: ipa-cache-{{ .CommitHash }}
+            - verbose: true
       - script@1:
           title: Run detox build
           run_if: '{{ not (enveq "BITRISE_CACHE_HIT" "exact") }}'
@@ -726,12 +735,14 @@ workflows:
           run_if: '{{not (enveq "SKIP_CCACHE_UPLOAD" "true")}}'
           inputs:
             - key: '{{ getenv "CCACHE_KEY" }}'
+            - verbose: true
             - paths: |-
                 ccache
       - save-cache@1:
           title: Save build
           inputs:
             - key: ipa-cache-{{ .CommitHash }}
+            - verbose: true
             - paths: |-
                 ios/build/Build
                 ../Library/Detox/ios
@@ -739,6 +750,7 @@ workflows:
           title: Save node_modules
           inputs:
             - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ .CommitHash }}
+            - verbose: true
             - paths: node_modules
   ios_e2e_test:
     before_run:
@@ -751,11 +763,13 @@ workflows:
           title: Restore cache build
           inputs:
             - key: ipa-cache-{{ .CommitHash }}
+            - verbose: true
       - restore-cocoapods-cache@2: {}
       - restore-cache@2:
           title: Restore cache node_modules
           inputs:
             - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ .CommitHash }}
+            - verbose: true
       - certificate-and-profile-installer@1: {}
       - set-xcode-build-number@1:
           inputs:


### PR DESCRIPTION
## **Description**

The `save-cache` and `restore-cache` steps now have verbose logs enabled anywhere they are used in our workflows. The verbose logs are meant to assist with debugging issue #9345

## **Related issues**

Relates to #9345

## **Manual testing steps**

Trigger a Bitrise run, then look at the "Save cache" and "Restore cache" steps to ensure verbose logging is enabled (`verbose` is a step input, it's printed each time the step is run)

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
