### PR TITLE
chore: Accounts/PreferencesController state syncing

### DIFF
--- a/app/components/UI/AccountOverview/index.js
+++ b/app/components/UI/AccountOverview/index.js
@@ -245,7 +245,10 @@ class AccountOverview extends PureComponent {
     });
 
     if (!this.isAccountLabelDefined(accountLabel)) {
-      Engine.setAccountLabel(selectedAddress, 'Account');
+      Engine.context.PreferencesController.setAccountLabel(
+        selectedAddress,
+        'Account',
+      );
     }
   };
 
@@ -266,7 +269,7 @@ class AccountOverview extends PureComponent {
 
     const lastAccountLabel = identities[selectedAddress].name;
 
-    Engine.setAccountLabel(
+    Engine.context.PreferencesController.setAccountLabel(
       selectedAddress,
       this.isAccountLabelDefined(accountLabel)
         ? accountLabel

--- a/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
+++ b/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
@@ -114,7 +114,6 @@ const AccountSelectorList = ({
                 nextActiveAddress = accounts[nextActiveIndex]?.address;
               }
               // Switching accounts on the PreferencesController must happen before account is removed from the KeyringController, otherwise UI will break.
-              // If needed, place Engine.setSelectedAddress in onRemoveImportedAccount callback.
               onRemoveImportedAccount?.({
                 removedAddress: address,
                 nextActiveAddress,

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -65,7 +65,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   const _onSelectAccount = useCallback(
     (address: string) => {
-      Engine.setSelectedAddress(address);
+      Engine.context.PreferencesController.setSelectedAddress(address);
       sheetRef.current?.onCloseBottomSheet();
       onSelectAccount?.(address);
 
@@ -80,7 +80,10 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   const onRemoveImportedAccount = useCallback(
     ({ nextActiveAddress }: { nextActiveAddress: string }) => {
-      nextActiveAddress && Engine.setSelectedAddress(nextActiveAddress);
+      nextActiveAddress &&
+        Engine.context.PreferencesController.setSelectedAddress(
+          nextActiveAddress,
+        );
     },
     [Engine],
   );

--- a/app/components/Views/AddAccountActions/AddAccountActions.tsx
+++ b/app/components/Views/AddAccountActions/AddAccountActions.tsx
@@ -41,7 +41,9 @@ const AddAccountActions = ({ onBack }: AddAccountActionsProps) => {
       setIsLoading(true);
 
       const { addedAccountAddress } = await KeyringController.addNewAccount();
-      Engine.setSelectedAddress(addedAccountAddress);
+      Engine.context.PreferencesController.setSelectedAddress(
+        addedAccountAddress,
+      );
       trackEvent(MetaMetricsEvents.ACCOUNTS_ADDED_NEW_ACCOUNT, {});
     } catch (e: any) {
       Logger.error(e, 'error while trying to add a new account');

--- a/app/components/Views/ConnectQRHardware/index.tsx
+++ b/app/components/Views/ConnectQRHardware/index.tsx
@@ -211,7 +211,9 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
     // removedAccounts and remainingAccounts are not checksummed here.
     const { removedAccounts, remainingAccounts } =
       await KeyringController.forgetQRDevice();
-    Engine.setSelectedAddress(remainingAccounts[remainingAccounts.length - 1]);
+    Engine.context.PreferencesController.setSelectedAddress(
+      remainingAccounts[remainingAccounts.length - 1],
+    );
     const checksummedRemovedAccounts = removedAccounts.map(
       safeToChecksumAddress,
     );

--- a/app/components/Views/EditAccountName/EditAccountName.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.tsx
@@ -84,7 +84,10 @@ const EditAccountName = () => {
 
   const saveAccountName = async () => {
     if (accountName && accountName.length > 0) {
-      Engine.setAccountLabel(selectedAddress, accountName);
+      Engine.context.PreferencesController.setAccountLabel(
+        selectedAddress,
+        accountName,
+      );
       navigate('WalletView');
 
       try {

--- a/app/components/hooks/useAccounts/useAccounts.ts
+++ b/app/components/hooks/useAccounts/useAccounts.ts
@@ -60,6 +60,33 @@ const useAccounts = ({
     selectIsMultiAccountBalancesEnabled,
   );
 
+  // TODO remove this useEffect before merging
+  useEffect(() => {
+    const id =
+      Engine.context.AccountsController.state.internalAccounts.selectedAccount;
+    const selectedAccount =
+      Engine.context.AccountsController.state.internalAccounts.accounts[id];
+    // eslint-disable-next-line no-console
+    console.log(
+      'Accounts/ AccountController',
+      JSON.stringify(selectedAccount, null, 2),
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      'Accounts/ PreferencesController',
+      JSON.stringify(
+        Engine.context.PreferencesController.state.selectedAddress,
+        null,
+        2,
+      ),
+    );
+  }, [
+    Engine.context.AccountsController.state,
+    Engine.context.PreferencesController.identities,
+    Engine.context.PreferencesController.state.identities,
+    Engine.context.PreferencesController.state.selectedAddress,
+  ]);
+
   const fetchENSNames = useCallback(
     async ({
       flattenedAccounts,

--- a/app/core/Accounts/accountsSync.test.ts
+++ b/app/core/Accounts/accountsSync.test.ts
@@ -92,7 +92,6 @@ describe('syncSelectedAddress', () => {
         },
       },
       selectedAddress: MOCK_ADDRESS,
-      // other properties...
     } as any;
 
     const mockAccountsController = {
@@ -124,7 +123,6 @@ describe('syncSelectedAddress', () => {
         },
       },
       selectedAddress: MOCK_ADDRESS_1,
-      // other properties...
     } as any;
 
     const mockAccountsController = {

--- a/app/core/Accounts/accountsSync.test.ts
+++ b/app/core/Accounts/accountsSync.test.ts
@@ -1,0 +1,216 @@
+import {
+  AccountsController,
+  AccountsControllerState,
+} from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import {
+  PreferencesController,
+  PreferencesState,
+} from '@metamask/preferences-controller';
+import { syncSelectedAddress, syncAccountName } from './accountsSync';
+
+const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+const MOCK_ADDRESS_1 = '0x1234567890abcdef1234567890abcdef12345678';
+const MOCK_ADDRESS_1_CHECKSUMMED = toChecksumHexAddress(MOCK_ADDRESS_1);
+
+const mockAccountsControllerState: AccountsControllerState = {
+  internalAccounts: {
+    accounts: {
+      '30313233-3435-4637-b839-383736353430': {
+        address: MOCK_ADDRESS,
+        id: '30313233-3435-4637-b839-383736353430',
+        options: {},
+        metadata: {
+          name: 'Account 1',
+          keyring: {
+            type: 'HD Key Tree',
+          },
+        },
+        methods: [
+          'personal_sign',
+          'eth_sign',
+          'eth_signTransaction',
+          'eth_signTypedData_v1',
+          'eth_signTypedData_v3',
+          'eth_signTypedData_v4',
+        ],
+        type: 'eip155:eoa',
+      },
+    },
+    selectedAccount: '30313233-3435-4637-b839-383736353430',
+  },
+};
+
+describe('syncSelectedAddress', () => {
+  it('should update the selected address if different', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'Account 1',
+        },
+        [MOCK_ADDRESS_1]: {
+          address: MOCK_ADDRESS_1,
+          name: 'New Account',
+        },
+      },
+      selectedAddress: MOCK_ADDRESS_1,
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      getAccountByAddress: jest
+        .fn()
+        .mockReturnValue({ id: 'account-2', address: MOCK_ADDRESS_1 }),
+      setSelectedAccount: jest.fn(),
+    } as unknown as AccountsController;
+
+    const mockPreferencesController = {
+      setSelectedAddress: jest.fn(),
+    } as unknown as PreferencesController;
+
+    syncSelectedAddress(
+      preferencesState,
+      () => mockAccountsController,
+      () => mockPreferencesController,
+    );
+
+    expect(mockAccountsController.setSelectedAccount).toHaveBeenCalledWith(
+      'account-2',
+    );
+    expect(mockPreferencesController.setSelectedAddress).toHaveBeenCalledWith(
+      MOCK_ADDRESS_1,
+    );
+  });
+
+  it('should not update the selected address if the same', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'Account 1',
+        },
+      },
+      selectedAddress: MOCK_ADDRESS,
+      // other properties...
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      getAccountByAddress: jest.fn(),
+      setSelectedAccount: jest.fn(),
+    } as unknown as AccountsController;
+
+    const mockPreferencesController = {
+      setSelectedAddress: jest.fn(),
+    } as unknown as PreferencesController;
+
+    syncSelectedAddress(
+      preferencesState,
+      () => mockAccountsController,
+      () => mockPreferencesController,
+    );
+
+    expect(mockAccountsController.setSelectedAccount).not.toHaveBeenCalled();
+    expect(mockPreferencesController.setSelectedAddress).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error if the account is not found', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'Account 1',
+        },
+      },
+      selectedAddress: MOCK_ADDRESS_1,
+      // other properties...
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      getAccountByAddress: jest.fn().mockReturnValue(undefined),
+      setSelectedAccount: jest.fn(),
+    } as unknown as AccountsController;
+
+    const mockPreferencesController = {
+      setSelectedAddress: jest.fn(),
+    } as unknown as PreferencesController;
+
+    expect(() => {
+      syncSelectedAddress(
+        preferencesState,
+        () => mockAccountsController,
+        () => mockPreferencesController,
+      );
+    }).toThrow(`Account not found for address: ${MOCK_ADDRESS_1_CHECKSUMMED}`);
+  });
+});
+
+describe('syncAccountName', () => {
+  it('should update the account name if different', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'New Name',
+        },
+      },
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      setAccountName: jest.fn(),
+    } as unknown as AccountsController;
+
+    syncAccountName(preferencesState, () => mockAccountsController);
+
+    expect(mockAccountsController.setAccountName).toHaveBeenCalledWith(
+      '30313233-3435-4637-b839-383736353430',
+      'New Name',
+    );
+  });
+
+  it('should not update the account name if the same', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'Account 1',
+        },
+      },
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      setAccountName: jest.fn(),
+    } as unknown as AccountsController;
+
+    syncAccountName(preferencesState, () => mockAccountsController);
+
+    expect(mockAccountsController.setAccountName).not.toHaveBeenCalled();
+  });
+
+  it('should handle lowercase and checksummed addresses correctly', () => {
+    const preferencesState: PreferencesState = {
+      identities: {
+        [MOCK_ADDRESS]: {
+          address: MOCK_ADDRESS,
+          name: 'New Name',
+        },
+      },
+    } as any;
+
+    const mockAccountsController = {
+      state: mockAccountsControllerState,
+      setAccountName: jest.fn(),
+    } as unknown as AccountsController;
+
+    syncAccountName(preferencesState, () => mockAccountsController);
+
+    expect(mockAccountsController.setAccountName).toHaveBeenCalledWith(
+      '30313233-3435-4637-b839-383736353430',
+      'New Name',
+    );
+  });
+});

