### PR TITLE
chore: change --skip-ios to --build-ios

### DIFF
--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -118,11 +118,7 @@ const gemInstallTask = {
         if (!BUILD_IOS) {
           return gemInstallTask.skip('Skipping iOS.')
         }
-        try {
-          await $`bundle install`;
-        } catch (error) {
-          throw new Error(error);
-        }
+        await $`bundle install`;
       },
     },
   ], {
@@ -141,11 +137,7 @@ const mainSetupTask = {
         if (!BUILD_IOS) {
           return podInstallTask.skip('Skipping iOS.')
         }
-        try {
-          await $`bundle exec pod install --project-directory=ios`;
-        } catch (error) {
-          throw new Error(error);
-        }
+        await $`bundle exec pod install --project-directory=ios`;
       },
     },
     {


### PR DESCRIPTION
## **Description**

- Change `setup.mjs` cli flag from `--skip-ios` to `--build-ios`
  - In the future, this can be extended to allow also setting `--build-ios=false`, `--build-andriod[=(true|false)]` 
- Simplify ios build skip logic
- `brew install` seems actually OS-specific, not build-target specific

## **Related issues**

- Targeting #9231 

## **Manual testing steps**

1. Run `yarn setup`
2. Run `yarn setup --build-ios`

## **Screenshots/Recordings**


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
