### PR TITLE
chore: fix pod install on linux

### DIFF
--- a/patches/react-native+0.72.15.patch
+++ b/patches/react-native+0.72.15.patch
@@ -242,10 +242,10 @@ diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/rnc
 new file mode 100644
 index 0000000..e69de29
 diff --git a/node_modules/react-native/scripts/cocoapods/utils.rb b/node_modules/react-native/scripts/cocoapods/utils.rb
-index 6507f8b..9e0ec97 100644
+index 6507f8b..924edd3 100644
 --- a/node_modules/react-native/scripts/cocoapods/utils.rb
 +++ b/node_modules/react-native/scripts/cocoapods/utils.rb
-@@ -354,20 +354,22 @@ class ReactNativePodsUtils
+@@ -354,20 +354,23 @@ class ReactNativePodsUtils
      end
  
      def self.is_using_xcode15_0(xcodebuild_manager: Xcodebuild)
@@ -261,6 +261,7 @@ index 6507f8b..9e0ec97 100644
 -            major = match_data[1].to_i
 -            minor = match_data[2].to_i
 -            return major == 15 && minor == 0
++        # Catch exception on Linux (fixed in RN 0.74+)
 +        begin
 +            xcodebuild_version = xcodebuild_manager.version
 +

--- a/patches/react-native+0.72.15.patch
+++ b/patches/react-native+0.72.15.patch
@@ -241,3 +241,43 @@ index 0000000..e69de29
 diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/rncore/States.h b/node_modules/react-native/ReactCommon/react/renderer/components/rncore/States.h
 new file mode 100644
 index 0000000..e69de29
+diff --git a/node_modules/react-native/scripts/cocoapods/utils.rb b/node_modules/react-native/scripts/cocoapods/utils.rb
+index 6507f8b..9e0ec97 100644
+--- a/node_modules/react-native/scripts/cocoapods/utils.rb
++++ b/node_modules/react-native/scripts/cocoapods/utils.rb
+@@ -354,20 +354,22 @@ class ReactNativePodsUtils
+     end
+ 
+     def self.is_using_xcode15_0(xcodebuild_manager: Xcodebuild)
+-        xcodebuild_version = xcodebuild_manager.version
+-
+-        # The output of xcodebuild -version is something like
+-        # Xcode 15.0
+-        # or
+-        # Xcode 14.3.1
+-        # We want to capture the version digits
+-        regex = /(\d+)\.(\d+)(?:\.(\d+))?/
+-        if match_data = xcodebuild_version.match(regex)
+-            major = match_data[1].to_i
+-            minor = match_data[2].to_i
+-            return major == 15 && minor == 0
++        begin
++            xcodebuild_version = xcodebuild_manager.version
++
++            # The output of xcodebuild -version is something like
++            # Xcode 15.0
++            # or
++            # Xcode 14.3.1
++            # We want to capture the version digits
++            regex = /(\d+)\.(\d+)(?:\.(\d+))?/
++            if match_data = xcodebuild_version.match(regex)
++                major = match_data[1].to_i
++                minor = match_data[2].to_i
++                return major == 15 && minor == 0
++            end
++        rescue => e
+         end
+-
+         return false
+     end
+ 


### PR DESCRIPTION
Treats xcode as not installed if not available.
Fixes `yarn setup --build-ios` error on Linux.

This patch will not be needed from `react-native` 0.74 and later: https://github.com/reactwg/react-native-releases/issues/296

## **Description**

## **Related issues**

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
