### PR TITLE
feat: add fiat support to simulations

### DIFF
--- a/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.styles.ts
+++ b/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.styles.ts
@@ -6,6 +6,9 @@ const styleSheet = () =>
       flexDirection: 'column',
       gap: 16,
     },
+    totalFiatDisplayContainer: {
+      flexDirection: 'row-reverse',
+    },
   });
 
 export default styleSheet;

--- a/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.test.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.test.tsx
@@ -9,6 +9,10 @@ import BalanceChangeRow from '../BalanceChangeRow/BalanceChangeRow';
 
 jest.mock('../sortBalanceChanges');
 jest.mock('../BalanceChangeRow/BalanceChangeRow', () => 'BalanceChangeRow');
+jest.mock('../FiatDisplay/FiatDisplay', () => ({
+  IndividualFiatDisplay: 'IndividualFiatDisplay',
+  TotalFiatDisplay: 'TotalFiatDisplay',
+}));
 
 const balanceChangesMock = [
   {
@@ -17,6 +21,7 @@ const balanceChangesMock = [
       address: '0xabc123',
     },
     amount: new BigNumber(100),
+    fiatAmount: 100,
   },
 ] as BalanceChange[];
 const headingMock = 'You received';
@@ -65,6 +70,7 @@ describe('BalanceChangeList', () => {
           address: '0xabc123',
         },
         amount: new BigNumber(100),
+        fiatAmount: 100,
       },
       {
         asset: {
@@ -72,6 +78,7 @@ describe('BalanceChangeList', () => {
           address: '0xabc456',
         },
         amount: new BigNumber(1000),
+        fiatAmount: 1000,
       },
     ] as BalanceChange[];
 
@@ -90,5 +97,19 @@ describe('BalanceChangeList', () => {
     expect(rows).toHaveLength(multipleBalanceChangesMock.length);
     expect(rows[0].props.label).toBe(headingMock);
     expect(rows[1].props.label).toBeUndefined();
+  });
+
+  it('does not render TotalFiatDisplay component when there is only one balance change', () => {
+    const { queryByTestId } = render(
+      <BalanceChangeList
+        heading={headingMock}
+        balanceChanges={balanceChangesMock}
+      />,
+    );
+    const container = queryByTestId(
+      'simulation-details-balance-change-list-total-fiat-display-container',
+    );
+
+    expect(container).toBeNull();
   });
 });

