### PR TITLE
fix: add resolution for existing override for @metamask/controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "react-native-ble-plx": "3.1.2",
     "**/babel-runtime/regenerator-runtime": "^0.13.8",
     "@metamask/transaction-controller/@metamask/controller-utils": "^5.0.0",
+    "@metamask/swaps-controller/@metamask/controllers": "git+https://github.com/MetaMask/core.git#d4e9507d9612f2d36c3f848333b33330a19b811b",
     "xmldom": "npm:@xmldom/xmldom@0.7.13",
     "web3-provider-engine": "^16.0.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,9 +3762,9 @@
     eth-ens-namehash "^2.0.8"
     fast-deep-equal "^3.1.3"
 
-"@metamask/controllers@^26.0.0":
+"@metamask/controllers@^26.0.0", "@metamask/controllers@git+https://github.com/MetaMask/core.git#d4e9507d9612f2d36c3f848333b33330a19b811b":
   version "26.0.0"
-  resolved "git+https://github.com/MetaMask/controllers.git#d4e9507d9612f2d36c3f848333b33330a19b811b"
+  resolved "git+https://github.com/MetaMask/core.git#d4e9507d9612f2d36c3f848333b33330a19b811b"
   dependencies:
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"


### PR DESCRIPTION
## **Description**

There is a published `npm:@metamask/controllers@26.0.0`, but it is not used as of #3915 (b9245564cb857060dbfc6a3e3db0a39e8f5fdf1a).

Instead, it is overriden through the lockfile to git commit https://github.com/metaMask/core/commit/d4e9507d9612f2d36c3f848333b33330a19b811b

This does not change the package override, but adds it as a resolution to make it explicit and visible, and updates the repo name (it is the same effective git repository and commit).

The package is used by `@metamask/swaps-controller`.

## **Related issues**

- Made redundant by #9286, which removes the dependency
- Introduced in #3915

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
