### PR TITLE
fix: hold to reveal UI/UX

### DIFF
--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
-import Icon from 'react-native-vector-icons/FontAwesome5';
+import Icon, {
+  IconSize,
+  IconName,
+} from '../../../component-library/components/Icons/Icon';
 import { fontStyles } from '../../../styles/common';
 import Svg, { Circle } from 'react-native-svg';
 import Animated, {
@@ -19,7 +22,6 @@ const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 const radius = 14;
 const strokeWidth = 2;
-const iconSize = radius - 4;
 const innerRadius = radius - strokeWidth / 2;
 const circumference = 2 * Math.PI * innerRadius;
 const animationDuration = 1200;
@@ -53,18 +55,15 @@ const createStyles = (colors: any) =>
     preCompletedContainerStyle: {
       ...StyleSheet.absoluteFillObject,
       borderRadius: radius,
-      backgroundColor: colors.primary.default,
     },
     outerCircle: {
       ...StyleSheet.absoluteFillObject,
       borderRadius: radius,
-      backgroundColor: colors.primary.inverse,
     },
     innerCircle: {
       flex: 1,
       borderRadius: radius - strokeWidth,
       margin: strokeWidth,
-      backgroundColor: colors.primary.default,
     },
     label: {
       color: colors.primary.inverse,
@@ -219,7 +218,6 @@ const ButtonReveal = ({ onLongPress, label }: Props) => {
 
   const lockIconStyle = useAnimatedStyle(() => ({
     opacity: pressControl.value,
-    // transform: [{ scale: pressControl.value }],
   }));
 
   const checkIconStyle = useAnimatedStyle(() => ({
@@ -255,9 +253,9 @@ const ButtonReveal = ({ onLongPress, label }: Props) => {
       </Animated.View>
       <Animated.View style={[styles.absoluteFillWithCenter, checkIconStyle]}>
         <Icon
-          name={'check'}
+          name={IconName.Check}
           color={colors.primary.inverse}
-          size={iconSize * 1.5}
+          size={IconSize.Lg}
         />
       </Animated.View>
     </View>
@@ -267,17 +265,14 @@ const ButtonReveal = ({ onLongPress, label }: Props) => {
     <Animated.View
       style={[styles.preCompletedContainerStyle, preCompletedContainerStyle]}
     >
-      <Animated.View style={[styles.absoluteFillWithCenter, lockIconStyle]}>
-        <Icon name={'lock'} color={colors.primary.inverse} size={iconSize} />
-      </Animated.View>
       <Svg style={styles.absoluteFill}>
         <Circle
           cx={radius}
           cy={radius}
           r={innerRadius}
-          stroke={colors.primary.alternative}
           strokeWidth={strokeWidth}
           strokeLinecap={'round'}
+          fill={colors.primary.inverse}
         />
       </Svg>
       <Svg style={[styles.absoluteFill, styles.animatedCircle]}>
@@ -286,12 +281,20 @@ const ButtonReveal = ({ onLongPress, label }: Props) => {
           cx={radius}
           cy={radius}
           r={innerRadius}
-          stroke={colors.primary.inverse}
+          stroke={colors.primary.alternative}
           strokeWidth={strokeWidth}
           strokeLinecap={'round'}
           strokeDasharray={`${circumference} ${circumference}`}
+          fill={colors.primary.inverse}
         />
       </Svg>
+      <Animated.View style={[styles.absoluteFillWithCenter, lockIconStyle]}>
+        <Icon
+          name={IconName.Lock}
+          color={colors.primary.default}
+          size={IconSize.Sm}
+        />
+      </Animated.View>
     </Animated.View>
   );
 

--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -55,15 +55,18 @@ const createStyles = (colors: any) =>
     preCompletedContainerStyle: {
       ...StyleSheet.absoluteFillObject,
       borderRadius: radius,
+      backgroundColor: colors.primary.default,
     },
     outerCircle: {
       ...StyleSheet.absoluteFillObject,
       borderRadius: radius,
+      backgroundColor: colors.primary.inverse,
     },
     innerCircle: {
       flex: 1,
       borderRadius: radius - strokeWidth,
       margin: strokeWidth,
+      backgroundColor: colors.primary.default,
     },
     label: {
       color: colors.primary.inverse,
@@ -270,6 +273,7 @@ const ButtonReveal = ({ onLongPress, label }: Props) => {
           cx={radius}
           cy={radius}
           r={innerRadius}
+          stroke={colors.primary.alternative}
           strokeWidth={strokeWidth}
           strokeLinecap={'round'}
           fill={colors.primary.inverse}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the UI/UX related to "Hold to reveal"

## **Related issues**

Fixes: NA

## **Manual testing steps**

1. Go to the Security & Privacy view
2. Try to reveal the SRP and/or Private Key
3. Verify that the hold to reveal UI/UX is fixed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

| Dark mode | Light mode |
|-----------|------------|
| <video src="https://github.com/user-attachments/assets/1b568844-0df6-4ea1-a92e-81d62c8b7ca0" /> | <video src="https://github.com/user-attachments/assets/40a50064-0bb9-47c9-bcb2-f530af32c71c" /> |

### **After**

| Dark mode | Light mode |
|-----------|------------|
| <video src="https://github.com/user-attachments/assets/2cbff7c1-bc8d-440e-851f-4b16a48c3da9" /> | <video src="https://github.com/user-attachments/assets/5f8b8c83-d371-4c6d-b8c2-11cb58881897" /> |

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
