### PR TITLE
fix: Undefined balance when fetching from chain

### DIFF
--- a/patches/@metamask+assets-controllers+26.0.0.patch
+++ b/patches/@metamask+assets-controllers+26.0.0.patch
@@ -19,24 +19,29 @@ index 0000000..b867ea9
 +* Run "yarn patch:assets <core-directory>" in the mobile repo
 +* If you have changes also add them to the branch: patch/mobile-assets-controllers-26
 diff --git a/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.js b/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.js
-index ee99eb2..a447b70 100644
+index ee99eb2..c786b6c 100644
 --- a/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.js
 +++ b/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.js
-@@ -69,8 +69,12 @@ class AccountTrackerController extends polling_controller_1.StaticIntervalPollin
+@@ -69,17 +69,28 @@ class AccountTrackerController extends polling_controller_1.StaticIntervalPollin
                      : [this.getSelectedAddress()];
                  const accountsForChain = Object.assign({}, accountsByChainId[chainId]);
                  for (const address of accountsToUpdate) {
+-                    accountsForChain[address] = {
+-                        balance: (0, controller_utils_1.BNToHex)(yield this.getBalanceFromChain(address, ethQuery)),
+-                    };
 +                    /**
 +                     * IMPORTANT NOTE ABOUT THIS PATCH
 +                     * This patch can be removed once Assets Controller is updated to v^27
 +                     */
-                     accountsForChain[address] = {
--                        balance: (0, controller_utils_1.BNToHex)(yield this.getBalanceFromChain(address, ethQuery)),
-+                        balance: yield this.getBalanceFromChain(address, ethQuery),
-                     };
++                    const balance = yield this.getBalanceFromChain(address, ethQuery);
++                    if(balance){
++                        accountsForChain[address] = {
++                            balance,
++                        };
++                    }
                  }
                  this.update(Object.assign(Object.assign({}, (chainId === this.getCurrentChainId() && {
-@@ -78,8 +82,12 @@ class AccountTrackerController extends polling_controller_1.StaticIntervalPollin
+                     accounts: accountsForChain,
                  })), { accountsByChainId: Object.assign(Object.assign({}, this.state.accountsByChainId), { [chainId]: accountsForChain }) }));
              }
              catch (err) {


### PR DESCRIPTION
## **Description**

When fetching the balance from chain, and it returns undefined, we keep the balance as it was before.
This will fix the behaviour for low speed internet devices!

The solution wrote here, it's already present on higher versions of assets-controllers, so in the next update, this change will not need to be patched anymore.

## **Related issues**

Fixes: #9849 

## **Manual testing steps**

1. Go to swaps view
2. Choose DAI to swap to and insert 0.0001
3. The quotes will process as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/MetaMask/metamask-mobile/assets/46944231/fd61a0a7-4e17-4f49-9240-ead10eb3de69


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
