### PR TITLE
fix: limit ReactNativeWebview message size

### DIFF
--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -71,6 +71,9 @@ import {
   PHISHFORT_BLOCKLIST_ISSUE_URL,
   MM_ETHERSCAN_URL,
 } from '../../../constants/urls';
+import {
+  MAX_MESSAGE_LENGTH,
+} from '../../../constants/dapp';
 import sanitizeUrlInput from '../../../util/url/sanitizeUrlInput';
 import {
   getPermittedAccounts,
@@ -121,7 +124,6 @@ const { HOMEPAGE_URL, NOTIFICATION_NAMES, OLD_HOMEPAGE_URL_HOST } =
   AppConstants;
 const HOMEPAGE_HOST = new URL(HOMEPAGE_URL)?.hostname;
 const MM_MIXPANEL_TOKEN = process.env.MM_MIXPANEL_TOKEN;
-const MAX_MESSAGE_LENGTH = 1000000;
 
 const createStyles = (colors, shadows) =>
   StyleSheet.create({

--- a/app/components/Views/BrowserTab/index.js
+++ b/app/components/Views/BrowserTab/index.js
@@ -121,6 +121,7 @@ const { HOMEPAGE_URL, NOTIFICATION_NAMES, OLD_HOMEPAGE_URL_HOST } =
   AppConstants;
 const HOMEPAGE_HOST = new URL(HOMEPAGE_URL)?.hostname;
 const MM_MIXPANEL_TOKEN = process.env.MM_MIXPANEL_TOKEN;
+const MAX_MESSAGE_LENGTH = 1000000;
 
 const createStyles = (colors, shadows) =>
   StyleSheet.create({
@@ -971,6 +972,15 @@ export const BrowserTab = (props) => {
   const onMessage = ({ nativeEvent }) => {
     let data = nativeEvent.data;
     try {
+      if (data.length > MAX_MESSAGE_LENGTH) {
+        console.warn(
+          `message exceeded size limit and will be dropped: ${data.slice(
+            0,
+            1000,
+          )}...`,
+        );
+        return;
+      }
       data = typeof data === 'string' ? JSON.parse(data) : data;
       if (!data || (!data.type && !data.name)) {
         return;

--- a/app/constants/dapp.ts
+++ b/app/constants/dapp.ts
@@ -1,0 +1,4 @@
+/**
+ * Max dapp message length
+ */
+export const MAX_MESSAGE_LENGTH = 1_000_000;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces a message size filter to the ReactNativeWebView created for dapps. Please see attached ticket for more info.


## **Related issues**

See: https://github.com/MetaMask/MetaMask-planning/issues/2836

## **Manual testing steps**

See ticket

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/97001330-8c72-4275-a70e-6dda59f499da

See that upon clicking the button, the app is unresponsive for many seconds. It doesn't completely crash, but it might crash on a slower device. It's certainly extremely slow until the message is fully resolved.

### **After**

https://github.com/user-attachments/assets/e1797c1a-ebe0-4e8d-bf5a-9dc8ee705508

Note that it is still a bit sluggish, but it prints the error message fairly quickly and then is responsive again.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- ~[ ] I’ve included tests if applicable~
  - Tests are certainly applicable, but I don't know how to test this. The `BrowserTab` component is very complex and has no pre-existing unit test (no real ones at least, the snapshot test currently present doesn't even execute any part of `BrowserTab`). We cannot even render that in a test without a great deal of mocks, I am unsure how to accomplish that. We could e2e test this, but this is a niche case that maybe doesn't warrant inclusion there either.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
