### PR TITLE
feat: temp PR, multichain ui change of SwitchNetwork bottom sheet

### DIFF
--- a/app/components/UI/SwitchCustomNetwork/index.js
+++ b/app/components/UI/SwitchCustomNetwork/index.js
@@ -32,7 +32,7 @@ const createStyles = (colors) =>
       paddingBottom: Device.isIphoneX() ? 20 : 0,
     },
     intro: {
-      fontSize: Device.isSmallDevice() | isMutichainVersion1Enabled ? 18 : 24,
+      fontSize: Device.isSmallDevice() || isMutichainVersion1Enabled ? 18 : 24,
       marginBottom: 16,
       marginTop: 16,
       marginRight: 24,
@@ -212,6 +212,10 @@ const SwitchCustomNetwork = ({
     );
   }
 
+  const title = isMutichainVersion1Enabled
+    ? strings('switch_custom_network.title_enabled_network')
+    : strings('switch_custom_network.title_existing_network');
+
   return (
     <View style={styles.root}>
       {type === 'switch' ? (
@@ -219,9 +223,7 @@ const SwitchCustomNetwork = ({
       ) : null}
       <Text bold centered primary noMargin style={styles.intro}>
         {type === 'switch'
-          ? isMutichainVersion1Enabled
-            ? strings('switch_custom_network.title_enabled_network')
-            : strings('switch_custom_network.title_existing_network')
+          ? title
           : strings('switch_custom_network.title_new_network')}
       </Text>
       {!isMutichainVersion1Enabled && renderSwitchWarningText()}

--- a/app/components/UI/SwitchCustomNetwork/index.js
+++ b/app/components/UI/SwitchCustomNetwork/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import StyledButton from '../StyledButton';
 import { StyleSheet, View } from 'react-native';
@@ -8,7 +8,18 @@ import Device from '../../../util/device';
 import Text from '../../Base/Text';
 import { useTheme } from '../../../util/theme';
 import { CommonSelectorsIDs } from '../../../../e2e/selectors/Common.selectors';
-import { isMutichainVersion1Enabled } from '../../../util/networks';
+import {
+  getNetworkImageSource,
+  isMutichainVersion1Enabled,
+} from '../../../util/networks';
+import Avatar, {
+  AvatarSize,
+  AvatarVariant,
+} from '../../../component-library/components/Avatars/Avatar';
+import { IconName } from '../../../component-library/components/Icons/Icon';
+import TextComponent, {
+  TextVariant,
+} from '../../../component-library/components/Texts/Text';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -64,6 +75,16 @@ const createStyles = (colors) =>
     networkContainer: {
       alignItems: 'center',
     },
+    siteRequestInfoCard: {
+      marginLeft: 24,
+      marginTop: 8,
+      marginBottom: 12,
+      alignItems: 'center',
+      flexDirection: 'row',
+    },
+    siteRequestDetails: {
+      marginLeft: 12,
+    },
     networkBadge: {
       flexDirection: 'row',
       borderColor: colors.border.default,
@@ -74,6 +95,11 @@ const createStyles = (colors) =>
     networkText: {
       fontSize: 12,
       color: colors.text.default,
+    },
+    networkAvatar: { marginLeft: 2 },
+    permissionRequestNetworkInfo: {
+      flexDirection: 'row',
+      alignItems: 'center',
     },
   });
 
@@ -89,6 +115,15 @@ const SwitchCustomNetwork = ({
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
+
+  const networkImageSource = useCallback(
+    () =>
+      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
+      getNetworkImageSource({
+        chainId: customNetworkInformation?.chainId,
+      }),
+    [customNetworkInformation],
+  );
 
   /**
    * Calls onConfirm callback and analytics to track connect confirmed event
@@ -141,6 +176,42 @@ const SwitchCustomNetwork = ({
     );
   }
 
+  function renderSiteRequestInfoCard() {
+    return (
+      <View style={styles.siteRequestInfoCard}>
+        <Avatar
+          variant={AvatarVariant.Icon}
+          name={IconName.Data}
+          size={AvatarSize.Md}
+          backgroundColor={colors.shadow.default}
+          iconColor={colors.icon.alternative}
+        />
+        <View style={styles.siteRequestDetails}>
+          <TextComponent variant={TextVariant.BodyMD}>
+            {strings('switch_custom_network.use_enabled_networks')}
+          </TextComponent>
+          <View style={styles.permissionRequestNetworkInfo}>
+            <TextComponent>
+              <TextComponent variant={TextVariant.BodySM}>
+                {strings('switch_custom_network.requesting_for_network')}
+              </TextComponent>
+              <TextComponent variant={TextVariant.BodySMMedium}>
+                {customNetworkInformation.chainName}
+              </TextComponent>
+            </TextComponent>
+            <Avatar
+              style={styles.networkAvatar}
+              variant={AvatarVariant.Network}
+              size={AvatarSize.Xs}
+              name={customNetworkInformation.chainName}
+              imageSource={networkImageSource()}
+            />
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.root}>
       {type === 'switch' ? (
@@ -155,7 +226,12 @@ const SwitchCustomNetwork = ({
       </Text>
       {!isMutichainVersion1Enabled && renderSwitchWarningText()}
       {!isMutichainVersion1Enabled && type === 'switch' && renderNetworkBadge()}
-      <View style={styles.actionContainer(type === 'new')}>
+      {isMutichainVersion1Enabled && renderSiteRequestInfoCard()}
+      <View
+        style={styles.actionContainer(
+          type === 'new' || isMutichainVersion1Enabled,
+        )}
+      >
         <StyledButton
           type={'cancel'}
           onPress={cancel}

--- a/app/components/UI/SwitchCustomNetwork/index.js
+++ b/app/components/UI/SwitchCustomNetwork/index.js
@@ -8,6 +8,7 @@ import Device from '../../../util/device';
 import Text from '../../Base/Text';
 import { useTheme } from '../../../util/theme';
 import { CommonSelectorsIDs } from '../../../../e2e/selectors/Common.selectors';
+import { isMutichainVersion1Enabled } from '../../../util/networks';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -20,7 +21,7 @@ const createStyles = (colors) =>
       paddingBottom: Device.isIphoneX() ? 20 : 0,
     },
     intro: {
-      fontSize: Device.isSmallDevice() ? 18 : 24,
+      fontSize: Device.isSmallDevice() | isMutichainVersion1Enabled ? 18 : 24,
       marginBottom: 16,
       marginTop: 16,
       marginRight: 24,
@@ -103,6 +104,43 @@ const SwitchCustomNetwork = ({
     onCancel && onCancel();
   };
 
+  const renderSwitchWarningText = () => (
+    <Text primary noMargin style={styles.warning}>
+      {type === 'switch' ? (
+        strings('switch_custom_network.switch_warning')
+      ) : (
+        <Text>
+          <Text
+            bold
+            primary
+            noMargin
+          >{`"${customNetworkInformation.chainName}"`}</Text>
+          <Text noMargin> {strings('switch_custom_network.available')}</Text>
+        </Text>
+      )}
+    </Text>
+  );
+
+  function renderNetworkBadge() {
+    return (
+      <View style={styles.networkContainer}>
+        <View style={styles.networkBadge}>
+          <View
+            style={[
+              styles.networkIcon,
+              customNetworkInformation.chainColor
+                ? { backgroundColor: customNetworkInformation.chainColor }
+                : styles.otherNetworkIcon,
+            ]}
+          />
+          <Text primary noMargin style={styles.networkText}>
+            {customNetworkInformation.chainName}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.root}>
       {type === 'switch' ? (
@@ -110,40 +148,13 @@ const SwitchCustomNetwork = ({
       ) : null}
       <Text bold centered primary noMargin style={styles.intro}>
         {type === 'switch'
-          ? strings('switch_custom_network.title_existing_network')
+          ? isMutichainVersion1Enabled
+            ? strings('switch_custom_network.title_enabled_network')
+            : strings('switch_custom_network.title_existing_network')
           : strings('switch_custom_network.title_new_network')}
       </Text>
-      <Text primary noMargin style={styles.warning}>
-        {type === 'switch' ? (
-          strings('switch_custom_network.switch_warning')
-        ) : (
-          <Text>
-            <Text
-              bold
-              primary
-              noMargin
-            >{`"${customNetworkInformation.chainName}"`}</Text>
-            <Text noMargin> {strings('switch_custom_network.available')}</Text>
-          </Text>
-        )}
-      </Text>
-      {type === 'switch' ? (
-        <View style={styles.networkContainer}>
-          <View style={styles.networkBadge}>
-            <View
-              style={[
-                styles.networkIcon,
-                customNetworkInformation.chainColor
-                  ? { backgroundColor: customNetworkInformation.chainColor }
-                  : styles.otherNetworkIcon,
-              ]}
-            />
-            <Text primary noMargin style={styles.networkText}>
-              {customNetworkInformation.chainName}
-            </Text>
-          </View>
-        </View>
-      ) : null}
+      {!isMutichainVersion1Enabled && renderSwitchWarningText()}
+      {!isMutichainVersion1Enabled && type === 'switch' && renderNetworkBadge()}
       <View style={styles.actionContainer(type === 'new')}>
         <StyledButton
           type={'cancel'}
@@ -159,7 +170,9 @@ const SwitchCustomNetwork = ({
           containerStyle={[styles.button, styles.confirm]}
           testID={CommonSelectorsIDs.CONNECT_BUTTON}
         >
-          {strings('switch_custom_network.switch')}
+          {isMutichainVersion1Enabled
+            ? strings('confirmation_modal.confirm_cta')
+            : strings('switch_custom_network.switch')}
         </StyledButton>
       </View>
     </View>

--- a/app/components/UI/TransactionHeader/index.js
+++ b/app/components/UI/TransactionHeader/index.js
@@ -5,7 +5,9 @@ import { fontStyles } from '../../../styles/common';
 import { connect } from 'react-redux';
 import WebsiteIcon from '../WebsiteIcon';
 import { getHost, getUrlObj } from '../../../util/browser';
-import networkList from '../../../util/networks';
+import networkList, {
+  isMutichainVersion1Enabled,
+} from '../../../util/networks';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import AppConstants from '../../../core/AppConstants';
 import { renderShortAddress } from '../../../util/address';
@@ -25,9 +27,9 @@ const createStyles = (colors) =>
       alignItems: 'center',
     },
     domainLogo: {
-      width: 56,
-      height: 56,
-      borderRadius: 32,
+      width: isMutichainVersion1Enabled ? 28 : 56,
+      height: isMutichainVersion1Enabled ? 28 : 56,
+      borderRadius: 16,
     },
     assetLogo: {
       alignItems: 'center',
@@ -192,19 +194,31 @@ const TransactionHeader = (props) => {
     return <Text style={styles.domainUrl}>{title}</Text>;
   };
 
-  return (
-    <View style={styles.transactionHeader}>
-      {renderTopIcon()}
+  const renderDomainUrlContainer = () => {
+    return (
       <View style={styles.domanUrlContainer}>
         {renderSecureIcon()}
         {renderTitle()}
       </View>
+    );
+  };
+
+  const renderNetworkContainer = () => {
+    return (
       <View style={styles.networkContainer}>
         {renderNetworkStatusIndicator()}
         <Text style={styles.network}>
           {props.nickname || networkList[props.networkType]?.shortName}
         </Text>
       </View>
+    );
+  };
+
+  return (
+    <View style={styles.transactionHeader}>
+      {renderTopIcon()}
+      {isMutichainVersion1Enabled ? null : renderDomainUrlContainer()}
+      {isMutichainVersion1Enabled ? null : renderNetworkContainer()}
     </View>
   );
 };

--- a/app/components/UI/TransactionHeader/index.js
+++ b/app/components/UI/TransactionHeader/index.js
@@ -27,9 +27,9 @@ const createStyles = (colors) =>
       alignItems: 'center',
     },
     domainLogo: {
-      width: isMutichainVersion1Enabled ? 28 : 56,
-      height: isMutichainVersion1Enabled ? 28 : 56,
-      borderRadius: 16,
+      width: isMutichainVersion1Enabled ? 32 : 56,
+      height: isMutichainVersion1Enabled ? 32 : 56,
+      borderRadius: isMutichainVersion1Enabled ? 16 : 32,
     },
     assetLogo: {
       alignItems: 'center',

--- a/app/components/UI/TransactionHeader/index.js
+++ b/app/components/UI/TransactionHeader/index.js
@@ -194,25 +194,21 @@ const TransactionHeader = (props) => {
     return <Text style={styles.domainUrl}>{title}</Text>;
   };
 
-  const renderDomainUrlContainer = () => {
-    return (
-      <View style={styles.domanUrlContainer}>
-        {renderSecureIcon()}
-        {renderTitle()}
-      </View>
-    );
-  };
+  const renderDomainUrlContainer = () => (
+    <View style={styles.domanUrlContainer}>
+      {renderSecureIcon()}
+      {renderTitle()}
+    </View>
+  );
 
-  const renderNetworkContainer = () => {
-    return (
-      <View style={styles.networkContainer}>
-        {renderNetworkStatusIndicator()}
-        <Text style={styles.network}>
-          {props.nickname || networkList[props.networkType]?.shortName}
-        </Text>
-      </View>
-    );
-  };
+  const renderNetworkContainer = () => (
+    <View style={styles.networkContainer}>
+      {renderNetworkStatusIndicator()}
+      <Text style={styles.network}>
+        {props.nickname || networkList[props.networkType]?.shortName}
+      </Text>
+    </View>
+  );
 
   return (
     <View style={styles.transactionHeader}>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2801,6 +2801,7 @@
   },
   "switch_custom_network": {
     "title_existing_network": "This site would like to switch the network",
+    "title_enabled_network": "This site wants to:",
     "title_new_network": "New network added",
     "switch_warning": "This will switch the selected network within MetaMask to a previously added network:",
     "add_network_and_give_dapp_permission_warning": "You're adding this network to MetaMask and giving {{dapp_origin}} permission to use it.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2804,6 +2804,8 @@
     "title_enabled_network": "This site wants to:",
     "title_new_network": "New network added",
     "switch_warning": "This will switch the selected network within MetaMask to a previously added network:",
+    "use_enabled_networks": "Use your enabled networks",
+    "requesting_for_network": "Requesting for ",
     "add_network_and_give_dapp_permission_warning": "You're adding this network to MetaMask and giving {{dapp_origin}} permission to use it.",
     "available": "is now available in the network selector.",
     "cancel": "Cancel",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,12 +11,6 @@ sonar.sources=app/
 # Excluded project files from analysis.
 sonar.exclusions=**.stories.**
 
-# Excluded project files from coverage.
-# TODO: // remove files in sonar.coverage.exclusions and update unit tests for excluded files below,
-# these files are related to MM_MULTICHAIN_V1_ENABLED,
-# unit tests to be updated after legacy code is replaced by new code and feature flag removed.
-sonar.coverage.exclusions=app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
-
 # Inclusions for test files.
 sonar.test.inclusions=**.test.**
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,9 +9,12 @@ sonar.projectName=MetaMask Mobile Project
 sonar.sources=app/
 
 # Excluded project files from analysis.
-sonar.exclusions=**.stories.**, app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
+sonar.exclusions=**.stories.**
 
 # Excluded project files from coverage.
+# TODO: // remove files in sonar.coverage.exclusions and update unit tests for excluded files below,
+# these files are related to MM_MULTICHAIN_V1_ENABLED,
+# unit tests to be updated after legacy code is replaced by new code and feature flag removed.
 sonar.coverage.exclusions=app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
 
 # Inclusions for test files.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.sources=app/
 sonar.exclusions=**.stories.**, app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
 
 # Excluded project files from coverage.
-sonar.coverage.exclusions= app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
+sonar.coverage.exclusions=app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
 
 # Inclusions for test files.
 sonar.test.inclusions=**.test.**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,10 @@ sonar.projectName=MetaMask Mobile Project
 sonar.sources=app/
 
 # Excluded project files from analysis.
-sonar.exclusions=**.stories.**
+sonar.exclusions=**.stories.**, app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
+
+# Excluded project files from coverage.
+sonar.coverage.exclusions= app/components/UI/SwitchCustomNetwork/index.js, app/components/UI/TransactionHeader/index.js
 
 # Inclusions for test files.
 sonar.test.inclusions=**.test.**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
feat: multichain ui change of SwitchNetwork bottom sheet, only shows when feature flag is enabled, else keep existing UI

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Contributes to solve issue: https://github.com/MetaMask/MetaMask-planning/issues/2799

## **Manual testing steps**

1. Go to in app dapp browser and open a dapp like open sea
2. If Etheureum is the currently enabled network, switch to another of the enabled networks (make sure its already part of the enabled network by having been added before this step)
3. The new bottom sheet will show up with updated UI content

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

| Before       | After        |
|--------------|--------------|
| <img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/beab5090-6d8c-4887-9b85-cb27caf4fbd9"> |<img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/728a7c4f-2092-43c5-9691-6441e3ecd181"> |



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
