### PR TITLE
chore: make `yarn watch` `clean` by the default and add missing step to testing.md

### DIFF
--- a/docs/readme/testing.md
+++ b/docs/readme/testing.md
@@ -33,10 +33,23 @@ Prerequisites for running tests
 
     - To ensure that the detox-cli is properly installed, please verify its presence by running the command `detox` in your terminal. The detox-cli serves as a convenient script that facilitates running commands through a local Detox executable located at node_modules/.bin/detox. Its purpose is to simplify the operation of Detox from the command line. For example, you can execute commands like `detox test -c ios.sim.debug` with ease using detox-cli. In case the detox-cli is not installed, please refer to the instructions provided [here](https://wix.github.io/Detox/docs/introduction/environment-setup/#1-command-line-tools-detox-cli) for detailed guidance. 
 - The default device for iOS is the iPhone 13 Pro and Android the Pixel 5. Ensure you have these set up. You can change the default devices at anytime by updating the `device.type` in the detox config `e2e/.detoxrc.js`
-- Make sure that Metro is running. Use this command to launch the metro server:
+
+- If you haven't already done so for the current branch you are on, run `yarn setup`.
+
+- Ensure `IS_TEST` is set to `"true"` in your `.js.env` file and source it.
 
 ```bash
-yarn watch
+export IS_TEST="true"
+```
+
+```bash
+source .js.env
+```
+
+- After sourcing `.js.env`, run this command to launch the metro server (note: use of `clean` is important)
+
+```bash
+yarn watch:clean
 ```
 
 You can trigger the tests against a `release` or `debug` build. It recommended that you trigger the tests against a debug build.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "audit:ci": "./scripts/yarn-audit.sh",
-    "watch": "./scripts/build.sh watcher watch",
+    "watch:no-clean": "./scripts/build.sh watcher watch",
+    "watch": "yarn watch:clean",
     "watch:clean": "./scripts/build.sh watcher clean",
     "clean:ios": "rm -rf ios/build",
     "pod:install": "command -v pod && (cd ios/ && bundle exec pod install && cd ..) || echo \"Skipping pod install\"",


### PR DESCRIPTION
## **Description**
Make `yarn watch` `clean` by the default. Update testing.md with missing step. 

@Cal-L wrote:
> Make sure you have IS_TEST in your .js.env file. After that, rebuild the app, then re-run the test

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
