### PR TITLE
chore: add deprecated tag to the websiteicon component

### DIFF
--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -32,6 +32,10 @@ const createStyles = (colors) =>
 /**
  * View that renders a website logo depending of the context
  */
+/**
+ * @deprecated This `<WebsiteIcon>` component has been deprecated, any new usage of it should use AvatarFavIcon instead:
+ * https://github.com/MetaMask/metamask-mobile/blob/55a03f3dbc70afce731f3eaf2cf95ce01eaaa5a1/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx#L1
+ */
 class WebsiteIcon extends PureComponent {
   static propTypes = {
     /**

--- a/app/components/UI/WebsiteIcon/index.js
+++ b/app/components/UI/WebsiteIcon/index.js
@@ -33,8 +33,8 @@ const createStyles = (colors) =>
  * View that renders a website logo depending of the context
  */
 /**
- * @deprecated This `<WebsiteIcon>` component has been deprecated, any new usage of it should use AvatarFavIcon instead:
- * https://github.com/MetaMask/metamask-mobile/blob/55a03f3dbc70afce731f3eaf2cf95ce01eaaa5a1/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx#L1
+ * @deprecated This `<WebsiteIcon>` component has been deprecated, any new usage of it should use Avatar with the favicon variant instead:
+ * https://github.com/MetaMask/metamask-mobile/blob/34f9da127435053a32e5f4e9c69ce8aa1e37c394/app/component-library/components/Avatars/Avatar/README.md#L1
  */
 class WebsiteIcon extends PureComponent {
   static propTypes = {


### PR DESCRIPTION
## **Description**

This PR only adds a JSDoc to add a deprecated tag to the WebsiteIcon component.

This eslint rule could also begin to be use on the future to help to show the deprecated components on the lint pipeline


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
