### PR TITLE
fix: migration 43 stringify to type of

### DIFF
--- a/app/store/migrations/043.test.ts
+++ b/app/store/migrations/043.test.ts
@@ -382,7 +382,7 @@ describe('Migration #43', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 43: Invalid NetworkController network configuration entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'null'",
+        "FATAL ERROR: Migration 43: Invalid NetworkController network configuration entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
       scenario: 'networkConfigurations is invalid',
     },
   ];

--- a/app/store/migrations/043.ts
+++ b/app/store/migrations/043.ts
@@ -57,7 +57,7 @@ export default function migrate(state: unknown) {
       new Error(
         `FATAL ERROR: Migration 43: Invalid NetworkController network configuration entry with id: '${
           invalidEntry?.[0]
-        }', type: '${JSON.stringify(invalidEntry?.[1])}'`,
+        }', type: '${typeof invalidEntry?.[1]}'`,
       ),
     );
     return state;


### PR DESCRIPTION
## **Description**
typeof rather than stringily here because this would result in a great deal of data in our error message. This is problematic for two reasons: it means that each unique network configuration gets interpreted as a unique error by Sentry, no grouping. And it potentially exposes private information.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