--- a/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.tsx
@@ -3,11 +3,11 @@ import React, { useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 
 import { useStyles } from '../../../hooks/useStyles';
-import styleSheet from './BalanceChangeList.styles';
 import { sortBalanceChanges } from '../sortBalanceChanges';
 import BalanceChangeRow from '../BalanceChangeRow/BalanceChangeRow';
 import { BalanceChange } from '../types';
-
+import { TotalFiatDisplay } from '../FiatDisplay/FiatDisplay';
+import styleSheet from './BalanceChangeList.styles';
 interface BalanceChangeListProperties extends ViewProps {
   heading: string;
   balanceChanges: BalanceChange[];
@@ -23,9 +23,16 @@ const BalanceChangeList: React.FC<BalanceChangeListProperties> = ({
     [balanceChanges],
   );
 
+  const fiatAmounts = useMemo(
+    () => sortedBalanceChanges.map((bc) => bc.fiatAmount),
+    [sortedBalanceChanges],
+  );
+
   if (sortedBalanceChanges.length === 0) {
     return null;
   }
+
+  const showFiatTotal = sortedBalanceChanges.length > 1;
 
   return (
     <View
@@ -37,8 +44,17 @@ const BalanceChangeList: React.FC<BalanceChangeListProperties> = ({
           key={index}
           label={index === 0 ? heading : undefined}
           balanceChange={balanceChange}
+          showFiat={!showFiatTotal}
         />
       ))}
+      {showFiatTotal && (
+        <View
+          testID="simulation-details-balance-change-list-total-fiat-display-container"
+          style={styles.totalFiatDisplayContainer}
+        >
+          <TotalFiatDisplay fiatAmounts={fiatAmounts} />
+        </View>
+      )}
     </View>
   );
 };

--- a/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.test.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.test.tsx
@@ -5,6 +5,10 @@ import { BigNumber } from 'bignumber.js';
 import BalanceChangeRow from './BalanceChangeRow';
 import { BalanceChange } from '../types';
 
+jest.mock('../FiatDisplay/FiatDisplay', () => ({
+  IndividualFiatDisplay: 'IndividualFiatDisplay',
+}));
+
 const balanceChangeMock = {
   asset: {
     type: 'ERC20',
@@ -39,5 +43,25 @@ describe('BalanceChangeList', () => {
     expect(queryByTestId('balance-change-row-label')).toBeNull();
     expect(getByTestId('balance-change-row-amount-pill')).toBeDefined();
     expect(getByTestId('balance-change-row-asset-pill')).toBeDefined();
+  });
+
+  it('renders IndividualFiatDisplay when showFiat is true', () => {
+    const { queryByTestId } = render(
+      <BalanceChangeRow showFiat balanceChange={balanceChangeMock} />,
+    );
+
+    const container = queryByTestId('balance-change-row-fiat-display');
+
+    expect(container).not.toBeNull();
+  });
+
+  it('does not render IndividualFiatDisplay when showFiat is false', () => {
+    const { queryByTestId } = render(
+      <BalanceChangeRow showFiat={false} balanceChange={balanceChangeMock} />,
+    );
+
+    const container = queryByTestId('balance-change-row-fiat-display');
+
+    expect(container).toBeNull();
   });
 });

--- a/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.tsx
@@ -1,27 +1,30 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { View, ViewProps } from 'react-native';
+
 import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../hooks/useStyles';
-
-import styleSheet from './BalanceChangeRow.styles';
 import { BalanceChange } from '../types';
 import AmountPill from '../AmountPill/AmountPill';
 import AssetPill from '../AssetPill/AssetPill';
+import { IndividualFiatDisplay } from '../FiatDisplay/FiatDisplay';
+import styleSheet from './BalanceChangeRow.styles';
 
 interface BalanceChangeRowProperties extends ViewProps {
   label?: string;
+  showFiat?: boolean;
   balanceChange: BalanceChange;
 }
 
 const BalanceChangeRow: React.FC<BalanceChangeRowProperties> = ({
   label,
   balanceChange,
+  showFiat,
 }) => {
   const { styles } = useStyles(styleSheet, {});
-  const { asset, amount } = balanceChange;
+  const { asset, amount, fiatAmount } = balanceChange;
   return (
     <View style={styles.container}>
       {label && (
@@ -41,6 +44,12 @@ const BalanceChangeRow: React.FC<BalanceChangeRowProperties> = ({
           />
           <AssetPill asset={asset} testID="balance-change-row-asset-pill" />
         </View>
+        {showFiat && (
+          <IndividualFiatDisplay
+            testID="balance-change-row-fiat-display"
+            fiatAmount={fiatAmount}
+          />
+        )}
       </View>
     </View>
   );

--- a/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.test.tsx
+++ b/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import useFiatFormatter from './useFiatFormatter';
+
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import initialBackgroundState from '../../../../util/test/initial-background-state.json';
+
+import { IndividualFiatDisplay, TotalFiatDisplay } from './FiatDisplay';
+import { FIAT_UNAVAILABLE } from '../types';
+
+jest.mock('./useFiatFormatter');
+(useFiatFormatter as jest.Mock).mockReturnValue((value: number) => `$${value}`);
+
+const mockInitialState = {
+  engine: {
+    backgroundState: initialBackgroundState,
+  },
+};
+
+describe('IndividualFiatDisplay', () => {
+  it.each([
+    [FIAT_UNAVAILABLE, 'Not Available'],
+    [100, '$100'],
+    [-100, '$100'],
+  ])('when fiatAmount is %s it renders %s', (fiatAmount, expected) => {
+    const { getByText } = renderWithProvider(
+      <IndividualFiatDisplay fiatAmount={fiatAmount} />,
+      { state: mockInitialState },
+    );
+    expect(getByText(expected)).toBeDefined();
+  });
+});
+
+describe('TotalFiatDisplay', () => {
+  it.each([
+    [[FIAT_UNAVAILABLE, FIAT_UNAVAILABLE], 'Not Available'],
+    [[], 'Not Available'],
+    [[100, 200, FIAT_UNAVAILABLE, 300], 'Total = $600'],
+    [[-100, -200, FIAT_UNAVAILABLE, -300], 'Total = $600'],
+  ])('when fiatAmounts is %s it renders %s', (fiatAmounts, expected) => {
+    const { getByText } = renderWithProvider(
+      <TotalFiatDisplay fiatAmounts={fiatAmounts} />,
+      { state: mockInitialState },
+    );
+    expect(getByText(expected)).toBeDefined();
+  });
+});

--- a/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.tsx
+++ b/app/components/UI/SimulationDetails/FiatDisplay/FiatDisplay.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { useStyles } from '../../../hooks/useStyles';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../component-library/components/Texts/Text';
+import { strings } from '../../../../../locales/i18n';
+import useFiatFormatter from './useFiatFormatter';
+import { FIAT_UNAVAILABLE, FiatAmount } from '../types';
+
+const styleSheet = () =>
+  StyleSheet.create({
+    base: {
+      paddingRight: 2,
+      textAlign: 'right',
+    },
+  });
+
+const sharedTextProps = {
+  color: TextColor.Alternative,
+  variant: TextVariant.BodyMD,
+} as const;
+
+const FiatNotAvailableDisplay: React.FC = () => {
+  const { styles } = useStyles(styleSheet, {});
+  return (
+    <Text {...sharedTextProps} style={styles.base}>
+      {strings('simulation_details.fiat_not_available')}
+    </Text>
+  );
+};
+
+export function calculateTotalFiat(fiatAmounts: FiatAmount[]): number {
+  return fiatAmounts.reduce(
+    (total: number, fiat) => total + (fiat === FIAT_UNAVAILABLE ? 0 : fiat),
+    0,
+  );
+}
+
+/**
+ * Displays the fiat value of a single balance change.
+ *
+ * @param props - Properties object.
+ * @param props.fiatAmount - The fiat amount to display.
+ */
+export const IndividualFiatDisplay: React.FC<{ fiatAmount: FiatAmount }> = ({
+  fiatAmount,
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+  const fiatFormatter = useFiatFormatter();
+
+  if (fiatAmount === FIAT_UNAVAILABLE) {
+    return <FiatNotAvailableDisplay />;
+  }
+  const absFiat = Math.abs(fiatAmount);
+
+  return (
+    <Text {...sharedTextProps} style={styles.base}>
+      {fiatFormatter(absFiat)}
+    </Text>
+  );
+};
+
+/**
+ * Displays the total fiat value of a list of balance changes.
+ *
+ * @param props - Properties object.
+ * @param props.fiatAmounts - The list of fiat amounts to sum.
+ */
+export const TotalFiatDisplay: React.FC<{
+  fiatAmounts: FiatAmount[];
+}> = ({ fiatAmounts }) => {
+  const { styles } = useStyles(styleSheet, {});
+  const fiatFormatter = useFiatFormatter();
+  const totalFiat = calculateTotalFiat(fiatAmounts);
+
+  return totalFiat === 0 ? (
+    <FiatNotAvailableDisplay />
+  ) : (
+    <Text {...sharedTextProps} style={styles.base}>
+      {strings('simulation_details.total_fiat', {
+        currency: fiatFormatter(Math.abs(totalFiat)),
+      })}
+    </Text>
+  );
+};

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react-hooks';
+import I18n from '../../../../../locales/i18n';
+import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
+import useFiatFormatter from './useFiatFormatter';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector) => selector()),
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/currencyRateController', () => ({
+  selectCurrentCurrency: jest.fn(),
+}));
+
+const mockI18n = I18n as unknown as jest.Mock;
+const mockSelectCurrentCurrency = selectCurrentCurrency as unknown as jest.Mock;
+
+describe('useFiatFormatter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a function that formats fiat amount correctly', () => {
+    mockI18n.mockReturnValue({
+      locale: 'en-US',
+    });
+    mockSelectCurrentCurrency.mockReturnValue('USD');
+
+    const { result } = renderHook(() => useFiatFormatter());
+    const formatFiat = result.current;
+
+    expect(formatFiat(1000)).toBe('$1,000.00');
+    expect(formatFiat(500.5)).toBe('$500.50');
+    expect(formatFiat(0)).toBe('$0.00');
+  });
+
+  it('should use the current locale and currency from the mocked functions', () => {
+    mockI18n.mockReturnValue({
+      locale: 'fr-FR',
+    });
+    mockSelectCurrentCurrency.mockReturnValue('EUR');
+
+    renderHook(() => useFiatFormatter());
+
+    expect(selectCurrentCurrency).toHaveBeenCalledTimes(1);
+  });
+
+  it('should gracefully handle unknown currencies by returning amount followed by currency code', () => {
+    mockSelectCurrentCurrency.mockReturnValue('storj');
+
+    const { result } = renderHook(() => useFiatFormatter());
+    const formatFiat = result.current;
+
+    // Testing the fallback formatting for an unknown currency
+    expect(formatFiat(1000)).toBe('1000 storj');
+    expect(formatFiat(500.5)).toBe('500.5 storj');
+    expect(formatFiat(0)).toBe('0 storj');
+  });
+});

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
@@ -1,0 +1,35 @@
+import { useSelector } from 'react-redux';
+import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
+import I18n from '../../../../../locales/i18n';
+
+type FiatFormatter = (fiatAmount: number) => string;
+
+/**
+ * Returns a function that formats a fiat amount as a localized string.
+ *
+ * Example usage:
+ *
+ * ```
+ * const formatFiat = useFiatFormatter();
+ * const formattedAmount = formatFiat(1000);
+ * ```
+ *
+ * @returns A function that takes a fiat amount as a number and returns a formatted string.
+ */
+const useFiatFormatter = (): FiatFormatter => {
+  const fiatCurrency = useSelector(selectCurrentCurrency);
+
+  return (fiatAmount: number) => {
+    try {
+      return new Intl.NumberFormat(I18n.locale, {
+        style: 'currency',
+        currency: fiatCurrency,
+      }).format(fiatAmount);
+    } catch (error) {
+      // Fallback for unknown or unsupported currencies
+      return `${fiatAmount} ${fiatCurrency}`;
+    }
+  };
+};
+
+export default useFiatFormatter;

