### PR TITLE
chore(iyarc): remove resolved audit advisory

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,2 +1,0 @@
-# ReDoS vulnerability, no impact to this application, and fix not backported yet to the versions we use
-GHSA-c2qf-rxjj-qqgw


### PR DESCRIPTION
## **Description**

It's not obvious to me how/why, but judging by CI results, apparently GHSA-c2qf-rxjj-qqgw (semver ReDos) is no longer present as of #9379? 

[`audit:ci` on `main`](https://github.com/MetaMask/metamask-mobile/actions/runs/8891839021/job/24414693621):
```
yarn run v1.22.22
$ ./scripts/yarn-audit.sh
$ /home/runner/work/metamask-mobile/metamask-mobile/node_modules/.bin/improved-yarn-audit --ignore-dev-deps --min-severity moderate --fail-on-missing-exclusions
Improved Yarn Audit - v3.0.0

Reading excluded advisories from .iyarc
Minimum severity level to report: moderate
Excluded Advisories: ["GHSA-c2qf-rxjj-qqgw"]

Running yarn audit...

Found 0 vulnerabilities

Run `yarn audit` for more information

WARNING: One or more excluded audit advisories were missing from yarn audit output: GHSA-c2qf-rxjj-qqgw
ERROR: --fail-on-missing-exclusions/-f was specified, exit code will indicate number of missing exclusions
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
{"type":"warning","data":"Resolution field \"react-native-ble-plx@3.1.2\" is incompatible with requested version \"react-native-ble-plx@2.0.3\""}
{"type":"warning","data":"Resolution field \"crypto-js@4.2.0\" is incompatible with requested version \"crypto-js@^3.1.4\""}
{"type":"warning","data":"Resolution field \"d3-color@3.1.0\" is incompatible with requested version \"d3-color@1\""}
{"type":"warning","data":"Resolution field \"d3-color@3.1.0\" is incompatible with requested version \"d3-color@1\""}
{"type":"warning","data":"Resolution field \"tough-cookie@4.1.3\" is incompatible with requested version \"tough-cookie@~2.5.0\""}
{"type":"warning","data":"Resolution field \"tough-cookie@4.1.3\" is incompatible with requested version \"tough-cookie@^2.3.3\""}
{"type":"warning","data":"Resolution field \"minimist@1.2.6\" is incompatible with requested version \"minimist@0.0.8\""}
✘ Audit shows 0 moderate or high severity advisories _in the production dependencies_
error Command failed with exit code 1.
```

## **Related issues**

- #9379 

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
