### PR TITLE
fix: synchronize accounts name

### DIFF
--- a/app/store/migrations/044.test.ts
+++ b/app/store/migrations/044.test.ts
@@ -92,7 +92,7 @@ describe('Migration #44', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 44: Invalid AccountsController state error: 'null'",
+        "FATAL ERROR: Migration 44: Invalid AccountsController state error: 'object'",
       scenario: 'AccountsController state is invalid',
     },
     {
@@ -104,7 +104,7 @@ describe('Migration #44', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: 'null'",
+        "FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: 'object'",
       scenario: 'AccountsController internalAccounts state is invalid',
     },
     {
@@ -117,7 +117,7 @@ describe('Migration #44', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 44: Invalid PreferencesController state error: 'null'",
+        "FATAL ERROR: Migration 44: Invalid PreferencesController state error: 'object'",
       scenario: 'PreferencesController state is invalid',
     },
     {
@@ -130,7 +130,7 @@ describe('Migration #44', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: 'null'",
+        "FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: 'object'",
       scenario: 'PreferencesController identities state is invalid',
     },
     {
@@ -147,8 +147,58 @@ describe('Migration #44', () => {
         },
       }),
       errorMessage:
-        "FATAL ERROR: Migration 44: Invalid AccountsController entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
+        "FATAL ERROR: Migration 44: Invalid AccountsController account entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
       scenario: 'AccountsController accounts account state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: { identities: null },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  '92c0e479-6133-4a18-b1bf-fa38f654e293': { metadata: null },
+                },
+              },
+            },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid AccountsController account metadata entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
+      scenario: 'AccountsController accounts account state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: { identities: null },
+            AccountsController: {
+              internalAccounts: {
+                accounts: { '92c0e479-6133-4a18-b1bf-fa38f654e293': null },
+              },
+            },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid AccountsController account entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
+      scenario: 'AccountsController accounts account state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: {
+              identities: { [mockChecksummedInternalAcc1]: null },
+            },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid PreferencesController identity entry with type: 'object'",
+      scenario: 'PreferencesController identities identity state is invalid',
     },
   ];
 

--- a/app/store/migrations/044.test.ts
+++ b/app/store/migrations/044.test.ts
@@ -26,11 +26,11 @@ const oldState = {
         identities: {
           [mockChecksummedInternalAcc1]: {
             address: mockChecksummedInternalAcc1,
-            name: 'Account 1',
+            name: 'First',
           },
           [mockChecksummedInternalAcc2]: {
             address: mockChecksummedInternalAcc2,
-            name: 'Account 2',
+            name: 'Second',
           },
         },
       },
