### PR TITLE
fix: revert use of sponge not available in actions Ubuntu image

### DIFF
--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -30,7 +30,9 @@ log_and_exit () {
 
 perform_updates () {
   # update package.json
-  jq ".version = \"$SEMVER_VERSION\"" $PACKAGE_JSON_FILE | sponge $PACKAGE_JSON_FILE
+  tmp="${PACKAGE_JSON_FILE}_temp"
+  jq ".version = \"$SEMVER_VERSION\"" $PACKAGE_JSON_FILE > "$tmp"
+  mv "$tmp" $PACKAGE_JSON_FILE
   echo "- $PACKAGE_JSON_FILE updated"
 
 


### PR DESCRIPTION
Revert use of sponge as it's not available in the Ubuntu image used in Github actions.

## **Related issues**

Fixes #9770

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
