### PR TITLE
fix: correctly get current PR number in bitrise e2e workflow

### DIFF
--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -22,9 +22,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Determine whether this PR is from a fork
         id: is-fork
-        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${{ github.event.number }}" )" >> "$GITHUB_OUTPUT"
+        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number || github.event.issue.number }}
 
   run-bitrise-e2e-check:
     needs: is-fork-pull-request


### PR DESCRIPTION
## **Description**

The bitrise e2e workflow was functioning incorrectly due to the fact that the object containing the pull request number differs depending on if the event is triggered by a pull request or a comment. For workflows triggered by comment events, we were incorrectly selecting the pull request number, and the workflow would end up in an error state.

This is resolved by checking both `github.event.number` (used in the case of pull request events) and `github.event.issue.number` (used in the case of comment events).

## **Manual testing steps**

### Testing `pull_request` events

1. Visit https://github.com/MetaMask/metamask-mobile/actions/runs/9960943181/job/27521345591 and see the workflow run for this pull_request. 
2. Expand the `Determine pull request source` and see the `PR_NUMBER` environment variable is populated:

<img width="1105" alt="Screenshot" src="https://github.com/user-attachments/assets/68b3a48e-af43-4130-ab10-12301330041f">

You can trigger this again for a fresh run by adding a label to the PR.

### Testing `issue_comment` events

**Note, this cannot be done on this PR since it runs in the context of MetaMask's main branch which doesn't have my changes**

1. Visit a PR on my fork at https://github.com/NicholasEllul/metamask-mobile/pull/2
2. Add and delete a comment OR edit an existing comment. 
3. Visit https://github.com/NicholasEllul/metamask-mobile/actions/workflows/run-bitrise-e2e-check.yml and see the status of the workflow run. 
4. Confirm that you see the PR number populated as noted above.


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
