### PR TITLE
fix: render images of networks removed from popularNetwork list

### DIFF
--- a/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.tsx
@@ -35,7 +35,7 @@ import { selectNetworkConfigurations } from '../../../../../selectors/networkCon
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 
-import PopularList from '../../../../../util/networks/customNetworks';
+import { PopularList } from '../../../../../util/networks/customNetworks';
 
 function NetworkSwitcher() {
   const navigation = useNavigation();

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -8,7 +8,7 @@ import EmptyPopularList from '../emptyList';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTheme } from '../../../../../../util/theme';
-import PopularList from '../../../../../../util/networks/customNetworks';
+import { PopularList } from '../../../../../../util/networks/customNetworks';
 import createStyles from '../styles';
 import { CustomNetworkProps, Network } from './CustomNetwork.types';
 import { selectNetworkConfigurations } from '../../../../../../selectors/networkController';

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -34,7 +34,7 @@ import AppConstants from '../../../../../core/AppConstants';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import DefaultTabBar from 'react-native-scrollable-tab-view/DefaultTabBar';
-import PopularList from '../../../../../util/networks/customNetworks';
+import { PopularList } from '../../../../../util/networks/customNetworks';
 import WarningMessage from '../../../confirmations/SendFlow/WarningMessage';
 import InfoModal from '../../../../UI/Swaps/components/InfoModal';
 import {

--- a/app/core/RPCMethods/networkChecker.util.ts
+++ b/app/core/RPCMethods/networkChecker.util.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { BannerAlertSeverity } from '../../component-library/components/Banners/Banner';
 import { strings } from '../../../locales/i18n';
-import PopularList from '../../util/networks/customNetworks';
+import { PopularList } from '../../util/networks/customNetworks';
 
 import { toHex } from '@metamask/controller-utils';
 

--- a/app/util/getImage.tsx
+++ b/app/util/getImage.tsx
@@ -1,4 +1,4 @@
-import PopularList from './networks/customNetworks';
+import { PopularList } from './networks/customNetworks';
 
 const getImage = (chainId: string) => {
   const customNetworkData = PopularList.filter(

--- a/app/util/networks/customNetworks.test.ts
+++ b/app/util/networks/customNetworks.test.ts
@@ -1,4 +1,4 @@
-import PopularList from './customNetworks';
+import { PopularList } from './customNetworks';
 import { toHex } from '@metamask/controller-utils';
 
 describe('popularNetwork', () => {

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -105,17 +105,6 @@ export const PopularList = [
  */
 export const UnpopularNetworkList = [
   {
-    chainId: toHex('11297108109'),
-    nickname: 'Palm',
-    rpcUrl: `https://palm-mainnet.infura.io/v3/${infuraProjectId}`,
-    ticker: 'PALM',
-    rpcPrefs: {
-      blockExplorerUrl: 'https://explorer.palm.io',
-      imageUrl: 'PALM',
-      imageSource: require('../../images/palm.png'),
-    },
-  },
-  {
     chainId: toHex('250'),
     nickname: 'Fantom Opera',
     rpcUrl: 'https://rpc.ftm.tools/',

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -4,7 +4,7 @@ import { toHex } from '@metamask/controller-utils';
 const InfuraKey = process.env.MM_INFURA_PROJECT_ID;
 const infuraProjectId = InfuraKey === 'null' ? '' : InfuraKey;
 
-const PopularList = [
+export const PopularList = [
   {
     chainId: toHex('43114'),
     nickname: 'Avalanche Mainnet C-Chain',
@@ -98,4 +98,47 @@ const PopularList = [
   },
 ];
 
-export default PopularList;
+/**
+ * List of popularList will change in the future, removing networks from the list will lead to users not
+ * seeing the logo of the network anymore.
+ * We can keep this new list updated with any network removed from the popular list so we keep returning the logo of the network.
+ */
+export const UnpopularNetworkList = [
+  {
+    chainId: toHex('11297108109'),
+    nickname: 'Palm',
+    rpcUrl: `https://palm-mainnet.infura.io/v3/${infuraProjectId}`,
+    ticker: 'PALM',
+    rpcPrefs: {
+      blockExplorerUrl: 'https://explorer.palm.io',
+      imageUrl: 'PALM',
+      imageSource: require('../../images/palm.png'),
+    }
+  },
+  {
+    chainId: toHex('250'),
+    nickname: 'Fantom Opera',
+    rpcUrl: 'https://rpc.ftm.tools/',
+    ticker: 'FTM',
+    warning: true,
+    rpcPrefs: {
+      blockExplorerUrl: 'https://ftmscan.com',
+      imageUrl: 'FTM',
+      imageSource: require('../../images/fantom.png'),
+    },
+  },
+  {
+    chainId: toHex('1666600000'),
+    nickname: 'Harmony Mainnet Shard 0',
+    rpcUrl: 'https://api.harmony.one/',
+    ticker: 'ONE',
+    warning: true,
+    rpcPrefs: {
+      blockExplorerUrl: 'https://basescan.org',
+      imageUrl: 'BASE',
+      imageSource: require('../../images/base.png'),
+    }
+  }
+
+]
+

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -113,7 +113,7 @@ export const UnpopularNetworkList = [
       blockExplorerUrl: 'https://explorer.palm.io',
       imageUrl: 'PALM',
       imageSource: require('../../images/palm.png'),
-    }
+    },
   },
   {
     chainId: toHex('250'),
@@ -137,8 +137,6 @@ export const UnpopularNetworkList = [
       blockExplorerUrl: 'https://basescan.org',
       imageUrl: 'BASE',
       imageSource: require('../../images/base.png'),
-    }
-  }
-
-]
-
+    },
+  },
+];

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -37,7 +37,7 @@ const lineaTestnetLogo = require('../../images/linea-testnet-logo.png');
 const lineaMainnetLogo = require('../../images/linea-mainnet-logo.png');
 
 /* eslint-enable */
-import PopularList from './customNetworks';
+import { PopularList, UnpopularNetworkList } from './customNetworks';
 import { strings } from '../../../locales/i18n';
 import {
   getEtherscanAddressUrl,
@@ -414,11 +414,17 @@ export const getNetworkImageSource = ({ networkType, chainId }) => {
     return defaultNetwork.imageSource;
   }
 
+  const unpopularNetwork = UnpopularNetworkList.find(
+    (networkConfig) => networkConfig.chainId === chainId,
+  );
+
   const popularNetwork = PopularList.find(
     (networkConfig) => networkConfig.chainId === chainId,
   );
-  if (popularNetwork) {
-    return popularNetwork.rpcPrefs.imageSource;
+
+  const network = unpopularNetwork || popularNetwork;
+  if (network) {
+    return network.rpcPrefs.imageSource;
   }
   return getTestNetImage(networkType);
 };


### PR DESCRIPTION

## **Description**

After [removing](https://github.com/MetaMask/metamask-mobile/commit/ff1b4c4e7e4cc24de7081caeeaeeac61a34dfaca#diff-d3ce58504d7b4f21605b92504335807809133cf96c85cc6d03545548e33c509a) Palm, harmony and Fantom from the popular network list, users who added these networks on versions prior to v7.21.0, can no longer see the logos after upgrading.


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/9322

## **Manual testing steps**

1. Build the app on v7.20.0
2. Add Palm network from the popular list
3. Build on this branch and you should be able to see the logo of Palm.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

This is on v7.20.0

https://github.com/MetaMask/metamask-mobile/assets/10994169/39bff35f-55f6-468f-a27b-519473480bb2

This is after upgrading to v7.21.0 or latest

https://github.com/MetaMask/metamask-mobile/assets/10994169/f718fb4f-f9d3-4355-84a7-1559b27cd9ce


### **After**


https://github.com/MetaMask/metamask-mobile/assets/10994169/2ee4fc5f-05d2-42e2-91ad-8c9a77163bf2



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
