### PR TITLE
RNWebView upgrade: Fix e2e tests on CI

### DIFF
--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -63,13 +63,22 @@ class Browser {
     );
   }
   get HomePageFavourtiesTab() {
-    return Matchers.getElementByXPath(BrowserViewSelectorsXPaths.FAVORITE_TAB);
+    return Matchers.getElementByXPath(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      BrowserViewSelectorsXPaths.FAVORITE_TAB,
+    );
   }
 
   get TestDappURLInFavourtiesTab() {
     return device.getPlatform() === 'ios'
-      ? Matchers.getElementByXPath(BrowserViewSelectorsXPaths.TEST_DAPP_LINK)
-      : Matchers.getElementByXPath(BrowserViewSelectorsXPaths.TEST_DAPP_TEXT);
+      ? Matchers.getElementByXPath(
+          BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+          BrowserViewSelectorsXPaths.TEST_DAPP_LINK,
+        )
+      : Matchers.getElementByXPath(
+          BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+          BrowserViewSelectorsXPaths.TEST_DAPP_TEXT,
+        );
   }
 
   get multiTabButton() {

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -23,42 +23,59 @@ class TestDApp {
   }
 
   get DappConnectButton() {
-    return Matchers.getElementByWebID(TestDappSelectorsWebIDs.CONNECT_BUTTON);
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.CONNECT_BUTTON,
+    );
   }
 
   get ApproveButton() {
     return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestDappSelectorsWebIDs.APPROVE_TOKENS_BUTTON_ID,
     );
   }
   // This taps on the transfer tokens button under the "SEND TOKENS section"
   get erc20TransferTokensButton() {
     return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestDappSelectorsWebIDs.ERC_20_SEND_TOKENS_TRANSFER_TOKENS_BUTTON_ID,
     );
   }
   get ethSignButton() {
-    return Matchers.getElementByWebID(TestDappSelectorsWebIDs.ETH_SIGN);
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.ETH_SIGN,
+    );
   }
   get personalSignButton() {
-    return Matchers.getElementByWebID(TestDappSelectorsWebIDs.PERSONAL_SIGN);
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.PERSONAL_SIGN,
+    );
   }
   get signTypedDataButton() {
-    return Matchers.getElementByWebID(TestDappSelectorsWebIDs.SIGN_TYPE_DATA);
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.SIGN_TYPE_DATA,
+    );
   }
   get signTypedDataV3Button() {
     return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestDappSelectorsWebIDs.SIGN_TYPE_DATA_V3,
     );
   }
   get signTypedDataV4Button() {
     return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestDappSelectorsWebIDs.SIGN_TYPE_DATA_V4,
     );
   }
   // This taps on the transfer tokens button under the "SEND TOKENS section"
   get nftTransferFromTokensButton() {
     return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestDappSelectorsWebIDs.NFT_TRANSFER_FROM_BUTTON_ID,
     );
   }