@@ -220,6 +220,66 @@ describe('Migration #44', () => {
       'engine'
     >;
 
+    Object.keys(
+      newState.engine.backgroundState.AccountsController.internalAccounts
+        .accounts,
+    ).forEach((accountId) => {
+      Object.values(
+        newState.engine.backgroundState.PreferencesController.identities,
+      ).forEach((identity) => {
+        if (
+          toChecksumHexAddress(
+            newState.engine.backgroundState.AccountsController.internalAccounts
+              .accounts[accountId].address,
+          ) === (identity as Identity).address
+        ) {
+          expect(
+            newState.engine.backgroundState.AccountsController.internalAccounts
+              .accounts[accountId].metadata.name,
+          ).toStrictEqual((identity as Identity).name);
+        }
+      });
+    });
+  });
+
+  it('should let the name properties be the same if they are synchronized', () => {
+    const oldState2 = {
+      engine: {
+        backgroundState: {
+          PreferencesController: {
+            identities: {
+              [mockChecksummedInternalAcc1]: {
+                address: mockChecksummedInternalAcc1,
+                name: 'Name1',
+              },
+              [mockChecksummedInternalAcc2]: {
+                address: mockChecksummedInternalAcc2,
+                name: 'Name2',
+              },
+            },
+          },
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [expectedUuid]: {
+                  ...internalAccount1,
+                  metadata: { ...internalAccount1.metadata, name: 'Name1' },
+                },
+                [expectedUuid2]: {
+                  ...internalAccount2,
+                  metadata: { ...internalAccount2.metadata, name: 'Name2 ' },
+                },
+              },
+              selectedAccount: {},
+            },
+          },
+        },
+      },
+    };
+    const newState: Pick<RootState, 'engine'> = migration(oldState2) as Pick<
+      RootState,
+      'engine'
+    >;
     Object.keys(
       newState.engine.backgroundState.AccountsController.internalAccounts
         .accounts,

--- a/app/store/migrations/044.test.ts
+++ b/app/store/migrations/044.test.ts
@@ -1,0 +1,194 @@
+import migration from './044';
+import { merge } from 'lodash';
+import initialRootState from '../../util/test/initial-root-state';
+import { captureException } from '@sentry/react-native';
+import {
+  expectedUuid,
+  expectedUuid2,
+  internalAccount1,
+  internalAccount2,
+} from '../../util/test/accountsControllerTestUtils';
+import { RootState } from '../../reducers';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { Identity } from './036';
+
+const mockChecksummedInternalAcc1 = toChecksumHexAddress(
+  internalAccount1.address,
+);
+const mockChecksummedInternalAcc2 = toChecksumHexAddress(
+  internalAccount2.address,
+);
+
+const oldState = {
+  engine: {
+    backgroundState: {
+      PreferencesController: {
+        identities: {
+          [mockChecksummedInternalAcc1]: {
+            address: mockChecksummedInternalAcc1,
+            name: 'Account 1',
+          },
+          [mockChecksummedInternalAcc2]: {
+            address: mockChecksummedInternalAcc2,
+            name: 'Account 2',
+          },
+        },
+      },
+      AccountsController: {
+        internalAccounts: {
+          accounts: {
+            [expectedUuid]: {
+              ...internalAccount1,
+              metadata: { ...internalAccount1.metadata, name: 'Account 1' },
+            },
+            [expectedUuid2]: {
+              ...internalAccount2,
+              metadata: { ...internalAccount2.metadata, name: undefined },
+            },
+          },
+          selectedAccount: {},
+        },
+      },
+    },
+  },
+};
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+const mockedCaptureException = jest.mocked(captureException);
+
+describe('Migration #44', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const invalidStates = [
+    {
+      state: merge({}, initialRootState, {
+        engine: null,
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid engine state error: 'object'",
+      scenario: 'engine state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: null,
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid engine backgroundState error: 'object'",
+      scenario: 'backgroundState is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            AccountsController: null,
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid AccountsController state error: 'null'",
+      scenario: 'AccountsController state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            AccountsController: { internalAccounts: null },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: 'null'",
+      scenario: 'AccountsController internalAccounts state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: null,
+            AccountsController: { internalAccounts: { accounts: {} } },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid PreferencesController state error: 'null'",
+      scenario: 'PreferencesController state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: { identities: null },
+            AccountsController: { internalAccounts: { accounts: {} } },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: 'null'",
+      scenario: 'PreferencesController identities state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: {
+            PreferencesController: { identities: null },
+            AccountsController: {
+              internalAccounts: {
+                accounts: { '92c0e479-6133-4a18-b1bf-fa38f654e293': null },
+              },
+            },
+          },
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 44: Invalid AccountsController entry with id: '92c0e479-6133-4a18-b1bf-fa38f654e293', type: 'object'",
+      scenario: 'AccountsController accounts account state is invalid',
+    },
+  ];
+
+  for (const { errorMessage, scenario, state } of invalidStates) {
+    it(`should capture exception if ${scenario}`, () => {
+      const newState = migration(state);
+
+      expect(newState).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockedCaptureException.mock.calls[0][0].message).toBe(
+        errorMessage,
+      );
+    });
+  }
+
+  it('should set name property of accounts of accounts controller to name property of identities of Preferences Controller', () => {
+    const newState: Pick<RootState, 'engine'> = migration(oldState) as Pick<
+      RootState,
+      'engine'
+    >;
+
+    Object.keys(
+      newState.engine.backgroundState.AccountsController.internalAccounts
+        .accounts,
+    ).forEach((accountId) => {
+      Object.values(
+        newState.engine.backgroundState.PreferencesController.identities,
+      ).forEach((identity) => {
+        if (
+          toChecksumHexAddress(
+            newState.engine.backgroundState.AccountsController.internalAccounts
+              .accounts[accountId].address,
+          ) === (identity as Identity).address
+        ) {
+          expect(
+            newState.engine.backgroundState.AccountsController.internalAccounts
+              .accounts[accountId].metadata.name,
+          ).toStrictEqual((identity as Identity).name);
+        }
+      });
+    });
+  });
+});