--- a/app/core/Accounts/accountsSync.ts
+++ b/app/core/Accounts/accountsSync.ts
@@ -1,0 +1,63 @@
+import { AccountsController } from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import {
+  PreferencesController,
+  PreferencesState,
+} from '@metamask/preferences-controller';
+
+export function syncSelectedAddress(
+  preferencesState: PreferencesState,
+  getAccountsController: () => AccountsController,
+  getPreferencesController: () => PreferencesController,
+) {
+  const accountsController = getAccountsController();
+  const preferencesController = getPreferencesController();
+  const selectedAddressFromPreferences = preferencesState.selectedAddress;
+  const { selectedAccount: currentAccountId, accounts: internalAccounts } =
+    accountsController.state.internalAccounts;
+  const currentSelectedAccount = internalAccounts[currentAccountId];
+
+  if (
+    toChecksumHexAddress(currentSelectedAccount.address) !==
+    toChecksumHexAddress(selectedAddressFromPreferences)
+  ) {
+    const checksumAddress = toChecksumHexAddress(
+      selectedAddressFromPreferences,
+    );
+    const account = accountsController.getAccountByAddress(
+      selectedAddressFromPreferences,
+    );
+
+    if (account) {
+      accountsController.setSelectedAccount(account.id);
+      preferencesController.setSelectedAddress(selectedAddressFromPreferences);
+    } else {
+      throw new Error(`Account not found for address: ${checksumAddress}`);
+    }
+  }
+}
+
+export function syncAccountName(
+  preferencesState: PreferencesState,
+  getAccountsController: () => AccountsController,
+) {
+  const accountsController = getAccountsController();
+
+  // Iterate over all accounts in the AccountsController
+  for (const accountId in accountsController.state.internalAccounts.accounts) {
+    const account =
+      accountsController.state.internalAccounts.accounts[accountId];
+    const checksummedAddress = account.address;
+    const lowercaseAddress = checksummedAddress.toLowerCase();
+
+    // Find the corresponding preference entry using the lowercase address
+    const preferenceEntry = Object.values(preferencesState.identities).find(
+      (identity) => identity.address.toLowerCase() === lowercaseAddress,
+    );
+
+    // If a matching preference entry is found and names are different, update the account name using setAccountLabel method
+    if (preferenceEntry && account.metadata.name !== preferenceEntry.name) {
+      accountsController.setAccountName(account.id, preferenceEntry.name);
+    }
+  }
+}

