### PR TITLE
fix: swap quote, gas, other modals closing immediately after open

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -1425,7 +1425,7 @@ function SwapsQuotesView({
 
   /* errorKey effect: hide every modal */
   useEffect(() => {
-    if (error) {
+    if (error?.key) {
       hideFeeModal();
       hideQuotesModal();
       hideUpdateModal();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue in Swaps where all the modals would close immediately after they are opened.

## **Related issues**

Fixes https://github.com/MetaMask/metamask-mobile/issues/10295
Fixes https://github.com/MetaMask/metamask-mobile/issues/10084

## **Manual testing steps**

1. Go to Swaps
2. Get a quote
3. Click on "View Details"
4. Observe that the modal doesn't close
5. Click on the estimated gas
6. Observe that the modal doesn't close

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5bd0a7a4-b95f-4b88-a093-40ced09d2139



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