--- a/app/components/UI/SimulationDetails/SimulationDetails.stories.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { View } from 'react-native';
+import { cloneDeep } from 'lodash';
 import { Provider } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { Meta, StoryObj } from '@storybook/react-native';
 import { configureStore } from '@reduxjs/toolkit';
 import {
-  SimulationData,
   SimulationErrorCode,
   SimulationTokenStandard,
 } from '@metamask/transaction-controller';
@@ -14,84 +14,121 @@ import {
   default as SimulationDetails,
   type SimulationDetailsProps,
 } from './SimulationDetails';
+import { CHAIN_IDS } from '@metamask/transaction-controller/dist/constants';
 
 const backdropStyle = { backgroundColor: 'white', padding: 16 };
 type Story = StoryObj<SimulationDetailsProps>;
-
-const CHAIN_ID_MOCK = '0x1';
-const FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK =
-  '0x0439e60F02a8900a951603950d8D4527f400C3f1';
-const FIRST_PARTY_CONTRACT_ADDRESS_2_MOCK =
-  '0x881D40237659C251811CEC9c364ef91dC08D300C';
-const ERC20_TOKEN_1_MOCK = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'; // WBTC
-const ERC20_TOKEN_2_MOCK = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'; // USDC
-const ERC721_TOKEN_MOCK = '0x06012c8cf97bead5deae237070f9587f8e7a266d'; // CryptoKitties
-const ERC1155_TOKEN_MOCK = '0x60e4d786628fea6478f785a6d7e704777c86a7c6'; // MAYC
 
 const DUMMY_BALANCE_CHANGE = {
   previousBalance: '0xIGNORED' as Hex,
   newBalance: '0xIGNORED' as Hex,
 };
 
