### PR TITLE
chore: Refactor Snaps integration

### DIFF
--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -18,7 +18,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { SnapPermissionCell } from '../SnapPermissionCell';
 import { RequestedPermissions } from '@metamask/permission-controller';
 import { RestrictedMethods } from '../../../../../core/Permissions/constants';
-import { EndowmentPermissions } from '../../../../../constants/permissions';
+import { EndowmentPermissions } from '../../../../../core/Snaps';
 import SNAP_PERMISSIONS from './SnapPermissions.contants';
 
 interface SnapPermissionsProps {

--- a/app/constants/permissions.ts
+++ b/app/constants/permissions.ts
@@ -1,14 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
-export const EndowmentPermissions = Object.freeze({
-  'endowment:network-access': 'endowment:network-access',
-  'endowment:transaction-insight': 'endowment:transaction-insight',
-  'endowment:cronjob': 'endowment:cronjob',
-  'endowment:ethereum-provider': 'endowment:ethereum-provider',
-  'endowment:rpc': 'endowment:rpc',
-} as const);
-///: END:ONLY_INCLUDE_IF
-
 export enum USER_INTENT {
   None,
   Create,

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -149,9 +149,6 @@ import {
 } from '../util/number';
 import NotificationManager from './NotificationManager';
 import Logger from '../util/Logger';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
-import { EndowmentPermissions } from '../constants/permissions';
-///: END:ONLY_INCLUDE_IF
 import { isZero } from '../util/lodash';
 import { MetaMetricsEvents, MetaMetrics } from './Analytics';
 
@@ -160,6 +157,7 @@ import {
   SnapBridge,
   ExcludedSnapEndowments,
   ExcludedSnapPermissions,
+  EndowmentPermissions,
   detectSnapLocation,
   fetchFunction,
   DetectSnapLocationOptions,

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -999,9 +999,10 @@ class Engine {
       //@ts-expect-error types need to be aligned between new encryptor and snaps-controllers
       encryptor,
       getMnemonic: getPrimaryKeyringMnemonic.bind(this),
-      getFeatureFlags: () => {
-        return { disableSnaps: store.getState().settings.basicFunctionalityEnabled === false };
-      }
+      getFeatureFlags: () => ({
+        disableSnaps:
+          store.getState().settings.basicFunctionalityEnabled === false,
+      }),
     });
     ///: END:ONLY_INCLUDE_IF
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -979,9 +979,8 @@ class Engine {
     const snapController = new SnapController({
       environmentEndowmentPermissions: Object.values(EndowmentPermissions),
       featureFlags: {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         requireAllowlist,
+        allowLocalSnaps,
       },
       state: initialState.SnapController || undefined,
       // TODO: Replace "any" with type
@@ -993,7 +992,6 @@ class Engine {
       ) =>
         detectSnapLocation(location, {
           ...options,
-          allowLocal: allowLocalSnaps,
           fetch: fetchFunction,
         }),
       //@ts-expect-error types need to be aligned with snaps-controllers
@@ -1001,6 +999,9 @@ class Engine {
       //@ts-expect-error types need to be aligned between new encryptor and snaps-controllers
       encryptor,
       getMnemonic: getPrimaryKeyringMnemonic.bind(this),
+      getFeatureFlags: () => {
+        return { disableSnaps: store.getState().settings.basicFunctionalityEnabled === false };
+      }
     });
     ///: END:ONLY_INCLUDE_IF
 

--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -305,4 +305,16 @@ export const unrestrictedMethods = Object.freeze([
   'metamask_logWeb3ShimUsage',
   'wallet_switchEthereumChain',
   'wallet_addEthereumChain',
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+  'wallet_getAllSnaps',
+  'wallet_getSnaps',
+  'wallet_requestSnaps',
+  'wallet_invokeSnap',
+  'wallet_invokeKeyring',
+  'snap_getClientStatus',
+  'snap_getFile',
+  'snap_createInterface',
+  'snap_updateInterface',
+  'snap_getInterfaceState',
+  ///: END:ONLY_INCLUDE_IF
 ]);

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -168,18 +168,18 @@ export default class SnapBridge {
     const { PermissionController } = context;
 
     engine.push(
+      PermissionController.createPermissionMiddleware({
+        origin: this.snapId,
+      }),
+    );
+
+    engine.push(
       snapMethodMiddlewareBuilder(
         context,
         controllerMessenger,
         this.snapId,
         SubjectType.Snap,
       ),
-    );
-
-    engine.push(
-      PermissionController.createPermissionMiddleware({
-        origin: this.snapId,
-      }),
     );
 
     // User-Facing RPC methods

--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -36,6 +36,11 @@ const snapMethodMiddlewareBuilder = (
       engineContext.PermissionController,
       origin,
     ),
+    getSnapFile: controllerMessenger.call.bind(
+      controllerMessenger,
+      'SnapController:getFile',
+      origin,
+    ),
     installSnaps: controllerMessenger.call.bind(
       controllerMessenger,
       'SnapController:install',

--- a/app/core/Snaps/index.ts
+++ b/app/core/Snaps/index.ts
@@ -3,6 +3,7 @@ import SnapBridge from './SnapBridge';
 import {
   ExcludedSnapPermissions,
   ExcludedSnapEndowments,
+  EndowmentPermissions,
 } from './permissions/permissions';
 import {
   detectSnapLocation,
@@ -14,6 +15,7 @@ export {
   SnapBridge,
   ExcludedSnapPermissions,
   ExcludedSnapEndowments,
+  EndowmentPermissions,
   fetchFunction,
   detectSnapLocation,
 };

--- a/app/core/Snaps/location/location.ts
+++ b/app/core/Snaps/location/location.ts
@@ -1,10 +1,11 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-import { NpmLocation, NpmOptions } from './npm';
+import { NpmLocation } from './npm';
 import {
   HttpLocation,
   type DetectSnapLocationOptions as DetectSnapLocationOptionsFromPackage,
   type SnapLocation,
   LocalLocation,
+  type NpmOptions,
 } from '@metamask/snaps-controllers';
 
 export type DetectSnapLocationOptions = DetectSnapLocationOptionsFromPackage &

--- a/app/core/Snaps/location/npm.test.ts
+++ b/app/core/Snaps/location/npm.test.ts
@@ -1,0 +1,49 @@
+import { NpmLocation } from './npm';
+
+jest.mock('react-native-blob-util', () => ({
+  config: jest.fn(() => ({
+    fetch: jest.fn(() => ({
+      flush: jest.fn(),
+      data: '/document-dir/archive.tgz',
+    })),
+  })),
+  fs: {
+    dirs: { DocumentDir: '/document-dir/' },
+    unlink: jest.fn().mockResolvedValue(undefined),
+    isDir: jest.fn((path) => path.endsWith('archive') || path.endsWith('dist')),
+    ls: jest.fn((path) => {
+      if (path === '/document-dir/archive') {
+        return ['snap.manifest.json', 'dist'];
+      } else if (path === '/document-dir/archive/dist') {
+        return ['bundle.js'];
+      }
+      return [];
+    }),
+    readFile: jest.fn((path) => {
+      if (path === '/document-dir/archive/dist/bundle.js') {
+        return `module.exports.onRpcRequest = () => null`;
+      } else if (path === '/document-dir/archive/snap.manifest.json') {
+        return `{ "proposedName": "Example Snap" }`;
+      }
+      throw new Error('File not found');
+    }),
+  },
+}));
+
+describe('NpmLocation', () => {
+  // This test is heavily mocked and not necesarily a good indicator that everything works E2E.
+  it('fetches and unpacks tarballs', async () => {
+    const location = new NpmLocation(new URL('npm:@metamask/example-snap'));
+    const manifest = await location.fetch('snap.manifest.json');
+    expect(manifest.path).toStrictEqual('snap.manifest.json');
+    expect(manifest.toString()).toStrictEqual(
+      `{ "proposedName": "Example Snap" }`,
+    );
+
+    const bundle = await location.fetch('dist/bundle.js');
+    expect(bundle.path).toStrictEqual('dist/bundle.js');
+    expect(bundle.toString()).toStrictEqual(
+      `module.exports.onRpcRequest = () => null`,
+    );
+  });
+});

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -43,7 +43,7 @@ const findAllPaths = async (path: string): Promise<string[]> => {
   }
   const fileNames = await ReactNativeBlobUtil.fs.ls(path);
   const paths = fileNames.map((fileName) => `${path}/${fileName}`);
-  return (await Promise.all(paths.map(findAllPaths))).flat(Infinity);
+  return (await Promise.all(paths.map(findAllPaths))).flat(Infinity) as string[];
 };
 
 const readAndParseAt = async (path: string) => {

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,55 +1,16 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-import {
-  createSnapManifest,
-  DEFAULT_REQUESTED_SNAP_VERSION,
-  getTargetVersion,
-  isValidUrl,
-  NpmSnapIdStruct,
-  SnapManifest,
-  VirtualFile,
-  normalizeRelative,
-  parseJson,
-} from '@metamask/snaps-utils';
-import {
-  assert,
-  assertStruct,
-  isObject,
-  assertIsSemVerVersion,
-  SemVerVersion,
-  stringToBytes,
-  bytesToString,
-  SemVerRange,
-} from '@metamask/utils';
+import { VirtualFile } from '@metamask/snaps-utils';
+import { stringToBytes } from '@metamask/utils';
 
-import { DetectSnapLocationOptions } from './location';
 import { NativeModules } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import Logger from '../../../util/Logger';
-import { SnapLocation } from '@metamask/snaps-controllers';
+import {
+  BaseNpmLocation,
+  getNpmCanonicalBasePath,
+} from '@metamask/snaps-controllers';
 
 const { RNTar } = NativeModules;
-
-const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org';
-
-interface NpmMeta {
-  registry: URL;
-  packageName: string;
-  requestedRange: SemVerRange;
-  version?: string;
-  fetch: typeof fetch;
-}
-export interface NpmOptions {
-  /**
-   * @default DEFAULT_REQUESTED_SNAP_VERSION
-   */
-  versionRange?: SemVerRange;
-  /**
-   * Whether to allow custom NPM registries outside of {@link DEFAULT_NPM_REGISTRY}.
-   *
-   * @default false
-   */
-  allowCustomRegistries?: boolean;
-}
 
 const SNAPS_NPM_LOG_TAG = 'snaps/ NPM';
 
@@ -74,9 +35,23 @@ const decompressFile = async (
     throw new Error(`${SNAPS_NPM_LOG_TAG} decompressFile error: ${error}`);
   }
 };
+
+const findAllPaths = async (path: string): Promise<string[]> => {
+  const isDir = await ReactNativeBlobUtil.fs.isDir(path);
+  if (!isDir) {
+    return [path];
+  }
+  const fileNames = await ReactNativeBlobUtil.fs.ls(path);
+  const paths = fileNames.map((fileName) => `${path}/${fileName}`);
+  return (await Promise.all(paths.map(findAllPaths))).flat(Infinity);
+};
+
 const readAndParseAt = async (path: string) => {
   try {
-    return stringToBytes(await ReactNativeBlobUtil.fs.readFile(path, 'utf8'));
+    const contents = stringToBytes(
+      await ReactNativeBlobUtil.fs.readFile(path, 'utf8'),
+    );
+    return { path, contents };
   } catch (error) {
     Logger.error(error as Error, `${SNAPS_NPM_LOG_TAG} readAndParseAt error`);
     throw new Error(`${SNAPS_NPM_LOG_TAG} readAndParseAt error: ${error}`);
@@ -130,306 +105,44 @@ const cleanupFileSystem = async (path: string) => {
   });
 };
 
-/**
- * The paths of files within npm tarballs appear to always be prefixed with
- * "package/".
- */
-export class NpmLocation implements SnapLocation {
-  private readonly meta: NpmMeta;
+export class NpmLocation extends BaseNpmLocation {
+  async fetchNpmTarball(
+    tarballUrl: URL,
+  ): Promise<Map<string, VirtualFile<unknown>>> {
+    // Fetches and unpacks the NPM package on the local filesystem using native code
+    const npmPackageDataLocation = await fetchAndStoreNPMPackage(
+      tarballUrl.toString(),
+    );
 
-  private validatedManifest?: VirtualFile<SnapManifest>;
+    // Find all paths contained within the tarball
+    const paths = await findAllPaths(npmPackageDataLocation);
 
-  private files?: Map<string, VirtualFile>;
+    const files = await Promise.all(paths.map(readAndParseAt));
 
-  constructor(url: URL, opts: DetectSnapLocationOptions = {}) {
-    const allowCustomRegistries = opts.allowCustomRegistries ?? false;
-    const fetchFunction = opts.fetch ?? globalThis.fetch.bind(globalThis);
-    const requestedRange = opts.versionRange ?? DEFAULT_REQUESTED_SNAP_VERSION;
+    const canonicalBase = getNpmCanonicalBasePath(
+      this.meta.registry,
+      this.meta.packageName,
+    );
 
-    assertStruct(url.toString(), NpmSnapIdStruct, 'Invalid Snap Id: ');
+    const map = new Map();
 
-    let registry: string | URL;
-    if (
-      url.host === '' &&
-      url.port === '' &&
-      url.username === '' &&
-      url.password === ''
-    ) {
-      registry = new URL(DEFAULT_NPM_REGISTRY);
-    } else {
-      registry = 'https://';
-      if (url.username) {
-        registry += url.username;
-        if (url.password) {
-          registry += `:${url.password}`;
-        }
-        registry += '@';
-      }
-      registry += url.host;
-      registry = new URL(registry);
-      assert(
-        allowCustomRegistries,
-        new TypeError(
-          `Custom NPM registries are disabled, tried to use "${registry.toString()}".`,
-        ),
+    files.forEach(({ path, contents }) => {
+      // Remove most of the base path
+      const normalizedPath = path.replace(`${npmPackageDataLocation}/`, '');
+      map.set(
+        normalizedPath,
+        new VirtualFile({
+          value: contents,
+          path: normalizedPath,
+          data: { canonicalPath: new URL(path, canonicalBase).toString() },
+        }),
       );
-    }
-
-    assert(
-      registry.pathname === '/' &&
-        registry.search === '' &&
-        registry.hash === '',
-    );
-
-    assert(
-      url.pathname !== '' && url.pathname !== '/',
-      new TypeError('The package name in NPM location is empty.'),
-    );
-    let packageName = url.pathname;
-    if (packageName.startsWith('/')) {
-      packageName = packageName.slice(1);
-    }
-
-    this.meta = {
-      requestedRange,
-      registry,
-      packageName,
-      fetch: fetchFunction,
-    };
-  }
-
-  async manifest(): Promise<VirtualFile<SnapManifest>> {
-    if (this.validatedManifest) {
-      return this.validatedManifest.clone();
-    }
-
-    const vfile = await this.fetch('snap.manifest.json');
-    const result = parseJson(vfile.toString());
-    vfile.result = createSnapManifest(result);
-    this.validatedManifest = vfile as VirtualFile<SnapManifest>;
-
-    return this.manifest();
-  }
-
-  async fetch(path: string): Promise<VirtualFile> {
-    const relativePath = normalizeRelative(path);
-    if (!this.files) {
-      await this.#lazyInit();
-      assert(this.files !== undefined);
-    }
-    const vfile = this.files.get(relativePath);
-    assert(
-      vfile !== undefined,
-      new TypeError(`File "${path}" not found in package.`),
-    );
-    return vfile.clone();
-  }
-
-  get packageName(): string {
-    return this.meta.packageName;
-  }
-
-  get version(): string {
-    assert(
-      this.meta.version !== undefined,
-      'Tried to access version without first fetching NPM package.',
-    );
-    return this.meta.version;
-  }
-
-  get registry(): URL {
-    return this.meta.registry;
-  }
-
-  get versionRange(): SemVerRange {
-    return this.meta.requestedRange;
-  }
-
-  #lazyInit = async () => {
-    assert(this.files === undefined);
-    const [manifestData, sourceCodeData, iconData, actualVersion, pathToFiles] =
-      await fetchNpmTarball(
-        this.meta.packageName,
-        this.meta.requestedRange,
-        this.meta.registry,
-        this.meta.fetch,
-      );
-    this.meta.version = actualVersion;
-
-    let canonicalBase = 'npm://';
-    if (this.meta.registry.username !== '') {
-      canonicalBase += this.meta.registry.username;
-      if (this.meta.registry.password !== '') {
-        canonicalBase += `:${this.meta.registry.password}`;
-      }
-      canonicalBase += '@';
-    }
-    canonicalBase += this.meta.registry.host;
-    const manifestVFile = new VirtualFile<SnapManifest>({
-      value: manifestData.data,
-      path: manifestData.filePath,
-      data: {
-        canonicalPath: `${canonicalBase}${manifestData.filePath}`,
-      },
     });
 
-    const sourceCodeVFile = new VirtualFile({
-      value: sourceCodeData.data,
-      path: sourceCodeData.filePath,
-      data: { canonicalPath: `${canonicalBase}${sourceCodeData.filePath}` },
-    });
+    // Cleanup filesystem
+    await cleanupFileSystem(npmPackageDataLocation);
 
-    this.files = new Map<string, VirtualFile>();
-
-    if (iconData) {
-      const iconVFile = new VirtualFile({
-        value: iconData.data,
-        path: iconData.filePath,
-        data: { canonicalPath: `${canonicalBase}${iconData.filePath}` },
-      });
-      this.files.set(iconVFile.path, iconVFile);
-    }
-
-    this.files.set(manifestVFile.path, manifestVFile);
-    this.files.set(sourceCodeVFile.path, sourceCodeVFile);
-
-    // cleanup filesystem
-    await cleanupFileSystem(pathToFiles);
-  };
-}
-
-/**
- * Fetches the tarball (`.tgz` file) of the specified package and version from
- * the public npm registry. Throws an error if fetching fails.
- *
- * @param packageName - The name of the package whose tarball to fetch.
- * @param versionRange - The SemVer range of the package to fetch. The highest
- * version satisfying the range will be fetched.
- * @param registryUrl - The URL of the npm registry to fetch the tarball from.
- * @param fetchFunction - The fetch function to use. Defaults to the global
- * {@link fetch}. Useful for Node.js compatibility.
- * @returns A tuple of the {@link Response} for the package tarball and the
- * actual version of the package.
- */
-
-interface NPMTarBallData {
-  filePath: string;
-  data: Uint8Array;
-}
-
-async function fetchNpmTarball(
-  packageName: string,
-  versionRange: SemVerRange,
-  registryUrl: URL,
-  fetchFunction: typeof fetch,
-): Promise<
-  [
-    NPMTarBallData,
-    NPMTarBallData,
-    NPMTarBallData | undefined,
-    SemVerVersion,
-    string,
-  ]
-> {
-  const urlToFetch = new URL(packageName, registryUrl.toString()).toString();
-  const packageMetadata = await (await fetchFunction(urlToFetch)).json();
-
-  if (!isObject(packageMetadata)) {
-    throw new Error(
-      `${SNAPS_NPM_LOG_TAG} Failed to fetch package "${packageName}" metadata from npm.`,
-    );
+    return map;
   }
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const versions = Object.keys((packageMetadata as any)?.versions ?? {}).map(
-    (version) => {
-      assertIsSemVerVersion(version);
-      return version;
-    },
-  );
-
-  const targetVersion = getTargetVersion(versions, versionRange);
-
-  if (targetVersion === null) {
-    throw new Error(
-      `${SNAPS_NPM_LOG_TAG} Failed to find a matching version in npm metadata for package "${packageName}" and requested semver range "${versionRange}".`,
-    );
-  }
-
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const tarballUrlString = (packageMetadata as any)?.versions?.[targetVersion]
-    ?.dist?.tarball;
-
-  if (
-    !isValidUrl(tarballUrlString) ||
-    !tarballUrlString.toString().endsWith('.tgz')
-  ) {
-    throw new Error(
-      `${SNAPS_NPM_LOG_TAG} Failed to find valid tarball URL in NPM metadata for package "${packageName}".`,
-    );
-  }
-
-  // Override the tarball hostname/protocol with registryUrl hostname/protocol
-  const newRegistryUrl = new URL(registryUrl.toString());
-  const newTarballUrl = new URL(tarballUrlString.toString());
-  newTarballUrl.hostname = newRegistryUrl.hostname;
-  newTarballUrl.protocol = newRegistryUrl.protocol;
-
-  // Perform a raw fetch because we want the Response object itself.
-  const npmPackageDataLocation = await fetchAndStoreNPMPackage(
-    newTarballUrl.toString(),
-  );
-
-  // read and parse data from file
-  const manifestPath = `${npmPackageDataLocation}/snap.manifest.json`;
-  const manifest = await readAndParseAt(manifestPath);
-
-  if (!manifest) {
-    throw new Error(
-      `${SNAPS_NPM_LOG_TAG} Failed to fetch manifest from tarball for package "${packageName}".`,
-    );
-  }
-
-  const manifestData: NPMTarBallData = {
-    filePath: 'snap.manifest.json',
-    data: manifest,
-  };
-  const parsedManifest = parseJson<SnapManifest>(bytesToString(manifest));
-  const locations = parsedManifest.source.location.npm;
-  const sourceCodePath = `${npmPackageDataLocation}/${locations.filePath}`;
-  const sourceCode = await readAndParseAt(sourceCodePath);
-
-  if (!sourceCode) {
-    throw new Error(
-      `${SNAPS_NPM_LOG_TAG} Failed to fetch source code from tarball for package "${packageName}".`,
-    );
-  }
-
-  const sourceCodeData: NPMTarBallData = {
-    filePath: locations.filePath,
-    data: sourceCode,
-  };
-  const icon: Uint8Array | undefined = locations.iconPath
-    ? await readAndParseAt(
-        `${npmPackageDataLocation}/${locations.iconPath}`,
-      ).catch(() => undefined)
-    : undefined;
-
-  const iconData: NPMTarBallData | undefined =
-    icon && locations.iconPath
-      ? {
-          filePath: locations.iconPath,
-          data: icon,
-        }
-      : undefined;
-
-  return [
-    manifestData,
-    sourceCodeData,
-    iconData,
-    targetVersion,
-    npmPackageDataLocation,
-  ];
 }
 ///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { VirtualFile } from '@metamask/snaps-utils';
 import { stringToBytes } from '@metamask/utils';
@@ -43,7 +44,9 @@ const findAllPaths = async (path: string): Promise<string[]> => {
   }
   const fileNames = await ReactNativeBlobUtil.fs.ls(path);
   const paths = fileNames.map((fileName) => `${path}/${fileName}`);
-  return (await Promise.all(paths.map(findAllPaths))).flat(Infinity) as string[];
+  return (await Promise.all(paths.map(findAllPaths))).flat(
+    Infinity,
+  ) as string[];
 };
 
 const readAndParseAt = async (path: string) => {

--- a/app/core/Snaps/permissions/permissions.ts
+++ b/app/core/Snaps/permissions/permissions.ts
@@ -4,10 +4,10 @@ export const ExcludedSnapPermissions = Object.freeze([]);
 export const ExcludedSnapEndowments = Object.freeze([]);
 
 export const EndowmentPermissions = Object.freeze({
-    'endowment:network-access': 'endowment:network-access',
-    'endowment:transaction-insight': 'endowment:transaction-insight',
-    'endowment:cronjob': 'endowment:cronjob',
-    'endowment:ethereum-provider': 'endowment:ethereum-provider',
-    'endowment:rpc': 'endowment:rpc',
-  } as const);
+  'endowment:network-access': 'endowment:network-access',
+  'endowment:transaction-insight': 'endowment:transaction-insight',
+  'endowment:cronjob': 'endowment:cronjob',
+  'endowment:ethereum-provider': 'endowment:ethereum-provider',
+  'endowment:rpc': 'endowment:rpc',
+} as const);
 ///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/permissions/permissions.ts
+++ b/app/core/Snaps/permissions/permissions.ts
@@ -2,4 +2,12 @@
 // TODO: Figure out which permissions should be disabled at this point
 export const ExcludedSnapPermissions = Object.freeze([]);
 export const ExcludedSnapEndowments = Object.freeze([]);
+
+export const EndowmentPermissions = Object.freeze({
+    'endowment:network-access': 'endowment:network-access',
+    'endowment:transaction-insight': 'endowment:transaction-insight',
+    'endowment:cronjob': 'endowment:cronjob',
+    'endowment:ethereum-provider': 'endowment:ethereum-provider',
+    'endowment:rpc': 'endowment:rpc',
+  } as const);
 ///: END:ONLY_INCLUDE_IF

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -225,6 +225,10 @@ NativeModules.AesForked = {
   decrypt: jest.fn().mockResolvedValue('{"mockData": "mockedPlainTextForked"}'),
 };
 
+NativeModules.RNTar = {
+  unTar: jest.fn().mockResolvedValue('/document-dir/archive'),
+}
+
 jest.mock(
   'react-native/Libraries/Components/Touchable/TouchableOpacity',
   () => 'TouchableOpacity',


### PR DESCRIPTION
## **Description**

Refactors a few parts of the Snaps integration in mobile and fixes some problems:
- Fixes RPC methods being called by dapps - which were broken due to moving the PermissionController
- Move PermissionController middleware to execute before all other middlewares when handling requests from Snaps
- Simplify NPM implementation significantly by using a base class `BaseNpmLocation` which handles most of the complexity
- Support `snap_getFile`, which was broken due to a missing hook
- Add proper feature flags for basic functionality and allowing local Snaps