### PR TITLE
test: Update Browserstack url as old link deprecated

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -426,9 +426,9 @@ workflows:
         stack: linux-docker-android-20.04
         machine_type_id: elite-xl
     envs:
-      - PRODUCTION_APP_URL: 'bs://3f81fdb66cba8140909d1ff0a05bc2ace97b307f' # Last production's QA build
-      - PRODUCTION_BUILD_VERSION_NAME: 7.20.0
-      - PRODUCTION_BUILD_VERSION_NUMBER: 1308
+      - PRODUCTION_APP_URL: 'bs://5e4f57286372b8e8c2d0db8c3c8c99fdd669c10c' # Last production's QA build
+      - PRODUCTION_BUILD_VERSION_NAME: 7.22.0
+      - PRODUCTION_BUILD_VERSION_NUMBER: 1325
       - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
       - PRODUCTION_BUILD_STRING: 'MetaMask-QA v$PRODUCTION_BUILD_VERSION_NAME ($PRODUCTION_BUILD_VERSION_NUMBER)'
       - NEW_BUILD_STRING: 'MetaMask-QA v$VERSION_NAME ($VERSION_NUMBER)'


### PR DESCRIPTION
Modify browserstack url with replaced V7.22.0 Build 1325

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Upgrade Tests were failing due to the .apk being removed from BrowserStack servers after 30 days.
- Uploaded a new .apk to Browserstack and updated the url and version
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