-const storeMock = configureStore({
-  reducer: (state) => state,
-  preloadedState: {
-    settings: { useBlockieIcon: false },
-    engine: {
-      backgroundState: {
-        PreferencesController: {
-          useNativeCurrencyAsPrimaryCurrency: false,
-          useTokenDetection: true,
+const CHAIN_ID_MOCK = '0x1';
+const ERC20_TOKEN_1_MOCK = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'; // WBTC
+const ERC20_TOKEN_2_MOCK = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'; // USDC
+const ERC721_TOKEN_MOCK = '0x06012c8cf97bead5deae237070f9587f8e7a266d'; // CryptoKitties
+const ERC1155_TOKEN_MOCK = '0x60e4d786628fea6478f785a6d7e704777c86a7c6'; // MAYC
+
+const preloadedEngineState = {
+  settings: { useBlockieIcon: false },
+  engine: {
+    backgroundState: {
+      PreferencesController: {
+        useNativeCurrencyAsPrimaryCurrency: false,
+        useTokenDetection: true,
+      },
+      NetworkController: {
+        providerConfig: {
+          type: 'rpc',
+          nickname: 'goerli',
+          id: 'chain5',
+          chainId: CHAIN_ID_MOCK,
+          ticker: 'ETH',
         },
-        NetworkController: {
-          providerConfig: {
-            chainId: CHAIN_ID_MOCK,
-            ticker: 'ETH',
+      },
+      NftController: {
+        allNfts: {},
+        allNftContracts: {},
+      },
+      TokenListController: {
+        tokenList: {
+          [ERC20_TOKEN_1_MOCK]: {
+            address: ERC20_TOKEN_1_MOCK,
+            symbol: 'WBTC',
+            name: 'Wrapped Bitcoin',
+            iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC20_TOKEN_1_MOCK}.png`,
+          },
+          [ERC20_TOKEN_2_MOCK]: {
+            address: ERC20_TOKEN_2_MOCK,
+            symbol: 'USDC',
+            name: 'USD Coin',
+            iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC20_TOKEN_2_MOCK}.png`,
+          },
+          [ERC721_TOKEN_MOCK]: {
+            address: ERC721_TOKEN_MOCK,
+            symbol: 'CK',
+            name: 'CryptoKitties',
+            iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC721_TOKEN_MOCK}.png`,
+          },
+          [ERC1155_TOKEN_MOCK]: {
+            address: ERC1155_TOKEN_MOCK,
+            symbol: 'MAYC',
+            name: 'Mutant Ape Yacht Club',
+            iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC1155_TOKEN_MOCK}.png `,
           },
         },
-        NftController: {
-          allNfts: {},
-          allNftContracts: {},
+      },
+      CurrencyRateController: {
+        currentCurrency: 'usd',
+        currencyRates: {
+          ETH: {
+            conversionRate: 10000,
+          },
+          MATIC: {
+            conversionRate: 1,
+          },
         },
-        TokenListController: {
-          tokenList: {
-            [ERC20_TOKEN_1_MOCK]: {
-              address: ERC20_TOKEN_1_MOCK,
-              symbol: 'WBTC',
-              name: 'Wrapped Bitcoin',
-              iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC20_TOKEN_1_MOCK}.png`,
-            },
+      },
+      NamesController: {
+        names: {
+          ethereumAddress: {
             [ERC20_TOKEN_2_MOCK]: {
-              address: ERC20_TOKEN_2_MOCK,
-              symbol: 'USDC',
-              name: 'USD Coin',
-              iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC20_TOKEN_2_MOCK}.png`,
-            },
-            [ERC721_TOKEN_MOCK]: {
-              address: ERC721_TOKEN_MOCK,
-              symbol: 'CK',
-              name: 'CryptoKitties',
-              iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC721_TOKEN_MOCK}.png`,
-            },
-            [ERC1155_TOKEN_MOCK]: {
-              address: ERC1155_TOKEN_MOCK,
-              symbol: 'MAYC',
-              name: 'Mutant Ape Yacht Club',
-              iconUrl: `https://static.metafi.codefi.network/api/v1/tokenIcons/1/${ERC1155_TOKEN_MOCK}.png `,
-            },
-          },
-        },
-        CurrencyRateController: {
-          currentCurrency: 'usd',
-          currencyRates: {
-            ETH: {
-              conversionRate: 10000,
+              [CHAIN_ID_MOCK]: {
+                name: 'USDC with a saved name',
+              },
             },
           },
         },
       },
     },
   },
+};
+
+const storeMock = configureStore({
+  reducer: (state) => state,
+  preloadedState: preloadedEngineState,
+});
+
+const preloadedPolygonState = cloneDeep(preloadedEngineState);
+preloadedPolygonState.engine.backgroundState.NetworkController.providerConfig.chainId =
+  CHAIN_IDS.POLYGON;
+preloadedPolygonState.engine.backgroundState.NetworkController.providerConfig.ticker =
+  'MATIC';
+
+const storeMockPolygon = configureStore({
+  reducer: (state) => state,
+  preloadedState: preloadedPolygonState,
+});
+
+const preloadedArbitrumState = cloneDeep(preloadedEngineState);
+preloadedArbitrumState.engine.backgroundState.NetworkController.providerConfig.chainId =
+  CHAIN_IDS.ARBITRUM;
+preloadedArbitrumState.engine.backgroundState.NetworkController.providerConfig.ticker =
+  'ETH';
+const storeMockArbitrum = configureStore({
+  reducer: (state) => state,
+  preloadedState: preloadedArbitrumState,
 });
 
 const meta: Meta<typeof SimulationDetails> = {
@@ -107,90 +144,182 @@ const meta: Meta<typeof SimulationDetails> = {
 };
 export default meta;
 
-export const Loading: Story = {
-  args: {},
-};
-
-export const InvalidResponseError: Story = {
-  args: {
-    simulationData: {
-      error: { code: SimulationErrorCode.InvalidResponse },
-    } as SimulationData,
-  },
-};
-
-export const RevertedTransaction: Story = {
-  args: {
-    simulationData: {
-      error: { code: SimulationErrorCode.Reverted },
-    } as SimulationData,
-  },
-};
-
-export const NoBalanceChange: Story = {
-  args: {
-    simulationData: {
-      tokenBalanceChanges: [],
-    },
-  },
-};
-
-export const TokenRecieveOnly: Story = {
-  args: {
-    simulationData: {
-      tokenBalanceChanges: [
-        {
-          ...DUMMY_BALANCE_CHANGE,
-          address: FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK,
-          difference: '0x123456',
-          isDecrease: false,
-          standard: SimulationTokenStandard.erc20,
-        },
-      ],
-    },
-  },
-};
-
-export const TokenSendOnly: Story = {
-  args: {
-    simulationData: {
-      tokenBalanceChanges: [
-        {
-          ...DUMMY_BALANCE_CHANGE,
-          address: FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK,
-          difference: '0x123456',
-          isDecrease: true,
-          standard: SimulationTokenStandard.erc20,
-        },
-      ],
-    },
-  },
-};
-
 export const MultipleTokens: Story = {
   args: {
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
-        difference: '0x12345678912322222',
+        difference: '0x12345678912345678',
         isDecrease: true,
       },
       tokenBalanceChanges: [
         {
           ...DUMMY_BALANCE_CHANGE,
-          address: FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK,
+          address: ERC20_TOKEN_1_MOCK,
           difference: '0x123456',
           isDecrease: false,
           standard: SimulationTokenStandard.erc20,
         },
         {
           ...DUMMY_BALANCE_CHANGE,
-          address: FIRST_PARTY_CONTRACT_ADDRESS_2_MOCK,
+          address: ERC20_TOKEN_2_MOCK,
+          difference: '0x123456901',
+          isDecrease: false,
+          standard: SimulationTokenStandard.erc20,
+        },
+        {
+          ...DUMMY_BALANCE_CHANGE,
+          address: ERC721_TOKEN_MOCK,
+          difference: '0x1',
+          isDecrease: false,
+          id: '0x721',
+          standard: SimulationTokenStandard.erc721,
+        },
+        {
+          ...DUMMY_BALANCE_CHANGE,
+          address: ERC1155_TOKEN_MOCK,
+          difference: '0x13',
+          isDecrease: false,
+          id: '0x1155',
+          standard: SimulationTokenStandard.erc1155,
+        },
+      ],
+    },
+  },
+};
+
+export const SendSmallAmount: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x123',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const LongValuesAndNames: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x12345678912345678',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [
+        {
+          ...DUMMY_BALANCE_CHANGE,
+          address: ERC20_TOKEN_1_MOCK,
+          difference: '0x42345909',
+          isDecrease: false,
+          standard: SimulationTokenStandard.erc20,
+        },
+        {
+          ...DUMMY_BALANCE_CHANGE,
+          address: ERC20_TOKEN_2_MOCK,
           difference: '0x123456901',
           isDecrease: false,
           standard: SimulationTokenStandard.erc20,
         },
       ],
+    },
+  },
+};
+
+export const PolygonNativeAsset: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x9345678923456789',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+  decorators: [
+    (story) => <Provider store={storeMockPolygon}>{story()}</Provider>,
+  ],
+};
+
+export const ArbitrumNativeAsset: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x9345678923456789',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+  decorators: [
+    (story) => <Provider store={storeMockArbitrum}>{story()}</Provider>,
+  ],
+};
+
+export const ReceiveOnly: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        previousBalance: '0x2',
+        newBalance: '0x1',
+        difference: '0x12345678912345678',
+        isDecrease: false,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const SendOnly: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        previousBalance: '0x1',
+        newBalance: '0x2',
+        difference: '0x12345678912345678',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const NoBalanceChanges: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: undefined,
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    simulationData: undefined,
+  },
+};
+
+export const TransactionReverted: Story = {
+  args: {
+    simulationData: {
+      error: { code: SimulationErrorCode.Reverted },
+      nativeBalanceChange: undefined,
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const GenericError: Story = {
+  args: {
+    simulationData: {
+      error: {},
+      nativeBalanceChange: undefined,
+      tokenBalanceChanges: [],
     },
   },
 };

--- a/app/components/UI/SimulationDetails/types.ts
+++ b/app/components/UI/SimulationDetails/types.ts
@@ -61,4 +61,9 @@ export type BalanceChange = Readonly<{
    * 1.5 tokens, or more precisely, 1.5 * 10^18 of the smallest divisible unit.
    */
   amount: BigNumber;
+
+  /**
+   * The amount of fiat currency that corresponds to the asset amount.
+   */
+  fiatAmount: FiatAmount;
 }>;

--- a/app/components/UI/SimulationDetails/useBalanceChanges.test.ts
+++ b/app/components/UI/SimulationDetails/useBalanceChanges.test.ts
@@ -5,21 +5,51 @@ import {
   SimulationData,
   SimulationTokenStandard,
 } from '@metamask/transaction-controller';
+import { fetchTokenContractExchangeRates } from '@metamask/assets-controllers';
 
 import { getTokenDetails } from '../../../util/address';
+import { selectConversionRate } from '../../../selectors/currencyRateController';
 import useBalanceChanges from './useBalanceChanges';
-import { AssetType } from './types';
+import { FIAT_UNAVAILABLE, AssetType } from './types';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn().mockImplementation((callback) => callback()),
+}));
+
+jest.mock('../../../selectors/currencyRateController', () => ({
+  selectConversionRate: jest.fn(),
+  selectCurrentCurrency: jest.fn(),
+}));
+
+jest.mock('../../../selectors/networkController', () => ({
+  selectChainId: jest.fn(),
+}));
 
 jest.mock('../../../util/address', () => ({
   getTokenDetails: jest.fn(),
 }));
 
