### PR TITLE
fix: App crashes when deleting browser favorites on android devices

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -783,11 +783,12 @@ export const getRpcMethodMiddleware = ({
 
       metamask_removeFavorite: async () => {
         checkTabActive();
-        const { bookmarks } = store.getState();
 
         if (!isHomepage()) {
           throw providerErrors.unauthorized('Forbidden.');
         }
+
+        const { bookmarks } = store.getState();
 
         return new Promise<void>((resolve) => {
           Alert.alert(

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -783,45 +783,49 @@ export const getRpcMethodMiddleware = ({
 
       metamask_removeFavorite: async () => {
         checkTabActive();
+        const { bookmarks } = store.getState();
+
         if (!isHomepage()) {
           throw providerErrors.unauthorized('Forbidden.');
         }
 
-        const { bookmarks } = store.getState();
-
-        Alert.alert(
-          strings('browser.remove_bookmark_title'),
-          strings('browser.remove_bookmark_msg'),
-          [
-            {
-              text: strings('browser.cancel'),
-              onPress: () => {
-                res.result = {
-                  favorites: bookmarks,
-                };
+        return new Promise<void>((resolve) => {
+          Alert.alert(
+            strings('browser.remove_bookmark_title'),
+            strings('browser.remove_bookmark_msg'),
+            [
+              {
+                text: strings('browser.cancel'),
+                onPress: () => {
+                  res.result = {
+                    favorites: bookmarks,
+                  };
+                  resolve();
+                },
+                style: 'cancel',
               },
-              style: 'cancel',
-            },
-            {
-              text: strings('browser.yes'),
-              onPress: () => {
-                const bookmark = { url: req.params[0] };
+              {
+                text: strings('browser.yes'),
+                onPress: () => {
+                  const bookmark = { url: req.params[0] };
 
-                store.dispatch(removeBookmark(bookmark));
+                  store.dispatch(removeBookmark(bookmark));
 
-                const { bookmarks: updatedBookmarks } = store.getState();
+                  const { bookmarks: updatedBookmarks } = store.getState();
 
-                if (isHomepage()) {
-                  injectHomePageScripts(updatedBookmarks);
-                }
+                  if (isHomepage()) {
+                    injectHomePageScripts(updatedBookmarks);
+                  }
 
-                res.result = {
-                  favorites: bookmarks,
-                };
+                  res.result = {
+                    favorites: bookmarks,
+                  };
+                  resolve();
+                },
               },
-            },
-          ],
-        );
+            ],
+          );
+        });
       },
 
       metamask_showTutorial: async () => {


### PR DESCRIPTION
## **Description**

Added a resolve() to the `metamask_removeFavorite` function to stop Hermes from crashing when trying to handle the Promise. 

Hermes would crash when trying to handle the Promise of the `Alert` method. Adding a `resolve()` fixes this issue and stops the app from crashing.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/10583

## **Manual testing steps**

1. Go to the web browser and visit a random website of your choosing.
2. Add said site to favourites (or favorites if you're based in North America).
3. Go back to favourites tab and delete the bookmark you just added.
4. Observe that an alert is displayed and the app does not crash to desktop.

## **Screenshots/Recordings**

### **Before**
https://github.com/user-attachments/assets/cc8c1a85-41a6-4b6b-829a-12b1c8ba83b0
### **After**
![fix](https://github.com/user-attachments/assets/40543a47-216c-4a9d-849c-caad477af820)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
