### PR TITLE
perf: Filter out certain Snaps fields in Engine redux slice

### DIFF
--- a/app/core/redux/slices/engine/engineReducer.test.tsx
+++ b/app/core/redux/slices/engine/engineReducer.test.tsx
@@ -52,4 +52,51 @@ describe('engineReducer', () => {
       AccountTrackerController: Engine.state[key],
     });
   });
+
+  it('should filter out unnecesary Snaps state', () => {
+    const reduxInitialState = {
+      backgroundState: {
+        SnapController: {
+          snaps: {},
+          snapStates: {},
+          unencryptedSnapStates: {},
+        },
+      },
+    };
+
+    const key = 'SnapController';
+    // changing the mock version to suit this test manually due to our current global mock
+    // TODO: Replace "any" with type
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Engine as any).state = {
+      SnapController: {
+      snaps: {
+        'npm:@metamask/bip32-example-snap': {
+          id: 'npm:@metamask/bip32-example-snap',
+          sourceCode: 'foo bar',
+        },
+      },
+      snapStates: {},
+      unencryptedSnapStates: {
+        'npm:@metamask-bip32-example-snap': JSON.stringify({ foo: 'bar' }),
+      },
+    }
+    };
+    const { backgroundState } = engineReducer(
+      reduxInitialState,
+      updateBgState({ key }),
+    );
+    expect(backgroundState).toEqual({
+      ...reduxInitialState.backgroundState,
+      SnapController: {
+        snaps: {
+          'npm:@metamask/bip32-example-snap': {
+            id: 'npm:@metamask/bip32-example-snap',
+          },
+        },
+        snapStates: {},
+        unencryptedSnapStates: {},
+      }
+    });
+  });
 });

--- a/app/core/redux/slices/engine/index.ts
+++ b/app/core/redux/slices/engine/index.ts
@@ -1,6 +1,9 @@
 import { cloneDeep } from 'lodash';
 import Engine from '../../../Engine';
 import { createAction, PayloadAction } from '@reduxjs/toolkit';
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+import { PersistedSnap } from '@metamask/snaps-utils';
+///: END:ONLY_INCLUDE_IF
 
 const initialState = {
   // TODO: Replace "any" with type
@@ -17,6 +20,34 @@ export const initBgState = createAction('INIT_BG_STATE');
 export const updateBgState = createAction('UPDATE_BG_STATE', (key) => ({
   payload: key,
 }));
+
+/**
+ * Filters out state values that we do not want to include in the Redux store.
+ *
+ * @param key The state key, which should also be the controller name.
+ * @param value The state blob for a controller.
+ * @returns A filtered state blob for a given controller.
+ */
+function filterState(key: string, value: any) {
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  if (key === 'SnapController') {
+    return {
+      snapStates: {},
+      unencryptedSnapStates: {},
+      snaps: Object.values(value.snaps as Record<string, PersistedSnap>).reduce<
+        Record<string, Omit<PersistedSnap, 'sourceCode'>>
+      >((acc, snap) => {
+        // eslint-disable-next-line no-unused-vars
+        const { sourceCode, auxiliaryFiles, ...rest } = snap;
+        acc[snap.id] = rest;
+        return acc;
+      }, {}),
+    };
+  }
+  ///: END:ONLY_INCLUDE_IF
+
+  return value;
+}
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,10 +77,12 @@ const engineReducer = (
         // - Deep comparison selectors do not fire since the cached objects are references to the original
         //  state object which has been mutated.
         // This is resolved by doing a deep clone in this scenario to force an entirely new object.
-        newState.backgroundState[action.payload?.key] =
+        newState.backgroundState[action.payload?.key] = filterState(
+          action.payload.key,
           legacyControllers.includes(action.payload.key)
             ? cloneDeep(newControllerState)
-            : newControllerState;
+            : newControllerState,
+        );
       }
 
       return newState;

--- a/app/selectors/snaps/snapController.ts
+++ b/app/selectors/snaps/snapController.ts
@@ -3,7 +3,6 @@ import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
 import { getLocalizedSnapManifest } from '@metamask/snaps-utils';
 
-// TODO: Filter out huge values
 export const selectSnapControllerState = (state: RootState) =>
   state.engine.backgroundState.SnapController;
 


### PR DESCRIPTION
## **Description**

This PR adds logic to filter out certain Snaps fields in the Engine redux slice. The `SnapController` contains multiple very large fields that aren't required to be surfaced in the UI and therefore doesn't need to be put into the Redux slice.

This is an attempt at mirroring the extension implementation: https://github.com/MetaMask/metamask-extension/blob/df81e73bfc8ad13ee1cbe12e15709d254723e944/app/scripts/metamask-controller.js#L2911-L2919