### PR TITLE
fix: Increase waiting for swaps and switch account on E2E

### DIFF
--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -32,7 +32,7 @@ export default class SwapView {
     try {
       await TestHelpers.checkIfElementByTextIsVisible(
         `Swap complete (${sourceTokenSymbol} to ${destTokenSymbol})`,
-        60000,
+        100000,
       );
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/e2e/specs/permission-systems/permission-system-revoking-multiple-accounts.spec.js
+++ b/e2e/specs/permission-systems/permission-system-revoking-multiple-accounts.spec.js
@@ -39,7 +39,7 @@ describe('Connecting to multiple dapps and revoking permission on one but stayin
         await Browser.navigateToTestDApp();
         await Browser.tapNetworkAvatarButtonOnBrowser();
         await Assertions.checkIfVisible(ConnectedAccountsModal.title);
-        // await TestHelpers.delay(1000);
+        await TestHelpers.delay(2000);
 
         await Assertions.checkIfNotVisible(CommonView.toast);
         await ConnectedAccountsModal.tapConnectMoreAccountsButton();


### PR DESCRIPTION


## **Description**
This PR aims to increase the waiting time for swaps to be confirmed and wait more time for the toast disappear when connecting a new account to a dapp

Regression: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/3582e885-d17c-4ef1-ab5c-d9f13b5222ae
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
