### PR TITLE
chore: remove unused base-64 shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "appium-adb": "^9.11.4",
     "asyncstorage-down": "4.2.0",
     "axios": "^1.6.8",
-    "base-64": "1.0.0",
     "bignumber.js": "^9.0.1",
     "buffer": "6.0.3",
     "cockatiel": "^3.1.2",

--- a/shim.js
+++ b/shim.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-nodejs-modules */
-import { decode, encode } from 'base-64';
 import {
   FIXTURE_SERVER_PORT,
   isTest,
@@ -13,14 +12,6 @@ if (isTest) {
   testConfig.fixtureServerPort = raw?.fixtureServerPort
     ? raw.fixtureServerPort
     : FIXTURE_SERVER_PORT;
-}
-
-if (!global.btoa) {
-  global.btoa = encode;
-}
-
-if (!global.atob) {
-  global.atob = decode;
 }
 
 // Fix for https://github.com/facebook/react-native/issues/5667

--- a/yarn.lock
+++ b/yarn.lock
@@ -11949,11 +11949,6 @@ base-64@0.1.0, base-64@^0.1.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
-base-64@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
-  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
-
 base-x@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-1.1.0.tgz#42d3d717474f9ea02207f6d1aa1f426913eeb7ac"


### PR DESCRIPTION
## **Description**

As all runtimes now support atob and btoa, the base-64 shim is not used.

- https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/API/btoa#browser_compatibility

## **Related issues**

- Originally introduced in #28 (b08e38062661bdd95a5a4dbe80f2238d865a66bf).


## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
