### PR TITLE
test: Update env variables for appium upgrading on bitrise.yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -427,9 +427,9 @@ workflows:
         stack: linux-docker-android-20.04
         machine_type_id: elite-xl
     envs:
-      - PRODUCTION_APP_URL: 'bs://c2c414d2b4935096274bd2fb98232cc7b8408b2a' # Last production's QA build
-      - PRODUCTION_BUILD_NAME: 7.24.4
-      - PRODUCTION_BUILD_NUMBER: 1354
+      - PRODUCTION_APP_URL: 'bs://f0eefdd04dd0b913eb8b6494e4990e3e9f1c2bd3' # Last production's QA build
+      - PRODUCTION_BUILD_NAME: 7.26.1
+      - PRODUCTION_BUILD_NUMBER: 1360
       - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
       - PRODUCTION_BUILD_STRING: 'MetaMask-QA v$PRODUCTION_BUILD_NAME ($PRODUCTION_BUILD_NUMBER)'
       - NEW_BUILD_STRING: 'MetaMask-QA v$VERSION_NAME ($VERSION_NUMBER)'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Currently, the env variables values required to run the Appium Upgrading test cases on bitrise.yml are deprecated. Browserstack constantly eliminates a build after 30 days of it being generated. The variables affected are:

PRODUCTION_APP_URL: 'bs://c2c414d2b4935096274bd2fb98232cc7b8408b2a'
PRODUCTION_BUILD_NAME: 7.24.4
PRODUCTION_BUILD_NUMBER: 1354
So its required to update the values from a valid QA build saved on Browserstack.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
