### PR TITLE
test: Fix flakiness caused by the notification permission dialog which caused confirmation test flakiness 

### DIFF
--- a/e2e/fixtures/fixture-helper.js
+++ b/e2e/fixtures/fixture-helper.js
@@ -156,6 +156,7 @@ export async function withFixtures(options, testSuite) {
     if (restartDevice) {
       await device.launchApp({
         delete: true,
+        permissions: { notifications: 'YES' },
         launchArgs: {
           fixtureServerPort: `${getFixturesServerPort()}`,
           detoxURLBlacklistRegex: Utilities.BlacklistURLs,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The purpose of this PR is to address sporadic test flakiness within the confirmations workflow. The test, at times, would timeout because it was unable to log into the app. Sometimes, this would result in long-running confirmation e2e workflows in Bitrise. 


### What caused the failure?
The approve-custom-erc20.spec.js and approve-default-erc20.spec.js tests assert that the submitted the txn is confirmed before making the test as passed. 

The notification dialog appears whenever a successful transaction is made. See below
![image](https://github.com/MetaMask/metamask-mobile/assets/12821081/4ef9a49f-6b3b-4585-89b6-09af440c16b8)

Unfortunately, the system dialog lingers on the simulator. 


Whenever new tests run on the simulator, the system dialog prevents the tests from moving forward.  See the below screenshot:

![image](https://github.com/MetaMask/metamask-mobile/assets/12821081/77b0ec94-f42e-4169-a280-137ecac364cf)


### Solution 

The solution is to set the notifications permission to true. This will prevent the notification dialog from appearing within the tests. Detox's api allows us to set this permission whenever we launch the app for testing. For the curious minds, please read up more [here](https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only). 


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