--- a/app/store/migrations/044.ts
+++ b/app/store/migrations/044.ts
@@ -27,9 +27,7 @@ export default function migrate(state: unknown) {
   if (!isObject(accountsControllerState)) {
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid AccountsController state error: '${JSON.stringify(
-          accountsControllerState,
-        )}'`,
+        `FATAL ERROR: Migration 44: Invalid AccountsController state error: '${typeof accountsControllerState}'`,
       ),
     );
     return state;
@@ -41,7 +39,7 @@ export default function migrate(state: unknown) {
   ) {
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: '${accountsControllerState.internalAccounts}'`,
+        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: '${typeof accountsControllerState.internalAccounts}'`,
       ),
     );
     return state;
@@ -53,7 +51,8 @@ export default function migrate(state: unknown) {
   ) {
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts accounts state error: '${accountsControllerState.internalAccounts.accounts}'`,
+        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts accounts state error: '${typeof accountsControllerState
+          .internalAccounts.accounts}'`,
       ),
     );
     return state;
@@ -69,7 +68,25 @@ export default function migrate(state: unknown) {
     ).find(([_, account]) => !isObject(account));
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid AccountsController entry with id: '${
+        `FATAL ERROR: Migration 44: Invalid AccountsController account entry with id: '${
+          invalidEntry?.[0]
+        }', type: '${typeof invalidEntry?.[1]}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    Object.values(accountsControllerState.internalAccounts.accounts).some(
+      (account) => isObject(account) && !isObject(account.metadata),
+    )
+  ) {
+    const invalidEntry = Object.entries(
+      accountsControllerState.internalAccounts.accounts,
+    ).find(([_, account]) => isObject(account) && !isObject(account.metadata));
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid AccountsController account metadata entry with id: '${
           invalidEntry?.[0]
         }', type: '${typeof invalidEntry?.[1]}'`,
       ),
@@ -83,9 +100,7 @@ export default function migrate(state: unknown) {
   if (!isObject(preferencesControllerState)) {
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid PreferencesController state error: '${JSON.stringify(
-          preferencesControllerState,
-        )}'`,
+        `FATAL ERROR: Migration 44: Invalid PreferencesController state error: '${typeof preferencesControllerState}'`,
       ),
     );
     return state;
@@ -97,27 +112,46 @@ export default function migrate(state: unknown) {
   ) {
     captureException(
       new Error(
-        `FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: '${preferencesControllerState.identities}'`,
+        `FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: '${typeof preferencesControllerState.identities}'`,
       ),
     );
     return state;
   }
