### PR TITLE
fix: fix regression tests

### DIFF
--- a/e2e/pages/Settings/NetworksView.js
+++ b/e2e/pages/Settings/NetworksView.js
@@ -88,6 +88,10 @@ class NetworkView {
     return Matchers.getElementByLabel(NetworkViewSelectorsText.BLOCK_EXPLORER);
   }
 
+  get chainIdLabel() {
+    return Matchers.getElementByLabel(NetworkViewSelectorsText.CHAIN_ID_LABEL);
+  }
+
   get rpcWarningBanner() {
     return Matchers.getElementByID(NetworksViewSelectorsIDs.RPC_WARNING_BANNER);
   }
@@ -169,7 +173,7 @@ class NetworkView {
 
   async swipeToRPCTitleAndDismissKeyboard() {
     // Because in bitrise the keyboard is blocking the "Add" CTA
-    await Gestures.waitAndTap(this.blockExplorer);
+    await Gestures.waitAndTap(this.chainIdLabel);
   }
 }
 

--- a/e2e/selectors/Settings/NetworksView.selectors.js
+++ b/e2e/selectors/Settings/NetworksView.selectors.js
@@ -22,6 +22,7 @@ export const NetworksViewSelectorsIDs = {
 
 export const NetworkViewSelectorsText = {
   BLOCK_EXPLORER: enContent.app_settings.network_block_explorer_label,
+  CHAIN_ID_LABEL: enContent.app_settings.network_chain_id_label,
   REMOVE_NETWORK: enContent.app_settings.remove_network,
   CUSTOM_NETWORK_TAB: enContent.app_settings.custom_network_name,
   POPULAR_NETWORK_TAB: enContent.app_settings.popular,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR will fix the regression tests

**The issue arose because the keyboard obscured the block explorer label, which we typically click on to dismiss the keyboard and reveal the add button. To resolve this, we opted to click on the chainId label instead.**

check the regression tests [here](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/4e5bafba-ccb2-4fdf-9c50-769b9c4c6e1d?tab=workflows)

## **Related issues**

Fixes: [#9513](https://github.com/MetaMask/metamask-mobile/issues/9513)

## **Manual testing steps**

1. Go to bitruse
2. Run regression tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
