### PR TITLE
feat: Update checkbox to be able to override checkbox style

### DIFF
--- a/app/component-library/components/Checkbox/Checkbox.styles.ts
+++ b/app/component-library/components/Checkbox/Checkbox.styles.ts
@@ -19,6 +19,7 @@ const styleSheet = (params: { theme: Theme; vars: CheckboxStyleSheetVars }) => {
   const { vars, theme } = params;
   const {
     style,
+    checkboxStyle,
     isChecked,
     isIndeterminate,
     isDisabled,
@@ -54,16 +55,19 @@ const styleSheet = (params: { theme: Theme; vars: CheckboxStyleSheetVars }) => {
       } as ViewStyle,
       style,
     ) as ViewStyle,
-    checkbox: {
-      width: 20,
-      height: 20,
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderRadius: 4,
-      borderWidth: 2,
-      backgroundColor,
-      borderColor,
-    },
+    checkbox: Object.assign(
+      {
+        width: 20,
+        height: 20,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 4,
+        borderWidth: 2,
+        backgroundColor,
+        borderColor,
+      } as ViewStyle,
+      checkboxStyle,
+    ) as ViewStyle,
     icon: {
       color: isReadOnly
         ? theme.colors.icon.alternative

--- a/app/component-library/components/Checkbox/Checkbox.tsx
+++ b/app/component-library/components/Checkbox/Checkbox.tsx
@@ -29,11 +29,13 @@ const Checkbox = ({
   isDisabled = false,
   isReadOnly = false,
   isDanger = false,
+  checkboxStyle,
   ...props
 }: CheckboxProps) => {
   const { hitSlop, ...iconProps } = props;
   const { styles } = useStyles(styleSheet, {
     style,
+    checkboxStyle,
     isChecked,
     isIndeterminate,
     isDisabled,

--- a/app/component-library/components/Checkbox/Checkbox.types.ts
+++ b/app/component-library/components/Checkbox/Checkbox.types.ts
@@ -1,6 +1,6 @@
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacityProps } from 'react-native';
+import { TouchableOpacityProps, StyleProp, ViewStyle } from 'react-native';
 
 /**
  * Checkbox component props.
@@ -34,12 +34,19 @@ export interface CheckboxProps extends TouchableOpacityProps {
    * Optional prop to configure the danger state.
    */
   isDanger?: boolean;
+  /**
+   * Optional prop to control the style of the Checkbox.
+   */
+  checkboxStyle?: StyleProp<ViewStyle> | undefined;
 }
 
 /**
  * Style sheet input parameters.
  */
-export type CheckboxStyleSheetVars = Pick<CheckboxProps, 'style'> & {
+export type CheckboxStyleSheetVars = Pick<
+  CheckboxProps,
+  'style' | 'checkboxStyle'
+> & {
   isChecked: boolean;
   isIndeterminate: boolean;
   isDisabled: boolean;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds the `checkboxStyle` prop to the checkbox component, to allow the checkbox border color to be override-able. This is required for this design https://www.figma.com/design/e5nnWsxenFXK6M3MEg4XGy/Metametrics-ID-for-marketing-opt-in?node-id=0-1&t=bY598gdgLjQBsvwp-0  
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
![Simulator Screenshot - iPhone 15 Pro - 2024-05-23 at 13 43 51](https://github.com/MetaMask/metamask-mobile/assets/14355083/afd19d59-45a9-49f3-a584-5baf0d5b0817)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
