### PR TITLE
fix(deps): @metamask/eth-sig-util@^4.0.1->^7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@metamask/contract-metadata": "^2.1.0",
     "@metamask/controller-utils": "^8.0.4",
     "@metamask/design-tokens": "^2.0.0",
-    "@metamask/eth-sig-util": "^4.0.1",
+    "@metamask/eth-sig-util": "^7.0.2",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/gas-fee-controller": "^13.0.0",
     "@metamask/key-tree": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,17 +4014,17 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
-"@metamask/eth-sig-util@^7.0.0", "@metamask/eth-sig-util@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-7.0.1.tgz#ad3227d6120f15f9293478de7dd9685a5c329586"
-  integrity sha512-59GSrMyFH2fPfu7nKeIQdZ150zxXNNhAQIUaFRUW+MGtVA4w/ONbiQobcRBLi+jQProfIyss51G8pfLPcQ0ylg==
+"@metamask/eth-sig-util@^7.0.0", "@metamask/eth-sig-util@^7.0.1", "@metamask/eth-sig-util@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-7.0.2.tgz#741de634b0d6ca96ce1ee3d064ac6a27756d8d21"
+  integrity sha512-DhTDMNEtED0ihIc4Tysm6qUJTvArCdgSTeeJWdo526W/cAk5mrSAvEYYgv8idAiBumDtcPWGimMTaB7MvY64bg==
   dependencies:
     "@ethereumjs/util" "^8.1.0"
     "@metamask/abi-utils" "^2.0.2"
     "@metamask/utils" "^8.1.0"
+    "@scure/base" "~1.1.3"
     ethereum-cryptography "^2.1.2"
     tweetnacl "^1.0.3"
-    tweetnacl-util "^0.15.1"
 
 "@metamask/eth-simple-keyring@^6.0.1":
   version "6.0.1"
@@ -5942,7 +5942,7 @@
     image-to-base64 "^2.2.0"
     open "^8.2.0"
 
-"@scure/base@^1.0.0", "@scure/base@^1.1.1", "@scure/base@^1.1.3", "@scure/base@~1.1.0", "@scure/base@~1.1.4":
+"@scure/base@^1.0.0", "@scure/base@^1.1.1", "@scure/base@^1.1.3", "@scure/base@~1.1.0", "@scure/base@~1.1.3", "@scure/base@~1.1.4":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.6.tgz#8ce5d304b436e4c84f896e0550c83e4d88cb917d"
   integrity sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==


### PR DESCRIPTION
## **Description**

- deps: Upgrade direct dependency `@metamask/eth-sig-util` from legacy v4.0.1 to latest v7.0.2.
  - [Release notes](https://github.com/MetaMask/eth-sig-util/releases/)
  - [Sources diff](https://github.com/MetaMask/eth-sig-util/compare/v4.0.1...v7.0.2)
  - [Package contents diff](https://npm-diff.app/@metamask/eth-sig-util@4.0.1...@metamask/eth-sig-util@7.0.2)
The package is only used for its [`recoverPersonalSignature`](https://github.com/MetaMask/eth-sig-util/blame/712d9fb3b43c04815d1fccb775d3adf56fa6146b/src/personal-sign.ts#L57) function in [`app/core/RPCMethods/RPCMethodMiddleware.ts`](https://github.com/MetaMask/metamask-mobile/blame/a46d40db00ec5b785b7926177653240d0322951c/app/core/RPCMethods/RPCMethodMiddleware.ts#L625). This function has no changes since `v4.0.1`.

- deps: Bump transitive `@metamask/eth-sig-util@7.0.1` to `@metamask/eth-sig-util@7.0.2` as effect of dedupe
  - [Sources diff](https://github.com/MetaMask/eth-sig-util/compare/v7.0.1...v7.0.2)
  - [Package contents diff](https://npm-diff.app/@metamask/eth-sig-util@7.0.1...@metamask/eth-sig-util@7.0.2)



## **Related issues**


## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.