### PR TITLE
chore: remove remaining use of Preferences Controller for account information

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -97,7 +97,7 @@ export class BackgroundBridge extends EventEmitter {
 
     // This will only be used for WalletConnect for now
     this.addressSent =
-      Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
+      Engine.context.AccountsController.getSelectedAccount().address.toLowerCase();
 
     const portStream = new MobilePortStream(this.port, url);
     // setup multiplexing

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -213,6 +213,7 @@ import { SmartTransactionStatuses } from '@metamask/smart-transactions-controlle
 import { submitSmartTransactionHook } from '../util/smart-transactions/smart-publish-hook';
 import { SmartTransactionsControllerState } from '@metamask/smart-transactions-controller/dist/SmartTransactionsController';
 import { zeroAddress } from 'ethereumjs-util';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -1595,14 +1596,16 @@ class Engine {
   } => {
     const {
       CurrencyRateController,
-      PreferencesController,
+      AccountsController,
       AccountTrackerController,
       TokenBalancesController,
       TokenRatesController,
       TokensController,
       NetworkController,
     } = this.context;
-    const { selectedAddress } = PreferencesController.state;
+    const selectedInternalAccount = AccountsController.getSelectedAccount();
+    const selectSelectedInternalAccountChecksummedAddress =
+      toChecksumHexAddress(selectedInternalAccount.address);
     const { currentCurrency } = CurrencyRateController.state;
     const { chainId, ticker } = NetworkController.state.providerConfig;
     const {
@@ -1626,9 +1629,15 @@ class Engine {
     let tokenFiat = 0;
     let tokenFiat1dAgo = 0;
     const decimalsToShow = (currentCurrency === 'usd' && 2) || undefined;
-    if (accountsByChainId?.[toHexadecimal(chainId)]?.[selectedAddress]) {
+    if (
+      accountsByChainId?.[toHexadecimal(chainId)]?.[
+        selectSelectedInternalAccountChecksummedAddress
+      ]
+    ) {
       ethFiat = weiToFiatNumber(
-        accountsByChainId[toHexadecimal(chainId)][selectedAddress].balance,
+        accountsByChainId[toHexadecimal(chainId)][
+          selectSelectedInternalAccountChecksummedAddress
+        ].balance,
         conversionRate,
         decimalsToShow,
       );

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -380,9 +380,13 @@ class NotificationManager {
     const {
       AccountTrackerController,
       TransactionController,
-      PreferencesController,
+      AccountsController,
     } = Engine.context;
-    const { selectedAddress } = PreferencesController.state;
+    const selectedInternalAccount = AccountsController.getSelectedAccount();
+    const selectedInternalAccountChecksummedAddress = safeToChecksumAddress(
+      selectedInternalAccount.address,
+    );
+
     const chainId = selectChainId(store.getState());
 
     /// Find the incoming TX
@@ -396,8 +400,10 @@ class NotificationManager {
         .reverse()
         .filter(
           (tx) =>
-            safeToChecksumAddress(tx.txParams?.to) === selectedAddress &&
-            safeToChecksumAddress(tx.txParams?.from) !== selectedAddress &&
+            safeToChecksumAddress(tx.txParams?.to) ===
+              selectedInternalAccountChecksummedAddress &&
+            safeToChecksumAddress(tx.txParams?.from) !==
+              selectedInternalAccountChecksummedAddress &&
             tx.chainId === chainId &&
             tx.status === 'confirmed' &&
             lastBlock <= parseInt(tx.blockNumber, 10) &&

--- a/app/core/RPCMethods/wallet_watchAsset.test.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.test.ts
@@ -6,6 +6,13 @@ import {
   TOKEN_NOT_SUPPORTED_FOR_NETWORK,
   TOKEN_NOT_VALID,
 } from '../../constants/error';
+import { createMockInternalAccount } from '../../util/test/accountsControllerTestUtils';
+
+const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
+  MOCK_ADDRESS,
+  'Account 1',
+);
 
 const mockEngine = Engine;
 jest.mock('../Engine', () => ({
@@ -37,10 +44,8 @@ jest.mock('../Engine', () => ({
       requestPermissions: jest.fn(),
       getPermissions: jest.fn(),
     },
-    PreferencesController: {
-      state: {
-        selectedAddress: '0x123',
-      },
+    AccountsController: {
+      getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
     },
   },
 }));

--- a/app/core/RPCMethods/wallet_watchAsset.test.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.test.ts
@@ -6,49 +6,53 @@ import {
   TOKEN_NOT_SUPPORTED_FOR_NETWORK,
   TOKEN_NOT_VALID,
 } from '../../constants/error';
-import { createMockInternalAccount } from '../../util/test/accountsControllerTestUtils';
 
-const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
-const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
-  MOCK_ADDRESS,
-  'Account 1',
-);
-
-const mockEngine = Engine;
-jest.mock('../Engine', () => ({
-  init: () => mockEngine.init({}),
-  context: {
-    AssetsContractController: {
-      getERC20TokenDecimals: jest.fn(),
-      getERC721AssetSymbol: jest.fn().mockResolvedValue('WBTC'),
-    },
-    NetworkController: {
-      state: {
-        networkConfigurations: {},
-        providerConfig: {
-          chainId: '0x1',
+jest.mock('../Engine', () => {
+  const {
+    createMockInternalAccount,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  } = require('../../util/test/accountsControllerTestUtils');
+  const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+  const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
+    MOCK_ADDRESS,
+    'Account 1',
+  );
+  return {
+    init: () => jest.fn(),
+    context: {
+      AssetsContractController: {
+        getERC20TokenDecimals: jest.fn(),
+        getERC721AssetSymbol: jest.fn().mockResolvedValue('WBTC'),
+      },
+      NetworkController: {
+        state: {
+          networkConfigurations: {},
+          providerConfig: {
+            chainId: '0x1',
+          },
         },
       },
-    },
-    TokensController: {
-      watchAsset: jest.fn(),
-    },
-    TokenListController: {
-      state: {
-        tokenList: {
-          '0x1': [],
+      TokensController: {
+        watchAsset: jest.fn(),
+      },
+      TokenListController: {
+        state: {
+          tokenList: {
+            '0x1': [],
+          },
         },
       },
+      PermissionController: {
+        requestPermissions: jest.fn(),
+        getPermissions: jest.fn(),
+      },
+      AccountsController: {
+        getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
+      },
     },
-    PermissionController: {
-      requestPermissions: jest.fn(),
-      getPermissions: jest.fn(),
-    },
-    AccountsController: {
-      getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
-    },
-  },
-}));
+  };
+});
+
 const MockEngine = jest.mocked(Engine);
 
 jest.mock('../Permissions', () => ({
@@ -80,6 +84,7 @@ describe('wallet_watchAsset', () => {
     decimals: '8',
     image: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
   };
+
   it('should throw an error if the token address is not valid', async () => {
     await expect(
       wallet_watchAsset({
@@ -107,6 +112,7 @@ describe('wallet_watchAsset', () => {
       }),
     ).rejects.toThrow(TOKEN_NOT_VALID);
   });
+
   it('should throw an error if the token address is not a smart contract address', async () => {
     jest
       .spyOn(transactionsUtils, 'isSmartContractAddress')
@@ -173,9 +179,10 @@ describe('wallet_watchAsset', () => {
     expect(spyOnWatchAsset).toHaveBeenCalledWith({
       asset: correctWBTC,
       type: ERC20,
-      interactingAddress: '0x123',
+      interactingAddress: '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272', // Checksummed version of MOCK_ADDRESS
     });
   });
+
   it('should call watchAsset with fake WBTC decimals and symbol', async () => {
     const fakeWBTC = {
       address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
@@ -218,7 +225,7 @@ describe('wallet_watchAsset', () => {
     expect(spyOnWatchAsset).toHaveBeenCalledWith({
       asset: correctWBTC,
       type: ERC20,
-      interactingAddress: '0x123',
+      interactingAddress: '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272', // Checksummed version of MOCK_ADDRESS
     });
   });
 });

--- a/app/core/RPCMethods/wallet_watchAsset.ts
+++ b/app/core/RPCMethods/wallet_watchAsset.ts
@@ -12,6 +12,7 @@ import {
 import { selectChainId } from '../../selectors/networkController';
 import { isValidAddress } from 'ethereumjs-util';
 import { JsonRpcRequest, PendingJsonRpcResponse } from 'json-rpc-engine';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 const wallet_watchAsset = async ({
   req,
@@ -64,11 +65,13 @@ const wallet_watchAsset = async ({
 
   const permittedAccounts = await getPermittedAccounts(hostname);
   // This should return the current active account on the Dapp.
-  const selectedAddress =
-    Engine.context.PreferencesController.state.selectedAddress;
+  const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+    Engine.context.AccountsController.getSelectedAccount().address,
+  );
 
   // Fallback to wallet address if there is no connected account to Dapp.
-  const interactingAddress = permittedAccounts?.[0] || selectedAddress;
+  const interactingAddress =
+    permittedAccounts?.[0] || selectedInternalAccountChecksummedAddress;
   // This variables are to override the value of decimals and symbol from the dapp
   // if they are wrong accordingly to the token address
   // *This is an hotfix this logic should live on whatchAsset method on TokensController*

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -25,7 +25,6 @@ import { SDKConnect } from '../SDKConnect';
 import { KeyringController } from '@metamask/keyring-controller';
 
 import { PermissionController } from '@metamask/permission-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
 import { PROTOCOLS } from '../../../constants/deeplinks';
 import BatchRPCManager from '../BatchRPCManager';
 import { DEFAULT_SESSION_TIMEOUT_MS } from '../SDKConnectConstants';
@@ -35,6 +34,8 @@ import AndroidSDKEventHandler from './AndroidNativeSDKEventHandler';
 import sendMessage from './AndroidService/sendMessage';
 import { DappClient, DappConnections } from './dapp-sdk-types';
 import getDefaultBridgeParams from './getDefaultBridgeParams';
+import { AccountsController } from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 export default class AndroidService extends EventEmitter2 {
   public communicationClient = NativeModules.CommunicationClient;
@@ -355,13 +356,15 @@ export default class AndroidService extends EventEmitter2 {
           }
         }
 
-        const preferencesController = (
+        const accountsController = (
           Engine.context as {
-            PreferencesController: PreferencesController;
+            AccountsController: AccountsController;
           }
-        ).PreferencesController;
+        ).AccountsController;
 
-        const selectedAddress = preferencesController.state.selectedAddress;
+        const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+          accountsController.getSelectedAccount().address,
+        );
 
         const networkController = (
           Engine.context as {
@@ -377,7 +380,7 @@ export default class AndroidService extends EventEmitter2 {
         const processedRpc = await handleCustomRpcCalls({
           batchRPCManager: this.batchRPCManager,
           selectedChainId: chainId,
-          selectedAddress,
+          selectedAddress: selectedInternalAccountChecksummedAddress,
           rpc: { id: data.id, method: data.method, params: data.params },
         });
 

--- a/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.test.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Logger from '../../../../util/Logger';
+import { createMockInternalAccount } from '../../../../util/test/accountsControllerTestUtils';
 import Engine from '../../../Engine';
 import { Minimizer } from '../../../NativeModules';
 import { RPC_METHODS } from '../../SDKConnectConstants';
@@ -22,6 +23,12 @@ jest.mock('@metamask/preferences-controller');
 jest.mock('../AndroidService');
 jest.mock('../../handlers/handleBatchRpcResponse', () => jest.fn());
 jest.mock('../../utils/DevLogger');
+
+const MOCK_ADDRESS = '0x1';
+const mockInternalAccount = createMockInternalAccount(
+  MOCK_ADDRESS,
+  'Account 1',
+);
 
 describe('sendMessage', () => {
   let instance: jest.Mocked<AndroidService>;
@@ -62,10 +69,8 @@ describe('sendMessage', () => {
     };
 
     (Engine.context as any) = {
-      PreferencesController: {
-        state: {
-          selectedAddress: '0x1',
-        },
+      AccountsController: {
+        getSelectedAccount: jest.fn().mockReturnValue(mockInternalAccount),
       },
     };
   });
@@ -87,7 +92,15 @@ describe('sendMessage', () => {
   });
 
   it('should send message without reordering if selectedAddress is not in result', async () => {
-    (Engine.context as any).PreferencesController.state.selectedAddress = '0x3';
+    const MOCK_ADDRESS_2 = '0x3';
+    const mockInternalAccount2 = createMockInternalAccount(
+      MOCK_ADDRESS_2.toLowerCase(),
+      'Account 2',
+    );
+
+    (Engine.context as any).AccountsController.getSelectedAccount = jest
+      .fn()
+      .mockReturnValue(mockInternalAccount2);
 
     mockGetId.mockReturnValue(RPC_METHODS.ETH_REQUESTACCOUNTS);
 

--- a/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.test.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.test.ts
@@ -19,7 +19,6 @@ jest.mock('../../../../util/Logger');
 jest.mock('../../utils/wait.util', () => ({
   wait: jest.fn().mockResolvedValue(undefined),
 }));
-jest.mock('@metamask/preferences-controller');
 jest.mock('../AndroidService');
 jest.mock('../../handlers/handleBatchRpcResponse', () => jest.fn());
 jest.mock('../../utils/DevLogger');

--- a/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.ts
@@ -3,11 +3,11 @@ import Engine from '../../../Engine';
 import { Minimizer } from '../../../NativeModules';
 import Logger from '../../../../util/Logger';
 import { wait } from '../../utils/wait.util';
-import { PreferencesController } from '@metamask/preferences-controller';
 import AndroidService from '../AndroidService';
 import { METHODS_TO_DELAY, RPC_METHODS } from '../../SDKConnectConstants';
 import handleBatchRpcResponse from '../../handlers/handleBatchRpcResponse';
 import DevLogger from '../../utils/DevLogger';
+import { AccountsController } from '@metamask/accounts-controller';
 
 async function sendMessage(
   instance: AndroidService,
@@ -20,14 +20,15 @@ async function sendMessage(
   const isConnectionResponse = rpcMethod === RPC_METHODS.ETH_REQUESTACCOUNTS;
 
   if (isConnectionResponse) {
-    const preferencesController = (
+    const accountsController = (
       Engine.context as {
-        PreferencesController: PreferencesController;
+        AccountsController: AccountsController;
       }
-    ).PreferencesController;
+    ).AccountsController;
 
-    const selectedAddress =
-      preferencesController.state.selectedAddress.toLowerCase();
+    const selectedAddress = accountsController
+      .getSelectedAccount()
+      .address.toLowerCase();
 
     const lowercaseAccounts = (message.data.result as string[]).map(
       (a: string) => a.toLowerCase(),

--- a/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.test.ts
+++ b/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.test.ts
@@ -10,6 +10,8 @@ import DevLogger from '../utils/DevLogger';
 import DeeplinkProtocolService from './DeeplinkProtocolService';
 import AppConstants from '../../AppConstants';
 import { DappClient } from '../AndroidSDK/dapp-sdk-types';
+import { createMockInternalAccount } from '../../../util/test/accountsControllerTestUtils';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 jest.mock('../SDKConnect');
 jest.mock('../../../core/Engine');
@@ -19,6 +21,12 @@ jest.mock('../utils/DevLogger');
 jest.mock('../../../util/Logger');
 jest.mock('../handlers/handleCustomRpcCalls');
 jest.mock('../handlers/handleBatchRpcResponse');
+
+const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+const mockInternalAccount = createMockInternalAccount(
+  MOCK_ADDRESS,
+  'Account 1',
+);
 
 describe('DeeplinkProtocolService', () => {
   let service: DeeplinkProtocolService;
@@ -48,7 +56,9 @@ describe('DeeplinkProtocolService', () => {
       },
       KeyringController: { unlock: jest.fn() },
       NetworkController: { state: { providerConfig: { chainId: '0x1' } } },
-      PreferencesController: { state: { selectedAddress: '0xAddress' } },
+      AccountsController: {
+        getSelectedAccount: jest.fn().mockReturnValue(mockInternalAccount),
+      },
     };
 
     (Linking.openURL as jest.Mock).mockResolvedValue(null);
@@ -484,7 +494,7 @@ describe('DeeplinkProtocolService', () => {
         ).toString('base64'),
         channelId: 'channel1',
         scheme: 'scheme',
-        account: '0xAddress@1',
+        account: `${toChecksumHexAddress(MOCK_ADDRESS)}@1`,
       };
       service.handleMessage(params);
       expect(DevLogger.log).toHaveBeenCalled();

--- a/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.ts
+++ b/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.ts
@@ -1,7 +1,6 @@
 import { KeyringController } from '@metamask/keyring-controller';
 import { NetworkController } from '@metamask/network-controller';
 import { PermissionController } from '@metamask/permission-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { Linking } from 'react-native';
 import { PROTOCOLS } from '../../../constants/deeplinks';
@@ -23,6 +22,8 @@ import handleBatchRpcResponse from '../handlers/handleBatchRpcResponse';
 import handleCustomRpcCalls from '../handlers/handleCustomRpcCalls';
 import DevLogger from '../utils/DevLogger';
 import { wait, waitForKeychainUnlocked } from '../utils/wait.util';
+import { AccountsController } from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 export default class DeeplinkProtocolService {
   public connections: DappConnections = {};
@@ -557,11 +558,15 @@ export default class DeeplinkProtocolService {
       this.currentClientId ?? '',
     );
 
-    const preferencesController = (
-      Engine.context as { PreferencesController: PreferencesController }
-    ).PreferencesController;
+    const accountsController = (
+      Engine.context as {
+        AccountsController: AccountsController;
+      }
+    ).AccountsController;
 
-    const selectedAddress = preferencesController.state.selectedAddress;
+    const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+      accountsController.getSelectedAccount().address,
+    );
 
     let connectedAddresses = permissions?.eth_accounts?.caveats?.[0]
       ?.value as string[];
@@ -580,15 +585,17 @@ export default class DeeplinkProtocolService {
     );
 
     const isPartOfConnectedAddresses = lowerCaseConnectedAddresses.includes(
-      selectedAddress.toLowerCase(),
+      selectedInternalAccountChecksummedAddress.toLowerCase(),
     );
 
     if (isPartOfConnectedAddresses) {
       // Create a new array with selectedAddress at the first position
       connectedAddresses = [
-        selectedAddress,
+        selectedInternalAccountChecksummedAddress,
         ...connectedAddresses.filter(
-          (address) => address.toLowerCase() !== selectedAddress.toLowerCase(),
+          (address) =>
+            address.toLowerCase() !==
+            selectedInternalAccountChecksummedAddress.toLowerCase(),
         ),
       ];
     }
@@ -597,20 +604,22 @@ export default class DeeplinkProtocolService {
   }
 
   public getSelectedAddress() {
-    const preferencesController = (
+    const accountsController = (
       Engine.context as {
-        PreferencesController: PreferencesController;
+        AccountsController: AccountsController;
       }
-    ).PreferencesController;
+    ).AccountsController;
 
-    const selectedAddress = preferencesController.state.selectedAddress;
+    const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+      accountsController.getSelectedAccount().address,
+    );
 
     DevLogger.log(
       `DeeplinkProtocolService::clients_connected selectedAddress`,
-      selectedAddress,
+      selectedInternalAccountChecksummedAddress,
     );
 
-    return selectedAddress;
+    return selectedInternalAccountChecksummedAddress;
   }
 
   public handleMessage(params: {

--- a/app/core/SDKConnect/handlers/handleConnectionMessage.test.ts
+++ b/app/core/SDKConnect/handlers/handleConnectionMessage.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { KeyringController } from '@metamask/keyring-controller';
 import { NetworkController } from '@metamask/network-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
 import {
   CommunicationLayerMessage,
   MessageType,
@@ -19,10 +18,11 @@ import handleCustomRpcCalls from './handleCustomRpcCalls';
 import handleSendMessage from './handleSendMessage';
 import { createMockInternalAccount } from '../../../util/test/accountsControllerTestUtils';
 import { AccountsController } from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
+jest.mock('../../Engine');
 jest.mock('@metamask/keyring-controller');
 jest.mock('@metamask/network-controller');
-jest.mock('@metamask/preferences-controller');
 jest.mock('@metamask/accounts-controller');
 jest.mock('@metamask/sdk-communication-layer');
 jest.mock('../utils/DevLogger');
@@ -31,6 +31,12 @@ jest.mock('../utils/wait.util');
 jest.mock('./checkPermissions');
 jest.mock('./handleCustomRpcCalls');
 jest.mock('./handleSendMessage');
+
+const MOCK_ADDRESS = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
+  MOCK_ADDRESS,
+  'Account 1',
+);
 
 describe('handleConnectionMessage', () => {
   const mockHandleSendMessage = handleSendMessage as jest.MockedFunction<
@@ -66,7 +72,6 @@ describe('handleConnectionMessage', () => {
   const mockBackgroundBridgeOnMessage = jest.fn();
 
   let connection = {} as unknown as Connection;
-  let engine = {} as unknown as typeof Engine;
   let message = {
     id: '01',
     method: 'eth_requestAccounts',
@@ -75,12 +80,6 @@ describe('handleConnectionMessage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    const MOCK_ADDRESS = '0x1abcd';
-    const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
-      MOCK_ADDRESS,
-      'Account 1',
-    );
 
     connection = {
       channelId: '1',
@@ -98,26 +97,19 @@ describe('handleConnectionMessage', () => {
       },
     } as unknown as Connection;
 
-    engine = {
-      context: {
-        KeyringController: {} as unknown as KeyringController,
-        NetworkController: {
-          state: {
-            providerConfig: {
-              chainId: '0x1',
-            },
+    (Engine.context as unknown) = {
+      KeyringController: {} as unknown as KeyringController,
+      NetworkController: {
+        state: {
+          providerConfig: {
+            chainId: '0x1',
           },
-        } as unknown as NetworkController,
-        PreferencesController: {
-          state: {
-            selectedAddress: '',
-          },
-        } as unknown as PreferencesController,
-        AccountsController: {
-          getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
-        } as unknown as AccountsController,
-      },
-    } as unknown as typeof Engine;
+        },
+      } as unknown as NetworkController,
+      AccountsController: {
+        getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
+      } as unknown as AccountsController,
+    };
 
     message = {
       type: MessageType.OTP,
@@ -136,7 +128,7 @@ describe('handleConnectionMessage', () => {
     it('should handle termination messages correctly', async () => {
       message.type = MessageType.TERMINATE;
 
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(connection.onTerminate).toHaveBeenCalledTimes(1);
       expect(connection.onTerminate).toHaveBeenCalledWith({
@@ -146,7 +138,7 @@ describe('handleConnectionMessage', () => {
     it('should log and return on ping messages', async () => {
       message.type = MessageType.PING;
 
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockDevLoggerLog).toHaveBeenCalledTimes(1);
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
@@ -159,7 +151,7 @@ describe('handleConnectionMessage', () => {
       message.method = '';
       message.id = '';
 
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockDevLoggerLog).toHaveBeenCalledTimes(1);
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
@@ -176,29 +168,29 @@ describe('handleConnectionMessage', () => {
       message.id = '1';
     });
     it('should set loading to false', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockSetLoading).toHaveBeenCalledTimes(1);
       expect(mockSetLoading).toHaveBeenCalledWith(false);
     });
     it('should wait for keychain to be unlocked before handling RPC calls', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockWaitForKeychainUnlocked).toHaveBeenCalledTimes(1);
       expect(mockWaitForKeychainUnlocked).toHaveBeenCalledWith({
-        keyringController: engine.context.KeyringController,
+        keyringController: Engine.context.KeyringController,
         context: 'connection::on_message',
       });
     });
     it('should retrieve necessary data from the engine context', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
-      expect(engine.context.KeyringController).toBeDefined();
-      expect(engine.context.NetworkController).toBeDefined();
-      expect(engine.context.PreferencesController).toBeDefined();
+      expect(Engine.context.KeyringController).toBeDefined();
+      expect(Engine.context.NetworkController).toBeDefined();
+      expect(Engine.context.AccountsController).toBeDefined();
     });
     it('should wait for connection readiness', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockWaitForConnectionReadiness).toHaveBeenCalledTimes(1);
       expect(mockWaitForConnectionReadiness).toHaveBeenCalledWith({
@@ -206,7 +198,7 @@ describe('handleConnectionMessage', () => {
       });
     });
     it('should handle the sendAuthorized process', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockSendAuthorized).toHaveBeenCalledTimes(1);
     });
@@ -218,7 +210,7 @@ describe('handleConnectionMessage', () => {
     });
 
     it('should send error message using handleSendMessage on permission error', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockCheckPermissions).toBeCalledTimes(1);
 
@@ -242,17 +234,16 @@ describe('handleConnectionMessage', () => {
       mockCheckPermissions.mockResolvedValueOnce(true);
     });
     it('should process custom RPC calls correctly', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockHandleCustomRpcCalls).toHaveBeenCalledTimes(1);
       expect(mockHandleCustomRpcCalls).toHaveBeenCalledWith({
         batchRPCManager: connection.batchRPCManager,
         navigation: undefined,
         connection,
-        selectedAddress:
-          engine.context.PreferencesController.state.selectedAddress,
+        selectedAddress: toChecksumHexAddress(MOCK_ADDRESS),
         selectedChainId:
-          engine.context.NetworkController.state.providerConfig.chainId,
+          Engine.context.NetworkController.state.providerConfig.chainId,
         rpc: {
           method: message.method,
           params: message.params,
@@ -292,7 +283,7 @@ describe('handleConnectionMessage', () => {
         mockHandleCustomRpcCalls.mockResolvedValueOnce(processedRpc);
       });
       it('should add processed RPC to the RPC queue', async () => {
-        await handleConnectionMessage({ message, engine, connection });
+        await handleConnectionMessage({ message, engine: Engine, connection });
 
         expect(mockRpcQueueManagerAdd).toHaveBeenCalledTimes(1);
         expect(mockRpcQueueManagerAdd).toHaveBeenCalledWith({
@@ -309,7 +300,7 @@ describe('handleConnectionMessage', () => {
       });
 
       it('should add processed RPC to the RPC queue', async () => {
-        await handleConnectionMessage({ message, engine, connection });
+        await handleConnectionMessage({ message, engine: Engine, connection });
 
         expect(mockRpcQueueManagerAdd).toHaveBeenCalledTimes(0);
       });
@@ -343,7 +334,7 @@ describe('handleConnectionMessage', () => {
     });
 
     it('should send the processed RPC message to the background bridge', async () => {
-      await handleConnectionMessage({ message, engine, connection });
+      await handleConnectionMessage({ message, engine: Engine, connection });
 
       expect(mockBackgroundBridgeOnMessage).toHaveBeenCalledTimes(1);
       expect(mockBackgroundBridgeOnMessage).toHaveBeenCalledWith({

--- a/app/core/SDKConnect/handlers/handleConnectionMessage.test.ts
+++ b/app/core/SDKConnect/handlers/handleConnectionMessage.test.ts
@@ -17,10 +17,13 @@ import checkPermissions from './checkPermissions';
 import handleConnectionMessage from './handleConnectionMessage';
 import handleCustomRpcCalls from './handleCustomRpcCalls';
 import handleSendMessage from './handleSendMessage';
+import { createMockInternalAccount } from '../../../util/test/accountsControllerTestUtils';
+import { AccountsController } from '@metamask/accounts-controller';
 
 jest.mock('@metamask/keyring-controller');
 jest.mock('@metamask/network-controller');
 jest.mock('@metamask/preferences-controller');
+jest.mock('@metamask/accounts-controller');
 jest.mock('@metamask/sdk-communication-layer');
 jest.mock('../utils/DevLogger');
 jest.mock('../../../util/Logger');
@@ -73,6 +76,12 @@ describe('handleConnectionMessage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    const MOCK_ADDRESS = '0x1abcd';
+    const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount(
+      MOCK_ADDRESS,
+      'Account 1',
+    );
+
     connection = {
       channelId: '1',
       setLoading: mockSetLoading,
@@ -104,6 +113,9 @@ describe('handleConnectionMessage', () => {
             selectedAddress: '',
           },
         } as unknown as PreferencesController,
+        AccountsController: {
+          getSelectedAccount: jest.fn().mockReturnValue(MOCK_INTERNAL_ACCOUNT),
+        } as unknown as AccountsController,
       },
     } as unknown as typeof Engine;
 

--- a/app/core/SDKConnect/handlers/handleConnectionMessage.ts
+++ b/app/core/SDKConnect/handlers/handleConnectionMessage.ts
@@ -1,6 +1,6 @@
 import { KeyringController } from '@metamask/keyring-controller';
 import { NetworkController } from '@metamask/network-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
+import { AccountsController } from '@metamask/accounts-controller';
 import {
   CommunicationLayerMessage,
   MessageType,
@@ -18,6 +18,7 @@ import {
 import checkPermissions from './checkPermissions';
 import handleCustomRpcCalls from './handleCustomRpcCalls';
 import handleSendMessage from './handleSendMessage';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 // eslint-disable-next-line
 const { version } = require('../../../../package.json');
 
@@ -96,12 +97,15 @@ export const handleConnectionMessage = async ({
     context: 'connection::on_message',
   });
 
-  const preferencesController = (
-    engine.context as {
-      PreferencesController: PreferencesController;
+  const accountsController = (
+    Engine.context as {
+      AccountsController: AccountsController;
     }
-  ).PreferencesController;
-  const selectedAddress = preferencesController.state.selectedAddress;
+  ).AccountsController;
+
+  const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+    accountsController.getSelectedAccount().address,
+  );
 
   const networkController = (
     engine.context as {
@@ -146,7 +150,7 @@ export const handleConnectionMessage = async ({
 
   const processedRpc = await handleCustomRpcCalls({
     batchRPCManager: connection.batchRPCManager,
-    selectedAddress,
+    selectedAddress: selectedInternalAccountChecksummedAddress,
     selectedChainId: chainId,
     connection,
     navigation: connection.navigation,

--- a/app/core/WalletConnect/WalletConnect.js
+++ b/app/core/WalletConnect/WalletConnect.js
@@ -171,7 +171,7 @@ class WalletConnect {
           if (payload.method === 'eth_sendTransaction') {
             try {
               const selectedAddress =
-                Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
+                Engine.context.AccountsController.getSelectedAccount().address?.toLowerCase();
 
               checkActiveAccountAndChainId({
                 address: payload.params[0].from,
@@ -305,7 +305,7 @@ class WalletConnect {
   startSession = async (sessionData, existing) => {
     const chainId = selectChainId(store.getState());
     const selectedAddress =
-      Engine.context.PreferencesController.state.selectedAddress?.toLowerCase();
+      Engine.context.AccountsController.getSelectedAccount().address?.toLowerCase();
     const approveData = {
       chainId: parseInt(chainId, 10),
       accounts: [selectedAddress],

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -4,7 +4,6 @@ import { Minimizer } from '../NativeModules';
 import getRpcMethodMiddleware from '../RPCMethods/RPCMethodMiddleware';
 
 import { KeyringController } from '@metamask/keyring-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
 import Logger from '../../util/Logger';
 
 import { WalletDevice } from '@metamask/transaction-controller';
@@ -45,6 +44,8 @@ import parseWalletConnectUri, {
   showWCLoadingState,
 } from './wc-utils';
 import { getDefaultNetworkByChainId } from '../../util/networks';
+import { AccountsController } from '@metamask/accounts-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 const { PROJECT_ID } = AppConstants.WALLET_CONNECT;
 export const isWC2Enabled =
@@ -557,10 +558,15 @@ export class WC2Manager {
       },
     );
 
-    const preferencesController = (
-      Engine.context as { PreferencesController: PreferencesController }
-    ).PreferencesController;
-    const selectedAddress = preferencesController.state.selectedAddress;
+    const accountsController = (
+      Engine.context as {
+        AccountsController: AccountsController;
+      }
+    ).AccountsController;
+
+    const selectedInternalAccountChecksummedAddress = toChecksumHexAddress(
+      accountsController.getSelectedAccount().address,
+    );
 
     // TODO: Misleading variable name, this is not the chain ID. This should be updated to use the chain ID.
     const chainId = selectChainId(store.getState());
@@ -640,7 +646,7 @@ export class WC2Manager {
 
           const nChainId = parseInt(chainId, 16);
           DevLogger.log(
-            `WC2::init updateSession session=${sessionKey} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedAddress}`,
+            `WC2::init updateSession session=${sessionKey} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedInternalAccountChecksummedAddress}`,
             approvedAccounts,
           );
           await this.sessions[sessionKey].updateSession({

--- a/app/selectors/preferencesController.ts
+++ b/app/selectors/preferencesController.ts
@@ -5,28 +5,10 @@ import { RootState } from '../reducers';
 const selectPreferencesControllerState = (state: RootState) =>
   state.engine.backgroundState.PreferencesController;
 
-/**
- * @deprecated use selectInternalAccounts rom selectors/accountsController.ts instead
- */
-export const selectIdentities = createSelector(
-  selectPreferencesControllerState,
-  (preferencesControllerState: PreferencesState) =>
-    preferencesControllerState.identities,
-);
-
 export const selectIpfsGateway = createSelector(
   selectPreferencesControllerState,
   (preferencesControllerState: PreferencesState) =>
     preferencesControllerState.ipfsGateway,
-);
-
-/**
- * @deprecated use selectSelectedInternal or selectSelectedInternalAccountChecksummedAddress from selectors/accountsController.ts
- */
-export const selectSelectedAddress = createSelector(
-  selectPreferencesControllerState,
-  (preferencesControllerState: PreferencesState) =>
-    preferencesControllerState.selectedAddress,
 );
 
 export const selectUseNftDetection = createSelector(

--- a/app/selectors/smartTransactionsController.test.ts
+++ b/app/selectors/smartTransactionsController.test.ts
@@ -43,8 +43,6 @@ const getDefaultState = () => {
       },
     },
   };
-  defaultState.engine.backgroundState.PreferencesController.selectedAddress =
-    '0xabc';
   defaultState.engine.backgroundState.NetworkController.providerConfig = {
     rpcUrl: undefined, // default rpc for chain 0x1
     chainId: '0x1',

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -1,8 +1,5 @@
 import { NETWORKS_CHAIN_ID } from '../constants/network';
-import {
-  selectSelectedAddress,
-  selectSmartTransactionsOptInStatus,
-} from './preferencesController';
+import { selectSmartTransactionsOptInStatus } from './preferencesController';
 import { RootState } from '../reducers';
 import { swapsSmartTxFlagEnabled } from '../reducers/swaps';
 import { isHardwareAccount } from '../util/address';
@@ -11,6 +8,7 @@ import {
   SmartTransaction,
   SmartTransactionStatuses,
 } from '@metamask/smart-transactions-controller/dist/types';
+import { selectSelectedInternalAccountChecksummedAddress } from './accountsController';
 
 export const ALLOWED_SMART_TRANSACTIONS_CHAIN_IDS = [
   NETWORKS_CHAIN_ID.MAINNET,
@@ -18,8 +16,11 @@ export const ALLOWED_SMART_TRANSACTIONS_CHAIN_IDS = [
   NETWORKS_CHAIN_ID.SEPOLIA,
 ];
 export const selectSmartTransactionsEnabled = (state: RootState) => {
-  const selectedAddress = selectSelectedAddress(state);
-  const addrIshardwareAccount = isHardwareAccount(selectedAddress);
+  const selectedAddress =
+    selectSelectedInternalAccountChecksummedAddress(state);
+  const addrIshardwareAccount = selectedAddress
+    ? isHardwareAccount(selectedAddress)
+    : false;
   const chainId = selectChainId(state);
   const providerConfigRpcUrl = selectProviderConfig(state).rpcUrl;
 
@@ -56,7 +57,8 @@ export const selectShouldUseSmartTransaction = (state: RootState) => {
 };
 
 export const selectPendingSmartTransactionsBySender = (state: RootState) => {
-  const selectedAddress = selectSelectedAddress(state);
+  const selectedAddress =
+    selectSelectedInternalAccountChecksummedAddress(state);
   const chainId = selectChainId(state);
 
   const smartTransactions: SmartTransaction[] =
@@ -68,7 +70,7 @@ export const selectPendingSmartTransactionsBySender = (state: RootState) => {
       ?.filter((stx) => {
         const { txParams } = stx;
         return (
-          txParams?.from.toLowerCase() === selectedAddress.toLowerCase() &&
+          txParams?.from.toLowerCase() === selectedAddress?.toLowerCase() &&
           ![
             SmartTransactionStatuses.SUCCESS,
             SmartTransactionStatuses.CANCELLED,

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -517,7 +517,7 @@ export function getEther(ticker) {
  * @param {object} config.addressBook - Object of address book entries
  * @param {string} config.chainId - network id
  * @param {string} config.toAddress - hex address of tx recipient
- * @param {array} config.identities - array of accounts objects from AccountsController
+ * @param {array} config.internalAccounts - array of accounts objects from AccountsController
  * @param {string} config.ensRecipient - name of ens recipient
  * @returns {string} - recipient name
  */


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- In previous issues we migrated all account information state to reference the the new accounts controller redux state. - This change furthers this effort and removes all remaining references to PreferencesController.identities and PreferencesController.selectedAddress. 
- All of the remaining references are non state values and thus are not going to be using the redux state implemented in the previous issues. Instead we will reference the Engine.context.AccountsController instance directly.
- This PR also removes `selectSelectedAddress` and `selectIdentities` from the available redux selectors to prevent future use of this data.
    - This is ideal since we eventually want to completely remove this data from the PreferencesController in favour of the AccountsController
- After this PR there should be `zero references to this data in the codebase`.

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/537

## **Review checklist**
- [x] confirm that there are no reference to `PreferencesController.identities` in the codebase
- [x] Confirm that there are no references to `PreferencesController.selectedAddress` in the codebase
- [x] Confirm that there are no references to `selectIdentities`
- [x] Confirm that there are no references to `selectSelectedAddress`

(There will still be use of these variables in the migration files that are migrating this data from PreferencesController to AccountsController. There should be no other references besides the migrations)

## **Manual testing steps**

1. Import a wallet ideally with funds
2. after onboarding, create a new account
5. edit then name of this new account
6. add a hardware wallet via ledger or QR
7. import a private key like orangefox.eth or another of your choosing
8. go through the send flow from an account with funds
9. EXPECT, all addresses, names and transaction data should match the account listed in the transaction
10. EXPECT, all addresses to be in checksum format (example 0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272 vs 0xc4955c0d639d99699bfd7ec54d9fafee40e4d272)
11. navigate to https://metamask.github.io/test-dapp/ in the mobile browser
12. connect one or more account
13. EXPECT, the connection modal should display the correct account information as well as the address in checksum format
14. perform a send on the test dapp
15. EXPECT, the send modal should display the correct account information and the address in checksum format
16. Disconnect the account from the test dapp
17. reconnect the account vai wallet connect
18. EXPECT, the connection should work and should display the correct account information as well as the address in checksum format

## **Screenshots/Recordings**


### **Before**


### **After**

<img width="639" alt="Screenshot 2024-07-24 at 3 15 51 PM" src="https://github.com/user-attachments/assets/97a7c262-f95a-4343-bfcf-d0ae4e1c6aff">
<img width="679" alt="Screenshot 2024-07-24 at 3 16 02 PM" src="https://github.com/user-attachments/assets/df88ce65-139c-4e54-9a60-a86ba9df5ee9">
<img width="801" alt="Screenshot 2024-07-24 at 3 16 37 PM" src="https://github.com/user-attachments/assets/0cd26e47-8073-4000-bb85-73a4de372450">
<img width="666" alt="Screenshot 2024-07-24 at 3 20 00 PM" src="https://github.com/user-attachments/assets/7a8fd678-414a-45ab-a8e9-05083f5fb138">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
