### PR TITLE
fix: transaction cancel speed up modal should disappear after transaction is confirmed

### DIFF
--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -275,6 +275,14 @@ class Transactions extends PureComponent {
 
   componentDidUpdate() {
     this.updateBlockExplorer();
+    if (
+      this.props.confirmedTransactions.some(
+        ({ id }) => id === this.existingTx?.id,
+      )
+    ) {
+      this.onSpeedUpCompleted();
+      this.onCancelCompleted();
+    }
   }
 
   init() {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

transaction cancel speed up modal should disappear after transaction is confirmed

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/7387

## **Manual testing steps**

1. Create s send transaction
2. Choose to speedup transaction
3. Speedup modal should disappear once transaction is confirmed

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/bf9a165b-0a5f-41da-aa65-5dd4f6a73a60


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
