### PR TITLE
chore: Revert "chore: update Android SDK to API Level 34 "

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
 
 	ext {
-		buildToolsVersion = "34.0.0"
+		buildToolsVersion = "33.0.0"
 		minSdkVersion = project.hasProperty('minSdkVersion') ? project.getProperty('minSdkVersion') : 23
-		compileSdkVersion = 34
-		targetSdkVersion = 34
+		compileSdkVersion = 33
+		targetSdkVersion = 33
 		// We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
 		ndkVersion = "24.0.8215888"
 		bitriseNdkPath = "/usr/local/share/android-sdk/ndk-bundle"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -679,7 +679,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.22.0):
+  - RNScreens (3.19.0):
     - React-Core
     - React-RCTImage
   - RNSensors (5.3.0):
@@ -1177,7 +1177,7 @@ SPEC CHECKSUMS:
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNPermissions: 4e3714e18afe7141d000beae3755e5b5fb2f5e05
   RNReanimated: b1220a0e5168745283ff5d53bfc7d2144b2cee1b
-  RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
+  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSensors: c363d486c879e181905dea84a2535e49af1c2d25
   RNSentry: 98e170b6eedc5c54e3ac88b6140fffb8b496deb4
   RNShare: f116bbb04f310c665ca483d0bd1e88cf59b3b334

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "react-native-reanimated": "3.1.0",
     "react-native-redash": "16.2.2",
     "react-native-safe-area-context": "^3.1.9",
-    "react-native-screens": "3.22.0",
+    "react-native-screens": "3.19.0",
     "react-native-scrollable-tab-view": "^1.0.0",
     "react-native-sensors": "5.3.0",
     "react-native-share": "7.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25686,10 +25686,10 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@3.22.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.22.0.tgz#7d892baf964fddb642b5eec71a09e2aeb501e578"
-  integrity sha512-csLypBSXIt/egh37YJmokETptZJCtZdoZBsZNLR9n31GesDyVogprT+MM22dEPDuxPxt/mFWq+lSpVwk7khuTw==
+react-native-screens@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.19.0.tgz#ec68685e04b074ebce4641b3a0ae7e2571629b75"
+  integrity sha512-Ehsmy7jr3H3j5pmN+/FqsAaIAD+k+xkcdePfLcg4rYRbN5X7fJPgaqhcmiCcZ0YxsU8ttsstP9IvRLNQuIkRRA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#10282

Fixes: #10352 

The solution will be to address: https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported