### PR TITLE
fix: error validating wallet connect signature with security provider

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -373,13 +373,7 @@ class WalletConnect2Session {
     let method = requestEvent.params.request.method;
     const chainId = parseInt(requestEvent.params.chainId);
 
-    const beforeMethodParams = requestEvent.params.request.params as any;
-    // Replace blockExplorerUrls with blockExplorerUrl
-    const methodParams = {
-      ...beforeMethodParams,
-      // blockExplorerUrl: beforeMethodParams.blockExplorerUrls,
-      // test: 'test',
-    };
+    const methodParams = requestEvent.params.request.params as any;
 
     DevLogger.log(
       `WalletConnect2Session::handleRequest chainId=${chainId} method=${method}`,


### PR DESCRIPTION
## **Description**

When connected to a dApp via WalletConnect, security provider validation on signature requests was unable to complete and displaying a warning.

This appears to be due to a change in the `WalletConnectV2` request handler causing the JSON-RPC params to be converted to an object, as opposed to the original array. This is non-standard and therefore the PPOM was throwing with the following error:

`Error validating JSON RPC using PPOM: Error: invalid type: map, expected a sequence at line 1 column 882` 

## **Related issues**

Fixes: #9778 

## **Manual testing steps**

See issue.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
