### PR TITLE
fix: bug report template - remove reference to recordit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -29,7 +29,7 @@ body:
    id: screenshot-recording
    attributes:
      label: Screenshots/Recordings
-     description: Please include screenshots/recordings if applicable! (https://recordit.co/ is recommended)
+     description: Please include screenshots/recordings if applicable!
  - type: textarea
    id: reproduce
    attributes:


### PR DESCRIPTION
## **Description**

Remove reference to recordit as the tool is deprecated.

## **Related issues**

- None

## **Manual testing steps**

- None

## **Screenshots/Recordings**

- None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/pull-requests.md) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
