### PR TITLE
fix: useAddressBalance hook selectors warning

### DIFF
--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -22,14 +22,10 @@ const useAddressBalance = (
 ) => {
   const [addressBalance, setAddressBalance] = useState('0');
 
-  const { accounts, contractBalances, selectedAddress } = useSelector(
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => ({
-      accounts: selectAccounts(state),
-      contractBalances: selectContractBalances(state),
-      selectedAddress: selectSelectedInternalAccountChecksummedAddress(state),
-    }),
+  const accounts = useSelector(selectAccounts);
+  const contractBalances = useSelector(selectContractBalances);
+  const selectedAddress = useSelector(
+    selectSelectedInternalAccountChecksummedAddress,
   );
   const ticker = useSelector(selectTicker);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refactors selection of state inside `useAddressBalance` hook. The previous selection of state was generating an object with the sole purpose of destructuring it without it being memoized, causing the next warning that is now fixed:

```
WARN Selector unknown returned a different result when called with the same parameters.
This can lead to unnecessary rerenders. Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/u sage/deriving-data-selectors#optimizing-selectors-with-memoization
{"selected": {"accounts":..., "contractBalances":..., "selectedAddress":...}
```

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**



### **Before**



### **After**


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
