### PR TITLE
refactor: update bitrise e2e check to not run on forks

### DIFF
--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -12,9 +12,24 @@ env:
   WORKFLOW_NAME: 'run-bitrise-e2e-check'
 
 jobs:
-  run-bitrise-e2e-check:
-    runs-on: ubuntu-latest
+  is-fork-pull-request:
+    name: Determine whether this pull request is from a fork
     if: ${{ github.event.issue.pull_request || github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    outputs:
+      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Determine whether this PR is from a fork
+        id: is-fork
+        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${{ github.event.number }}" )" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-bitrise-e2e-check:
+    needs: is-fork-pull-request
+    runs-on: ubuntu-latest
+    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   is-fork-pull-request:
-    name: Determine whether this pull request is from a fork
+    name: Determine pull request source
     if: ${{ github.event.issue.pull_request || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## **Description**

This pull request updates the bitrise e2e check workflow to only trigger from branches within the MetaMask Mobile repository. This brings it in line with other patterns we see across MetaMask such as in [core](https://github.com/MetaMask/core/blob/4fe6141a24aa11bb6672ea31a6e33efe041ffcc1/.github/workflows/publish-preview.yml#L13).


## **Manual testing steps**

**Pull request on repository (non-fork)**
1. Look at CI on this pull request
2. See the successful run of `Run Bitrise E2E Check`.

**Pull Request From Fork**
1.  Visit https://github.com/NicholasEllul/metamask-mobile/pull/3
2. See in the CI output that the `run-bitrise-e2e-check` was [skipped](https://github.com/NicholasEllul/metamask-mobile/actions/runs/9686283967/job/26728373509?pr=3).

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
