### PR TITLE
chore: added the requirement for PRs to contain a QA label

### DIFF
--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -16,11 +16,13 @@ It's essential to ensure that PRs have the appropriate labels before they are co
 ### Mandatory QA labels:
 Every PR shall include one the QA labels below:
 - **needs-qa**: If the PR includes a new features, complex testing steps, or large refactors, this label must be added to indicated PR requires a full manual QA prior being merged and added to a release.
-- **No QA/E2E only**: If the PR does not require any manual QA effort, this label must be added. However, prior to merging, you must ensure end-to-end test runs in Bitrise are successful.
+
 - **Spot check on release build**: If PR does not require feature QA but needs non-automated verification, this label must be added. Furthermore, when that label is added, you must provide test scenarios in the description section, as well as add screenshots, and or recordings of what was tested.
 
-Once PR has been tested by QA (only if the PR was labeled with `needs-qa`):
+To merge your PR one of the following QA labels are required:
 - **QA Passed**: If the PR was labeled with `needs-qa`, this label must be added once QA has signed off
+- **No QA Needed**: If the PR does not require any QA effort. This label should only be used in case you are updating a README or other files that does not impact the building or runtime of the application.
+- **Run E2E Smoke**: This label will kick-off E2E testing and trigger a check to make sure the E2E tests pass. 
 
 ### Optional labels:
 - **regression-develop**: This label can manually be added to a bug report issue at the time of its creation if the bug is present on the development branch, i.e., `main`, but is not yet released in production.

--- a/.github/scripts/check-pr-has-required-labels.ts
+++ b/.github/scripts/check-pr-has-required-labels.ts
@@ -79,7 +79,6 @@ async function main(): Promise<void> {
     errorMessage += 'No team labels found on the PR. ';
   }
   
-  let errorMessage = '';
   if (!hasQALabel) {
     errorMessage += 'No \'Run E2E Smoke\' or \'No QA Needed/E2E Only\' label';
   }

--- a/.github/scripts/check-pr-has-required-labels.ts
+++ b/.github/scripts/check-pr-has-required-labels.ts
@@ -50,6 +50,7 @@ async function main(): Promise<void> {
     'DO-NOT-MERGE',
   ];
   let hasTeamLabel = false;
+  let hasQALabel = false;
 
   // Check pull request has at least required QA label and team label
   for (const label of pullRequestLabels) {
@@ -57,21 +58,30 @@ async function main(): Promise<void> {
       console.log(`PR contains a team label as expected: ${label}`);
       hasTeamLabel = true;
     }
+    if (label.includes('Run Smoke E2E') || label.includes('No QA Needed') || label.includes('QA Passed')  ) {
+      console.log(`PR contains a QA label as expected: ${label}`);
+      hasQALabel = true;
+    }
     if (preventMergeLabels.includes(label)) {
       core.setFailed(
         `PR cannot be merged because it still contains this label: ${label}`,
       );
       process.exit(1);
     }
-    if (hasTeamLabel) {
+    if (hasTeamLabel && hasQALabel) {
       return;
     }
   }
 
-  // Otherwise, throw an arror to prevent from merging
+  // Otherwise, throw an error to prevent from merging
   let errorMessage = '';
   if (!hasTeamLabel) {
     errorMessage += 'No team labels found on the PR. ';
+  }
+  
+  let errorMessage = '';
+  if (!hasQALabel) {
+    errorMessage += 'No \'Run E2E Smoke\' or \'No QA Needed/E2E Only\' label';
   }
   errorMessage += `Please make sure the PR is appropriately labeled before merging it.\n\nSee labeling guidelines for more detail: https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md`;
   core.setFailed(errorMessage);

--- a/.github/scripts/check-pr-has-required-labels.ts
+++ b/.github/scripts/check-pr-has-required-labels.ts
@@ -80,7 +80,7 @@ async function main(): Promise<void> {
   }
   
   if (!hasQALabel) {
-    errorMessage += 'No \'Run E2E Smoke\' or \'No QA Needed/E2E Only\' label';
+    errorMessage += 'No \'Run E2E Smoke\' or \'No QA Needed\' or \'QA Passed\' label. ';
   }
   errorMessage += `Please make sure the PR is appropriately labeled before merging it.\n\nSee labeling guidelines for more detail: https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md`;
   core.setFailed(errorMessage);


### PR DESCRIPTION
## **Description**

This PR add the requirement for all PRs to contain 1 of 3 QA labels:
- `No QA Needed`
- `Run E2E Smoke`
- `QA Passed`

## **Related issues**

Fixes:

## **Manual testing steps**

1. PASS - Add no QA labels and see CI Check template and add labels / check-template-and-add-labels Fail
2. PASS - Add `No QA Needed` QA labels and see CI Check template and add labels / check-template-and-add-labels Pass
3. PASS - Add `Run E2E Smoke` QA labels and see CI Check template and add labels / check-template-and-add-labels Pass
4. PASS - Add `QA Passed` QA labels and see CI Check template and add labels / check-template-and-add-labels Pass

## **Screenshots/Recordings**

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
