### PR TITLE
fix: flakey CI asdf node version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -211,7 +211,7 @@ workflows:
                 echo "${NVM_SHA256SUM} install-nvm.sh" > install-nvm.sh.SHA256SUM
                 sha256sum -c install-nvm.sh.SHA256SUM
                 chmod +x install-nvm.sh && ./install-nvm.sh && rm ./install-nvm.sh
-                source ${HOME}/.profile
+                source "${HOME}/.nvm/nvm.sh"
 
                 nvm install ${NODE_VERSION}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -212,6 +212,7 @@ workflows:
                 sha256sum -c install-nvm.sh.SHA256SUM
                 chmod +x install-nvm.sh && ./install-nvm.sh && rm ./install-nvm.sh
                 source "${HOME}/.nvm/nvm.sh"
+                echo 'source "${HOME}/.nvm/nvm.sh"' | tee -a ${HOME}/.{bashrc,profile}
 
                 nvm install ${NODE_VERSION}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -202,11 +202,13 @@ workflows:
                 #!/usr/bin/env bash
                 echo "Gems being installed with bundler gem"
                 bundle install
-                echo "Node $NODE_VERSION being installed with asdf"
+                echo "Node $NODE_VERSION being installed"
+
+                set -e
 
                 # Install and enable NVM
                 wget -O install-nvm.sh https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
-                echo "${NVM_SHA256SUM} nvm-install.sh' > nvm-install.sh.SHA256SUM
+                echo "${NVM_SHA256SUM} nvm-install.sh" > nvm-install.sh.SHA256SUM
                 sha256sum -c nvm-install.sh.SHA256SUM
                 chmod +x nvm-install.sh && ./nvm-install.sh && rm ./nvm-install.sh
                 source $PROFILE
@@ -215,8 +217,6 @@ workflows:
 
                 envman add --key PATH --value $PATH
 
-                # using set -e earlier caused issues, so at least check if the install succeeded at the end
-                set -e
                 node --version
 
                 echo "Corepack being installed with npm"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -208,9 +208,9 @@ workflows:
 
                 # Install and enable NVM
                 wget -O install-nvm.sh "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh"
-                echo "${NVM_SHA256SUM} nvm-install.sh" > nvm-install.sh.SHA256SUM
-                sha256sum -c nvm-install.sh.SHA256SUM
-                chmod +x nvm-install.sh && ./nvm-install.sh && rm ./nvm-install.sh
+                echo "${NVM_SHA256SUM} install-nvm.sh" > install-nvm.sh.SHA256SUM
+                sha256sum -c install-nvm.sh.SHA256SUM
+                chmod +x install-nvm.sh && ./install-nvm.sh && rm ./install-nvm.sh
                 source $PROFILE
 
                 nvm install ${NODE_VERSION}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -211,7 +211,7 @@ workflows:
                 echo "${NVM_SHA256SUM} install-nvm.sh" > install-nvm.sh.SHA256SUM
                 sha256sum -c install-nvm.sh.SHA256SUM
                 chmod +x install-nvm.sh && ./install-nvm.sh && rm ./install-nvm.sh
-                source $PROFILE
+                source ${HOME}/.profile
 
                 nvm install ${NODE_VERSION}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -207,7 +207,7 @@ workflows:
                 set -e
 
                 # Install and enable NVM
-                wget -O install-nvm.sh https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
+                wget -O install-nvm.sh "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh"
                 echo "${NVM_SHA256SUM} nvm-install.sh" > nvm-install.sh.SHA256SUM
                 sha256sum -c nvm-install.sh.SHA256SUM
                 chmod +x nvm-install.sh && ./nvm-install.sh && rm ./nvm-install.sh

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -204,8 +204,12 @@ workflows:
                 bundle install
                 echo "Node $NODE_VERSION being installed with asdf"
 
-                # Install NVM
-                curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
+                # Install and enable NVM
+                wget -O install-nvm.sh https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
+                echo "${NVM_SHA256SUM} nvm-install.sh' > nvm-install.sh.SHA256SUM
+                sha256sum -c nvm-install.sh.SHA256SUM
+                chmod +x nvm-install.sh && ./nvm-install.sh && rm ./nvm-install.sh
+                source $PROFILE
 
                 nvm install ${NODE_VERSION}
 
@@ -436,7 +440,7 @@ workflows:
         machine_type_id: elite-xl
     envs:
       - PRODUCTION_APP_URL: 'bs://ba40e5b7b4210a06c659b5c6818a3efec2624513' # Last production's QA build
-      - PRODUCTION_BUILD_VERSION_NAME: 7.22.0 
+      - PRODUCTION_BUILD_VERSION_NAME: 7.22.0
       - PRODUCTION_BUILD_VERSION_NUMBER: 1325
       - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
       - PRODUCTION_BUILD_STRING: 'MetaMask-QA v$PRODUCTION_BUILD_VERSION_NAME ($PRODUCTION_BUILD_VERSION_NUMBER)'
