### PR TITLE
fix: Stop running fencing logic on `node_modules`

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -59,7 +59,7 @@ module.exports.transform = async ({ src, filename, options }) => {
    * Params based on builds we're code splitting
    * i.e: flavorDimensions "version" productFlavors from android/app/build.gradle
    */
-  if (fileExtsToScan.includes(path.extname(filename))) {
+  if (!path.normalize(filename).split(path.sep).includes('node_modules') && fileExtsToScan.includes(path.extname(filename))) {
     const [processedSource, didModify] = removeFencedCode(filename, src, {
       all: availableFeatures,
       active: getBuildTypeFeatures(),

--- a/metro.transform.js
+++ b/metro.transform.js
@@ -59,7 +59,10 @@ module.exports.transform = async ({ src, filename, options }) => {
    * Params based on builds we're code splitting
    * i.e: flavorDimensions "version" productFlavors from android/app/build.gradle
    */
-  if (!path.normalize(filename).split(path.sep).includes('node_modules') && fileExtsToScan.includes(path.extname(filename))) {
+  if (
+    !path.normalize(filename).split(path.sep).includes('node_modules') &&
+    fileExtsToScan.includes(path.extname(filename))
+  ) {
     const [processedSource, didModify] = removeFencedCode(filename, src, {
       all: availableFeatures,
       active: getBuildTypeFeatures(),


### PR DESCRIPTION
## **Description**

Stops running fencing logic on `node_modules`, mirroring the extension implementation. There is no reason for us to run fencing on code coming from `node_modules` anyway. This may have a potential positive performance impact as well during build-time.