### PR TITLE
chore: remove jetify step in setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -461,7 +461,6 @@
     "improved-yarn-audit": "^3.0.0",
     "jest": "^29.7.0",
     "jest-junit": "^15.0.0",
-    "jetifier": "2.0.0",
     "koa": "^2.14.2",
     "lint-staged": "10.5.4",
     "listr2": "^8.0.2",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -146,12 +146,6 @@ const patchModulesTask = {
       }
     },
     {
-      title: 'Jetify',
-      task: async () => {
-        await $`yarn jetify`;
-      }
-    },
-    {
       title: 'Patch npm packages',
       task: async () => {
         await $`yarn patch-package`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20856,11 +20856,6 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-jetifier@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-2.0.0.tgz#699391367ca1fe7bc4da5f8bf691eb117758e4cb"
-  integrity sha512-J4Au9KuT74te+PCCCHKgAjyLlEa+2VyIAEPNCdE5aNkAJ6FAJcAqcdzEkSnzNksIa9NkGmC4tPiClk2e7tCJuQ==
-
 jimp@^0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.5.6.tgz#dd114decd060927ae439f2e0980df619c179f912"


### PR DESCRIPTION
## **Description**

From jetifier [README](https://github.com/mikehardy/jetifier?tab=readme-ov-file#do-not-use-this-obsolete-package):

> DO NOT USE THIS OBSOLETE PACKAGE
> No one should be using non-AndroidX libraries at this point, and thus no one should be using this utility any more at this point
> Specifically: you should already use the --no-jetifier command line option for react-native build so this does not even run, and if you still have dependencies that need it, you should go make a PR in their repo so jetifier is no longer in the dependency list

> Note that jetifier is included and ran automatically with [react-native-community/cli](https://github.com/react-native-community/cli) for React Native versions 0.60 and above, so you do not need to install and run jetifier manually.

## **Related issues**
- #9364 

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**
n/a

### **After**
n/a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
