### PR TITLE
fix(translations): Fix hard coded repo name left from testing in diff repo

### DIFF
--- a/.github/workflows/crowdin-pull-branch-pr-completed-translations.yml
+++ b/.github/workflows/crowdin-pull-branch-pr-completed-translations.yml
@@ -40,9 +40,10 @@ jobs:
         id: get-branches
         run: |
           GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          REPO="${{ github.repository }}"
           
           LABEL="ready-for-translation"
-          API_URL="https://api.github.com/repos/Metamask/crowdin-sandbox/pulls?state=open&per_page=100"
+          API_URL="https://api.github.com/repos/$REPO/pulls?state=open&per_page=100"
           
           # Fetch the list of open pull requests with the specified label using curl
           PRS=$(curl -sS --header "Authorization: Bearer $GITHUB_TOKEN" "$API_URL")


### PR DESCRIPTION
## **Description**

Testing is being done via another repo and I accidentally brought over a hard coded url from that repo. :( 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Manual tested in other repo
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