@@ -1375,6 +1379,9 @@ app:
     - opts:
         is_expand: false
       NVM_VERSION: 0.39.7
+    - opts:
+        is_expand: false
+      NVM_SHA256SUM: '8e45fa547f428e9196a5613efad3bfa4d4608b74ca870f930090598f5af5f643'
     - opts:
         is_expand: false
       NODE_VERSION: 20.12.2

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -203,9 +203,33 @@ workflows:
                 echo "Gems being installed with bundler gem"
                 bundle install
                 echo "Node $NODE_VERSION being installed with asdf"
-                asdf list all nodejs
-                asdf install nodejs "$NODE_VERSION"
-                asdf global nodejs "$NODE_VERSION"
+
+                # Install NVM
+                PROFILE=$HOME/.profile
+                touch $PROFILE
+                curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | PROFILE=$PROFILE bash
+                source $PROFILE
+
+                if [ ! -z "${working_dir}" ] ; then
+                  echo "Switching to working directory: ${working_dir}"
+
+                  cd "${working_dir}"
+                  if [ $? -ne 0 ] ; then
+                    echo "Failed to switch to working directory: ${working_dir}"
+                  fi
+                fi
+
+                # Install latest node version by default
+                # if [[ -z "$node_version" && ! -e "./.nvmrc" ]]; then node_version="node"; fi
+
+                nvm install ${NODE_VERSION}
+
+                envman add --key PATH --value $PATH
+
+                # using set -e earlier caused issues, so at least check if the install succeeded at the end
+                set -e
+                node --version
+
                 echo "Corepack being installed with npm"
                 npm i -g "corepack@$COREPACK_VERSION"
                 echo "Corepack enabling $YARN_VERSION"
@@ -1363,6 +1387,9 @@ app:
     - opts:
         is_expand: false
       IOS_APP_LINK: ''
+    - opts:
+        is_expand: false
+      NVM_VERSION: 0.39.7
     - opts:
         is_expand: false
       NODE_VERSION: 20.12.2

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -205,22 +205,7 @@ workflows:
                 echo "Node $NODE_VERSION being installed with asdf"
 
                 # Install NVM
-                PROFILE=$HOME/.profile
-                touch $PROFILE
-                curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | PROFILE=$PROFILE bash
-                source $PROFILE
-
-                if [ ! -z "${working_dir}" ] ; then
-                  echo "Switching to working directory: ${working_dir}"
-
-                  cd "${working_dir}"
-                  if [ $? -ne 0 ] ; then
-                    echo "Failed to switch to working directory: ${working_dir}"
-                  fi
-                fi
-
-                # Install latest node version by default
-                # if [[ -z "$node_version" && ! -e "./.nvmrc" ]]; then node_version="node"; fi
+                curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
 
                 nvm install ${NODE_VERSION}
 


### PR DESCRIPTION
## **Description**

Fix flakey CI
failing on Node v16
instead of using Node v20 (set in: package.json, bitrise.yml, .nvmrc)

```console
$ yarn "setup"

yarn run v1.22.22
error metamask@7.24.0: The engine "node" is incompatible with this module. Expected version "^20.12.2". Got "16.20.2"
error Commands cannot run with an incompatible environment.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Run: provided yarn command failed: exit status 1
```

```console
TEST_SUITE_FOLDER value is: ./e2e/specs/confirmations/*
TEST_SUITE_TAG value is: .*SmokeConfirmations.*
/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22762
    throw new Error(
          ^
Error: Error when performing the request to https://registry.npmjs.org/yarn/latest; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting
    at fetch (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22762:11)
    at async fetchAsJson (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22776:20)
    ... 4 lines matching cause stack trace ...
    at async Object.runMain (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:24232:5) {
  [cause]: TypeError: globalThis.fetch is not a function
      at fetch (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22756:33)
      at async fetchAsJson (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22776:20)
      at async fetchLatestStableVersion (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22703:20)
      at async fetchLatestStableVersion2 (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:22826:14)
      at async Engine.getDefaultVersion (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:23433:23)
      at async Engine.executePackageManagerRequest (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:23525:47)
      at async Object.runMain (/root/.asdf/installs/nodejs/16.20.2/lib/node_modules/corepack/dist/lib/corepack.cjs:24232:5)
}
```

- remove asdf to setup node
- add [bitrise-nvm-step](https://github.com/Almouro/bitrise-nvm-step)

if flakiness continues, consider removing `/root/.asdf/installs/nodejs/16.20.2`

## **Related issues**

Fixes: CI

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
