### PR TITLE
test: disable privacy policy toast and whats new modal using fixtures

### DIFF
--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -48,6 +48,10 @@ class FixtureBuilder {
   withDefaultFixture() {
     this.fixture = {
       state: {
+        legalNotices: {
+          newPrivacyPolicyToastClickedOrClosed: true,
+          newPrivacyPolicyToastShownDate: Date.now(),
+        },
         collectibles: {
           favorites: {},
         },
@@ -619,7 +623,7 @@ class FixtureBuilder {
         '@MetaMask:existingUser': 'true',
         '@MetaMask:onboardingWizard': 'explored',
         '@MetaMask:UserTermsAcceptedv1.0': 'true',
-        '@MetaMask:WhatsNewAppVersionSeen': '6.5.0',
+        '@MetaMask:WhatsNewAppVersionSeen': '7.24.3',
       },
     };
     return this;

--- a/e2e/viewHelper.js
+++ b/e2e/viewHelper.js
@@ -218,6 +218,4 @@ export const loginToApp = async () => {
   const PASSWORD = '123123123';
   await LoginView.isVisible();
   await LoginView.enterPassword(PASSWORD);
-
-  await this.closeOnboardingModals();
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Within the E2E tests that use fixtures, we want to disable the what's new modal in addition to the privacy policy toast message that appears as soon as you land on the wallet view. This shaves off ~7 mins of E2E run time on CI. 

A new state (legalNotices) was added to the default fixture for the privacy policy. Furthermore, the Whats New modal version used in the default fixture was updated to match the most recent release: 7.24.3.   


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See main before the PR is merged: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/9f51cf6c-ffd3-4a7a-8aa4-f420a81547f9 

### **After**

Here is main after: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/f15f1200-4164-4d56-a740-32687b3f5134 

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
