### PR TITLE
feat: smart-tx opt in modal 2

### DIFF
--- a/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
@@ -261,6 +261,7 @@ const SmartTransactionsOptInModal = () => {
       ref={modalRef}
       style={styles.screen}
       onDismiss={handleDismiss}
+      isInteractable={false}
     >
       <View
         style={styles.modal}

--- a/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
@@ -197,7 +197,7 @@ const SmartTransactionsOptInModal = () => {
         ]}
       />
       <Benefit
-        iconName={IconName.Security}
+        iconName={IconName.Coin}
         text={[
           strings('whats_new.stx.benefit_2_1'),
           strings('whats_new.stx.benefit_2_2'),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2570,16 +2570,16 @@
       "action_text": "Try it out"
     },
     "stx": {
-      "header": "Transactions just got smarter",
+      "header": "Enhanced Transaction Protection",
       "description_1": "Unlock higher success rates, frontrunning protection, and better visibility with Smart Transactions.",
       "description_2": "Only available on Ethereum. Enable or disable any time in settings.",
-      "secondary_button": "No thanks",
+      "secondary_button": "Don't enable enhanced protection",
       "primary_button": "Enable",
       "learn_more": "Learn more.",
       "benefit_1_1": "99.5% success",
       "benefit_1_2": "rate",
-      "benefit_2_1": "Transaction",
-      "benefit_2_2": "protection",
+      "benefit_2_1": "Saves you",
+      "benefit_2_2": "money",
       "benefit_3_1": "Real-time",
       "benefit_3_2": "updates"
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds some small changes to the STX Opt In Modal:

- Updates the copy
- Makes it not possible to close by accident

## **Related issues**

n/a

## **Manual testing steps**

1. Install the extension from scratch
1. Check the updated Opt In modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
![Screenshot 2024-05-15 at 5 15 13 PM](https://github.com/MetaMask/metamask-mobile/assets/139582705/966ff8fc-c9f0-4b49-ae1b-0c962f3d5d44)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
