### PR TITLE
fix: add eth_accounts to permission middleware

### DIFF
--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -231,6 +231,7 @@ function validateCaveatAccounts(accounts, getInternalAccounts) {
  * "method not found" error.
  */
 export const unrestrictedMethods = Object.freeze([
+  'eth_accounts',
   'eth_blockNumber',
   'eth_call',
   'eth_decrypt',


### PR DESCRIPTION


## **Description**

add eth_accounts to permission middleware

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to test dapp
2. It shouldn't appear a warning saying that eth_accounts is not permitted
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
