### PR TITLE
fix: include blockaid parameters in metrics of send flow

### DIFF
--- a/app/components/Views/confirmations/Send/index.js
+++ b/app/components/Views/confirmations/Send/index.js
@@ -48,6 +48,7 @@ import {
 
 import { KEYSTONE_TX_CANCELED } from '../../../../constants/error';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
+import { getBlockaidTransactionMetricsParams } from '../../../../util/blockaid';
 import {
   selectChainId,
   selectProviderType,
@@ -686,6 +687,7 @@ class Send extends PureComponent {
   getTrackingParams = () => {
     const {
       networkType,
+      transaction,
       transaction: { selectedAsset, assetType },
     } = this.props;
 
@@ -697,6 +699,7 @@ class Send extends PureComponent {
           (selectedAsset.symbol || selectedAsset.contractName)) ||
         'ETH',
       assetType,
+      ...getBlockaidTransactionMetricsParams(transaction),
     };
   };
 

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -395,11 +395,6 @@ class Confirm extends PureComponent {
     this.setState({
       pollToken,
     });
-    // For analytics
-    this.props.metrics.trackEvent(
-      MetaMetricsEvents.SEND_TRANSACTION_STARTED,
-      this.getAnalyticsParams(),
-    );
 
     showCustomNonce && (await this.setNetworkNonce());
     navigation.setParams({ providerType, isPaymentRequest });
@@ -443,6 +438,15 @@ class Confirm extends PureComponent {
 
       ppomUtil.validateRequest(reqObject, id);
     }
+
+    // For analytics
+    this.props.metrics.trackEvent(MetaMetricsEvents.SEND_TRANSACTION_STARTED, {
+      ...this.getAnalyticsParams(),
+      ...getBlockaidTransactionMetricsParams({
+        ...this.props.transaction,
+        id: transactionMeta.id,
+      }),
+    });
   };
 
   componentDidUpdate = (prevProps, prevState) => {

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -395,6 +395,11 @@ class Confirm extends PureComponent {
     this.setState({
       pollToken,
     });
+    // For analytics
+    this.props.metrics.trackEvent(
+      MetaMetricsEvents.SEND_TRANSACTION_STARTED,
+      this.getAnalyticsParams(),
+    );
 
     showCustomNonce && (await this.setNetworkNonce());
     navigation.setParams({ providerType, isPaymentRequest });
@@ -438,15 +443,6 @@ class Confirm extends PureComponent {
 
       ppomUtil.validateRequest(reqObject, id);
     }
-
-    // For analytics
-    this.props.metrics.trackEvent(MetaMetricsEvents.SEND_TRANSACTION_STARTED, {
-      ...this.getAnalyticsParams(),
-      ...getBlockaidTransactionMetricsParams({
-        ...this.props.transaction,
-        id: transactionMeta.id,
-      }),
-    });
   };
 
   componentDidUpdate = (prevProps, prevState) => {


### PR DESCRIPTION
## **Description**
Include blockaid data in metrics on send from inside the app.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/8824

## **Manual testing steps**

1. Submit a transaction to a malicious address, ensure that error is reported by blockaid
2. Check that the send metrics events include blockaid results

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
