### PR TITLE
chore: abort on fail smoke e2e pipeline

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -50,7 +50,6 @@ pipelines:
       - notify: {}
   #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
   pr_smoke_e2e_pipeline:
-    abort_on_fail: true
     stages:
       - build_smoke_e2e_ios_android_stage: {}
       - run_smoke_e2e_ios_android_stage: {}
@@ -116,7 +115,6 @@ stages:
       - ios_e2e_build: {}
       - android_e2e_build: {}
   run_smoke_e2e_ios_android_stage:
-    abort_on_fail: true
     workflows:
       - run_ios_api_specs: {}
       - run_tag_smoke_accounts_ios: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -50,6 +50,7 @@ pipelines:
       - notify: {}
   #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
   pr_smoke_e2e_pipeline:
+    abort_on_fail: true
     stages:
       - build_smoke_e2e_ios_android_stage: {}
       - run_smoke_e2e_ios_android_stage: {}
@@ -110,10 +111,12 @@ stages:
     workflows:
       - ios_e2e_test: {}
   build_smoke_e2e_ios_android_stage:
+    abort_on_fail: true
     workflows:
       - ios_e2e_build: {}
       - android_e2e_build: {}
   run_smoke_e2e_ios_android_stage:
+    abort_on_fail: true
     workflows:
       - run_ios_api_specs: {}
       - run_tag_smoke_accounts_ios: {}


### PR DESCRIPTION
## **Description**

This pr aborts on fail smoke e2e pipeline when a build stage fails, this will help save credits.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
