### PR TITLE
fix: Selecting custom ethereum mainnet on fresh install

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -630,15 +630,19 @@ class NetworkSettings extends PureComponent {
       const isRPCDifferent = url.href !== prevRPCURL;
       if ((editable || isCustomMainnet) && isRPCDifferent) {
         // Only remove from frequent list if RPC URL is different.
-        const [prevNetworkConfigurationId] = Object.entries(
+        const foundNetworkConfiguration = Object.entries(
           this.props.networkConfigurations,
         ).find(
           ([, networkConfiguration]) =>
             networkConfiguration.rpcUrl === prevRPCURL,
         );
-        NetworkController.removeNetworkConfiguration(
-          prevNetworkConfigurationId,
-        );
+
+        if (foundNetworkConfiguration) {
+          const [prevNetworkConfigurationId] = foundNetworkConfiguration;
+          NetworkController.removeNetworkConfiguration(
+            prevNetworkConfigurationId,
+          );
+        }
       }
 
       const analyticsParamsAdd = {
@@ -646,6 +650,7 @@ class NetworkSettings extends PureComponent {
         source: 'Custom network form',
         symbol: ticker,
       };
+
       metrics.trackEvent(MetaMetricsEvents.NETWORK_ADDED, analyticsParamsAdd);
       this.props.showNetworkOnboardingAction({
         networkUrl,


### PR DESCRIPTION
## **Description**

On fresh install, there was an error when the user wanted to change to a custom rpc url of ethereum, because there was no other network configurations to override at that point


## **Related issues**

Fixes:

## **Manual testing steps**

1. Fresh install
2. Press change rpc url of ethereum before importing account
3. write the custom rpc url
4. add it successfully

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
