### PR TITLE
fix: swap completed event not firing

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -73,7 +73,11 @@ import InstallSnapApproval from '../../Approvals/InstallSnapApproval';
 
 const hstInterface = new ethers.utils.Interface(abi);
 
-const useSwapConfirmedEvent = ({ swapsTransactions, trackSwaps }) => {
+export const useSwapConfirmedEvent = ({
+  TransactionController,
+  swapsTransactions,
+  trackSwaps,
+}) => {
   const [transactionMetaIdsForListening, setTransactionMetaIdsForListening] =
     useState([]);
 
@@ -86,7 +90,6 @@ const useSwapConfirmedEvent = ({ swapsTransactions, trackSwaps }) => {
 
   useEffect(() => {
     // Cannot directly call trackSwaps from the event listener in autoSign due to stale closure of swapsTransactions
-    const { TransactionController } = Engine.context;
     const [txMetaId, ...restTxMetaIds] = transactionMetaIdsForListening;
 
     if (txMetaId && swapsTransactions[txMetaId]) {
@@ -107,10 +110,16 @@ const useSwapConfirmedEvent = ({ swapsTransactions, trackSwaps }) => {
       );
       setTransactionMetaIdsForListening(restTxMetaIds);
     }
-  }, [trackSwaps, transactionMetaIdsForListening, swapsTransactions]);
+  }, [
+    trackSwaps,
+    transactionMetaIdsForListening,
+    swapsTransactions,
+    TransactionController,
+  ]);
 
   return {
     addTransactionMetaIdForListening,
+    transactionMetaIdsForListening,
   };
 };
 
@@ -244,6 +253,7 @@ const RootRPCMethodsUI = (props) => {
   );
 
   const { addTransactionMetaIdForListening } = useSwapConfirmedEvent({
+    TransactionController: Engine.context.TransactionController,
     swapsTransactions: props.swapsTransactions,
     trackSwaps,
   });

--- a/app/components/Nav/Main/index.test.tsx
+++ b/app/components/Nav/Main/index.test.tsx
@@ -85,12 +85,7 @@ describe('Main', () => {
           TransactionController: {
             hub: eventEmitter,
           },
-          swapsTransactions: {
-            [txMetaId]: {
-              analytics: 'hello',
-              paramsForAnalytics: 'world',
-            },
-          },
+          swapsTransactions,
           trackSwaps: jest.fn(),
         }),
       );

--- a/app/components/Nav/Main/index.test.tsx
+++ b/app/components/Nav/Main/index.test.tsx
@@ -1,8 +1,13 @@
+/* eslint-disable import/no-nodejs-modules */
 import React from 'react';
 import { shallow } from 'enzyme';
 // eslint-disable-next-line import/named
 import { NavigationContainer } from '@react-navigation/native';
+import EventEmitter from 'events';
 import Main from './';
