### PR TITLE
chore: fix release action

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1503,8 +1503,6 @@ trigger_map:
     pipeline: release_e2e_pipeline
   - push_branch: main
     pipeline: pr_smoke_e2e_pipeline
-  - tag: 'v*.*.*-RC-*'
-    pipeline: release_builds_to_store_pipeline
   - tag: 'qa-*'
     pipeline: create_qa_builds_pipeline
   - tag: 'dev-e2e-*'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,8 +12,7 @@ pipelines:
   #Builds MetaMask, MetaMask-QA apps and stores apk/ipa in Bitrise
   build_all_targets_pipeline:
     stages:
-      - create_build_release: {}
-      - create_build_qa: {} #Generate QA builds for E2E app upgrade tests
+      - create_build_all_targets: {}
   #Releases MetaMask apps and stores apk/ipa into Play(Internal Testing)/App(TestFlight) Store
   release_builds_to_store_pipeline:
     stages:
@@ -73,6 +72,12 @@ pipelines:
 
 #Stages reference workflows. Those workflows cannot but utility "_this-is-a-utility"
 stages:
+  create_build_all_targets:
+    workflows:
+      - build_android_release: {}
+      - build_ios_release: {}
+      - build_android_qa: {}
+      - build_ios_qa: {}
   create_build_release:
     workflows:
       - build_android_release: {}

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -14,7 +14,8 @@ if [[ -z $NEW_VERSION ]]; then
 fi
 
 RELEASE_BRANCH_NAME="${RELEASE_BRANCH_PREFIX}${NEW_VERSION}"
-RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}. The test plan can be found at [commit.csv](https://github.com/MetaMask/metamask-mobile/blob/${RELEASE_BRANCH_NAME}/commits.csv)"
+CHANGELOG_BRANCH_NAME="chore/${NEW_VERSION}-Changelog"
+RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}. The changelog will be found in another PR ${CHANGELOG_BRANCH_NAME}."
 
 git config user.name metamaskbot
 git config user.email metamaskbot@users.noreply.github.com
@@ -35,15 +36,9 @@ gh pr create \
   --body "${RELEASE_BODY}" \
   --head "${RELEASE_BRANCH_NAME}";
 
-CHANGELOG_BRANCH_NAME="${RELEASE_BRANCH_NAME}-Changelog"
 
 git checkout -b "${CHANGELOG_BRANCH_NAME}"
 
-if ! (git add . && git commit -m "${NEW_VERSION}");
-then
-    echo "Error: No changes detected."
-    exit 1
-fi
 
 #Generate changelog and test plan csv
 node ./scripts/generate-rc-commits.mjs "${PREVIOUS_VERSION}" "${RELEASE_BRANCH_NAME}" 
@@ -51,7 +46,11 @@ node ./scripts/generate-rc-commits.mjs "${PREVIOUS_VERSION}" "${RELEASE_BRANCH_N
 
 git add ./commits.csv
 
-git commit -am "updated changelog and generated feature test plan"
+if ! (git commit -am "updated changelog and generated feature test plan");
+then
+    echo "Error: No changes detected."
+    exit 1
+fi
 
 PR_BODY="This is PR updateds the change log for ${NEW_VERSION} and generates the test plan here [commit.csv](https://github.com/MetaMask/metamask-mobile/blob/${RELEASE_BRANCH_NAME}/commits.csv)"
 

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -35,9 +35,31 @@ gh pr create \
   --body "${RELEASE_BODY}" \
   --head "${RELEASE_BRANCH_NAME}";
 
+CHANGELOG_BRANCH_NAME="${RELEASE_BRANCH_NAME}-Changelog"
+
+git checkout -b "${CHANGELOG_BRANCH_NAME}"
+
+if ! (git add . && git commit -m "${NEW_VERSION}");
+then
+    echo "Error: No changes detected."
+    exit 1
+fi
+
 #Generate changelog and test plan csv
 node ./scripts/generate-rc-commits.mjs "${PREVIOUS_VERSION}" "${RELEASE_BRANCH_NAME}" 
 ./scripts/changelog-csv.sh  "${RELEASE_BRANCH_NAME}" 
+
 git add ./commits.csv
+
 git commit -am "updated changelog and generated feature test plan"
-git push
+
+PR_BODY="This is PR updateds the change log for ${NEW_VERSION} and generates the test plan here [commit.csv](https://github.com/MetaMask/metamask-mobile/blob/${RELEASE_BRANCH_NAME}/commits.csv)"
+
+git push --set-upstream origin "${CHANGELOG_BRANCH_NAME}"
+
+gh pr create \
+  --draft \
+  --title "chore: ${CHANGELOG_BRANCH_NAME}" \
+  --body "${PR_BODY}" \
+  --base "${RELEASE_BRANCH_NAME}" \
+  --head "${CHANGELOG_BRANCH_NAME}";


### PR DESCRIPTION
## **Description**

The current [release action fails](https://github.com/MetaMask/metamask-mobile/actions/runs/10011339127/job/27674536322#step:6:25) due when it tries to push the changelog updates to the protected release branch. 

It also updates the build_all_targets_pipeline to start QA and Prod builds at the same time instead of staggering them.

## **Related issues**

Fixes: AN

## **Manual testing steps**

1. NA
2.
3.

## **Screenshots/Recordings**

NA

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
