### PR TITLE
fix(deps): bump `@metamask/composable-controller` from `^3.0.0` to `^6.0.2`

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1384,13 +1384,13 @@ class Engine {
         ],
       }),
     });
-    this.context = controllers.reduce<Partial<typeof this.context>>(
+    this.context = controllers.reduce<typeof this.context>(
       (context, controller) => ({
         ...context,
         [controller.name]: controller,
       }),
-      {},
-    ) as typeof this.context;
+      {} as never,
+    );
 
     const {
       NftController: nfts,

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -397,7 +397,12 @@ class Engine {
   /**
    * ComposableController reference containing all child controllers
    */
-  datamodel: any;
+  datamodel: ComposableController<
+    EngineState,
+    // TODO: Remove once `BaseControllerV1Instance` type is updated in composable-controller
+    // @ts-expect-error Hotfix for mismatch between `Controllers` type properties and `BaseControllerV1Instance` type
+    Controllers[keyof Controllers],
+  >;
 
   /**
    * Object containing the info for the latest incoming tx block
@@ -1354,7 +1359,9 @@ class Engine {
 
     this.datamodel = new ComposableController<
       EngineState,
-      Controllers[keyof Controllers]
+      // TODO: Remove once `BaseControllerV1Instance` type is updated in composable-controller
+      // @ts-expect-error Hotfix for mismatch between `Controllers` type properties and `BaseControllerV1Instance` type
+      Controllers[keyof Controllers],
     >({
       controllers,
       messenger: this.controllerMessenger.getRestricted({

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -13,10 +13,10 @@ import {
   NftDetectionController,
   NftState,
   TokenBalancesController,
+  TokenBalancesControllerEvents,
   TokenDetectionController,
   TokenListController,
   TokenListState,
-  TokenListStateChange,
   TokenRatesController,
   TokenRatesState,
   TokensController,
@@ -36,7 +36,11 @@ import {
   AddressBookController,
   AddressBookState,
 } from '@metamask/address-book-controller';
-import { BaseState, ControllerMessenger } from '@metamask/base-controller';
+import {
+  BaseState,
+  ControllerMessenger,
+  ControllerStateChangeEvent,
+} from '@metamask/base-controller';
 import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
@@ -262,19 +266,35 @@ type GlobalEvents =
   | CurrencyRateStateChange
   | GasFeeStateChange
   | KeyringControllerEvents
-  | TokenListStateChange
   | NetworkControllerEvents
   | PermissionControllerEvents
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | SnapsGlobalEvents
   ///: END:ONLY_INCLUDE_IF
   | SignatureControllerEvents
-  | KeyringControllerEvents
-  | PPOMControllerEvents
   | AccountsControllerEvents
   | PreferencesControllerEvents
+  | TokenBalancesControllerEvents
+  | TokenListControllerEvents
   | TokensControllerEvents
-  | TokenListControllerEvents;
+  // TODO: Replace with `LoggingControllerEvents` once it's defined to include `LoggingControllerStateChangeEvent`
+  | ControllerStateChangeEvent<'LoggingController', LoggingControllerState>
+  // TODO: Replace with `NftControllerEvents` once it's defined to include `NftControllerStateChangeEvent`
+  | ControllerStateChangeEvent<
+      'NftController',
+      NftState & { [key: string]: Json }
+    >
+  // TODO: Replace with `PhishingControllerEvents` once it's defined to include `PhishingControllerStateChangeEvent`
+  | ControllerStateChangeEvent<'PhishingController', PhishingControllerState>
+  // TODO: `NetworkControllerStateChangeEvent` is already provided by `NetworkControllerEvents` and should be excluded from `PPOMControllerEvents`
+  | PPOMControllerEvents
+  // TODO: Remove once `PPOMControllerStateChangeEvent` is defined and is included in `PPOMControllerEvents`
+  | ControllerStateChangeEvent<'PPOMController', PPOMState>
+  // TODO: Replace with `TransactionControllerEvents` once it's defined to include `TransactionControllerStateChangeEvent`
+  | ControllerStateChangeEvent<
+      'TransactionController',
+      TransactionState & { [key: string]: Json }
+    >;
 
 type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
 type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1379,7 +1379,6 @@ class Engine {
           'TokenListController:stateChange',
           'TokensController:stateChange',
           'TransactionController:stateChange',
-          'SignatureController:stateChange',
           'SnapController:stateChange',
           'SubjectMetadataController:stateChange',
         ],

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1337,7 +1337,33 @@ class Engine {
       Controllers[keyof Controllers]
     >({
       controllers,
-      messenger: this.controllerMessenger,
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'ComposableController',
+        allowedActions: [],
+        // Add `stateChange` event here and in the `GlobalEvents` type
+        // whenever `messagingSystem` is added to a V1 child controller (or it is upgraded to V2)
+        allowedEvents: [
+          'AccountsController:stateChange',
+          'ApprovalController:stateChange',
+          'CurrencyRateController:stateChange',
+          'GasFeeController:stateChange',
+          'KeyringController:stateChange',
+          'LoggingController:stateChange',
+          'NetworkController:stateChange',
+          'NftController:stateChange',
+          'PermissionController:stateChange',
+          'PhishingController:stateChange',
+          'PreferencesController:stateChange',
+          'PPOMController:stateChange',
+          'TokenBalancesController:stateChange',
+          'TokenListController:stateChange',
+          'TokensController:stateChange',
+          'TransactionController:stateChange',
+          'SignatureController:stateChange',
+          'SnapController:stateChange',
+          'SubjectMetadataController:stateChange',
+        ],
+      }),
     });
     this.context = controllers.reduce<Partial<typeof this.context>>(
       (context, controller) => ({

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -279,7 +279,7 @@ type GlobalEvents =
 type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
 type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];
 
-export interface EngineState {
+export type EngineState = {
   AccountTrackerController: AccountTrackerState;
   AddressBookController: AddressBookState;
   AssetsContractController: BaseState;
@@ -309,7 +309,7 @@ export interface EngineState {
   LoggingController: LoggingControllerState;
   PPOMController: PPOMState;
   AccountsController: AccountsControllerState;
-}
+};
 
 /**
  * All mobile controllers, keyed by name
@@ -1332,7 +1332,10 @@ class Engine {
       }
     }
 
-    this.datamodel = new ComposableController({
+    this.datamodel = new ComposableController<
+      EngineState,
+      Controllers[keyof Controllers]
+    >({
       controllers,
       messenger: this.controllerMessenger,
     });


### PR DESCRIPTION
## **Description**

- Applies `ComposableController` API changes introduced to the controller in the following series of PRs:
  - https://github.com/MetaMask/core/pull/3590 (`v5.0.0`)
  - https://github.com/MetaMask/core/pull/3904 (`v6.0.0`)
  - https://github.com/MetaMask/core/pull/3964 (`v6.0.0`)
  - https://github.com/MetaMask/core/pull/3952 (`v6.0.2`)

- Provides hotfix for type error caused by mismatch between  the `ControllerInstance` generic constraint to the `ChildControllers` generic parameter of the `ComposableController` class.
    - As long as we're confident about the accuracy of the `Controllers` type, it should be safe to apply this `@ts-expect-error`, since we're overloading the `ChildControllers` generic parameter with known information about the input child controllers (`Controllers[keyof Controllers]`).

## Required follow-up changes
    
- `ComposableController`:
  - The `BaseControllerV1Instance` type needs to be fixed to accommodate controller versions used in mobile that inherit from `BaseControllerV1`.
  ```ts
  Type 'PhishingController | AccountsController | AccountTrackerController | AddressBookController | ... 22 more ... | SwapsController' does not satisfy the constraint 'ControllerInstance'.
  Type 'AccountTrackerController' is not assignable to type 'ControllerInstance'.
    Type 'AccountTrackerController' is not assignable to type 'BaseControllerV1Instance'.
      Types have separate declarations of a private property 'initialConfig'.ts(2344)
  ```
  - Add jsdoc for the `ChildControllers` optional generic parameter, making it clearer that a full list of controllers can be supplied by the consumer. 
  - Fix `LegacyComposableControllerStateConstraint` to `{ [name: string]: Record<any, any> }`, since index signature of `interface` types used for V1 state objects is not fixed to `string`.
  - Test on mobile engine whether runtime checks `isBaseController()` and `isBaseControllerV1()` are functioning as intended.
  
- On mobile, upgrade the affected controllers to V2:
  - V2 upgrades are available for all of the following:
    - `AccountTrackerController`
    - `NftController`
    - `TokenRatesController`
    - `TransactionController`
  - Exceptions:
    - `AssetsContractController`: set to be upgraded to non-controller that uses messenger but doesn't inherit from `BaseControllerV2`. `ComposableController` will need to be updated to accommodated non-controllers
    - `NftDetectionController`: current release inherits from `BaseControllerV2`, but should be upgraded to non-controller.
    - `SwapsController`: V2 upgrade unavailable

## **Related issues**

- Resolves issues found in @kylanhurt's branch: https://github.com/MetaMask/metamask-mobile/compare/main...kylan/composable-controller
- Blocked by https://github.com/metamask/metamask-mobile/10073

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
