### PR TITLE
[SDK] Fix: Wait for backgroundBridge before alerting it of messages

### DIFF
--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -246,6 +246,7 @@ export class SDKConnect {
     }
     DevLogger.log(`SDKConnect::refreshChannel channelId=${channelId}`);
     // Force enitting updated accounts
+    // TODO(Eddie): Do we need to ensure that backgroundBridge is not undefined here?
     session.backgroundBridge?.notifySelectedAddressChanged();
   }
 

--- a/app/core/SDKConnect/handlers/checkPermissions.ts
+++ b/app/core/SDKConnect/handlers/checkPermissions.ts
@@ -117,7 +117,7 @@ export const checkPermissions = async ({
         allowed,
       );
       // Add delay for backgroundBridge to complete setup
-      await wait(300);
+      await connection.waitForBackgroundBridge();
       return allowed;
     }
 

--- a/app/core/SDKConnect/handlers/handleBatchRpcResponse.ts
+++ b/app/core/SDKConnect/handlers/handleBatchRpcResponse.ts
@@ -12,7 +12,7 @@ export const handleBatchRpcResponse = async ({
 }: {
   chainRpcs: BatchRPCState;
   batchRPCManager: BatchRPCManager;
-  backgroundBridge?: BackgroundBridge;
+  backgroundBridge: BackgroundBridge;
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendMessage: ({ msg }: { msg: any }) => Promise<void>;
@@ -91,7 +91,7 @@ export const handleBatchRpcResponse = async ({
       nextRpc.params,
     );
 
-    backgroundBridge?.onMessage({
+    backgroundBridge.onMessage({
       name: 'metamask-provider',
       data: nextRpc,
       origin: 'sdk',

--- a/app/core/SDKConnect/handlers/handleConnectionMessage.ts
+++ b/app/core/SDKConnect/handlers/handleConnectionMessage.ts
@@ -167,7 +167,9 @@ export const handleConnectionMessage = async ({
       method: processedRpc?.method ?? message.method,
     });
 
-    connection.backgroundBridge?.onMessage({
+    const backgroundBridge = await connection.waitForBackgroundBridge();
+
+    backgroundBridge.onMessage({
       name: 'metamask-provider',
       data: processedRpc,
       origin: 'sdk',

--- a/app/core/SDKConnect/handlers/handleSendMessage.ts
+++ b/app/core/SDKConnect/handlers/handleSendMessage.ts
@@ -29,11 +29,13 @@ export const handleSendMessage = async ({
     const chainRPCs = connection.batchRPCManager.getById(msgId);
     DevLogger.log(`[handleSendMessage] chainRPCs`, chainRPCs);
     if (chainRPCs) {
+      const backgroundBridge = await connection.waitForBackgroundBridge();
+
       const isLastRpcOrError = await handleBatchRpcResponse({
         chainRpcs: chainRPCs,
         msg,
         batchRPCManager: connection.batchRPCManager,
-        backgroundBridge: connection.backgroundBridge,
+        backgroundBridge,
         // TODO: Replace "any" with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         sendMessage: ({ msg: newmsg }: { msg: any }) =>


### PR DESCRIPTION
## **Description**

This PR adds the `waitForBackgroundBridge` method to the SDK `Connection` class so that modules using it can have a guaranteed reference to a `BackgroundBridge` (instead of `BackgroundBridge | undefined`). The method will wait in the background for the `BackgroundBridge` object to become defined (it does not set it up, it assumes something else will call `setupBridge`).

This is important for modules that need to emit `BackgroundBridge.onMessage`, previously we would do `connection.backgroundBridge?.onMessage(...)`, which would sometimes cause messages to be dropped / not prompted to user due to a race condition on when `connection.backgroundBridge` is assigned.

This PR updates the `handleBatchRpcResponse`, `handleConnectionMessage` and `handleSendMessage` to use the new `connection.waitForBackgroundBridge()` function so that it can emit the `onMessage()` on a defined `BackgroundBridge`.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Clear all SDK connection 
2. Start a new SDK connection using `metamask_connectSign`
3. Observe that you are prompted to authorize and sign

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-07-02 at 12 35 54 PM](https://github.com/MetaMask/metamask-mobile/assets/879484/ef5cfb1b-8c80-4312-b1cd-62d5e2b5923a)


### **After**

https://github.com/MetaMask/metamask-mobile/assets/879484/5f4bc2ad-0b21-4153-acd3-dc5ff00c64ff


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
