### PR TITLE
fix: Always mark the STX Opt In modal as seen

### DIFF
--- a/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTranactionsOptInModal.tsx
@@ -149,39 +149,40 @@ const SmartTransactionsOptInModal = () => {
     modalRef.current?.dismissModal();
   };
 
-  const optIn = () => {
+  const markOptInModalAsSeen = async () => {
+    const version = await AsyncStorage.getItem(CURRENT_APP_VERSION);
+    dispatch(updateOptInModalAppVersionSeen(version));
+  };
+
+  const optIn = async () => {
     Engine.context.PreferencesController.setSmartTransactionsOptInStatus(true);
     trackEvent(MetaMetricsEvents.SMART_TRANSACTION_OPT_IN, {
       stx_opt_in: true,
       location: 'SmartTransactionsOptInModal',
     });
-
     hasOptedIn.current = true;
+    await markOptInModalAsSeen();
     dismissModal();
   };
 
-  const optOut = () => {
+  const optOut = async () => {
     Engine.context.PreferencesController.setSmartTransactionsOptInStatus(false);
     trackEvent(MetaMetricsEvents.SMART_TRANSACTION_OPT_IN, {
       stx_opt_in: false,
       location: 'SmartTransactionsOptInModal',
     });
-
     hasOptedIn.current = false;
+    await markOptInModalAsSeen();
     navigation.navigate(Routes.SETTINGS_VIEW, {
       screen: Routes.SETTINGS.ADVANCED_SETTINGS,
     });
   };
 
   const handleDismiss = async () => {
-    // Opt out of STX if no prior decision made
+    // Opt out of STX if no prior decision made.
     if (hasOptedIn.current === null) {
       optOut();
     }
-
-    // Save the current app version as the last app version seen
-    const version = await AsyncStorage.getItem(CURRENT_APP_VERSION);
-    dispatch(updateOptInModalAppVersionSeen(version));
   };
 
   const Header = () => (

--- a/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import SmartTransactionsOptInModal from './SmartTranactionsOptInModal';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import initialBackgroundState from '../../../util/test/initial-background-state.json';
@@ -96,7 +96,7 @@ describe('SmartTransactionsOptInModal', () => {
       Engine.context.PreferencesController.setSmartTransactionsOptInStatus,
     ).toHaveBeenCalledWith(true);
   });
-  it('should opt user out when secondary button is pressed and navigate to Advanced Settings', () => {
+  it('should opt user out when secondary button is pressed and navigate to Advanced Settings', async () => {
     const { getByText } = renderWithProvider(<SmartTransactionsOptInModal />, {
       state: initialState,
     });
@@ -109,8 +109,11 @@ describe('SmartTransactionsOptInModal', () => {
     expect(
       Engine.context.PreferencesController.setSmartTransactionsOptInStatus,
     ).toHaveBeenCalledWith(false);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
-      screen: Routes.SETTINGS.ADVANCED_SETTINGS,
+    expect(updateOptInModalAppVersionSeen).toHaveBeenCalledWith(VERSION);
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
+        screen: Routes.SETTINGS.ADVANCED_SETTINGS,
+      });      
     });
   });
   it('should update last app version seen on primary button press', () => {

--- a/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
@@ -113,7 +113,7 @@ describe('SmartTransactionsOptInModal', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
         screen: Routes.SETTINGS.ADVANCED_SETTINGS,
-      });      
+      });
     });
   });
   it('should update last app version seen on primary button press', () => {

--- a/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
+++ b/app/components/Views/SmartTransactionsOptInModal/SmartTransactionsOptInModal.test.tsx
@@ -96,7 +96,7 @@ describe('SmartTransactionsOptInModal', () => {
       Engine.context.PreferencesController.setSmartTransactionsOptInStatus,
     ).toHaveBeenCalledWith(true);
   });
-  it('should opt user out when secondary button is pressed and navigate to Advanced Settings', async () => {
+  it('opts user out when secondary button is pressed and navigate to Advanced Settings', async () => {
     const { getByText } = renderWithProvider(<SmartTransactionsOptInModal />, {
       state: initialState,
     });


### PR DESCRIPTION
## **Description**

It seems that after a redirection to Settings was added when a user clicks on "Manage in settings", it wasn't marking the modal as seen. This PR fixes it.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Set up the app from scratch
2. Select "Enable" or "Manage in Settings" on the STX Opt In modal
3. You will not see the modal again, even when you switch to a different network and then back to Ethereum Mainnet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