+
+  if (
+    Object.values(preferencesControllerState.identities).some(
+      (identity) => !isObject(identity),
+    )
+  ) {
+    const invalidEntry = Object.entries(
+      preferencesControllerState.identities,
+    ).find(([_, identity]) => !isObject(identity));
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid PreferencesController identity entry with type: '${typeof invalidEntry?.[1]}'`,
+      ),
+    );
+    return state;
+  }
+
   const accounts = accountsControllerState.internalAccounts.accounts;
   const identities = preferencesControllerState.identities;
-  Object.keys(accounts).forEach((accountId) => {
-    const account = accounts[accountId];
-    if (isObject(account) && isObject(account.metadata)) {
+  Object.entries(accounts).forEach(([accountId, account]) => {
+    if (
+      isObject(account) &&
+      isObject(account.metadata) &&
+      typeof account.address === 'string'
+    ) {
       if (Object.keys(identities).length) {
-        Object.keys(identities).forEach((identityAddress) => {
+        Object.entries(identities).forEach(([identityAddress, identity]) => {
           if (
-            toChecksumHexAddress(identityAddress) ===
-            toChecksumHexAddress(account.address as string)
+            identityAddress.toLowerCase() ===
+            (account.address as string).toLowerCase()
           ) {
-            const identity = identities[identityAddress];
             if (
               isObject(identity) &&
               isObject(account.metadata) &&
-              identity.name !== account.metadata.name
+              identity?.name !== account.metadata.name
             ) {
               (
                 accountsControllerState as AccountsControllerState

--- a/app/store/migrations/044.ts
+++ b/app/store/migrations/044.ts
@@ -1,8 +1,6 @@
 import { hasProperty, isObject } from '@metamask/utils';
 import { ensureValidState } from './util';
 import { captureException } from '@sentry/react-native';
-import { Identity } from '@metamask/preferences-controller';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 
 /**

--- a/app/store/migrations/044.ts
+++ b/app/store/migrations/044.ts
@@ -1,0 +1,134 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+import { captureException } from '@sentry/react-native';
+import { Identity } from '@metamask/preferences-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { AccountsControllerState } from '@metamask/accounts-controller';
+
+/**
+ * Synchronize `AccountsController` names with `PreferencesController` identities.
+ *
+ * There was a bug in versions below v7.23.0 that resulted in the account `name` state in the
+ * `AccountsController` being reset. However, users account names were preserved in the
+ * `identities` state in the `PreferencesController`. This migration restores the names to the
+ * `AccountsController` if they are found.
+ *
+ * @param state Persisted Redux state that is potentially corrupted
+ * @returns Valid persisted Redux state
+ */
+export default function migrate(state: unknown) {
+  if (!ensureValidState(state, 44)) {
+    return state;
+  }
+
+  const accountsControllerState =
+    state.engine.backgroundState.AccountsController;
+
+  if (!isObject(accountsControllerState)) {
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid AccountsController state error: '${JSON.stringify(
+          accountsControllerState,
+        )}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    !hasProperty(accountsControllerState, 'internalAccounts') ||
+    !isObject(accountsControllerState.internalAccounts)
+  ) {
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts state error: '${accountsControllerState.internalAccounts}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    !hasProperty(accountsControllerState.internalAccounts, 'accounts') ||
+    !isObject(accountsControllerState.internalAccounts.accounts)
+  ) {
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid AccountsController internalAccounts accounts state error: '${accountsControllerState.internalAccounts.accounts}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    Object.values(accountsControllerState.internalAccounts.accounts).some(
+      (account) => !isObject(account),
+    )
+  ) {
+    const invalidEntry = Object.entries(
+      accountsControllerState.internalAccounts.accounts,
+    ).find(([_, account]) => !isObject(account));
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid AccountsController entry with id: '${
+          invalidEntry?.[0]
+        }', type: '${typeof invalidEntry?.[1]}'`,
+      ),
+    );
+    return state;
+  }
+
+  const preferencesControllerState =
+    state.engine.backgroundState.PreferencesController;
+
+  if (!isObject(preferencesControllerState)) {
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid PreferencesController state error: '${JSON.stringify(
+          preferencesControllerState,
+        )}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    !hasProperty(preferencesControllerState, 'identities') ||
+    !isObject(preferencesControllerState.identities)
+  ) {
+    captureException(
+      new Error(
+        `FATAL ERROR: Migration 44: Invalid PreferencesController identities state error: '${preferencesControllerState.identities}'`,
+      ),
+    );
+    return state;
+  }
+  const accounts = accountsControllerState.internalAccounts.accounts;
+  const identities = preferencesControllerState.identities;
+  Object.keys(accounts).forEach((accountId) => {
+    const account = accounts[accountId];
+    if (isObject(account) && isObject(account.metadata)) {
+      if (Object.keys(identities).length) {
+        Object.keys(identities).forEach((identityAddress) => {
+          if (
+            toChecksumHexAddress(identityAddress) ===
+            toChecksumHexAddress(account.address as string)
+          ) {
+            const identity = identities[identityAddress];
+            if (
+              isObject(identity) &&
+              isObject(account.metadata) &&
+              identity.name !== account.metadata.name
+            ) {
+              (
+                accountsControllerState as AccountsControllerState
+              ).internalAccounts.accounts[accountId].metadata.name =
+                identity.name as string;
+            }
+          }
+        });
+      }
+    }
+  });
+
+  return state;
+}


### PR DESCRIPTION
## **Description**

Migration to synchronise accounts name based on identities names of preferences controller


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
