### PR TITLE
feat: Add the "is_smart_transaction" prop for the "Swap Started" event

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -889,6 +889,7 @@ function SwapsQuotesView({
         ),
         network_fees_ETH: renderFromWei(toWei(selectedQuoteValue?.ethFee)),
         chain_id: getDecimalChainId(chainId),
+        is_smart_transaction: shouldUseSmartTransaction,
       };
       trackAnonymousEvent(MetaMetricsEvents.SWAP_STARTED, parameters);
     },


### PR DESCRIPTION
## **Description**
Adds the "is_smart_transaction" prop for the "Swap Started" event.
We want to know if a swap was started as a smart transaction or just a regular transaction.


## **Related issues**

Fixes:

## **Manual testing steps**

1. Trigger a swap on a testnet
2. The "Swap Started" event will have the new "is_smart_transaction" prop

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
