### PR TITLE
chore: cherry pick fix for aggregated balance calculation

### DIFF
--- a/app/core/Engine.test.js
+++ b/app/core/Engine.test.js
@@ -1,7 +1,9 @@
 import Engine from './Engine';
 import { backgroundState } from '../util/test/initial-root-state';
+import { zeroAddress } from 'ethereumjs-util';
 
 jest.unmock('./Engine');
+jest.mock('../store', () => ({ store: { getState: jest.fn(() => ({})) } }));
 
 describe('Engine', () => {
   it('should expose an API', () => {
@@ -90,5 +92,155 @@ describe('Engine', () => {
     expect(() => engine.setSelectedAccount(invalidAddress)).toThrow(
       `No account found for address: ${invalidAddress}`,
     );
+  });
+
+  describe('getTotalFiatAccountBalance', () => {
+    let engine;
+    afterEach(() => engine?.destroyEngineInstance());
+
+    const selectedAddress = '0x9DeE4BF1dE9E3b930E511Db5cEBEbC8d6F855Db0';
+    const chainId = '0x1';
+    const ticker = 'ETH';
+    const ethConversionRate = 4000; // $4,000 / ETH
+
+    const state = {
+      AccountsController: {
+        internalAccounts: {
+          selectedAccount: selectedAddress,
+          accounts: { [selectedAddress]: { address: selectedAddress } },
+        },
+      },
+      NetworkController: {
+        state: { providerConfig: { chainId, ticker } },
+      },
+      CurrencyRateController: {
+        currencyRates: {
+          [ticker]: { conversionRate: ethConversionRate },
+        },
+      },
+    };
+
+    it('calculates when theres no balances', () => {
+      engine = Engine.init(state);
+      const totalFiatBalance = engine.getTotalFiatAccountBalance();
+      expect(totalFiatBalance).toStrictEqual({
+        ethFiat: 0,
+        ethFiat1dAgo: 0,
+        tokenFiat: 0,
+        tokenFiat1dAgo: 0,
+      });
+    });
+
+    it('calculates when theres only ETH', () => {
+      const ethBalance = 1; // 1 ETH
+      const ethPricePercentChange1d = 5; // up 5%
+
+      engine = Engine.init({
+        ...state,
+        AccountTrackerController: {
+          accountsByChainId: {
+            [chainId]: {
+              [selectedAddress]: { balance: ethBalance * 1e18 },
+            },
+          },
+        },
+        TokenRatesController: {
+          marketData: {
+            [chainId]: {
+              [zeroAddress()]: {
+                pricePercentChange1d: ethPricePercentChange1d,
+              },
+            },
+          },
+        },
+      });
+
+      const totalFiatBalance = engine.getTotalFiatAccountBalance();
+
+      const ethFiat = ethBalance * ethConversionRate;
+      expect(totalFiatBalance).toStrictEqual({
+        ethFiat,
+        ethFiat1dAgo: ethFiat / (1 + ethPricePercentChange1d / 100),
+        tokenFiat: 0,
+        tokenFiat1dAgo: 0,
+      });
+    });
+
+    it('calculates when there are ETH and tokens', () => {
+      const ethBalance = 1;
+      const ethPricePercentChange1d = 5;
+
+      const tokens = [
+        {
+          address: '0x001',
+          balance: 1,
+          price: '1',
+          pricePercentChange1d: -1,
+        },
+        {
+          address: '0x002',
+          balance: 2,
+          price: '2',
+          pricePercentChange1d: 2,
+        },
+      ];
+
+      engine = Engine.init({
+        ...state,
+        AccountTrackerController: {
+          accountsByChainId: {
+            [chainId]: {
+              [selectedAddress]: { balance: ethBalance * 1e18 },
+            },
+          },
+        },
+        TokensController: {
+          tokens: tokens.map((token) => ({
+            address: token.address,
+            balance: token.balance,
+          })),
+        },
+        TokenRatesController: {
+          marketData: {
+            [chainId]: {
+              [zeroAddress()]: {
+                pricePercentChange1d: ethPricePercentChange1d,
+              },
+              ...tokens.reduce(
+                (acc, token) => ({
+                  ...acc,
+                  [token.address]: {
+                    price: token.price,
+                    pricePercentChange1d: token.pricePercentChange1d,
+                  },
+                }),
+                {},
+              ),
+            },
+          },
+        },
+      });
+
+      const totalFiatBalance = engine.getTotalFiatAccountBalance();
+
+      const ethFiat = ethBalance * ethConversionRate;
+      const [tokenFiat, tokenFiat1dAgo] = tokens.reduce(
+        ([fiat, fiat1d], token) => {
+          const value = token.balance * token.price * ethConversionRate;
+          return [
+            fiat + value,
+            fiat1d + value / (1 + token.pricePercentChange1d / 100),
+          ];
+        },
+        [0, 0],
+      );
+
+      expect(totalFiatBalance).toStrictEqual({
+        ethFiat,
+        ethFiat1dAgo: ethFiat / (1 + ethPricePercentChange1d / 100),
+        tokenFiat,
+        tokenFiat1dAgo,
+      });
+    });
   });
 });

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1625,9 +1625,7 @@ class Engine {
       toChecksumHexAddress(selectedInternalAccount.address);
     const { currentCurrency } = CurrencyRateController.state;
     const { chainId, ticker } = NetworkController.state.providerConfig;
-    const {
-      settings: { showFiatOnTestnets },
-    } = store.getState();
+    const { settings: { showFiatOnTestnets } = {} } = store.getState();
 
     if (isTestNet(chainId) && !showFiatOnTestnets) {
       return { ethFiat: 0, tokenFiat: 0, ethFiat1dAgo: 0, tokenFiat1dAgo: 0 };
@@ -1639,7 +1637,8 @@ class Engine {
 
     const { accountsByChainId } = AccountTrackerController.state;
     const { tokens } = TokensController.state;
-    const { marketData: tokenExchangeRates } = TokenRatesController.state;
+    const { marketData } = TokenRatesController.state;
+    const tokenExchangeRates = marketData?.[toHexadecimal(chainId)];
 
     let ethFiat = 0;
     let ethFiat1dAgo = 0;
@@ -1660,24 +1659,19 @@ class Engine {
       );
     }
 
+    const ethPricePercentChange1d =
+      tokenExchangeRates?.[zeroAddress() as Hex]?.pricePercentChange1d;
+
     ethFiat1dAgo =
-      ethFiat +
-        (ethFiat *
-          tokenExchangeRates?.[toHexadecimal(chainId)]?.[
-            zeroAddress() as `0x${string}`
-          ]?.pricePercentChange1d) /
-          100 || ethFiat;
+      ethPricePercentChange1d !== undefined
+        ? ethFiat / (1 + ethPricePercentChange1d / 100)
+        : ethFiat;
 
     if (tokens.length > 0) {
       const { contractBalances: tokenBalances } = TokenBalancesController.state;
-      const { marketData } = TokenRatesController.state;
-      const tokenExchangeRates = marketData[chainId];
       tokens.forEach(
         (item: { address: string; balance?: string; decimals: number }) => {
-          const exchangeRate =
-            tokenExchangeRates && item.address in tokenExchangeRates
-              ? tokenExchangeRates[item.address as Hex]?.price
-              : undefined;
+          const exchangeRate = tokenExchangeRates?.[item.address as Hex]?.price;
 
           const tokenBalance =
             item.balance ||
@@ -1696,12 +1690,13 @@ class Engine {
             decimalsToShow,
           );
 
+          const tokenPricePercentChange1d =
+            tokenExchangeRates?.[item.address as Hex]?.pricePercentChange1d;
+
           const tokenBalance1dAgo =
-            tokenBalanceFiat +
-              (tokenBalanceFiat *
-                tokenExchangeRates?.[item.address as `0x${string}`]
-                  ?.pricePercentChange1d) /
-                100 || tokenBalanceFiat;
+            tokenPricePercentChange1d !== undefined
+              ? tokenBalanceFiat / (1 + tokenPricePercentChange1d / 100)
+              : tokenBalanceFiat;
 
           tokenFiat += tokenBalanceFiat;
           tokenFiat1dAgo += tokenBalance1dAgo;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

Cherry picks https://github.com/MetaMask/metamask-mobile/pull/10404

## **Related issues**
#10406 

## **Manual testing steps**

1. Open a wallet with just eth, no erc20 tokens (or hide them all)
2. Verify the aggregated fiat balance % matches the balance % for ETH in the token list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Simplest case: a wallet with just eth. The aggregated balance should match ETH since it's the only token:

<img width="345" alt="Screenshot 2024-07-24 at 6 46 20 PM" src="https://github.com/user-attachments/assets/11f22fc7-abe8-46db-87d4-37f86fc8986d">



### **After**

<img width="344" alt="Screenshot 2024-07-24 at 6 45 54 PM" src="https://github.com/user-attachments/assets/7c982c95-ebce-437b-a394-f5b6d0d4601d">

Matches extension now:

<img width="878" alt="Screenshot 2024-07-24 at 6 41 16 PM" src="https://github.com/user-attachments/assets/c9c67a3e-07a9-4ea0-ad1a-d87dc37ca387">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
