### PR TITLE
fix: convert Sentry messages to log

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -873,7 +873,7 @@ export const BrowserTab = (props) => {
     // Continue request loading it the protocol is whitelisted
     const { protocol } = new URL(url);
     if (protocolAllowList.includes(protocol)) return true;
-    Logger.message(`Protocol not allowed ${protocol}`);
+    Logger.log(`Protocol not allowed ${protocol}`);
 
     // If it is a trusted deeplink protocol, do not show the
     // warning alert. Allow the OS to deeplink the URL

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -126,7 +126,7 @@ class EngineService {
 
     engine?.datamodel?.subscribe?.(() => {
       if (!engine.context.KeyringController.metadata.vault) {
-        Logger.message('keyringController vault missing for INIT_BG_STATE_KEY');
+        Logger.log('keyringController vault missing for INIT_BG_STATE_KEY');
       }
       if (!this.engineInitialized) {
         store.dispatch({ type: INIT_BG_STATE_KEY });
@@ -138,9 +138,7 @@ class EngineService {
       const { name, key = undefined } = controller;
       const update_bg_state_cb = () => {
         if (!engine.context.KeyringController.metadata.vault) {
-          Logger.message(
-            'keyringController vault missing for UPDATE_BG_STATE_KEY',
-          );
+          Logger.log('keyringController vault missing for UPDATE_BG_STATE_KEY');
         }
         store.dispatch({ type: UPDATE_BG_STATE_KEY, payload: { key: name } });
       };

--- a/app/util/Logger/index.test.ts
+++ b/app/util/Logger/index.test.ts
@@ -1,9 +1,5 @@
 import Logger from '.';
-import {
-  captureException,
-  withScope,
-  captureMessage,
-} from '@sentry/react-native';
+import { captureException, withScope } from '@sentry/react-native';
 import { AGREED, METRICS_OPT_IN } from '../../constants/storage';
 import DefaultPreference from 'react-native-default-preference';
 
@@ -13,7 +9,6 @@ jest.mock('@sentry/react-native', () => ({
   withScope: jest.fn(),
 }));
 const mockedCaptureException = jest.mocked(captureException);
-const mockedCaptureMessage = jest.mocked(captureMessage);
 const mockedWithScope = jest.mocked(withScope);
 
 describe('Logger', () => {
@@ -73,25 +68,6 @@ describe('Logger', () => {
       const testError = 'testError' as any;
       await Logger.error(testError);
       expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    });
-  });
-
-  describe('message', () => {
-    it('skips captureMessage if metrics is opted out', async () => {
-      DefaultPreference.get = jest.fn((key: string) => {
-        switch (key) {
-          case METRICS_OPT_IN:
-            return Promise.resolve('');
-          default:
-            return Promise.resolve('');
-        }
-      });
-      await Logger.message('testMessage');
-      expect(mockedCaptureMessage).not.toHaveBeenCalled();
-    });
-    it('calls captureMessage if metrics is opted in', async () => {
-      await Logger.message('testMessage');
-      expect(mockedCaptureMessage).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/util/Logger/index.ts
+++ b/app/util/Logger/index.ts
@@ -1,7 +1,6 @@
 import {
   addBreadcrumb,
   captureException,
-  captureMessage,
   withScope,
 } from '@sentry/react-native';
 import DefaultPreference from 'react-native-default-preference';
@@ -95,26 +94,6 @@ export class AsyncLogger {
       }
     }
   }
-
-  /**
-   * captureMessage wrapper
-   *
-   * @param {object} args - data to be logged
-   * @returns - void
-   */
-  static async message(...args: unknown[]): Promise<void> {
-    if (__DEV__) {
-      args.unshift('[MetaMask DEBUG]:');
-      // console.log.apply(null, args); // eslint-disable-line no-console
-      return;
-    }
-
-    // Check if user passed accepted opt-in to metrics
-    const metricsOptIn = await DefaultPreference.get(METRICS_OPT_IN);
-    if (metricsOptIn === 'agreed') {
-      captureMessage(JSON.stringify(args));
-    }
-  }
 }
 
 export default class Logger {
@@ -143,18 +122,6 @@ export default class Logger {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static error(error: Error, extra?: ExtraInfo | string | any) {
     AsyncLogger.error(error, extra).catch(() => {
-      // ignore error but avoid dangling promises
-    });
-  }
-
-  /**
-   * captureMessage wrapper
-   *
-   * @param {object} args - data to be logged
-   * @returns - void
-   */
-  static message(...args: unknown[]) {
-    AsyncLogger.message(...args).catch(() => {
       // ignore error but avoid dangling promises
     });
   }

--- a/app/util/Logger/index.ts
+++ b/app/util/Logger/index.ts
@@ -16,6 +16,11 @@ interface ExtraInfo {
  * console.log and console.error and in the future
  * we will have flags to do different actions based on
  * the environment, for ex. log to a remote server if prod
+ *
+ * The previously available message function has been removed
+ * favoring the use of the error or log function:
+ * - error: for logging errors that you want to see in Sentry,
+ * - log: for logging general information and sending breadcrumbs only with the next Sentry event.
  */
 export class AsyncLogger {
   /**


### PR DESCRIPTION
## **Description**

Convert `Logger.message` to `Logger.log` as to provide breadcrumb for next event instead of filling Sentry with events that are hitting our quotas.

Our `Logger.message` util internally uses Sentry `captureMessage` and `Logger.message` util internally uses Sentry `addBreadcrumb`.

### Sentry breadcrumbs vs message
```js
/**
 * Captures a message event and sends it to Sentry.
 *
 * @param exception The exception to capture.
 * @param captureContext Define the level of the message or pass in additional data to attach to the message.
 * @returns the id of the captured message.
 */
export declare function captureMessage(message: string, captureContext?: CaptureContext | Severity | SeverityLevel): string;

/**
 * Records a new breadcrumb which will be attached to future events.
 *
 * Breadcrumbs will be added to subsequent events to provide more context on
 * user's actions prior to an error or crash.
 *
 * @param breadcrumb The breadcrumb to record.
 */
export declare function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): ReturnType<Hub['addBreadcrumb']>;
```

### Improvement suggestion

In order to prevent this `Logger.message` to be used again I recommend to completely remove it from utils and force the use of either logs or errors.
We had only 3 places it was used, as they are now removed, deleting the utility function has no impact.

## **Related issues**

see MetaMask/mobile-planning/issues/1814

## **Manual testing steps**

NA

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
