### PR TITLE
fix: Auto capitalize letter to none to have the same behaviour as the password field on create new wallet flow

### DIFF
--- a/app/components/Views/ManualBackupStep1/index.js
+++ b/app/components/Views/ManualBackupStep1/index.js
@@ -213,6 +213,7 @@ const ManualBackupStep1 = ({ route, navigation, appTheme }) => {
               onSubmitEditing={tryUnlock}
               testID={ManualBackUpStepsSelectorsIDs.CONFIRM_PASSWORD_INPUT}
               keyboardAppearance={themeAppearance}
+              autoCapitalize="none"
             />
             {warningIncorrectPassword && (
               <Text style={styles.warningMessageText}>


### PR DESCRIPTION
## **Description**
Auto capitalize letter to none to have the same behaviour as the password field on create new wallet flow

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
