### PR TITLE
test: Disable bitrise slack notification step

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -315,25 +315,6 @@ workflows:
             - issue_number: '$GITHUB_PR_NUMBER'
             - api_base_url: 'https://api.github.com'
             - update_comment_tag: '$GITHUB_PR_HASH'
-      - slack@3:
-          inputs:
-            - text: '${BITRISE_APP_TITLE} ${BITRISEIO_PIPELINE_TITLE} workflow notification'
-            - pretext: ':large_green_circle: *${BITRISEIO_PIPELINE_TITLE} succeeded!*'
-            - title: 'Commit #$COMMIT_SHORT_HASH $BRANCH_HEIGHT'
-            - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
-            - message: ${BITRISE_GIT_MESSAGE}
-            - fields: |
-                Branch|${BITRISE_GIT_BRANCH}
-                Workflow|${BITRISEIO_PIPELINE_TITLE}
-                Trigger|${WORKFLOW_TRIGGER}
-                Build|${BITRISE_BUILD_NUMBER}
-            - buttons: |
-                View app|${BITRISE_APP_URL}
-                View build|${BITRISEIO_PIPELINE_BUILD_URL}
-                View commit|https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
-            - footer: 'Bitrise ${BITRISEIO_PIPELINE_TITLE} workflow notification'
-            - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
-
   # Send a Slack message when workflow fails
   notify_failure:
     before_run:
@@ -373,27 +354,6 @@ workflows:
             - issue_number: '$GITHUB_PR_NUMBER'
             - api_base_url: 'https://api.github.com'
             - update_comment_tag: '$GITHUB_PR_HASH'
-      - slack@3:
-          is_always_run: true
-          run_if: .IsBuildFailed
-          inputs:
-            - text: '${BITRISE_APP_TITLE} ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow notification'
-            - pretext_on_error: ':red_circle: *${BITRISE_TRIGGERED_WORKFLOW_TITLE} failed!*'
-            - title: 'Commit #$COMMIT_SHORT_HASH $BRANCH_HEIGHT'
-            - title_link: https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
-            - message: ${BITRISE_GIT_MESSAGE}
-            - fields: |
-                Branch|${BITRISE_GIT_BRANCH}
-                Workflow|${BITRISE_TRIGGERED_WORKFLOW_TITLE}
-                Trigger|${WORKFLOW_TRIGGER}
-                Build|${BITRISE_BUILD_NUMBER}
-            - buttons: |
-                View app|${BITRISE_APP_URL}
-                View build|${BITRISE_BUILD_URL}
-                View commit|https://github.com/${BITRISEIO_GIT_REPOSITORY_OWNER}/${BITRISEIO_GIT_REPOSITORY_SLUG}/commit/${COMMIT_SHORT_HASH}
-            - footer: 'Bitrise ${BITRISE_TRIGGERED_WORKFLOW_TITLE} workflow notification'
-            - webhook_url: https://hooks.slack.com/services/${MM_SLACK_TOKEN}/${MM_SLACK_SECRET}/${MM_SLACK_ROOM}
-
   # CI Steps
   ci_test:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -149,7 +149,6 @@ stages:
       - run_tag_smoke_core_ios: {}
       - run_tag_smoke_core_android: {}
       - run_tag_upgrade_android: {}
-      - notify_success: {}
   run_e2e_ios_android_stage:
     workflows:
       - ios_e2e_test: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,6 +52,7 @@ pipelines:
     stages:
       - build_smoke_e2e_ios_android_stage: {}
       - run_smoke_e2e_ios_android_stage: {}
+      # - notify: {}
   # Pipeline for Flask
   create_flask_release_builds_pipeline:
     stages:
@@ -148,6 +149,7 @@ stages:
       - run_tag_smoke_core_ios: {}
       - run_tag_smoke_core_android: {}
       - run_tag_upgrade_android: {}
+      - notify_success: {}
   run_e2e_ios_android_stage:
     workflows:
       - ios_e2e_test: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,6 @@ pipelines:
     stages:
       - build_smoke_e2e_ios_android_stage: {}
       - run_smoke_e2e_ios_android_stage: {}
-      - notify: {}
   # Pipeline for Flask
   create_flask_release_builds_pipeline:
     stages:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,7 @@ pipelines:
     stages:
       - build_smoke_e2e_ios_android_stage: {}
       - run_smoke_e2e_ios_android_stage: {}
-      # - notify: {}
+      - notify: {}
   # Pipeline for Flask
   create_flask_release_builds_pipeline:
     stages:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The purpose of this pull request (PR) is to disable Slack notifications when the end-to-end (e2e) tests pass or fail. This is because we already have a GitHub action that posts the test status as a comment on the PR, so there's no need for additional alerts to be sent in #metamask-mobile-ci-alerts.



## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/2bca1f72-02f6-4d0a-9099-f5fe601f9f36)


### **After**

![image](https://github.com/user-attachments/assets/31688146-25c0-423c-94ef-ddd014135187)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