@@ -102,6 +119,7 @@ class TestDApp {
   }
 
   async tapButton(elementId) {
+    await Gestures.scrollToWebViewPort(elementId);
     await Gestures.tapWebElement(elementId);
   }
 

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -74,9 +74,12 @@ class Matchers {
   }
 
   /**
+   * Get Native WebView instance by elementId
    *
-   * TODO: add method comment
-   *
+   *  Because Android Webview might have more that one WebView instance present on the main activity, the correct element
+   *  is select based on its parent element id.
+   *  @param {string} elementId The web ID of the browser webview
+   *  @returns {Detox.WebViewElement} WebView element
    */
   static getWebViewByID(elementId) {
     return device.getPlatform() === 'ios'

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -104,7 +104,10 @@ class Matchers {
    * @return {Promise<Detox.IndexableWebElement>} - Resolves to the located element
    */
   static async getElementByXPath(webviewID, xpath) {
-    const myWebView = web(by.id(webviewID));
+    const myWebView =
+      device.getPlatform() === 'ios'
+        ? web(by.id(webviewID))
+        : web(by.type('android.webkit.WebView'));
     return myWebView.element(by.web.xpath(xpath)).atIndex(0);
   }
   /**

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -1,4 +1,4 @@
-import { web } from 'detox';
+import { web, log } from 'detox';
 
 /**
  * Utility class for matching (locating) UI elements
@@ -108,7 +108,9 @@ class Matchers {
       device.getPlatform() === 'ios'
         ? web(by.id(webviewID))
         : web(by.type('android.webkit.WebView').withAncestor(by.id(webviewID)));
-    return myWebView.element(by.web.xpath(xpath));
+    const returnElement = myWebView.element(by.web.xpath(xpath));
+    log.info('returnElement', returnElement);
+    return returnElement;
   }
   /**
    * Get element by href.

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -108,7 +108,7 @@ class Matchers {
       device.getPlatform() === 'ios'
         ? web(by.id(webviewID))
         : web(by.type('android.webkit.WebView').withAncestor(by.id(webviewID)));
-    return myWebView.element(by.web.xpath(xpath)).atIndex(0);
+    return myWebView.element(by.web.xpath(xpath));
   }
   /**
    * Get element by href.

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -1,4 +1,4 @@
-import { web, log } from 'detox';
+import { web } from 'detox';
 
 /**
  * Utility class for matching (locating) UI elements
@@ -74,6 +74,17 @@ class Matchers {
   }
 
   /**
+   *
+   * TODO: add method comment
+   *
+   */
+  static getWebViewByID(elementId) {
+    return device.getPlatform() === 'ios'
+      ? web(by.id(elementId))
+      : web(by.type('android.webkit.WebView').withAncestor(by.id(elementId)));
+  }
+
+  /**
    * Get element by web ID.
    *
    * * @param {string} webviewID - The web ID of the inner element to locate within the webview
@@ -81,7 +92,7 @@ class Matchers {
    * @return {Promise<Detox.IndexableWebElement>} Resolves to the located element
    */
   static async getElementByWebID(webviewID, innerID) {
-    const myWebView = web(by.id(webviewID));
+    const myWebView = this.getWebViewByID(webviewID);
     return myWebView.element(by.web.id(innerID));
   }
 
@@ -104,13 +115,8 @@ class Matchers {
    * @return {Promise<Detox.IndexableWebElement>} - Resolves to the located element
    */
   static async getElementByXPath(webviewID, xpath) {
-    const myWebView =
-      device.getPlatform() === 'ios'
-        ? web(by.id(webviewID))
-        : web(by.type('android.webkit.WebView').withAncestor(by.id(webviewID)));
-    const returnElement = myWebView.element(by.web.xpath(xpath));
-    log.info('returnElement', returnElement);
-    return returnElement;
+    const myWebView = this.getWebViewByID(webviewID);
+    return myWebView.element(by.web.xpath(xpath));
   }
   /**
    * Get element by href.

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -76,10 +76,10 @@ class Matchers {
   /**
    * Get Native WebView instance by elementId
    *
-   *  Because Android Webview might have more that one WebView instance present on the main activity, the correct element
-   *  is select based on its parent element id.
-   *  @param {string} elementId The web ID of the browser webview
-   *  @returns {Detox.WebViewElement} WebView element
+   * Because Android Webview might have more that one WebView instance present on the main activity, the correct element
+   * is select based on its parent element id.
+   * @param {string} elementId The web ID of the browser webview
+   * @returns {Detox.WebViewElement} WebView element
    */
   static getWebViewByID(elementId) {
     return device.getPlatform() === 'ios'
@@ -90,8 +90,8 @@ class Matchers {
   /**
    * Get element by web ID.
    *
-   * * @param {string} webviewID - The web ID of the inner element to locate within the webview
-   *  @param {string} innerID - The web ID of the browser webview
+   * @param {string} webviewID - The web ID of the inner element to locate within the webview
+   * @param {string} innerID - The web ID of the browser webview
    * @return {Promise<Detox.IndexableWebElement>} Resolves to the located element
    */
   static async getElementByWebID(webviewID, innerID) {

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -107,7 +107,7 @@ class Matchers {
     const myWebView =
       device.getPlatform() === 'ios'
         ? web(by.id(webviewID))
-        : web(by.type('android.webkit.WebView'));
+        : web(by.type('android.webkit.WebView').withAncestor(by.id(webviewID)));
     return myWebView.element(by.web.xpath(xpath)).atIndex(0);
   }
   /**

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -76,16 +76,13 @@ class Matchers {
   /**
    * Get element by web ID.
    *
+   * * @param {string} webviewID - The web ID of the inner element to locate within the webview
    *  @param {string} innerID - The web ID of the browser webview
    * @return {Promise<Detox.IndexableWebElement>} Resolves to the located element
    */
-  static async getElementByWebID(innerID) {
-    if ((await device.getPlatform()) === 'android') {
-      return web.element(by.web.id(innerID));
-    } else if ((await device.getPlatform()) === 'ios') {
-      const myWebView = web(by.id('browser-webview'));
-      return myWebView.element(by.web.id(innerID));
-    }
+  static async getElementByWebID(webviewID, innerID) {
+    const myWebView = web(by.id(webviewID));
+    return myWebView.element(by.web.id(innerID));
   }
 
   /**
@@ -95,8 +92,9 @@ class Matchers {
    * @return {Promise<Detox.IndexableWebElement>} - Resolves to the located element
    */
 
-  static async getElementByCSS(selector) {
-    return web.element(by.web.cssSelector(selector));
+  static async getElementByCSS(webviewID, selector) {
+    const myWebView = web(by.id(webviewID));
+    return myWebView.element(by.web.cssSelector(selector)).atIndex(0);
   }
 
   /**
@@ -105,16 +103,19 @@ class Matchers {
    * @param {string} xpath - XPath expression to locate the element
    * @return {Promise<Detox.IndexableWebElement>} - Resolves to the located element
    */
-  static async getElementByXPath(xpath) {
-    return web.element(by.web.xpath(xpath)).atIndex(0);
+  static async getElementByXPath(webviewID, xpath) {
+    const myWebView = web(by.id(webviewID));
+    return myWebView.element(by.web.xpath(xpath)).atIndex(0);
   }
   /**
    * Get element by href.
+   * @param {string} webviewID - The web ID of the browser webview
    * @param {string} xpath - XPath expression to locate the element
    * @return {Promise<Detox.IndexableWebElement>} - Resolves to the located element
    */
-  static async getElementByHref(url) {
-    return web.element(by.web.href(url)).atIndex(0);
+  static async getElementByHref(webviewID, url) {
+    const myWebView = web(by.id(webviewID));
+    return myWebView.element(by.web.href(url)).atIndex(0);
   }
 
   /**


### PR DESCRIPTION
## **Description**
Update detox matchers to grab the correct webview instance to test.

Even though e2e tests pass locally, on our CI they fail with the error 

```
- [1] RNCWebView{id=-1, visibility=VISIBLE, width=0, height=0, has-focus=true, has-focusable=true, has-window-focus=true, is-clickable=true, is-enabled=true, is-focused=true, is-focusable=true, is-layout-requested=true, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=false, has-input-connection=true, editor-info=[inputType=0x0 imeOptions=0x1000000 privateImeOptions=null actionLabel=null actionId=0 initialSelStart=-1 initialSelEnd=-1 initialCapsMode=0x0 hintText=null label=null packageName=null autofillId=null fieldId=0 fieldName=null extras=null hintLocales=null contentMimeTypes=null ], x=0.0, y=0.0, child-count=0}
- [2] RNCWebView{id=-1, visibility=VISIBLE, width=1080, height=1650, has-focus=false, has-focusable=true, has-window-focus=true, is-clickable=true, is-enabled=true, is-focused=false, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=android.widget.FrameLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=false, has-input-connection=true, editor-info=[inputType=0x0 imeOptions=0x1000000 privateImeOptions=null actionLabel=null actionId=0 initialSelStart=-1 initialSelEnd=-1 initialCapsMode=0x0 hintText=null label=null packageName=null autofillId=null fieldId=0 fieldName=null extras=null hintLocales=null contentMimeTypes=null ], x=0.0, y=0.0, child-count=0}
```

Using a combination of detox matchers, such as, by.id, by.type and withAncestor. we are able to select the single webview instance we want to interact with.

See also detox documentation: https://wix.github.io/Detox/docs/guide/testing-webviews/#step-1-locating-the-webview

## **Related issues**

Fixes: #7759 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