--- a/app/core/Accounts/accountsSync.ts
+++ b/app/core/Accounts/accountsSync.ts
@@ -42,20 +42,16 @@ export function syncAccountName(
   getAccountsController: () => AccountsController,
 ) {
   const accountsController = getAccountsController();
-
-  // Iterate over all accounts in the AccountsController
   for (const accountId in accountsController.state.internalAccounts.accounts) {
     const account =
       accountsController.state.internalAccounts.accounts[accountId];
     const checksummedAddress = account.address;
     const lowercaseAddress = checksummedAddress.toLowerCase();
 
-    // Find the corresponding preference entry using the lowercase address
     const preferenceEntry = Object.values(preferencesState.identities).find(
       (identity) => identity.address.toLowerCase() === lowercaseAddress,
     );
 
-    // If a matching preference entry is found and names are different, update the account name using setAccountLabel method
     if (preferenceEntry && account.metadata.name !== preferenceEntry.name) {
       accountsController.setAccountName(account.id, preferenceEntry.name);
     }

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1376,38 +1376,33 @@ class Engine {
     this.controllerMessenger.subscribe(
       'PreferencesController:stateChange',
       (preferencesState: PreferencesState) => {
-        // eslint-disable-next-line no-console
-        console.log('accounts/ sync state', preferencesState.selectedAddress);
-        const currentAccountId =
-          accountsController.state.internalAccounts.selectedAccount;
-        const currentSelectedAccount =
-          accountsController.state.internalAccounts.accounts[currentAccountId];
-
-        // Ensure selectedAddress exists in preferencesState
         const selectedAddressFromPreferences = preferencesState.selectedAddress;
+        const {
+          selectedAccount: currentAccountId,
+          accounts: internalAccounts,
+        } = accountsController.state.internalAccounts;
+        const currentSelectedAccount = internalAccounts[currentAccountId];
 
         if (
           toChecksumHexAddress(currentSelectedAccount.address) !==
           toChecksumHexAddress(selectedAddressFromPreferences)
         ) {
-          // eslint-disable-next-line no-console
-          console.log('accounts/ sync state accounts inside if');
           const checksumAddress = toChecksumHexAddress(
             selectedAddressFromPreferences,
           );
-
           const account = accountsController.getAccountByAddress(
             selectedAddressFromPreferences,
           );
+
           if (account) {
-            // eslint-disable-next-line no-console
-            console.log('accounts/ sync calling methods');
             accountsController.setSelectedAccount(account.id);
             preferencesController.setSelectedAddress(
               selectedAddressFromPreferences,
             );
           } else {
-            throw new Error(`No account found for address: ${checksumAddress}`);
+            throw new Error(
+              `Account not found for address: ${checksumAddress}`,
+            );
           }
         }
       },

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -202,6 +202,7 @@ import { SmartTransactionStatuses } from '@metamask/smart-transactions-controlle
 import { submitSmartTransactionHook } from '../util/smart-transactions/smart-publish-hook';
 import { SmartTransactionsControllerState } from '@metamask/smart-transactions-controller/dist/SmartTransactionsController';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { syncAccountName, syncSelectedAddress } from './Accounts/accountsSync';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -1376,35 +1377,12 @@ class Engine {
     this.controllerMessenger.subscribe(
       'PreferencesController:stateChange',
       (preferencesState: PreferencesState) => {
-        const selectedAddressFromPreferences = preferencesState.selectedAddress;
-        const {
-          selectedAccount: currentAccountId,
-          accounts: internalAccounts,
-        } = accountsController.state.internalAccounts;
-        const currentSelectedAccount = internalAccounts[currentAccountId];
-
-        if (
-          toChecksumHexAddress(currentSelectedAccount.address) !==
-          toChecksumHexAddress(selectedAddressFromPreferences)
-        ) {
-          const checksumAddress = toChecksumHexAddress(
-            selectedAddressFromPreferences,
-          );
-          const account = accountsController.getAccountByAddress(
-            selectedAddressFromPreferences,
-          );
-
-          if (account) {
-            accountsController.setSelectedAccount(account.id);
-            preferencesController.setSelectedAddress(
-              selectedAddressFromPreferences,
-            );
-          } else {
-            throw new Error(
-              `Account not found for address: ${checksumAddress}`,
-            );
-          }
-        }
+        syncSelectedAddress(
+          preferencesState,
+          () => accountsController,
+          () => preferencesController,
+        );
+        syncAccountName(preferencesState, () => accountsController);
       },
     );
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -201,7 +201,6 @@ import { selectSwapsChainFeatureFlags } from '../reducers/swaps';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
 import { submitSmartTransactionHook } from '../util/smart-transactions/smart-publish-hook';
 import { SmartTransactionsControllerState } from '@metamask/smart-transactions-controller/dist/SmartTransactionsController';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { syncAccountName, syncSelectedAddress } from './Accounts/accountsSync';
 
 const NON_EMPTY = 'NON_EMPTY';

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1657,32 +1657,32 @@ class Engine {
     }
   }
 
-  // This should be used instead of directly calling PreferencesController.setSelectedAddress or AccountsController.setSelectedAccount
-  setSelectedAccount(address: string) {
-    const { AccountsController, PreferencesController } = this.context;
-    const account = AccountsController.getAccountByAddress(address);
-    if (account) {
-      AccountsController.setSelectedAccount(account.id);
-      PreferencesController.setSelectedAddress(address);
-    } else {
-      throw new Error(`No account found for address: ${address}`);
-    }
-  }
+  // // This should be used instead of directly calling PreferencesController.setSelectedAddress or AccountsController.setSelectedAccount
+  // setSelectedAccount(address: string) {
+  //   const { AccountsController, PreferencesController } = this.context;
+  //   const account = AccountsController.getAccountByAddress(address);
+  //   if (account) {
+  //     AccountsController.setSelectedAccount(account.id);
+  //     PreferencesController.setSelectedAddress(address);
+  //   } else {
+  //     throw new Error(`No account found for address: ${address}`);
+  //   }
+  // }
 
-  /**
-   * This should be used instead of directly calling PreferencesController.setAccountLabel or AccountsController.setAccountName in order to keep the names in sync
-   * We are currently incrementally migrating the accounts data to the AccountsController so we must keep these values
-   * in sync until the migration is complete.
-   */
-  setAccountLabel(address: string, label: string) {
-    const { AccountsController, PreferencesController } = this.context;
-    const accountToBeNamed = AccountsController.getAccountByAddress(address);
-    if (accountToBeNamed === undefined) {
-      throw new Error(`No account found for address: ${address}`);
-    }
-    AccountsController.setAccountName(accountToBeNamed.id, label);
-    PreferencesController.setAccountLabel(address, label);
-  }
+  // /**
+  //  * This should be used instead of directly calling PreferencesController.setAccountLabel or AccountsController.setAccountName in order to keep the names in sync
+  //  * We are currently incrementally migrating the accounts data to the AccountsController so we must keep these values
+  //  * in sync until the migration is complete.
+  //  */
+  // setAccountLabel(address: string, label: string) {
+  //   const { AccountsController, PreferencesController } = this.context;
+  //   const accountToBeNamed = AccountsController.getAccountByAddress(address);
+  //   if (accountToBeNamed === undefined) {
+  //     throw new Error(`No account found for address: ${address}`);
+  //   }
+  //   AccountsController.setAccountName(accountToBeNamed.id, label);
+  //   PreferencesController.setAccountLabel(address, label);
+  // }
 }
 
 /**
@@ -1821,12 +1821,4 @@ export default {
       logErrors?: boolean;
     } = {},
   ) => instance?.rejectPendingApproval(id, reason, opts),
-  setSelectedAddress: (address: string) => {
-    assertEngineExists(instance);
-    instance.setSelectedAccount(address);
-  },
-  setAccountLabel: (address: string, label: string) => {
-    assertEngineExists(instance);
-    instance.setAccountLabel(address, label);
-  },
 };

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1692,33 +1692,6 @@ class Engine {
       }
     }
   }
-
-  // // This should be used instead of directly calling PreferencesController.setSelectedAddress or AccountsController.setSelectedAccount
-  // setSelectedAccount(address: string) {
-  //   const { AccountsController, PreferencesController } = this.context;
-  //   const account = AccountsController.getAccountByAddress(address);
-  //   if (account) {
-  //     AccountsController.setSelectedAccount(account.id);
-  //     PreferencesController.setSelectedAddress(address);
-  //   } else {
-  //     throw new Error(`No account found for address: ${address}`);
-  //   }
-  // }
-
-  // /**
-  //  * This should be used instead of directly calling PreferencesController.setAccountLabel or AccountsController.setAccountName in order to keep the names in sync
-  //  * We are currently incrementally migrating the accounts data to the AccountsController so we must keep these values
-  //  * in sync until the migration is complete.
-  //  */
-  // setAccountLabel(address: string, label: string) {
-  //   const { AccountsController, PreferencesController } = this.context;
-  //   const accountToBeNamed = AccountsController.getAccountByAddress(address);
-  //   if (accountToBeNamed === undefined) {
-  //     throw new Error(`No account found for address: ${address}`);
-  //   }
-  //   AccountsController.setAccountName(accountToBeNamed.id, label);
-  //   PreferencesController.setAccountLabel(address, label);
-  // }
 }
 
 /**

--- a/app/core/Vault.js
+++ b/app/core/Vault.js
@@ -124,7 +124,7 @@ export const recreateVaultWithNewPassword = async (
   // Reselect previous selected account if still available
   for (const keyring of recreatedKeyrings) {
     if (keyring.accounts.includes(selectedAddress.toLowerCase())) {
-      Engine.setSelectedAddress(selectedAddress);
+      Engine.context.PreferencesController.setSelectedAddress(selectedAddress);
       return;
     }
   }

--- a/app/util/address/index.js
+++ b/app/util/address/index.js
@@ -141,7 +141,9 @@ export async function importAccountFromPrivateKey(private_key) {
   const { importedAccountAddress } =
     await KeyringController.importAccountWithStrategy('privateKey', [pkey]);
   const checksummedAddress = safeToChecksumAddress(importedAccountAddress);
-  return Engine.setSelectedAddress(checksummedAddress);
+  return Engine.context.PreferencesController.setSelectedAddress(
+    checksummedAddress,
+  );
 }
 
 /**


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
The methods `Engine.setAccountLabel` and `Engine.setSelectedAddress` were added in in these two ( [one](https://github.com/MetaMask/metamask-mobile/pull/9162) and [two](https://github.com/MetaMask/metamask-mobile/pull/8759/files)) Prs. These mehtods are used to keep the shared state between the AccountsController and PreferenfesController in sync. However is not a good method since it is prone to error and requires a lot of context. This pr removes these methods in favour of automated state sync listeners.
2. What is the improvement/solution?
Listen for state change on the PreferencesController and automatically update the relevant state inside the accounts controller.
These listeners will ensure that the selected address and the account names stay in sync.  


## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/445

## **Manual testing steps**

1. create a wallet
2. open the wallet view
3. add a new account
4. the state logs should indicate this new selected address
5. the state between the preferences controller and the accounts controller should match
6. change the account's name
7. the account name should also get updated in the accounts controller.
8. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
