### PR TITLE
fix(ramp): memoize asset before passing it to balance hook (#9968)

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -186,16 +186,19 @@ const BuildQuote = () => {
     estimateRange: 'high',
   });
 
-  const assetForBalance =
-    selectedAsset && selectedAsset.address !== NATIVE_ADDRESS
-      ? {
-          address: selectedAsset.address,
-          symbol: selectedAsset.symbol,
-          decimals: selectedAsset.decimals,
-        }
-      : {
-          isETH: true,
-        };
+  const assetForBalance = useMemo(
+    () =>
+      selectedAsset && selectedAsset.address !== NATIVE_ADDRESS
+        ? {
+            address: selectedAsset.address,
+            symbol: selectedAsset.symbol,
+            decimals: selectedAsset.decimals,
+          }
+        : {
+            isETH: true,
+          },
+    [selectedAsset],
+  );
 
   const { addressBalance } = useAddressBalance(
     assetForBalance as Asset,


### PR DESCRIPTION
> [!NOTE]  
> This PR cherry picks #9968 into `relelase/7.24.1`


## **Description**

This PR fixes a bug that froze the app when using the Ramp flow. This bug was introduced in 7.24.0. 
Slack conversations for context:
- https://consensys.slack.com/archives/C077MS3667Q/p1718231625259709

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Ramp flow must not freeze when reaching the Build Quote screen

## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
