### PR TITLE
chore: bootstraps mark all as read button

### DIFF
--- a/app/components/UI/Notification/List/index.tsx
+++ b/app/components/UI/Notification/List/index.tsx
@@ -11,6 +11,9 @@ import { createStyles } from './styles';
 import { useMetrics } from '../../../hooks/useMetrics';
 import Empty from '../Empty';
 import { NotificationRow } from '../Row';
+import Button, {
+  ButtonVariants,
+} from '../../../../component-library/components/Buttons/Button';
 import {
   FeatureAnnouncementRawNotification,
   HalRawNotification,
@@ -18,6 +21,7 @@ import {
   getRowDetails,
 } from '../../../../util/notifications';
 import { NotificationsViewSelectorsIDs } from '../../../../../e2e/selectors/NotificationsView.selectors';
+import { NOTIFICATION_TEST_ID_TYPES } from '../Row/constants';
 
 interface NotificationsList {
   navigation: any;
@@ -46,6 +50,8 @@ const Notifications = ({
     },
     [navigation],
   );
+
+  const handleMarkAllAsRead = useCallback(() => {}, []);
 
   const renderTabBar = useCallback(
     (props) => (
@@ -129,27 +135,42 @@ const Notifications = ({
 
   const renderList = useCallback(
     (list, idx) => (
-      <FlatList
-        // This has been ts ignored due the need of extend this component to support injected tabLabel prop.
-        // eslint-disable-next-line
+      <>
+        <FlatList
+          // This has been ts ignored due the need of extend this component to support injected tabLabel prop.
+          // eslint-disable-next-line
         // @ts-ignore
-        tabLabel={strings(`notifications.list.${idx.toString()}`)}
-        keyExtractor={(_, index) => index.toString()}
-        key={combinedLists.indexOf(list)}
-        data={list}
-        ListEmptyComponent={
-          <Empty
-            testID={NotificationsViewSelectorsIDs.NO_NOTIFICATIONS_CONTAINER}
-          />
-        }
-        contentContainerStyle={styles.list}
-        renderItem={({ item }) => renderNotificationRow(item)}
-        initialNumToRender={10}
-        maxToRenderPerBatch={2}
-        onEndReachedThreshold={0.5}
-      />
+          tabLabel={strings(`notifications.list.${idx.toString()}`)}
+          keyExtractor={(_, index) => index.toString()}
+          key={combinedLists.indexOf(list)}
+          data={list}
+          ListEmptyComponent={
+            <Empty
+              testID={NotificationsViewSelectorsIDs.NO_NOTIFICATIONS_CONTAINER}
+            />
+          }
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => renderNotificationRow(item)}
+          initialNumToRender={10}
+          maxToRenderPerBatch={2}
+          onEndReachedThreshold={0.5}
+        />
+        <Button
+          testID={NOTIFICATION_TEST_ID_TYPES.NOTIFICATION_MARK_ALL_AS_READ}
+          variant={ButtonVariants.Primary}
+          label={strings('notifications.mark_all_as_read')}
+          onPress={handleMarkAllAsRead}
+          style={styles.stickyButton}
+        />
+      </>
     ),
-    [combinedLists, renderNotificationRow, styles.list],
+    [
+      combinedLists,
+      handleMarkAllAsRead,
+      renderNotificationRow,
+      styles.stickyButton,
+      styles.list,
+    ],
   );
 
   return (

--- a/app/components/UI/Notification/List/styles.ts
+++ b/app/components/UI/Notification/List/styles.ts
@@ -124,6 +124,7 @@ export const createStyles = ({ colors, typography }: Theme) =>
       width: '100%',
       alignSelf: 'center',
     },
+    stickyButton: { alignSelf: 'center', width: '100%', zIndex: 1, bottom: 50 },
     trashIconContainer: {
       position: 'absolute',
       paddingHorizontal: 24,

--- a/app/components/UI/Notification/Row/constants.ts
+++ b/app/components/UI/Notification/Row/constants.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
 export const NOTIFICATION_TEST_ID_TYPES = {
   NOTIFICATION_ACTION_BUTTON: 'notification-actions-button',
+  NOTIFICATION_MARK_ALL_AS_READ: 'notification-mark-all-as-read',
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1974,6 +1974,7 @@
     "wallet": "Wallet",
     "web3": "Web3",
     "staking_provider": "Staking Provider",
+    "mark_all_as_read": "Mark all as read",
     "empty": {
       "title": "Nothing to see here",
       "message": "This is where you can find notifications once there’s activity in your wallet. "
@@ -3065,7 +3066,7 @@
   "simulation_details": {
     "failed": "There was an error loading your estimation.",
     "fiat_not_available": "Not Available",
-    "incoming_heading": "You receive", 
+    "incoming_heading": "You receive",
     "no_balance_changes": "No changes predicted for your wallet",
     "outgoing_heading": "You send",
     "reverted": "This transaction is likely to fail",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a sticky button to allow users mark all notifications as read based on [this design](https://www.figma.com/design/XcAVSI5z4myb1DtlbIHw7U/ProfileID-(UUID)-mobile?node-id=2105-14742&t=GDihvijGHM0k76if-0)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
