### PR TITLE
chore: replace swaps slider with a normal button

### DIFF
--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -108,6 +108,7 @@ import { createBuyNavigationDetails } from '../Ramp/routes/utils';
 import {
   SWAP_QUOTE_SUMMARY,
   SWAP_GAS_FEE,
+  TAP_TO_SWAP_BUTTON,
 } from '../../../../wdio/screen-objects/testIDs/Screens/SwapView.js';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { addTransaction } from '../../../util/transaction-controller';
@@ -2148,6 +2149,7 @@ function SwapsQuotesView({
           width={ButtonWidthTypes.Full}
           size={ButtonSize.Lg}
           isDisabled={unableToSwap || isAnimating}
+          testID={TAP_TO_SWAP_BUTTON}
         />
         <TouchableOpacity onPress={handleTermsPress} style={styles.termsButton}>
           <Text link centered>

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -55,7 +55,6 @@ import ScreenView from '../../Base/ScreenView';
 import Text from '../../Base/Text';
 import Alert, { AlertType } from '../../Base/Alert';
 import StyledButton from '../StyledButton';
-import SliderButton from '../SliderButton';
 
 import LoadingAnimation from './components/LoadingAnimation';
 import TokenIcon from './components/TokenIcon';
@@ -116,6 +115,11 @@ import trackErrorAsAnalytics from '../../../util/metrics/TrackError/trackErrorAs
 import { selectGasFeeEstimates } from '../../../selectors/confirmTransaction';
 import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransactionsController';
 import { selectGasFeeControllerEstimateType } from '../../../selectors/gasFeeController';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../component-library/components/Buttons/Button';
 
 const POLLING_INTERVAL = 30000;
 const SLIPPAGE_BUCKETS = {
@@ -444,6 +448,7 @@ function SwapsQuotesView({
   const [trackedError, setTrackedError] = useState(false);
   const [animateOnGasChange, setAnimateOnGasChange] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [isSwapping, setIsSwapping] = useState(false);
   const [multiLayerL1ApprovalFeeTotal, setMultiLayerL1ApprovalFeeTotal] =
     useState(null);
 
@@ -459,8 +464,6 @@ function SwapsQuotesView({
 
   const [customGasEstimate, setCustomGasEstimate] = useState(null);
   const [customGasLimit, setCustomGasLimit] = useState(null);
-
-  const [isSwiping, setIsSwiping] = useState(false);
 
   // TODO: use this variable in the future when calculating savings
   const [isSaving] = useState(false);
@@ -652,13 +655,15 @@ function SwapsQuotesView({
       isInFetch ||
       !selectedQuote ||
       !hasEnoughTokenBalance ||
-      !hasEnoughEthBalance,
+      !hasEnoughEthBalance ||
+      isSwapping,
     [
       isInPolling,
       isInFetch,
       selectedQuote,
       hasEnoughTokenBalance,
       hasEnoughEthBalance,
+      isSwapping,
     ],
   );
 
@@ -1052,6 +1057,8 @@ function SwapsQuotesView({
       return;
     }
 
+    setIsSwapping(true);
+
     const isHardwareAddress = isHardwareAccount(selectedAddress);
 
     startSwapAnalytics(selectedQuote, selectedAddress);
@@ -1087,6 +1094,7 @@ function SwapsQuotesView({
       );
     }
 
+    setIsSwapping(false);
     navigation.dangerouslyGetParent()?.pop();
   }, [
     selectedQuote,
@@ -1698,7 +1706,6 @@ function SwapsQuotesView({
       contentContainerStyle={styles.screen}
       style={styles.container}
       keyboardShouldPersistTaps="handled"
-      scrollEnabled={!isSwiping}
     >
       <View style={styles.topBar}>
         {(!hasEnoughTokenBalance || !hasEnoughEthBalance) && (
@@ -2134,23 +2141,13 @@ function SwapsQuotesView({
             </QuotesSummary.Body>
           </QuotesSummary>
         )}
-        <SliderButton
-          incompleteText={
-            <Text style={styles.sliderButtonText}>
-              {`${strings('swaps.swipe_to')} `}
-              <Text reset bold>
-                {strings('swaps.swap')}
-              </Text>
-            </Text>
-          }
-          onSwipeChange={setIsSwiping}
-          completeText={
-            <Text style={styles.sliderButtonText}>
-              {strings('swaps.completed_swap')}
-            </Text>
-          }
-          disabled={unableToSwap || isAnimating}
-          onComplete={handleCompleteSwap}
+        <Button
+          label={strings('swaps.swap')}
+          variant={ButtonVariants.Primary}
+          onPress={handleCompleteSwap}
+          width={ButtonWidthTypes.Full}
+          size={ButtonSize.Lg}
+          isDisabled={unableToSwap || isAnimating}
         />
         <TouchableOpacity onPress={handleTermsPress} style={styles.termsButton}>
           <Text link centered>

--- a/app/components/UI/Swaps/QuotesView.test.tsx
+++ b/app/components/UI/Swaps/QuotesView.test.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import QuotesView from './QuotesView';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import Engine from '../../../core/Engine';
+import { backgroundState } from '../../../util/test/initial-root-state';
+import {
+  expectedUuid,
+  MOCK_ACCOUNTS_CONTROLLER_STATE,
+  MOCK_ADDRESS_1,
+} from '../../../util/test/accountsControllerTestUtils';
+
+jest.setTimeout(10_000);
+
+const mockEngine = Engine;
+
+const mockInitialState = {
+  swaps: { '0x1': { isLive: true }, hasOnboarded: false, isLive: true },
+  fiatOrders: {
+    networks: [
+      {
+        active: true,
+        chainId: '0x1',
+        chainName: 'Ethereum Mainnet',
+        nativeTokenSupported: true,
+      },
+    ],
+  },
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      NetworkController: {
+        providerConfig: {
+          type: 'mainnet' as
+            | 'mainnet'
+            | 'rpc'
+            | 'goerli'
+            | 'sepolia'
+            | 'linea-goerli'
+            | 'linea-sepolia'
+            | 'linea-mainnet'
+            | undefined,
+          chainId: '0x1' as '0x${string}',
+          ticker: 'ETH',
+        },
+      },
+      SwapsControlller: {
+        quotesLastFetched: Date.now(),
+        topAggId: 'airswapV4',
+        tokens: [
+          [
+            {
+              address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              aggregators: ['socket', 'coinmarketcap'],
+              decimals: 6,
+              iconUrl:
+                'https://static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+              name: 'USD Coin',
+              occurrences: 10,
+              symbol: 'USDC',
+              type: 'erc20',
+            },
+          ],
+        ],
+        isInPolling: false,
+        quotes: {
+          airswapV4: {
+            aggType: 'RFQ',
+            aggregator: 'airswapV4',
+            approvalNeeded: null,
+            averageGas: 190431,
+            destinationAmount: '2636315',
+            destinationToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            destinationTokenRate: 0.00037280152318031886,
+            error: null,
+            estimatedRefund: 48635,
+            fee: 0.875,
+            fetchTime: 823,
+            gasEstimate: '0x3a5da',
+            gasEstimateWithRefund: '2e7df',
+            gasMultiplier: 1,
+            hasRoute: false,
+            maxGas: 239066,
+            priceSlippage: {
+              bucket: 'low',
+              calculationError: '',
+              destinationAmountInETH: 0.000987688784254516,
+              destinationAmountInNativeCurrency: 0.000987688784254516,
+              destinationAmountInUSD: 2.64300052191,
+              ratio: 1.0108456942379809,
+              sourceAmountInETH: 0.001,
+              sourceAmountInNativeCurrency: 0.001,
+              sourceAmountInUSD: 2.67198,
+            },
+            quoteRefreshSeconds: 30,
+            slippage: 2,
+            sourceAmount: '1000000000000000',
+            sourceToken: '0x0000000000000000000000000000000000000000',
+            sourceTokenRate: 1,
+            trade: {
+              data: '0x5f5755290000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000038d7ea4c6800000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000001c616972737761704c696768743446656544796e616d696346697865640000000000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000190e021676f0000000000000000000000000000000000000000000000000000000066ba7b9700000000000000000000000051c72848c68a965f66fa7a88855f9f7784502a7f000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000002857a100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003858960223400000000000000000000000000000000000000000000000000000000000000001be9fc4346e69a599f2e81e99b6e41b633430d9214b4d46f7919604931e5b193b40ebe350105169a651e5afd44ea7d06958e621b21ffbec6159f6adf4ce8148b47000000000000000000000000000000000000000000000000000007f544a44c00000000000000000000000000f326e4de8f66a0bdc0970b79e0924e33c79f1915000000000000000000000000000000000000000000000000000000000000000000f8',
+              from: '0xc5fe6ef47965741f6f7a4734bf784bf3ae3f2452',
+              gas: '0x3e9b5',
+              to: '0x881d40237659c251811cec9c364ef91dc08d300c',
+              value: '0x38d7ea4c68000',
+            },
+          },
+        },
+      },
+      AccountTrackerController: {
+        accounts: {
+          [MOCK_ADDRESS_1]: {
+            balance: '0x0',
+          },
+        },
+      },
+      AccountsController: {
+        ...MOCK_ACCOUNTS_CONTROLLER_STATE,
+        internalAccounts: {
+          ...MOCK_ACCOUNTS_CONTROLLER_STATE.internalAccounts,
+          selectedAccount: expectedUuid,
+        },
+        accounts: {
+          [MOCK_ADDRESS_1]: {
+            balance: '0x0',
+            name: 'Account 1',
+            address: MOCK_ADDRESS_1,
+          },
+        },
+      },
+    },
+  },
+};
+
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockEngine.init({}),
+  context: {
+    SwapsController: {
+      stopPollingAndResetState: jest.fn(),
+      startFetchAndSetQuotes: jest.fn(),
+    },
+    KeyringController: {
+      state: {
+        keyrings: [
+          {
+            // Can't use MOCK_ADDRESS_1 variable due to mocks being hoisted before the import, so just hard code it
+            accounts: ['0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272'],
+          },
+        ],
+      },
+    },
+  },
+}));
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      setOptions: jest.fn(),
+    }),
+    useRoute: jest.fn(() => ({
+      params: {
+        destinationTokenAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        slippage: 2,
+        sourceAmount: '1000000000000000',
+        sourceTokenAddress: '0x0000000000000000000000000000000000000000',
+        tokens: [
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            decimals: 18,
+            name: 'Ether',
+            occurrences: 0,
+            symbol: 'ETH',
+          },
+          {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            aggregators: [],
+            decimals: 6,
+            iconUrl:
+              'https://static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+            name: 'USDC',
+            occurrences: 16,
+            symbol: 'USDC',
+            type: 'erc20',
+          },
+        ],
+      },
+    })),
+  };
+});
+
+jest.mock('./utils/useBalance', () => jest.fn(() => 1_000_000));
+jest.mock('./components/QuotesModal', () => 'QuotesModal');
+
+describe('QuotesView', () => {
+  it.only('should render correctly', async () => {
+    const { findByText } = renderWithProvider(
+      <QuotesView />,
+      {
+        state: mockInitialState,
+      },
+      false,
+    );
+
+    const swapButton = await findByText('Swap', {}, { timeout: 5000 });
+    expect(swapButton).toBeDefined();
+  });
+});

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -28,6 +28,15 @@ export default class SwapView {
     await TestHelpers.delay(2000);
   }
 
+  static async tapToSwap() {
+    await waitFor(element(by.id(SwapsViewSelectors.TAP_TO_SWAP_BUTTON)))
+      .toBeVisible(100)
+      .withTimeout(8000);
+    await TestHelpers.delay(3000);
+    await TestHelpers.tapByText('Swap');
+    await TestHelpers.delay(2000);
+  }
+
   static async waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol) {
     try {
       await TestHelpers.checkIfElementByTextIsVisible(

--- a/e2e/selectors/swaps/SwapsView.selectors.js
+++ b/e2e/selectors/swaps/SwapsView.selectors.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/prefer-default-export
 export const SwapsViewSelectors = {
   SWIPE_TO_SWAP_BUTTON: 'swipe-to-swap-button',
+  TAP_TO_SWAP_BUTTON: 'tap-to-swap-button',
   SWAP_QUOTE_SUMMARY: 'swap-quote-summary',
   SWAP_GAS_FEE: 'swap-gas-fee',
 };

--- a/e2e/specs/swaps/swap-action-regression.spec.js
+++ b/e2e/specs/swaps/swap-action-regression.spec.js
@@ -79,7 +79,7 @@ describe(Regression('Multiple Swaps from Actions'), () => {
       }
       await QuoteView.tapOnGetQuotes();
       await SwapView.tapIUnderstandPriceWarning();
-      await SwapView.swipeToSwap();
+      await SwapView.tapToSwap();
       await SwapView.waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol);
       await TabBarComponent.tapActivity();
       await ActivitiesView.isVisible();

--- a/e2e/specs/swaps/swap-action-smoke.spec.js
+++ b/e2e/specs/swaps/swap-action-smoke.spec.js
@@ -81,7 +81,7 @@ describe(SmokeSwaps('Swap from Actions'), () => {
       await QuoteView.tapOnGetQuotes();
       await SwapView.isVisible();
       await SwapView.tapIUnderstandPriceWarning();
-      await SwapView.swipeToSwap();
+      await SwapView.tapToSwap();
       await SwapView.waitForSwapToComplete(sourceTokenSymbol, destTokenSymbol);
       await Assertions.checkIfVisible(TabBarComponent.tabBarActivityButton);
       await TabBarComponent.tapActivity();

--- a/e2e/specs/swaps/swap-token-chart.spec.js
+++ b/e2e/specs/swaps/swap-token-chart.spec.js
@@ -61,7 +61,7 @@ describe(Regression('Swap from Token view'), () => {
     await QuoteView.tapOnGetQuotes();
     await SwapView.isVisible();
     await SwapView.tapIUnderstandPriceWarning();
-    await SwapView.swipeToSwap();
+    await SwapView.tapToSwap();
     await SwapView.waitForSwapToComplete('USDC', 'DAI');
   });
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2640,9 +2640,7 @@
     "edit": "Edit",
     "quotes_include_fee": "Quotes include a {{fee}}% MetaMask fee",
     "tap_to_swap": "Tap to Swap",
-    "swipe_to_swap": "Swipe to swap",
-    "swipe_to": "Swipe to",
-    "swap": "swap",
+    "swap": "Swap",
     "completed_swap": "Swap!",
     "metamask_swap_fee": "MetaMask Swap fee",
     "fee_text": {

--- a/wdio/screen-objects/testIDs/Screens/SwapView.js
+++ b/wdio/screen-objects/testIDs/Screens/SwapView.js
@@ -1,4 +1,5 @@
 export const SWIPE_TO_SWAP_BUTTON = 'swipe-to-swap-button';
+export const TAP_TO_SWAP_BUTTON = 'tap-to-swap-button';
 export const SWAP_QUOTE_SUMMARY = 'swap-quote-summary';
 export const SWAP_GAS_FEE = 'swap-gas-fee';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR replaces the Swaps slider button with a normal primary button.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go Swaps
2. Fetch a quote for a Swap
3. Execute a Swap by pressing the Swap button (with Smart Transactions on and off)
4. Transaction should execute without failures

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