+jest.mock('@metamask/assets-controllers', () => ({
+  CodefiTokenPricesServiceV2: jest.fn(),
+  fetchTokenContractExchangeRates: jest.fn(),
+}));
+
+const mockSelectConversionRate = selectConversionRate as any;
 const mockGetTokenDetails = getTokenDetails as jest.Mock;
+const mockFetchTokenContractExchangeRates =
+  fetchTokenContractExchangeRates as jest.Mock;
+
+const ETH_TO_FIAT_RATE = 3;
 
 const ERC20_TOKEN_ADDRESS_1_MOCK: Hex = '0x0erc20_1';
 const ERC20_TOKEN_ADDRESS_2_MOCK: Hex = '0x0erc20_2';
+const ERC20_TOKEN_ADDRESS_3_MOCK: Hex = '0x0erc20_3';
 const ERC20_DECIMALS_1_MOCK = 3;
 const ERC20_DECIMALS_2_MOCK = 4;
+const ERC20_DECIMALS_INVALID_MOCK = null;
+const ERC20_TO_FIAT_RATE_1_MOCK = 1.5;
+const ERC20_TO_FIAT_RATE_2_MOCK = 6;
 
 const NFT_TOKEN_ADDRESS_MOCK: Hex = '0x0nft';
 
@@ -43,9 +73,11 @@ describe('useBalanceChanges', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetTokenDetails.mockImplementation((address: Hex) => {
-      const decimalMap: Record<Hex, number> = {
+      const decimalMap: Record<Hex, number | string> = {
         [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_DECIMALS_1_MOCK,
         [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_DECIMALS_2_MOCK,
+        [ERC20_TOKEN_ADDRESS_3_MOCK]:
+          ERC20_DECIMALS_INVALID_MOCK as unknown as number,
       };
       if (decimalMap[address]) {
         return Promise.resolve({
@@ -53,6 +85,11 @@ describe('useBalanceChanges', () => {
         });
       }
       return Promise.reject(new Error('Unable to determine token standard'));
+    });
+    mockSelectConversionRate.mockReturnValue(ETH_TO_FIAT_RATE);
+    mockFetchTokenContractExchangeRates.mockResolvedValue({
+      [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_TO_FIAT_RATE_1_MOCK,
+      [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_TO_FIAT_RATE_2_MOCK,
     });
   });
 
@@ -67,6 +104,30 @@ describe('useBalanceChanges', () => {
 
     it('returns pending=true while fetching token decimals', async () => {
       mockGetTokenDetails.mockImplementation(PENDING_PROMISE);
+      const simulationData: SimulationData = {
+        nativeBalanceChange: undefined,
+        tokenBalanceChanges: [
+          {
+            ...dummyBalanceChange,
+            difference: DIFFERENCE_1_MOCK,
+            isDecrease: true,
+            address: ERC20_TOKEN_ADDRESS_1_MOCK,
+            standard: SimulationTokenStandard.erc20,
+          },
+        ],
+      };
+      const { result, unmount, waitForNextUpdate } = renderHook(() =>
+        useBalanceChanges(simulationData),
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current).toEqual({ pending: true, value: [] });
+      unmount();
+    });
+
+    it('returns pending=true while fetching token fiat rates', async () => {
+      mockFetchTokenContractExchangeRates.mockImplementation(PENDING_PROMISE);
       const simulationData: SimulationData = {
         nativeBalanceChange: undefined,
         tokenBalanceChanges: [
@@ -121,6 +182,7 @@ describe('useBalanceChanges', () => {
             tokenId: undefined,
           },
           amount: new BigNumber('-0.017'),
+          fiatAmount: -0.0255,
         },
       ]);
       expect(changes[0].amount.toString()).toBe('-0.017');
@@ -149,7 +211,9 @@ describe('useBalanceChanges', () => {
       const changes = result.current.value;
       expect(changes).toHaveLength(2);
       expect(changes[0].amount.toString()).toBe('-0.017');
+      expect(changes[0].fiatAmount).toBe(Number('-0.0255'));
       expect(changes[1].amount.toString()).toBe('0.0002');
+      expect(changes[1].fiatAmount).toBe(Number('0.0012'));
     });
 
     it('handles non-ERC20 tokens', async () => {
@@ -174,6 +238,7 @@ describe('useBalanceChanges', () => {
             tokenId: TOKEN_ID_1_MOCK,
           },
           amount: new BigNumber('-1'),
+          fiatAmount: FIAT_UNAVAILABLE,
         },
       ]);
     });
@@ -192,6 +257,41 @@ describe('useBalanceChanges', () => {
       await waitForNextUpdate();
 
       expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+    });
+
+    it('uses default decimals when token details are not valid numbers', async () => {
+      const { result, waitForNextUpdate } = setupHook([
+        {
+          ...dummyBalanceChange,
+          difference: DIFFERENCE_1_MOCK,
+          isDecrease: true,
+          address: ERC20_TOKEN_ADDRESS_3_MOCK,
+          standard: SimulationTokenStandard.erc20,
+        },
+      ]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+    });
+
+    it('handles token fiat rate with more than 15 significant digits', async () => {
+      mockFetchTokenContractExchangeRates.mockResolvedValue({
+        [ERC20_TOKEN_ADDRESS_1_MOCK]: 0.1234567890123456,
+      });
+      const { result, waitForNextUpdate } = setupHook([
+        {
+          ...dummyBalanceChange,
+          difference: DIFFERENCE_1_MOCK,
+          isDecrease: true,
+          address: ERC20_TOKEN_ADDRESS_1_MOCK,
+          standard: SimulationTokenStandard.erc20,
+        },
+      ]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(-0.002098765413209875);
     });
   });
 
@@ -222,8 +322,22 @@ describe('useBalanceChanges', () => {
             type: AssetType.Native,
           },
           amount: new BigNumber('-5373.003641998677469065'),
+          fiatAmount: Number('-16119.010925996032'),
         },
       ]);
+    });
+
+    it('handles native fiat rate with more than 15 significant digits', async () => {
+      mockSelectConversionRate.mockReturnValue(0.1234567890123456);
+      const { result, waitForNextUpdate } = setupHook({
+        ...dummyBalanceChange,
+        difference: DIFFERENCE_ETH_MOCK,
+        isDecrease: true,
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
     });
 
     it('handles no native balance change', async () => {
@@ -264,6 +378,7 @@ describe('useBalanceChanges', () => {
     expect(changes[0].amount).toEqual(
       new BigNumber('-5373.003641998677469065'),
     );
+    expect(changes[0].fiatAmount).toBe(Number('-16119.010925996032'));
     expect(changes[1].asset).toEqual({
       address: ERC20_TOKEN_ADDRESS_1_MOCK,
       type: AssetType.ERC20,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3047,12 +3047,13 @@
   },
   "simulation_details": {
     "failed": "There was an error loading your estimation.",
+    "fiat_not_available": "Not Available",
     "incoming_heading": "You receive", 
     "no_balance_changes": "No changes predicted for your wallet",
     "outgoing_heading": "You send",
     "reverted": "This transaction is likely to fail",
     "title": "Estimated changes",
     "tooltip_description": "Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee.",
-    "total_fiat": "Total {{currency}}"
+    "total_fiat": "Total = {{currency}}"
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add fiat display support to simulation details component.

## **Screenshots/Recordings**

https://github.com/MetaMask/metamask-mobile/assets/7644512/4bd242d5-ba62-415c-b5d2-e04cf035515d

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
