### PR TITLE
chore: move detox setup into its own script

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -264,7 +264,7 @@ workflows:
         inputs:
           - content: |-
               #!/usr/bin/env bash
-              ./scripts/setup-detox.sh
+              scripts/detox-setup.sh
         title: Install Detox Dependencies
 
   # Notifications utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -264,7 +264,7 @@ workflows:
         inputs:
           - content: |-
               #!/usr/bin/env bash
-              scripts/setup-detox.sh
+              ./scripts/setup-detox.sh
         title: Install Detox Dependencies
 
   # Notifications utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,6 +214,7 @@ workflows:
   code_setup:
     before_run:
       - setup
+      - install_detox
       - prep_environment
     steps:
       - restore-cocoapods-cache@2: {}
@@ -258,6 +259,12 @@ workflows:
                 echo "Corepack enabling $YARN_VERSION"
                 corepack enable
           title: Install node, yarn and corepack
+  install_detox:
+    steps:
+    - yarn@0:
+        inputs:
+           - args: ''
+           - command: setup:detox-e2e
 
   # Notifications utility workflows
   # Provides values for commit or branch message and path depending on commit env setup initialised or not
@@ -610,6 +617,7 @@ workflows:
   android_e2e_test:
     before_run:
       - setup
+      - install_detox
       - prep_environment
     after_run:
       - notify_failure
@@ -708,6 +716,7 @@ workflows:
   ios_api_specs:
     before_run:
       - setup
+      - install_detox
       - prep_environment
     after_run:
       - notify_failure
@@ -859,6 +868,7 @@ workflows:
   ios_e2e_test:
     before_run:
       - setup
+      - install_detox
       - prep_environment
     after_run:
       - notify_failure

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,7 +214,6 @@ workflows:
   code_setup:
     before_run:
       - setup
-      - install_detox
       - prep_environment
     steps:
       - restore-cocoapods-cache@2: {}
@@ -261,10 +260,12 @@ workflows:
           title: Install node, yarn and corepack
   install_detox:
     steps:
-    - yarn@0:
+    - script@1:
         inputs:
-           - args: ''
-           - command: setup:detox-e2e
+          - content: |-
+              #!/usr/bin/env bash
+              scripts/setup-detox.sh
+        title: Install Detox Dependencies
 
   # Notifications utility workflows
   # Provides values for commit or branch message and path depending on commit env setup initialised or not
@@ -536,6 +537,7 @@ workflows:
   android_e2e_build:
     before_run:
       - code_setup
+      - install_detox
       - set_commit_hash
     after_run:
       - notify_failure
@@ -783,6 +785,7 @@ workflows:
   ios_e2e_build:
     before_run:
       - code_setup
+      - install_detox
       - set_commit_hash
     after_run:
       - notify_failure

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "setup": "yarn clean && node scripts/setup.mjs",
     "setup:node": "yarn clean:node && yarn allow-scripts && yarn patch-package",
     "setup:e2e": "cd wdio && yarn install",
+    "setup:detox-e2e": "./scripts/detox-setup.sh",
     "start:ios": "./scripts/build.sh ios debug",
     "start:ios:qa": "./scripts/build.sh ios qaDebug",
     "start:ios:e2e": "./scripts/build.sh ios debugE2E",

--- a/scripts/detox-setup.sh
+++ b/scripts/detox-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Install detox-cli
+echo "Installing detox-cli..."
+yarn global add detox-cli
+
+# Install applesimutils
+echo "Installing applesimutils..."
+brew tap wix/brew
+brew install applesimutils
+
+echo "Installation complete."

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,36 +13,7 @@ const rendererOptions = {
   collapseSubtasks: false
 };
 
-/*
- * FIXME: We shouldn't be making system wide installs without user consent.
- * Should make it optional on non-CI environments
-*/
-const detoxGlobalInstallTask = {
-  title: 'Install Detox utils',
-  task: (_, task) => task.newListr([
-    {
-      title: 'Install detox-cli globally',
-      task: async () => {
-        await $`yarn global add detox-cli`;
-      }
-    },
-    {
-      title: 'Install applesimutils globally',
-      task: async (_, appSimTask) => {
-        if (!IS_OSX) {
-          appSimTask.skip('Not macOS.');
-        } else {
-          await $`brew tap wix/brew`;
-          await $`brew install applesimutils`;
-        }
-      }
-    }
-  ],
-    {
-     rendererOptions
-    }
-  )
-};
+
 
 /*
  * TODO: parse example env file and add missing variables to existing .js.env
@@ -148,7 +119,6 @@ const mainSetupTask = {
       },
     },
     copyEnvVarsTask,
-    detoxGlobalInstallTask
   ],
     {
       exitOnError: false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Purpose of this PR is to create a separate yarn script to install detox dependencies. 


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
