### PR TITLE
test: comment out flaky test from `encryption-with-key`

### DIFF
--- a/e2e/specs/accounts/aes/encryption-with-key.spec.js
+++ b/e2e/specs/accounts/aes/encryption-with-key.spec.js
@@ -22,11 +22,11 @@ describe(
   SmokeAccounts('AES Crypto - Encryption and decryption with encryption key'),
   () => {
     const PASSWORD_ONE = '123123123';
-    const PASSWORD_TWO = '456456456';
+    // const PASSWORD_TWO = '456456456';
     const SALT_ONE = 'ZDuWAyf5kcDxVvMgVaoyzJNB9kP3Ykdq8DSx8rR/+ro=';
-    const SALT_TWO = 'avJ8b37znYTLyeCL0sNxkYxctQrfUdFKoK7SeqC3JSU=';
+    // const SALT_TWO = 'avJ8b37znYTLyeCL0sNxkYxctQrfUdFKoK7SeqC3JSU=';
     const DATA_TO_ENCRYPT_ONE = 'random data to encrypt';
-    const DATA_TO_ENCRYPT_TWO = 'more random data to encrypt';
+    // const DATA_TO_ENCRYPT_TWO = 'more random data to encrypt';
 
     beforeAll(async () => {
       jest.setTimeout(150000);

--- a/e2e/specs/accounts/aes/encryption-with-key.spec.js
+++ b/e2e/specs/accounts/aes/encryption-with-key.spec.js
@@ -49,9 +49,7 @@ describe(
       await SettingsView.scrollToAesCryptoButton();
       await SettingsView.tapAesCryptoTestForm();
 
-      let encryptionKey;
-
-      encryptionKey = await AesCryptoTestForm.generateEncryptionKey(
+      const encryptionKey = await AesCryptoTestForm.generateEncryptionKey(
         PASSWORD_ONE,
         SALT_ONE,
       );
@@ -65,20 +63,20 @@ describe(
         DATA_TO_ENCRYPT_ONE,
       );
 
-      await AesCryptoTestForm.scrollUpToGenerateEncryptionKey();
-      encryptionKey = await AesCryptoTestForm.generateEncryptionKey(
-        PASSWORD_TWO,
-        SALT_TWO,
-      );
-      await AesCryptoTestForm.encryptWithKey(
-        encryptionKey,
-        DATA_TO_ENCRYPT_TWO,
-      );
-      await AesCryptoTestForm.decryptWithKey(encryptionKey);
-      await Assertions.checkIfElementHasLabel(
-        AesCryptoTestForm.decryptWithKeyResponse,
-        DATA_TO_ENCRYPT_TWO,
-      );
+      // await AesCryptoTestForm.scrollUpToGenerateEncryptionKey();
+      // encryptionKey = await AesCryptoTestForm.generateEncryptionKey(
+      //   PASSWORD_TWO,
+      //   SALT_TWO,
+      // );
+      // await AesCryptoTestForm.encryptWithKey(
+      //   encryptionKey,
+      //   DATA_TO_ENCRYPT_TWO,
+      // );
+      // await AesCryptoTestForm.decryptWithKey(encryptionKey);
+      // await Assertions.checkIfElementHasLabel(
+      //   AesCryptoTestForm.decryptWithKeyResponse,
+      //   DATA_TO_ENCRYPT_TWO,
+      // );
     });
   },
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The scroll detox functionality in Android is introducing flakiness into the test, this PR removes that portion of it until the cause is discovered and solved.

## **Related issues**

Fixes: None

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
