### PR TITLE
fix: confirmations failing ci tests

### DIFF
--- a/app/util/test/ganache.js
+++ b/app/util/test/ganache.js
@@ -5,6 +5,7 @@ export const DEFAULT_GANACHE_PORT = 8545;
 
 const defaultOptions = {
   blockTime: 2,
+  network_id: 1338,
   chainId: 1338,
   port: DEFAULT_GANACHE_PORT,
   vmErrorsOnRPCResponse: false,

--- a/app/util/test/ganache.js
+++ b/app/util/test/ganache.js
@@ -5,7 +5,7 @@ export const DEFAULT_GANACHE_PORT = 8545;
 
 const defaultOptions = {
   blockTime: 2,
-  network_id: 1337,
+  network_id: 1338,
   port: DEFAULT_GANACHE_PORT,
   vmErrorsOnRPCResponse: false,
   hardfork: 'muirGlacier',

--- a/app/util/test/ganache.js
+++ b/app/util/test/ganache.js
@@ -5,7 +5,7 @@ export const DEFAULT_GANACHE_PORT = 8545;
 
 const defaultOptions = {
   blockTime: 2,
-  network_id: 1338,
+  chainId: 1338,
   port: DEFAULT_GANACHE_PORT,
   vmErrorsOnRPCResponse: false,
   hardfork: 'muirGlacier',

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -173,7 +173,7 @@ class FixtureBuilder {
               networkConfigurations: {
                 networkId1: {
                   rpcUrl: `http://localhost:${getGanachePort()}`,
-                  chainId: '1337',
+                  chainId: '1338',
                   ticker: 'ETH',
                   nickname: 'Localhost',
                 },
@@ -536,7 +536,7 @@ class FixtureBuilder {
             },
             {
               active: true,
-              chainId: 1337,
+              chainId: 1338,
               chainName: 'Localhost',
               shortName: 'Localhost',
               nativeTokenSupported: true,
@@ -678,7 +678,7 @@ class FixtureBuilder {
       isCustomNetwork: true,
       providerConfig: {
         type: 'rpc',
-        chainId: '0x539',
+        chainId: '0x53A',
         rpcUrl: `http://localhost:${getGanachePort()}`,
         nickname: 'Localhost',
         ticker: 'ETH',

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -678,7 +678,7 @@ class FixtureBuilder {
       isCustomNetwork: true,
       providerConfig: {
         type: 'rpc',
-        chainId: '0x53A',
+        chainId: '0x53a',
         rpcUrl: `http://localhost:${getGanachePort()}`,
         nickname: 'Localhost',
         ticker: 'ETH',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This fixes an issue introduced by the new support of chainId 1337 from the gasAPI. The problem is that now we are fetching the gasAPI for getting the gas, and since we don't have mocks, the gas value changes and makes the tests flaky.

The quick fix is to start ganache on a different chainId, that the gasAPI doesn't support it. This way we'll rely again on the gas values coming from the RPC (ganache) which are stable.

In the long term, we'll want to add mocks and also test the flows for the gasAPI 200 response

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/fba55c3f-244c-4f4f-836b-1add65cb741e

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
