### PR TITLE
revert: revert changes to ganache chainID. 

### DIFF
--- a/app/util/test/ganache.js
+++ b/app/util/test/ganache.js
@@ -5,8 +5,7 @@ export const DEFAULT_GANACHE_PORT = 8545;
 
 const defaultOptions = {
   blockTime: 2,
-  network_id: 1338,
-  chainId: 1338,
+  network_id: 1337,
   port: DEFAULT_GANACHE_PORT,
   vmErrorsOnRPCResponse: false,
   hardfork: 'muirGlacier',

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -173,7 +173,7 @@ class FixtureBuilder {
               networkConfigurations: {
                 networkId1: {
                   rpcUrl: `http://localhost:${getGanachePort()}`,
-                  chainId: '1338',
+                  chainId: '1337',
                   ticker: 'ETH',
                   nickname: 'Localhost',
                 },
@@ -536,7 +536,7 @@ class FixtureBuilder {
             },
             {
               active: true,
-              chainId: 1338,
+              chainId: 1337,
               chainName: 'Localhost',
               shortName: 'Localhost',
               nativeTokenSupported: true,
@@ -678,7 +678,7 @@ class FixtureBuilder {
       isCustomNetwork: true,
       providerConfig: {
         type: 'rpc',
-        chainId: '0x53a',
+        chainId: '0x539',
         rpcUrl: `http://localhost:${getGanachePort()}`,
         nickname: 'Localhost',
         ticker: 'ETH',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Earlier in the week we made changes to the gasAPI where chainID 1337 returns data. This is not ideal. We want to ensure the devnet chainID does not rely on external services. Furthermore, we want to strive to be as close to the extension when it comes to development and this subtle change may cause some confusion. Lastly, if we are testing any external APIs we should be able to mock them. This is not available on mobile, but we plan on introducing it in the coming weeks. 


**NOTE**
Once the API platform team reverts the changes to the gas api, this PR can be merged. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
