### PR TITLE
chore(ramp): upgrade sdk to 1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "dependencies": {
     "@consensys/ledgerhq-metamask-keyring": "0.0.9",
-    "@consensys/on-ramp-sdk": "1.27.1",
+    "@consensys/on-ramp-sdk": "1.28.0",
     "@eth-optimism/contracts": "0.0.0-2021919175625",
     "@ethereumjs/tx": "^3.2.1",
     "@ethersproject/abi": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,10 +1316,10 @@
     buffer "^6.0.3"
     ethereumjs-util "^7.1.5"
 
-"@consensys/on-ramp-sdk@1.27.1":
-  version "1.27.1"
-  resolved "https://registry.yarnpkg.com/@consensys/on-ramp-sdk/-/on-ramp-sdk-1.27.1.tgz#a422dbfb16a23cdc53b32d9cd307d75b3a438827"
-  integrity sha512-C/ekiaPwFmWDCk0JhXopdvWJ5WuFvZmLPg4DrMEuqIi984+AwDkThU6fCiQ8FjmBIwdMiiYACQlXKjOAKy2/Ww==
+"@consensys/on-ramp-sdk@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@consensys/on-ramp-sdk/-/on-ramp-sdk-1.28.0.tgz#ae048dec47c61e35caa3a07d5fe97da45f0e8b08"
+  integrity sha512-DD+oQ1rzMaIljIZkjwbn3UqFYCb4thD8KI8IJE6SrLl7ATfxZSfs6F4BI5u58txVRz+AzD8e4nxfCJY+GleUGQ==
   dependencies:
     async "^3.2.3"
     axios "^0.28.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR upgrades the Ramp SDK to version 1.28.0. 

This version changes the networks chain id type from number to string.This will be addressed in an upcoming PR.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RAMPS-1613

## **Manual testing steps**

1. Ramps Flows (Buy & Sell) must not be impacted.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
