### PR TITLE
fix: Engine does not exist 

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1124,7 +1124,15 @@ class Engine {
       },
       initialState.SmartTransactionsController,
     );
-
+    if (!networkController.state.selectedNetworkClientId) {
+      captureException(
+        new Error(
+          `No selectedNetworkClientId in network controller: ${JSON.stringify(
+            networkController.state,
+          )}`,
+        ),
+      );
+    }
     const controllers: Controllers[keyof Controllers][] = [
       keyringController,
       accountTrackerController,

--- a/patches/@metamask+network-controller+18.1.3.patch
+++ b/patches/@metamask+network-controller+18.1.3.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@metamask/network-controller/dist/chunk-4ZD3DTQ7.js b/node_modules/@metamask/network-controller/dist/chunk-4ZD3DTQ7.js
+index e172d15..c387fda 100644
+--- a/node_modules/@metamask/network-controller/dist/chunk-4ZD3DTQ7.js
++++ b/node_modules/@metamask/network-controller/dist/chunk-4ZD3DTQ7.js
+@@ -314,7 +314,14 @@ var NetworkController = class extends _basecontroller.BaseController {
+   }
+   getNetworkClientById(networkClientId) {
+     if (!networkClientId) {
+-      throw new Error("No network client ID was provided.");
++      // This patch is for the Engine continue initialization when opening the app
++      // When the selectedNetworkClientId is null
++      // What's the needs of the consumers of getNetworkClientById:
++      // - Currency Rate controller needs the ticker
++      // - Token Detection controller needs the chainId
++      // - Tokens controller needs the provider but have fallback so no need to return the provider
++      // - Transaction controller needs the type
++      return {configuration: {chainId: this.state.providerConfig.chainId, ticker: this.state.providerConfig.ticker, type: this.state.providerConfig.type}};
+     }
+     const autoManagedNetworkClientRegistry = _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _ensureAutoManagedNetworkClientRegistryPopulated, ensureAutoManagedNetworkClientRegistryPopulated_fn).call(this);
+     if (_controllerutils.isInfuraNetworkType.call(void 0, networkClientId)) {


### PR DESCRIPTION

## **Description**

* Added a patch that replaces throw an error when the selectedNetworkClientId is not defined, returns the state data that other controllers need
 * Added a capture exception so we know the state of the network controller if no selectedNetworkClientId is defined

## **Related issues**

Fixes #9958

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