+import { useSwapConfirmedEvent } from './RootRPCMethodsUI';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { MetaMetricsEvents } from '../../hooks/useMetrics';
 
 describe('Main', () => {
   it('should render correctly', () => {
@@ -13,5 +18,115 @@ describe('Main', () => {
     );
     const wrapper = shallow(<MainAppContainer />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('useSwapConfirmedEvent', () => {
+    it('queues transactionMeta ids correctly', () => {
+      const txMetaId = 'foo';
+      const eventEmitter = new EventEmitter();
+
+      const { result } = renderHook(() =>
+        useSwapConfirmedEvent({
+          TransactionController: {
+            hub: eventEmitter,
+          },
+          swapsTransactions: {}, // This has to be empty object, otherwise test fails
+          trackSwaps: jest.fn(),
+        }),
+      );
+      act(() => {
+        result.current.addTransactionMetaIdForListening(txMetaId);
+      });
+
+      expect(result.current.transactionMetaIdsForListening).toEqual([txMetaId]);
+    });
+    it('adds a listener for transaction confirmation on the TransactionController', () => {
+      const txMetaId = 'foo';
+      const eventEmitter = new EventEmitter();
+
+      const { result } = renderHook(() =>
+        useSwapConfirmedEvent({
+          TransactionController: {
+            hub: eventEmitter,
+          },
+          swapsTransactions: {
+            [txMetaId]: {
+              analytics: 'hello',
+              paramsForAnalytics: 'world',
+            },
+          },
+          trackSwaps: jest.fn(),
+        }),
+      );
+      act(() => {
+        result.current.addTransactionMetaIdForListening(txMetaId);
+      });
+
+      expect(eventEmitter.listenerCount(`${txMetaId}:confirmed`)).toBe(1);
+    });
+    it('tracks Swap Confirmed after transaction confirmed', () => {
+      const txMetaId = 'foo';
+      const eventEmitter = new EventEmitter();
+      const trackSwaps = jest.fn();
+      const swapsTransactions = {
+        [txMetaId]: {
+          analytics: 'hello',
+          paramsForAnalytics: 'world',
+        },
+      };
+      const txMeta = {
+        id: txMetaId,
+      };
+
+      const { result } = renderHook(() =>
+        useSwapConfirmedEvent({
+          TransactionController: {
+            hub: eventEmitter,
+          },
+          swapsTransactions,
+          trackSwaps,
+        }),
+      );
+      act(() => {
+        result.current.addTransactionMetaIdForListening(txMetaId);
+      });
+      eventEmitter.emit(`${txMetaId}:confirmed`, txMeta);
+
+      expect(trackSwaps).toHaveBeenCalledWith(
+        MetaMetricsEvents.SWAP_COMPLETED,
+        txMeta,
+        swapsTransactions,
+      );
+    });
+    it('removes transactionMeta id after tracking', () => {
+      const txMetaId = 'foo';
+      const eventEmitter = new EventEmitter();
+      const trackSwaps = jest.fn();
+      const swapsTransactions = {
+        [txMetaId]: {
+          analytics: 'hello',
+          paramsForAnalytics: 'world',
+        },
+      };
+      const txMeta = {
+        id: txMetaId,
+      };
+
+      const { result } = renderHook(() =>
+        useSwapConfirmedEvent({
+          TransactionController: {
+            hub: eventEmitter,
+          },
+          swapsTransactions,
+          trackSwaps,
+        }),
+      );
+      act(() => {
+        result.current.addTransactionMetaIdForListening(txMetaId);
+      });
+      eventEmitter.emit(`${txMetaId}:confirmed`, txMeta);
+
+      expect(result.current.transactionMetaIdsForListening).toEqual([]);
+    });
   });
 });

--- a/app/components/Nav/Main/index.test.tsx
+++ b/app/components/Nav/Main/index.test.tsx
@@ -21,8 +21,45 @@ describe('Main', () => {
   });
 
   describe('useSwapConfirmedEvent', () => {
+    const txMetaId = '04541dc0-2e69-11ef-b995-33aef2c88d1e';
+    const swapsTransactions = {
+      [txMetaId]: {
+        action: 'swap',
+        analytics: {
+          available_quotes: 5,
+          best_quote_source: 'oneInchV5',
+          chain_id: '1',
+          custom_slippage: false,
+          network_fees_ETH: '0.00337',
+          network_fees_USD: '$12.04',
+          other_quote_selected: false,
+          request_type: 'Order',
+          token_from: 'ETH',
+          token_from_amount: '0.001254',
+          token_to: 'USDC',
+          token_to_amount: '4.440771',
+        },
+        destinationAmount: '4440771',
+        destinationToken: {
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          decimals: 6,
+        },
+        paramsForAnalytics: {
+          approvalTransactionMetaId: {},
+          ethAccountBalance: '0xedfffbea734a07',
+          gasEstimate: '0x33024',
+          sentAt: '0x66732203',
+        },
+        sourceAmount: '1254000000000000',
+        sourceAmountInFiat: '$4.47',
+        sourceToken: {
+          address: '0x0000000000000000000000000000000000000000',
+          decimals: 18,
+        },
+      },
+    };
+
     it('queues transactionMeta ids correctly', () => {
-      const txMetaId = 'foo';
       const eventEmitter = new EventEmitter();
 
       const { result } = renderHook(() =>
@@ -41,7 +78,6 @@ describe('Main', () => {
       expect(result.current.transactionMetaIdsForListening).toEqual([txMetaId]);
     });
     it('adds a listener for transaction confirmation on the TransactionController', () => {
-      const txMetaId = 'foo';
       const eventEmitter = new EventEmitter();
 
       const { result } = renderHook(() =>
@@ -65,15 +101,8 @@ describe('Main', () => {
       expect(eventEmitter.listenerCount(`${txMetaId}:confirmed`)).toBe(1);
     });
     it('tracks Swap Confirmed after transaction confirmed', () => {
-      const txMetaId = 'foo';
       const eventEmitter = new EventEmitter();
       const trackSwaps = jest.fn();
-      const swapsTransactions = {
-        [txMetaId]: {
-          analytics: 'hello',
-          paramsForAnalytics: 'world',
-        },
-      };
       const txMeta = {
         id: txMetaId,
       };
@@ -99,15 +128,8 @@ describe('Main', () => {
       );
     });
     it('removes transactionMeta id after tracking', () => {
-      const txMetaId = 'foo';
       const eventEmitter = new EventEmitter();
       const trackSwaps = jest.fn();
-      const swapsTransactions = {
-        [txMetaId]: {
-          analytics: 'hello',
-          paramsForAnalytics: 'world',
-        },
-      };
       const txMeta = {
         id: txMetaId,
       };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the `SWAP_COMPLETED` event not firing after a transaction has been confirmed.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/9138

## **Manual testing steps**

1. Do a Smart Transaction swap 
2. Wait for tx to be confirmed
3. Observe `TRACK event saved {"event": "Swap Completed"` in the terminal

Repeat the above with a non Smart Transaction swap

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

n/a 

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
