### PR TITLE
feat: Revamp Snap connection screen

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 export const SNAP_INSTALL_FLOW = 'snap-install-flow';
 export const SNAP_INSTALL_OK = 'snap-install-ok';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 import Device from '../../../util/device';
@@ -36,6 +36,10 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     snapCell: {
       marginVertical: 16,
+    },
+    snapAvatar: {
+      alignSelf: 'center',
+      marginTop: 16,
     },
     snapPermissionContainer: {
       maxHeight: 300,

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -83,10 +83,6 @@ const InstallSnapApproval = () => {
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 
-  const onInstallSnapFinished = () => {
-    setInstallState(SnapInstallState.SnapInstallFinished);
-  };
-
   const onPermissionsConfirm = async () => {
     try {
       await onConfirm(undefined, {
@@ -133,17 +129,12 @@ const InstallSnapApproval = () => {
           />
         );
       case SnapInstallState.SnapInstalled:
-        return (
-          <InstallSnapSuccess
-            snapName={snapName}
-            onConfirm={onInstallSnapFinished}
-          />
-        );
+        return <InstallSnapSuccess snapName={snapName} onConfirm={onConfirm} />;
       case SnapInstallState.SnapInstallError:
         return (
           <InstallSnapError
             snapName={snapName}
-            onConfirm={onInstallSnapFinished}
+            onConfirm={onConfirm}
             error={installError}
           />
         );
@@ -157,13 +148,7 @@ const InstallSnapApproval = () => {
   const content = renderModalContent();
 
   return content ? (
-    <ApprovalModal
-      isVisible={
-        installState !== undefined &&
-        installState !== SnapInstallState.SnapInstallFinished
-      }
-      onCancel={onReject}
-    >
+    <ApprovalModal isVisible={installState !== undefined} onCancel={onReject}>
       {content}
     </ApprovalModal>
   ) : null;

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -1,32 +1,50 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { useEffect, useState } from 'react';
 import ApprovalModal from '../ApprovalModal';
 import useApprovalRequest from '../../Views/confirmations/hooks/useApprovalRequest';
 import { ApprovalTypes } from '../../../core/RPCMethods/RPCMethodMiddleware';
-import Logger from '../../../util/Logger';
 import { SnapInstallState } from './InstallSnapApproval.types';
 import {
   InstallSnapConnectionRequest,
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   InstallSnapError,
   InstallSnapPermissionsRequest,
   InstallSnapSuccess,
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 } from './components';
-import { SNAP_INSTALL_FLOW } from './InstallSnapApproval.constants';
 import { ApprovalRequest } from '@metamask/approval-controller';
+import { useSelector } from 'react-redux';
+import { selectSnapsMetadata } from '../../../selectors/snaps/snapController';
+import {
+  WALLET_SNAP_PERMISSION_KEY,
+  stripSnapPrefix,
+} from '@metamask/snaps-utils';
 
 const InstallSnapApproval = () => {
+  const snapsMetadata = useSelector(selectSnapsMetadata);
+
   const [installState, setInstallState] = useState<
     SnapInstallState | undefined
   >(undefined);
-  const [isFinished, setIsFinished] = useState<boolean>(false);
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   const [installError, setInstallError] = useState<Error | undefined>(
     undefined,
   );
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   const { approvalRequest, onConfirm, onReject } = useApprovalRequest();
 
   useEffect(() => {
     if (approvalRequest) {
-      if (approvalRequest.type === ApprovalTypes.REQUEST_PERMISSIONS) {
+      if (
+        approvalRequest.type === ApprovalTypes.REQUEST_PERMISSIONS &&
+        Object.keys(approvalRequest?.requestData?.permissions).includes(
+          WALLET_SNAP_PERMISSION_KEY,
+        )
+      ) {
         setInstallState(SnapInstallState.Confirm);
       } else if (
         approvalRequest.type === ApprovalTypes.INSTALL_SNAP &&
@@ -41,14 +59,11 @@ const InstallSnapApproval = () => {
 
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const getSnapName = (request: ApprovalRequest<any>): string => {
+  const getSnapId = (request: ApprovalRequest<any>): string => {
     // We first look for the name inside the snapId approvalRequest data
     const snapId = request?.requestData?.snapId;
     if (typeof snapId === 'string') {
-      const colonIndex = snapId.indexOf(':');
-      if (colonIndex !== -1) {
-        return snapId.substring(colonIndex + 1);
-      }
+      return snapId;
     }
     // If there is no snapId present in the approvalRequest data, we look for the name inside the snapIds caveat
     const snapIdsCaveat =
@@ -57,14 +72,19 @@ const InstallSnapApproval = () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (c: any) => c.type === 'snapIds',
       );
-    // return an empty string if we can't find the snap name in the approvalRequest data
-    return snapIdsCaveat?.value ? Object.keys(snapIdsCaveat.value)[0] : '';
+    return Object.keys(snapIdsCaveat.value)[0];
   };
+
+  const getSnapMetadata = (snapId: string) =>
+    snapsMetadata[snapId] ?? { name: stripSnapPrefix(snapId) };
 
   if (!approvalRequest) return null;
 
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+
   const onInstallSnapFinished = () => {
-    setIsFinished(true);
+    setInstallState(SnapInstallState.SnapInstallFinished);
   };
 
   const onPermissionsConfirm = async () => {
@@ -75,34 +95,38 @@ const InstallSnapApproval = () => {
       });
       setInstallState(SnapInstallState.SnapInstalled);
     } catch (error) {
-      Logger.error(
-        error as Error,
-        `${SNAP_INSTALL_FLOW} Failed to install snap`,
-      );
       setInstallError(error as Error);
       setInstallState(SnapInstallState.SnapInstallError);
     }
   };
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 
-  if (!approvalRequest) return null;
+  if (!approvalRequest || installState === undefined) return null;
 
-  const snapName = getSnapName(approvalRequest);
+  const snapId = getSnapId(approvalRequest);
+  const snapName = getSnapMetadata(snapId).name;
 
+  // TODO: This component should support connecting to multiple Snaps at once.
   const renderModalContent = () => {
     switch (installState) {
       case SnapInstallState.Confirm:
         return (
           <InstallSnapConnectionRequest
             approvalRequest={approvalRequest}
+            snapId={snapId}
             snapName={snapName}
             onConfirm={onConfirm}
             onCancel={onReject}
           />
         );
+      ///: END:ONLY_INCLUDE_IF
+      ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
       case SnapInstallState.AcceptPermissions:
         return (
           <InstallSnapPermissionsRequest
             approvalRequest={approvalRequest}
+            snapId={snapId}
             snapName={snapName}
             onConfirm={onPermissionsConfirm}
             onCancel={onReject}
@@ -123,6 +147,8 @@ const InstallSnapApproval = () => {
             error={installError}
           />
         );
+      ///: END:ONLY_INCLUDE_IF
+      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
       default:
         return null;
     }
@@ -132,7 +158,10 @@ const InstallSnapApproval = () => {
 
   return content ? (
     <ApprovalModal
-      isVisible={installState !== undefined && !isFinished}
+      isVisible={
+        installState !== undefined &&
+        installState !== SnapInstallState.SnapInstallFinished
+      }
       onCancel={onReject}
     >
       {content}

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
@@ -16,7 +16,6 @@ export enum SnapInstallState {
   AcceptPermissions = 'AcceptPermissions',
   SnapInstalled = 'SnapInstalled',
   SnapInstallError = 'SnapInstallError',
-  SnapInstallFinished = 'SnapInstallFinished',
 }
 
 // eslint-disable-next-line import/prefer-default-export

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
@@ -1,8 +1,9 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 interface InstallSnapFlowProps {
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   approvalRequest: any;
+  snapId: string;
   snapName: string;
   onConfirm: () => void;
   onCancel: () => void;
@@ -15,6 +16,7 @@ export enum SnapInstallState {
   AcceptPermissions = 'AcceptPermissions',
   SnapInstalled = 'SnapInstalled',
   SnapInstallError = 'SnapInstallError',
+  SnapInstallFinished = 'SnapInstallFinished',
 }
 
 // eslint-disable-next-line import/prefer-default-export

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
@@ -1,6 +1,6 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { useMemo } from 'react';
-import { ImageSourcePropType, View } from 'react-native';
+import { View } from 'react-native';
 import { InstallSnapFlowProps } from '../../InstallSnapApproval.types';
 import styleSheet from '../../InstallSnapApproval.styles';
 import { strings } from '../../../../../../locales/i18n';
@@ -11,10 +11,6 @@ import Text, {
 import TagUrl from '../../../../../component-library/components/Tags/TagUrl';
 import { getUrlObj, prefixUrlWithProtocol } from '../../../../../util/browser';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import Cell, {
-  CellVariant,
-} from '../../../../../component-library/components/Cells/Cell';
-import { AvatarVariant } from '../../../../../component-library/components/Avatars/Avatar';
 import {
   ButtonSize,
   ButtonVariants,
@@ -29,15 +25,18 @@ import {
   SNAP_INSTALL_CONNECT,
   SNAP_INSTALL_CONNECTION_REQUEST,
 } from './InstallSnapConnectionRequest.constants';
+import { useFavicon } from '../../../../hooks/useFavicon';
+import { SnapAvatar } from '../../../../UI/Snaps/SnapAvatar/SnapAvatar';
 
 const InstallSnapConnectionRequest = ({
   approvalRequest,
+  snapId,
   snapName,
   onConfirm,
   onCancel,
 }: Pick<
   InstallSnapFlowProps,
-  'approvalRequest' | 'onConfirm' | 'onCancel' | 'snapName'
+  'approvalRequest' | 'onConfirm' | 'onCancel' | 'snapId' | 'snapName'
 >) => {
   const { styles } = useStyles(styleSheet, {});
 
@@ -46,10 +45,7 @@ const InstallSnapConnectionRequest = ({
     [approvalRequest.origin],
   );
 
-  const favicon: ImageSourcePropType = useMemo(() => {
-    const iconUrl = `https://api.faviconkit.com/${origin}/50`;
-    return { uri: iconUrl };
-  }, [origin]);
+  const favicon = useFavicon(origin);
 
   const urlWithProtocol = prefixUrlWithProtocol(origin);
 
@@ -85,6 +81,11 @@ const InstallSnapConnectionRequest = ({
           label={urlWithProtocol}
           iconName={secureIcon}
         />
+        <SnapAvatar
+          snapId={snapId}
+          snapName={snapName}
+          style={styles.snapAvatar}
+        />
         <SheetHeader title={strings('install_snap.title')} />
         <Text style={styles.description} variant={TextVariant.BodyMD}>
           {strings('install_snap.description', {
@@ -92,15 +93,6 @@ const InstallSnapConnectionRequest = ({
             snap: snapName,
           })}
         </Text>
-        <Cell
-          style={styles.snapCell}
-          variant={CellVariant.Display}
-          title={snapName}
-          avatarProps={{
-            variant: AvatarVariant.Icon,
-            name: IconName.Snaps,
-          }}
-        />
         <View style={styles.actionContainer}>
           <BottomSheetFooter
             buttonsAlignment={ButtonsAlignment.Horizontal}

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 /* eslint-disable import/prefer-default-export */
 import InstallSnapConnectionRequest from './InstallSnapConnectionRequest';
 

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/test/InstallSnapConnectionRequest.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/test/InstallSnapConnectionRequest.test.tsx
@@ -1,6 +1,7 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 import InstallSnapConnectionRequest from '../InstallSnapConnectionRequest';
 import {
   SNAP_INSTALL_CANCEL,
@@ -38,6 +39,28 @@ describe('InstallSnapConnectionRequest', () => {
     expectsResult: false,
   };
 
+  const mockStore = configureMockStore();
+  const mockInitialState = {
+    settings: {},
+    engine: {
+      backgroundState: {
+        SubjectMetadataController: {
+          subjectMetadata: {},
+        },
+        SnapController: {
+          snaps: {},
+        },
+      },
+    },
+  };
+  const store = mockStore(mockInitialState);
+
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Wrapper = ({ children }: any) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
   const onConfirm = jest.fn();
   const onCancel = jest.fn();
 
@@ -51,8 +74,10 @@ describe('InstallSnapConnectionRequest', () => {
         approvalRequest={requestPermissionsData}
         onConfirm={onConfirm}
         onCancel={onCancel}
+        snapId="npm:@metamask/bip32-example-snap"
         snapName="@metamask/bip32-example-snap"
       />,
+      { wrapper: Wrapper },
     );
     expect(getByTestId(SNAP_INSTALL_CONNECTION_REQUEST)).toBeDefined();
   });
@@ -63,8 +88,10 @@ describe('InstallSnapConnectionRequest', () => {
         approvalRequest={requestPermissionsData}
         onConfirm={onConfirm}
         onCancel={onCancel}
+        snapId="npm:@metamask/bip32-example-snap"
         snapName="@metamask/bip32-example-snap"
       />,
+      { wrapper: Wrapper },
     );
 
     fireEvent.press(getByTestId(SNAP_INSTALL_CONNECT));
@@ -77,8 +104,10 @@ describe('InstallSnapConnectionRequest', () => {
         approvalRequest={requestPermissionsData}
         onConfirm={onConfirm}
         onCancel={onCancel}
+        snapId="npm:@metamask/bip32-example-snap"
         snapName="@metamask/bip32-example-snap"
       />,
+      { wrapper: Wrapper },
     );
 
     fireEvent.press(getByTestId(SNAP_INSTALL_CANCEL));
@@ -91,12 +120,13 @@ describe('InstallSnapConnectionRequest', () => {
         approvalRequest={requestPermissionsData}
         onConfirm={onConfirm}
         onCancel={onCancel}
+        snapId="npm:@metamask/bip32-example-snap"
         snapName="@metamask/bip32-example-snap"
       />,
+      { wrapper: Wrapper },
     );
 
     const expectedUrl = 'https://metamask.github.io';
     expect(getByText(expectedUrl)).toBeTruthy();
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/test/InstallSnapConnectionRequest.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/test/InstallSnapConnectionRequest.test.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import InstallSnapConnectionRequest from '../InstallSnapConnectionRequest';

--- a/app/components/Approvals/InstallSnapApproval/components/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/index.ts
@@ -1,11 +1,18 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+/* eslint-disable import/prefer-default-export */
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
 import { InstallSnapConnectionRequest } from './InstallSnapConnectionRequest';
+///: END:ONLY_INCLUDE_IF
+///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import { InstallSnapSuccess } from './InstallSnapSuccess';
 import { InstallSnapError } from './InstallSnapError';
 import { InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
+///: END:ONLY_INCLUDE_IF
 
+///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 export { InstallSnapPermissionsRequest };
 export { InstallSnapError };
 export { InstallSnapSuccess };
+///: END:ONLY_INCLUDE_IF
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
 export { InstallSnapConnectionRequest };
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/index.ts
@@ -1,3 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 export { default } from './InstallSnapApproval';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
@@ -1,8 +1,9 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import InstallSnapApproval from '../InstallSnapApproval';
 import { ApprovalRequest } from '@metamask/approval-controller';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import InstallSnapApproval from '../InstallSnapApproval';
 import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import {
   SNAP_INSTALL_CANCEL,
@@ -127,20 +128,46 @@ describe('InstallSnapApprovalFlow', () => {
     expectsResult: false,
   };
 
+  const mockStore = configureMockStore();
+  const mockInitialState = {
+    settings: {},
+    engine: {
+      backgroundState: {
+        SubjectMetadataController: {
+          subjectMetadata: {},
+        },
+        SnapController: {
+          snaps: {},
+        },
+      },
+    },
+  };
+  const store = mockStore(mockInitialState);
+
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Wrapper = ({ children }: any) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders InstallSnapConnectionRequest component initially when approval type is wallet_requestPermissions', () => {
     mockApprovalRequest(requestPermissionsData);
-    const { getByTestId } = render(<InstallSnapApproval />);
+    const { getByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const connectionRequest = getByTestId(SNAP_INSTALL_CONNECTION_REQUEST);
     expect(connectionRequest).toBeDefined();
   });
 
   it('renders InstallSnapPermissionsRequest when approval type is wallet_installSnap', async () => {
     mockApprovalRequest(installSnapData);
-    const { findByTestId } = render(<InstallSnapApproval />);
+    const { findByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const permissionsRequest = await findByTestId(
       SNAP_INSTALL_PERMISSIONS_REQUEST,
     );
@@ -149,7 +176,9 @@ describe('InstallSnapApprovalFlow', () => {
 
   it('calls onConfirm when Approve button is pressed in InstallSnapPermissionsRequest', async () => {
     mockApprovalRequest(installSnapData);
-    const { getByTestId } = render(<InstallSnapApproval />);
+    const { getByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const permissionsApproveButton = getByTestId(
       SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE,
     );
@@ -159,7 +188,9 @@ describe('InstallSnapApprovalFlow', () => {
 
   it('renders InstallSnapSuccess on successful installation', async () => {
     mockApprovalRequest(installSnapData);
-    const { getByTestId, findByTestId } = render(<InstallSnapApproval />);
+    const { getByTestId, findByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const permissionsRequest = await findByTestId(
       SNAP_INSTALL_PERMISSIONS_REQUEST,
     );
@@ -178,7 +209,9 @@ describe('InstallSnapApprovalFlow', () => {
       throw new Error('Installation error');
     });
 
-    const { getByTestId, findByTestId } = render(<InstallSnapApproval />);
+    const { getByTestId, findByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const permissionsRequest = getByTestId(SNAP_INSTALL_PERMISSIONS_REQUEST);
     expect(permissionsRequest).toBeDefined();
     const permissionsConfirmButton = getByTestId(
@@ -192,10 +225,11 @@ describe('InstallSnapApprovalFlow', () => {
 
   it('calls onCancel on cancel button click', () => {
     mockApprovalRequest(installSnapData);
-    const { getByTestId } = render(<InstallSnapApproval />);
+    const { getByTestId } = render(<InstallSnapApproval />, {
+      wrapper: Wrapper,
+    });
     const cancelButton = getByTestId(SNAP_INSTALL_CANCEL);
     fireEvent.press(cancelButton);
     expect(onReject).toHaveBeenCalledTimes(1);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -67,7 +67,7 @@ import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransac
 import { STX_NO_HASH_ERROR } from '../../../util/smart-transactions/smart-publish-hook';
 import { getSmartTransactionMetricsProperties } from '../../../util/smart-transactions';
 
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import InstallSnapApproval from '../../Approvals/InstallSnapApproval';
 ///: END:ONLY_INCLUDE_IF
 
@@ -487,7 +487,7 @@ const RootRPCMethodsUI = (props) => {
       <FlowLoaderModal />
       <TemplateConfirmationModal />
       {
-        ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
       }
       <InstallSnapApproval />
       {

--- a/app/components/UI/Snaps/SnapAvatar/SnapAvatar.styles.ts
+++ b/app/components/UI/Snaps/SnapAvatar/SnapAvatar.styles.ts
@@ -1,0 +1,39 @@
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../util/theme/models';
+
+/**
+ *
+ * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+  return StyleSheet.create({
+    avatar: {
+      backgroundColor: colors.background.alternativeHover,
+    },
+    fallbackAvatar: {
+      backgroundColor: colors.background.alternativeHover,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: colors.text.alternative,
+    },
+    fallbackAvatarText: {
+      textTransform: 'uppercase',
+    },
+    badge: {
+      backgroundColor: colors.info.default,
+      color: colors.info.inverse,
+      borderColor: colors.background.alternative,
+      borderWidth: 2,
+    },
+  });
+};
+
+export default styleSheet;
+///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Snaps/SnapAvatar/SnapAvatar.test.tsx
+++ b/app/components/UI/Snaps/SnapAvatar/SnapAvatar.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react-native';
+import { SnapAvatar } from './SnapAvatar';
+
+describe('SnapAvatar', () => {
+  const mockStore = configureMockStore();
+  const mockInitialState = {
+    settings: {},
+    engine: {
+      backgroundState: {
+        SubjectMetadataController: {
+          subjectMetadata: {
+            'npm:@metamask/bip32-example-snap': {
+              extensionId: null,
+              iconUrl: null,
+              name: 'BIP-32 Example Snap',
+              origin: 'npm:@metamask/bip32-example-snap',
+              subjectType: 'snap',
+              svgIcon: '<svg />',
+              version: '1.0.0',
+            },
+          },
+        },
+      },
+    },
+  };
+  const store = mockStore(mockInitialState);
+
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Wrapper = ({ children }: any) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  it('renders an icon using subject metadata', () => {
+    const { getByTestId } = render(
+      <SnapAvatar
+        snapId="npm:@metamask/bip32-example-snap"
+        snapName="BIP-32 Example Snap"
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+    expect(getByTestId('snap-avatar-icon')).toBeDefined();
+  });
+
+  it('falls back to the first non symbol in the snap name', () => {
+    const { getByTestId, getByText } = render(
+      <SnapAvatar
+        snapId="npm:@metamask/bip44-example-snap"
+        snapName="BIP-44 Example Snap"
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+    expect(getByText('B')).toBeDefined();
+    expect(getByTestId('snap-avatar-fallback')).toBeDefined();
+  });
+});

--- a/app/components/UI/Snaps/SnapAvatar/SnapAvatar.tsx
+++ b/app/components/UI/Snaps/SnapAvatar/SnapAvatar.tsx
@@ -20,7 +20,7 @@ import { AvatarSize } from '../../../../component-library/components/Avatars/Ava
 import { ViewStyle } from 'react-native';
 
 const getAvatarFallbackLetter = (subjectName: string) =>
-  subjectName?.match(/[a-z0-9]/iu)?.[0] ?? '?';
+  subjectName?.match(/[a-z0-9]/iu)?.[0];
 
 export interface SnapAvatarProps {
   snapId: string;
@@ -61,9 +61,14 @@ export const SnapAvatar: React.FunctionComponent<SnapAvatarProps> = ({
           style={styles.avatar}
           size={AvatarSize.Xl}
           imageSource={{ uri: iconUrl }}
+          testID="snap-avatar-icon"
         />
       ) : (
-        <AvatarBase style={styles.fallbackAvatar} size={AvatarSize.Xl}>
+        <AvatarBase
+          style={styles.fallbackAvatar}
+          size={AvatarSize.Xl}
+          testID="snap-avatar-fallback"
+        >
           <Text style={styles.fallbackAvatarText}>{fallbackAvatar}</Text>
         </AvatarBase>
       )}

--- a/app/components/UI/Snaps/SnapAvatar/SnapAvatar.tsx
+++ b/app/components/UI/Snaps/SnapAvatar/SnapAvatar.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable react/prop-types */
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+import React from 'react';
+import { useSelector } from 'react-redux';
+import AvatarFavicon from '../../../../component-library/components/Avatars/Avatar/variants/AvatarFavicon';
+import { selectTargetSubjectMetadata } from '../../../../selectors/snaps/permissionController';
+import BadgeWrapper from '../../../../component-library/components/Badges/BadgeWrapper';
+import { BadgePosition } from '../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
+import AvatarIcon from '../../../../component-library/components/Avatars/Avatar/variants/AvatarIcon';
+import {
+  IconColor,
+  IconName,
+} from '../../../..//component-library/components/Icons/Icon';
+import AvatarBase from '../../../../component-library/components/Avatars/Avatar/foundation/AvatarBase';
+import Text from '../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../component-library/hooks';
+import styleSheet from './SnapAvatar.styles';
+import { RootState } from '../../../../reducers';
+import { AvatarSize } from '../../../../component-library/components/Avatars/Avatar';
+import { ViewStyle } from 'react-native';
+
+const getAvatarFallbackLetter = (subjectName: string) =>
+  subjectName?.match(/[a-z0-9]/iu)?.[0] ?? '?';
+
+export interface SnapAvatarProps {
+  snapId: string;
+  snapName: string; // TODO: Don't pass this in, derive it in the component instead.
+  style?: ViewStyle;
+}
+
+export const SnapAvatar: React.FunctionComponent<SnapAvatarProps> = ({
+  snapId,
+  snapName,
+  style,
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+
+  const subjectMetadata = useSelector((state: RootState) =>
+    selectTargetSubjectMetadata(state, snapId),
+  );
+
+  const iconUrl = subjectMetadata?.iconUrl;
+
+  const fallbackAvatar = getAvatarFallbackLetter(snapName);
+
+  return (
+    <BadgeWrapper
+      style={style}
+      badgeElement={
+        <AvatarIcon
+          name={IconName.Snaps}
+          iconColor={IconColor.Inverse}
+          size={AvatarSize.Md}
+          style={styles.badge}
+        />
+      }
+      badgePosition={BadgePosition.BottomRight}
+    >
+      {iconUrl ? (
+        <AvatarFavicon
+          style={styles.avatar}
+          size={AvatarSize.Xl}
+          imageSource={{ uri: iconUrl }}
+        />
+      ) : (
+        <AvatarBase style={styles.fallbackAvatar} size={AvatarSize.Xl}>
+          <Text style={styles.fallbackAvatarText}>{fallbackAvatar}</Text>
+        </AvatarBase>
+      )}
+    </BadgeWrapper>
+  );
+};
+///: END:ONLY_INCLUDE_IF

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -99,7 +99,7 @@ class EngineService {
         key: `${engine.context.SnapController.name}:stateChange`,
       },
       {
-        name: 'subjectMetadataController',
+        name: 'SubjectMetadataController',
         key: `${engine.context.SubjectMetadataController.name}:stateChange`,
       },
       ///: END:ONLY_INCLUDE_IF

--- a/app/selectors/snaps/permissionController.ts
+++ b/app/selectors/snaps/permissionController.ts
@@ -1,0 +1,30 @@
+import { RootState } from '../../reducers';
+import { memoize } from 'lodash';
+import { SubjectType } from '@metamask/permission-controller';
+
+export const selectPermissionControllerState = (state: RootState) =>
+  state.engine.backgroundState.PermissionController;
+
+export const selectSubjectMetadataControllerState = (state: RootState) =>
+  state.engine.backgroundState.SubjectMetadataController;
+
+const getEmbeddableSvg = memoize(
+  (svgString) => `data:image/svg+xml;utf8,${encodeURIComponent(svgString)}`,
+);
+
+function selectSubjectMetadata(state: RootState) {
+  return selectSubjectMetadataControllerState(state).subjectMetadata;
+}
+
+export function selectTargetSubjectMetadata(state: RootState, origin: string) {
+  const metadata = selectSubjectMetadata(state)[origin];
+
+  if (metadata?.subjectType === SubjectType.Snap) {
+    return {
+      ...metadata,
+      iconUrl: metadata.svgIcon ? getEmbeddableSvg(metadata.svgIcon) : null,
+    };
+  }
+
+  return metadata;
+}

--- a/app/selectors/snaps/snapController.ts
+++ b/app/selectors/snaps/snapController.ts
@@ -1,0 +1,37 @@
+import { createSelector } from 'reselect';
+import { RootState } from '../../reducers';
+import { createDeepEqualSelector } from '../util';
+import { getLocalizedSnapManifest } from '@metamask/snaps-utils';
+
+// TODO: Filter out huge values
+export const selectSnapControllerState = (state: RootState) =>
+  state.engine.backgroundState.SnapController;
+
+export const selectSnaps = createSelector(
+  selectSnapControllerState,
+  (controller) => controller.snaps,
+);
+
+export const selectSnapsMetadata = createDeepEqualSelector(
+  selectSnaps,
+  (snaps) =>
+    Object.values(snaps).reduce<
+      Record<string, { name: string; description: string }>
+    >((snapsMetadata, snap) => {
+      const snapId = snap.id;
+      const manifest = snap.localizationFiles
+        ? getLocalizedSnapManifest(
+            snap.manifest,
+            // TODO: Use actual locale here.
+            'en',
+            snap.localizationFiles,
+          )
+        : snap.manifest;
+
+      snapsMetadata[snapId] = {
+        name: manifest.proposedName,
+        description: manifest.description,
+      };
+      return snapsMetadata;
+    }, {}),
+);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3075,7 +3075,7 @@
   },
   "install_snap": {
     "title": "Connection request",
-    "description": "{{origin}} wants to download and connect with {{snap}}. Make sure you trust the authors before you proceed.",
+    "description": "{{origin}} wants to use {{snap}}.",
     "permissions_request_title": "Permissions request",
     "permissions_request_description": "{{origin}} wants to install {{snap}}, which is requesting the following permissions.",
     "approve_permissions": "Approve",


### PR DESCRIPTION
## **Description**

This PR reworks the Snaps connection screen to add the Snap icon and simplify the implementation. It also tweaks the fencing to allow connecting to Snaps with only the `preinstalled-snaps` flag on. 

## **Screenshots/Recordings**

<img src="https://github.com/MetaMask/metamask-mobile/assets/1561200/0a4a2efb-c3f7-48b0-a2c6-82b9d08489eb" width="400" />
