### PR TITLE
chore: disable protect modal in development

### DIFF
--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -87,7 +87,7 @@ import { selectSelectedInternalAccountChecksummedAddress } from '../../../select
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 import NetworkInfo from '../NetworkInfo';
 import { withMetricsAwareness } from '../../../components/hooks/useMetrics';
-import { isDevelopment } from 'app/util/env';
+import { isDevelopment } from '../../../util/env';
 
 const createStyles = (colors) =>
   StyleSheet.create({

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -87,6 +87,7 @@ import { selectSelectedInternalAccountChecksummedAddress } from '../../../select
 import { createAccountSelectorNavDetails } from '../../Views/AccountSelector';
 import NetworkInfo from '../NetworkInfo';
 import { withMetricsAwareness } from '../../../components/hooks/useMetrics';
+import { isDevelopment } from 'app/util/env';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -949,8 +950,7 @@ class DrawerView extends PureComponent {
   };
 
   renderProtectModal = () => {
-    const NODE_ENV = 'NODE_ENV';
-    if (process.env[NODE_ENV] === 'development') {
+    if (isDevelopment()) {
       return null;
     }
 

--- a/app/components/UI/DrawerView/index.js
+++ b/app/components/UI/DrawerView/index.js
@@ -949,6 +949,11 @@ class DrawerView extends PureComponent {
   };
 
   renderProtectModal = () => {
+    const NODE_ENV = 'NODE_ENV';
+    if (process.env[NODE_ENV] === 'development') {
+      return null;
+    }
+
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
 

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -1,0 +1,4 @@
+const NODE_ENV = 'NODE_ENV';
+
+// eslint-disable-next-line import/prefer-default-export
+export const isDevelopment = () => process.env[NODE_ENV] === 'development';


### PR DESCRIPTION
## **Description**
This PR disables the "Protect your wallet" blocking modal when NODE_ENV is 'development'
<img width="351" alt="image" src="https://github.com/MetaMask/metamask-mobile/assets/507015/c0ec3127-336e-45c7-b1d2-f0c94d39910f">


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
