### PR TITLE
fix: upgrade test failure fix for 7.24.0 release branch

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -427,7 +427,7 @@ workflows:
         machine_type_id: elite-xl
     envs:
       - PRODUCTION_APP_URL: 'bs://ba40e5b7b4210a06c659b5c6818a3efec2624513' # Last production's QA build
-      - PRODUCTION_BUILD_VERSION_NAME: 7.20.0
+      - PRODUCTION_BUILD_VERSION_NAME: 7.22.0
       - PRODUCTION_BUILD_VERSION_NUMBER: 1325
       - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
       - PRODUCTION_BUILD_STRING: 'MetaMask-QA v$PRODUCTION_BUILD_VERSION_NAME ($PRODUCTION_BUILD_VERSION_NUMBER)'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -426,9 +426,9 @@ workflows:
         stack: linux-docker-android-20.04
         machine_type_id: elite-xl
     envs:
-      - PRODUCTION_APP_URL: 'bs://3f81fdb66cba8140909d1ff0a05bc2ace97b307f' # Last production's QA build
-      - PRODUCTION_BUILD_VERSION_NAME: 7.24.0
-      - PRODUCTION_BUILD_VERSION_NUMBER: 1334
+      - PRODUCTION_APP_URL: 'bs://ba40e5b7b4210a06c659b5c6818a3efec2624513' # Last production's QA build
+      - PRODUCTION_BUILD_VERSION_NAME: 7.20.0
+      - PRODUCTION_BUILD_VERSION_NUMBER: 1325
       - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
       - PRODUCTION_BUILD_STRING: 'MetaMask-QA v$PRODUCTION_BUILD_VERSION_NAME ($PRODUCTION_BUILD_VERSION_NUMBER)'
       - NEW_BUILD_STRING: 'MetaMask-QA v$VERSION_NAME ($VERSION_NUMBER)'

--- a/wdio/features/Upgrading/ConnectedTestNetwork.feature
+++ b/wdio/features/Upgrading/ConnectedTestNetwork.feature
@@ -29,7 +29,7 @@ Feature: Upgrade previous app build with current release
     And the splash animation completes
     And I fill my password in the Login screen
     And I log into my wallet
-    Then I should see the added network name "<Network>" in the top navigation bar
+    Then I should see the added network name "Sepolia" in the top navigation bar
     And tokens <TOKEN> in account should be displayed
     And I tap on the Settings tab option
     And I scroll up

--- a/wdio/features/Upgrading/MultipleAccounts.feature
+++ b/wdio/features/Upgrading/MultipleAccounts.feature
@@ -41,4 +41,4 @@ Feature: Upgrade previous app build with current release while being connected t
 
     Examples:
       | PRIVATEKEY                                                       | AccountName |
-      | cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1 | Account 4   |
+      | cbfd798afcfd1fd8ecc48cbecb6dc7e876543395640b758a90e11d986e758ad1 | Account 3   |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- updates the the Browserstack url for upgrade test
- updates the wdio cucumber steps to match the expected process flow
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: This failure on Bitrise https://app.bitrise.io/build/273524f9-ffa0-4adf-a4ca-0f2e5f1a0694

## **Manual testing steps**

1. Run `release_e2e_pipeline `
2. All tests should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://app.bitrise.io/build/273524f9-ffa0-4adf-a4ca-0f2e5f1a0694

### **After**
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/5252a0f6-ecfe-405b-987e-bc33f37c5e74


- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
