### PR TITLE
fix: issue in blockaid spinner for batched confirmations

### DIFF
--- a/app/components/Views/confirmations/Approval/index.js
+++ b/app/components/Views/confirmations/Approval/index.js
@@ -51,6 +51,7 @@ import { withMetricsAwareness } from '../../../../components/hooks/useMetrics';
 import { STX_NO_HASH_ERROR } from '../../../../util/smart-transactions/smart-publish-hook';
 import { getSmartTransactionMetricsProperties } from '../../../../util/smart-transactions';
 import { selectTransactionMetrics } from '../../../../core/redux/slices/transactionMetrics';
+import { selectCurrentTransactionSecurityAlertResponse } from '../../../../selectors/confirmTransaction';
 import { selectTransactions } from '../../../../selectors/transactionController';
 import { selectShowCustomNonce } from '../../../../selectors/settings';
 import { buildTransactionParams } from '../../../../util/confirmation/transactions';
@@ -130,6 +131,11 @@ class Approval extends PureComponent {
      * Object containing transaction metrics by id
      */
     transactionMetricsById: PropTypes.object,
+
+    /**
+     * Object containing blockaid validation response for confirmation
+     */
+    securityAlertResponse: PropTypes.object,
   };
 
   state = {
@@ -306,17 +312,10 @@ class Approval extends PureComponent {
   };
 
   getBlockaidMetricsParams = () => {
-    const { transaction } = this.props;
-    const { transactionSecurityAlertResponses, id } = transaction;
-
-    let blockaidParams = {};
-
-    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
-    if (securityAlertResponse) {
-      blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
-    }
-
-    return blockaidParams;
+    const { securityAlertResponse } = this.props;
+    return securityAlertResponse
+      ? getBlockaidMetricsParams(securityAlertResponse)
+      : {};
   };
 
   getAnalyticsParams = ({ gasEstimateType, gasSelected } = {}) => {
@@ -661,6 +660,7 @@ const mapStateToProps = (state) => ({
   activeTabUrl: getActiveTabUrl(state),
   shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
   transactionMetricsById: selectTransactionMetrics(state),
+  securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/confirmations/Approval/index.js
+++ b/app/components/Views/confirmations/Approval/index.js
@@ -307,15 +307,13 @@ class Approval extends PureComponent {
 
   getBlockaidMetricsParams = () => {
     const { transaction } = this.props;
+    const { transactionSecurityAlertResponses, id } = transaction;
 
     let blockaidParams = {};
 
-    if (
-      transaction.id === transaction.currentTransactionSecurityAlertResponse?.id
-    ) {
-      blockaidParams = getBlockaidMetricsParams(
-        transaction.currentTransactionSecurityAlertResponse?.response,
-      );
+    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+    if (securityAlertResponse) {
+      blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
     }
 
     return blockaidParams;

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -114,6 +114,7 @@ import { withMetricsAwareness } from '../../../../../components/hooks/useMetrics
 import {
   selectTransactionGasFeeEstimates,
   selectCurrentTransactionMetadata,
+  selectCurrentTransactionSecurityAlertResponse,
 } from '../../../../../selectors/confirmTransaction';
 import { selectGasFeeControllerEstimateType } from '../../../../../selectors/gasFeeController';
 import { createBuyNavigationDetails } from '../../../../UI/Ramp/routes/utils';
@@ -265,6 +266,10 @@ class Confirm extends PureComponent {
      * Indicates whether the transaction simulations feature is enabled
      */
     useTransactionSimulations: PropTypes.bool,
+    /**
+     * Object containing blockaid validation response for confirmation
+     */
+    securityAlertResponse: PropTypes.object,
   };
 
   state = {
@@ -1172,11 +1177,9 @@ class Confirm extends PureComponent {
   };
 
   getConfirmButtonStyles() {
-    const { transaction } = this.props;
-    const { transactionSecurityAlertResponses, id } = transaction;
+    const { securityAlertResponse } = this.props;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
-    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
 
     let confirmButtonStyle = {};
     if (securityAlertResponse) {
@@ -1477,6 +1480,7 @@ const mapStateToProps = (state) => ({
   transactionSimulationData:
     selectCurrentTransactionMetadata(state)?.simulationData,
   useTransactionSimulations: selectUseTransactionSimulations(state),
+  securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -1172,27 +1172,17 @@ class Confirm extends PureComponent {
   };
 
   getConfirmButtonStyles() {
-    const { transactionMeta } = this.state;
     const { transaction } = this.props;
-    const { currentTransactionSecurityAlertResponse } = transaction;
+    const { transactionSecurityAlertResponses, id } = transaction;
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
+    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
 
     let confirmButtonStyle = {};
-    if (
-      transactionMeta.id &&
-      currentTransactionSecurityAlertResponse?.id &&
-      currentTransactionSecurityAlertResponse.id === transactionMeta.id
-    ) {
-      if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Malicious
-      ) {
+    if (securityAlertResponse) {
+      if (securityAlertResponse?.result_type === ResultType.Malicious) {
         confirmButtonStyle = styles.confirmButtonError;
-      } else if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Warning
-      ) {
+      } else if (securityAlertResponse?.result_type === ResultType.Warning) {
         confirmButtonStyle = styles.confirmButtonWarning;
       }
     }
@@ -1478,8 +1468,6 @@ const mapStateToProps = (state) => ({
   gasFeeEstimates: selectTransactionGasFeeEstimates(state),
   gasEstimateType: selectGasFeeControllerEstimateType(state),
   isPaymentRequest: state.transaction.paymentRequest,
-  securityAlertResponse:
-    state.transaction.currentTransactionSecurityAlertResponse,
   isNativeTokenBuySupported: isNetworkRampNativeTokenSupported(
     selectChainId(state),
     getRampNetworks(state),

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.test.tsx
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.test.tsx
@@ -53,9 +53,8 @@ const mockInitialState = {
     showHexData: true,
   },
   transaction: {
-    currentTransactionSecurityAlertResponse: {
-      id: 1,
-      response: {
+    transactionSecurityAlertResponses: {
+      1: {
         result_type: 'Malicious',
         reason: 'blur_farming',
         providerRequestsCount: {},

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.test.tsx
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.test.tsx
@@ -53,7 +53,7 @@ const mockInitialState = {
     showHexData: true,
   },
   transaction: {
-    transactionSecurityAlertResponses: {
+    securityAlertResponses: {
       1: {
         result_type: 'Malicious',
         reason: 'blur_farming',

--- a/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
@@ -85,6 +85,7 @@ import {
 import { selectTokenList } from '../../../../../selectors/tokenListController';
 import { selectTokensLength } from '../../../../../selectors/tokensController';
 import { selectAccountsLength } from '../../../../../selectors/accountTrackerController';
+import { selectCurrentTransactionSecurityAlertResponse } from '../../../../../selectors/confirmTransaction';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -283,6 +284,10 @@ class ApproveTransactionReview extends PureComponent {
      * Boolean that indicates if smart transaction should be used
      */
     shouldUseSmartTransaction: PropTypes.bool,
+    /**
+     * Object containing blockaid validation response for confirmation
+     */
+    securityAlertResponse: PropTypes.object,
   };
 
   state = {
@@ -731,10 +736,8 @@ class ApproveTransactionReview extends PureComponent {
   };
 
   getConfirmButtonState() {
-    const { transaction } = this.props;
-    const { id, transactionSecurityAlertResponses } = transaction;
+    const { securityAlertResponse } = this.props;
     let confirmButtonState = ConfirmButtonState.Normal;
-    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
 
     if (securityAlertResponse) {
       if (securityAlertResponse.result_type === ResultType.Malicious) {
@@ -1298,6 +1301,7 @@ const mapStateToProps = (state) => ({
     getRampNetworks(state),
   ),
   shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+  securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
@@ -732,22 +732,14 @@ class ApproveTransactionReview extends PureComponent {
 
   getConfirmButtonState() {
     const { transaction } = this.props;
-    const { id, currentTransactionSecurityAlertResponse } = transaction;
+    const { id, transactionSecurityAlertResponses } = transaction;
     let confirmButtonState = ConfirmButtonState.Normal;
-    if (
-      id &&
-      currentTransactionSecurityAlertResponse?.id &&
-      currentTransactionSecurityAlertResponse.id === id
-    ) {
-      if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Malicious
-      ) {
+    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+
+    if (securityAlertResponse) {
+      if (securityAlertResponse.result_type === ResultType.Malicious) {
         confirmButtonState = ConfirmButtonState.Error;
-      } else if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Warning
-      ) {
+      } else if (securityAlertResponse.result_type === ResultType.Warning) {
         confirmButtonState = ConfirmButtonState.Warning;
       }
     }

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
@@ -31,6 +31,7 @@ const mockState = {
     },
   },
   transaction: {
+    id: 123,
     securityAlertResponses: {
       123: {
         result_type: ResultType.Warning,

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
@@ -31,7 +31,7 @@ const mockState = {
     },
   },
   transaction: {
-    transactionSecurityAlertResponses: {
+    securityAlertResponses: {
       123: {
         result_type: ResultType.Warning,
         reason: Reason.approvalFarming,
@@ -65,14 +65,14 @@ describe('TransactionBlockaidBanner', () => {
     expect(await wrapper.queryByTestId(TESTID_ACCORDION_CONTENT)).toBeNull();
   });
 
-  it('should not render if transactionSecurityAlertResponses.id is undefined', async () => {
+  it('should not render if securityAlertResponses.id is undefined', async () => {
     const wrapper = renderWithProvider(
       <TransactionBlockaidBanner transactionId="123" />,
       {
         state: {
           ...mockState,
           transaction: {
-            transactionSecurityAlertResponses: {},
+            securityAlertResponses: {},
           },
         },
       },

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.test.tsx
@@ -31,9 +31,8 @@ const mockState = {
     },
   },
   transaction: {
-    currentTransactionSecurityAlertResponse: {
-      id: '123',
-      response: {
+    transactionSecurityAlertResponses: {
+      123: {
         result_type: ResultType.Warning,
         reason: Reason.approvalFarming,
         block: 123,
@@ -66,23 +65,18 @@ describe('TransactionBlockaidBanner', () => {
     expect(await wrapper.queryByTestId(TESTID_ACCORDION_CONTENT)).toBeNull();
   });
 
-  it('should not render if currentTransactionSecurityAlertResponse.id is undefined', async () => {
-    const wrapper = renderWithProvider(<TransactionBlockaidBanner />, {
-      state: {
-        ...mockState,
-        transaction: {
-          currentTransactionSecurityAlertResponse: {
-            response: {
-              result_type: ResultType.Warning,
-              reason: Reason.approvalFarming,
-              block: 123,
-              req: {},
-              chainId: '0x1',
-            },
+  it('should not render if transactionSecurityAlertResponses.id is undefined', async () => {
+    const wrapper = renderWithProvider(
+      <TransactionBlockaidBanner transactionId="123" />,
+      {
+        state: {
+          ...mockState,
+          transaction: {
+            transactionSecurityAlertResponses: {},
           },
         },
       },
-    });
+    );
 
     expect(wrapper).toMatchSnapshot();
     expect(await wrapper.queryByTestId(TESTID_ACCORDIONHEADER)).toBeNull();

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
@@ -10,17 +10,11 @@ const TransactionBlockaidBanner = (
 ) => {
   const { transactionId, ...rest } = bannerProps;
 
-  const securityAlertResponses = useSelector(
+  const securityAlertResponse = useSelector(
     selectCurrentTransactionSecurityAlertResponse,
   );
 
-  if (!transactionId) {
-    return null;
-  }
-
-  const securityAlertResponse = securityAlertResponses?.[transactionId];
-
-  if (!securityAlertResponse) {
+  if (!transactionId || !securityAlertResponse) {
     return null;
   }
 

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
@@ -1,25 +1,24 @@
 import React from 'react';
-import { TransactionBlockaidBannerProps } from './TransactionBlockaidBanner.types';
-import BlockaidBanner from '../BlockaidBanner/BlockaidBanner';
 import { useSelector } from 'react-redux';
+
+import { selectCurrentTransactionSecurityAlertResponse } from '../../../../../selectors/confirmTransaction';
+import BlockaidBanner from '../BlockaidBanner/BlockaidBanner';
+import { TransactionBlockaidBannerProps } from './TransactionBlockaidBanner.types';
 
 const TransactionBlockaidBanner = (
   bannerProps: TransactionBlockaidBannerProps,
 ) => {
   const { transactionId, ...rest } = bannerProps;
 
-  const transactionSecurityAlertResponses = useSelector(
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => state.transaction.transactionSecurityAlertResponses,
+  const securityAlertResponses = useSelector(
+    selectCurrentTransactionSecurityAlertResponse,
   );
 
   if (!transactionId) {
     return null;
   }
 
-  const securityAlertResponse =
-    transactionSecurityAlertResponses?.[transactionId];
+  const securityAlertResponse = securityAlertResponses?.[transactionId];
 
   if (!securityAlertResponse) {
     return null;

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/TransactionBlockaidBanner.tsx
@@ -8,25 +8,25 @@ const TransactionBlockaidBanner = (
 ) => {
   const { transactionId, ...rest } = bannerProps;
 
-  const securityAlertResponse = useSelector(
+  const transactionSecurityAlertResponses = useSelector(
     // TODO: Replace "any" with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => state.transaction.currentTransactionSecurityAlertResponse,
+    (state: any) => state.transaction.transactionSecurityAlertResponses,
   );
 
-  if (
-    !transactionId ||
-    !securityAlertResponse?.id ||
-    securityAlertResponse.id !== transactionId
-  ) {
+  if (!transactionId) {
+    return null;
+  }
+
+  const securityAlertResponse =
+    transactionSecurityAlertResponses?.[transactionId];
+
+  if (!securityAlertResponse) {
     return null;
   }
 
   return (
-    <BlockaidBanner
-      securityAlertResponse={securityAlertResponse.response}
-      {...rest}
-    />
+    <BlockaidBanner securityAlertResponse={securityAlertResponse} {...rest} />
   );
 };
 

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/__snapshots__/TransactionBlockaidBanner.test.tsx.snap
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/__snapshots__/TransactionBlockaidBanner.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TransactionBlockaidBanner should not render if transactionId passed is undefined 1`] = `null`;
 
-exports[`TransactionBlockaidBanner should not render if transactionSecurityAlertResponses.id is undefined 1`] = `null`;
+exports[`TransactionBlockaidBanner should not render if securityAlertResponses.id is undefined 1`] = `null`;
 
 exports[`TransactionBlockaidBanner should render correctly 1`] = `
 <View

--- a/app/components/Views/confirmations/components/TransactionBlockaidBanner/__snapshots__/TransactionBlockaidBanner.test.tsx.snap
+++ b/app/components/Views/confirmations/components/TransactionBlockaidBanner/__snapshots__/TransactionBlockaidBanner.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransactionBlockaidBanner should not render if currentTransactionSecurityAlertResponse.id is undefined 1`] = `null`;
-
 exports[`TransactionBlockaidBanner should not render if transactionId passed is undefined 1`] = `null`;
+
+exports[`TransactionBlockaidBanner should not render if transactionSecurityAlertResponses.id is undefined 1`] = `null`;
 
 exports[`TransactionBlockaidBanner should render correctly 1`] = `
 <View

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -10,7 +10,10 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import AppConstants from '../../../../../core/AppConstants';
 import Engine from '../../../../../core/Engine';
 import { SDKConnect } from '../../../../../core/SDKConnect/SDKConnect';
-import { selectCurrentTransactionMetadata } from '../../../../../selectors/confirmTransaction';
+import {
+  selectCurrentTransactionMetadata,
+  selectCurrentTransactionSecurityAlertResponse,
+} from '../../../../../selectors/confirmTransaction';
 import {
   selectConversionRate,
   selectCurrentCurrency,
@@ -269,6 +272,10 @@ class TransactionReview extends PureComponent {
      * Boolean that indicates if transaction simulations should be enabled
      */
     useTransactionSimulations: PropTypes.bool,
+    /**
+     * Object containing blockaid validation response for confirmation
+     */
+    securityAlertResponse: PropTypes.object,
   };
 
   state = {
@@ -358,10 +365,7 @@ class TransactionReview extends PureComponent {
   };
 
   onContactUsClicked = () => {
-    const { transaction, metrics } = this.props;
-    const { id, transactionSecurityAlertResponses } = transaction;
-    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
-
+    const { securityAlertResponse, metrics } = this.props;
     const additionalParams = {
       ...getBlockaidMetricsParams(securityAlertResponse),
       external_link_clicked: 'security_alert_support_link',
@@ -472,10 +476,8 @@ class TransactionReview extends PureComponent {
   }
 
   getConfirmButtonState() {
-    const { transaction } = this.props;
-    const { id, transactionSecurityAlertResponses } = transaction;
+    const { securityAlertResponse } = this.props;
     let confirmButtonState = ConfirmButtonState.Normal;
-    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
 
     if (securityAlertResponse) {
       if (securityAlertResponse?.result_type === ResultType.Malicious) {
@@ -702,6 +704,7 @@ const mapStateToProps = (state) => ({
   transactionSimulationData:
     selectCurrentTransactionMetadata(state)?.simulationData,
   useTransactionSimulations: selectUseTransactionSimulations(state),
+  securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
 });
 
 TransactionReview.contextType = ThemeContext;

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -359,12 +359,14 @@ class TransactionReview extends PureComponent {
 
   onContactUsClicked = () => {
     const { transaction, metrics } = this.props;
+    const { id, transactionSecurityAlertResponses } = transaction;
+    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+
     const additionalParams = {
-      ...getBlockaidMetricsParams(
-        transaction?.currentTransactionSecurityAlertResponse,
-      ),
+      ...getBlockaidMetricsParams(securityAlertResponse),
       external_link_clicked: 'security_alert_support_link',
     };
+
     metrics.trackEvent(
       MetaMetricsEvents.TRANSACTIONS_CONFIRM_STARTED,
       additionalParams,
@@ -471,22 +473,14 @@ class TransactionReview extends PureComponent {
 
   getConfirmButtonState() {
     const { transaction } = this.props;
-    const { id, currentTransactionSecurityAlertResponse } = transaction;
+    const { id, transactionSecurityAlertResponses } = transaction;
     let confirmButtonState = ConfirmButtonState.Normal;
-    if (
-      id &&
-      currentTransactionSecurityAlertResponse?.id &&
-      currentTransactionSecurityAlertResponse.id === id
-    ) {
-      if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Malicious
-      ) {
+    const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+
+    if (securityAlertResponse) {
+      if (securityAlertResponse?.result_type === ResultType.Malicious) {
         confirmButtonState = ConfirmButtonState.Error;
-      } else if (
-        currentTransactionSecurityAlertResponse?.response?.result_type ===
-        ResultType.Warning
-      ) {
+      } else if (securityAlertResponse?.result_type === ResultType.Warning) {
         confirmButtonState = ConfirmButtonState.Warning;
       }
     }

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -567,7 +567,7 @@ class TransactionReview extends PureComponent {
               confirmDisabled={
                 transactionConfirmed || Boolean(error) || isAnimating
               }
-              confirmButtonState={this.getConfirmButtonState()}
+              confirmButtonState={this.getConfirmButtonState.bind(this)()}
             >
               <View style={styles.actionViewChildren}>
                 <ScrollView nestedScrollEnabled>

--- a/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
@@ -161,9 +161,8 @@ jest.mock('react-redux', () => {
         ...mockState,
         transaction: {
           ...mockState.transaction,
-          currentTransactionSecurityAlertResponse: {
-            id: '123',
-            response: securityAlertResponse,
+          transactionSecurityAlertResponses: {
+            123: securityAlertResponse,
           },
         },
       }),
@@ -234,9 +233,8 @@ describe('TransactionReview', () => {
             ...mockState.transaction,
             id: '123',
             securityAlertResponse,
-            currentTransactionSecurityAlertResponse: {
-              id: '123',
-              response: securityAlertResponse,
+            transactionSecurityAlertResponses: {
+              123: securityAlertResponse,
             },
           },
         },
@@ -261,17 +259,9 @@ describe('TransactionReview', () => {
     fireEvent.press(await getByText('Report an issue'));
 
     expect(blockaidMetricsParamsSpy).toHaveBeenCalledTimes(1);
-    expect(blockaidMetricsParamsSpy).toHaveBeenCalledWith({
-      id: '123',
-      response: {
-        providerRequestsCount: {},
-        reason: 'blur_farming',
-        result_type: 'Malicious',
-        block: 123,
-        req: {},
-        chainId: '0x1',
-      },
-    });
+    expect(blockaidMetricsParamsSpy).toHaveBeenCalledWith(
+      securityAlertResponse,
+    );
   });
 
   it('should have enabled confirm button if from account has balance', async () => {

--- a/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
@@ -161,6 +161,7 @@ jest.mock('react-redux', () => {
         ...mockState,
         transaction: {
           ...mockState.transaction,
+          id: 123,
           securityAlertResponses: {
             123: securityAlertResponse,
           },
@@ -208,6 +209,7 @@ describe('TransactionReview', () => {
       block: 123,
       req: {},
       chainId: '0x1',
+      features: ['test', 'test'],
     };
 
     const blockaidMetricsParamsSpy = jest

--- a/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
+++ b/app/components/Views/confirmations/components/TransactionReview/index.test.tsx
@@ -161,7 +161,7 @@ jest.mock('react-redux', () => {
         ...mockState,
         transaction: {
           ...mockState.transaction,
-          transactionSecurityAlertResponses: {
+          securityAlertResponses: {
             123: securityAlertResponse,
           },
         },
@@ -233,7 +233,7 @@ describe('TransactionReview', () => {
             ...mockState.transaction,
             id: '123',
             securityAlertResponse,
-            transactionSecurityAlertResponses: {
+            securityAlertResponses: {
               123: securityAlertResponse,
             },
           },

--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -28,6 +28,7 @@ const initialState = {
   type: undefined,
   proposedNonce: undefined,
   nonce: undefined,
+  transactionSecurityAlertResponses: {},
 };
 
 const getAssetType = (selectedAsset) => {
@@ -132,9 +133,9 @@ const transactionReducer = (state = initialState, action) => {
       const { transactionId, securityAlertResponse } = action;
       return {
         ...state,
-        currentTransactionSecurityAlertResponse: {
-          id: transactionId,
-          response: securityAlertResponse,
+        transactionSecurityAlertResponses: {
+          ...state.transactionSecurityAlertResponses,
+          [transactionId]: securityAlertResponse,
         },
       };
     }

--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -28,7 +28,7 @@ const initialState = {
   type: undefined,
   proposedNonce: undefined,
   nonce: undefined,
-  transactionSecurityAlertResponses: {},
+  securityAlertResponses: {},
 };
 
 const getAssetType = (selectedAsset) => {
@@ -133,8 +133,8 @@ const transactionReducer = (state = initialState, action) => {
       const { transactionId, securityAlertResponse } = action;
       return {
         ...state,
-        transactionSecurityAlertResponses: {
-          ...state.transactionSecurityAlertResponses,
+        securityAlertResponses: {
+          ...state.securityAlertResponses,
           [transactionId]: securityAlertResponse,
         },
       };

--- a/app/selectors/confirmTransaction.ts
+++ b/app/selectors/confirmTransaction.ts
@@ -7,6 +7,13 @@ import { createDeepEqualSelector } from './util';
 
 const selectCurrentTransactionId = (state: RootState) => state.transaction?.id;
 
+export const selectCurrentTransactionSecurityAlertResponse = (
+  state: RootState,
+) => {
+  const { id, securityAlertResponses } = state.transaction;
+  return securityAlertResponses?.[id];
+};
+
 export const selectCurrentTransactionMetadata = createSelector(
   selectTransactions,
   selectCurrentTransactionId,

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -51,9 +51,8 @@ describe('Blockaid util', () => {
         txParams: {
           from: '0x1',
         },
-        currentTransactionSecurityAlertResponse: {
-          id: '2',
-          response: {
+        transactionSecurityAlertResponses: {
+          2: {
             result_type: ResultType.Malicious,
             reason: Reason.notApplicable,
             providerRequestsCount: {
@@ -78,9 +77,8 @@ describe('Blockaid util', () => {
         txParams: {
           from: '0x1',
         },
-        currentTransactionSecurityAlertResponse: {
-          id: '1',
-          response: {
+        transactionSecurityAlertResponses: {
+          1: {
             result_type: ResultType.Malicious,
             reason: Reason.notApplicable,
             providerRequestsCount: {

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -51,7 +51,7 @@ describe('Blockaid util', () => {
         txParams: {
           from: '0x1',
         },
-        transactionSecurityAlertResponses: {
+        securityAlertResponses: {
           2: {
             result_type: ResultType.Malicious,
             reason: Reason.notApplicable,
@@ -77,7 +77,7 @@ describe('Blockaid util', () => {
         txParams: {
           from: '0x1',
         },
-        transactionSecurityAlertResponses: {
+        securityAlertResponses: {
           1: {
             result_type: ResultType.Malicious,
             reason: Reason.notApplicable,

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -9,7 +9,7 @@ import { selectChainId } from '../../selectors/networkController';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
 interface TransactionSecurityAlertResponseType {
-  transactionSecurityAlertResponses: Record<string, SecurityAlertResponse>;
+  securityAlertResponses: Record<string, SecurityAlertResponse>;
 }
 
 export type TransactionType = TransactionMeta &
@@ -88,8 +88,8 @@ export const getBlockaidTransactionMetricsParams = (
     return blockaidParams;
   }
 
-  const { transactionSecurityAlertResponses, id } = transaction;
-  const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+  const { securityAlertResponses, id } = transaction;
+  const securityAlertResponse = securityAlertResponses?.[id];
   if (securityAlertResponse) {
     blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
   }

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -9,10 +9,7 @@ import { selectChainId } from '../../selectors/networkController';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
 interface TransactionSecurityAlertResponseType {
-  currentTransactionSecurityAlertResponse: {
-    id: string;
-    response: SecurityAlertResponse;
-  };
+  transactionSecurityAlertResponses: Record<string, SecurityAlertResponse>;
 }
 
 export type TransactionType = TransactionMeta &
@@ -91,12 +88,10 @@ export const getBlockaidTransactionMetricsParams = (
     return blockaidParams;
   }
 
-  if (
-    transaction.id === transaction?.currentTransactionSecurityAlertResponse?.id
-  ) {
-    blockaidParams = getBlockaidMetricsParams(
-      transaction.currentTransactionSecurityAlertResponse?.response,
-    );
+  const { transactionSecurityAlertResponses, id } = transaction;
+  const securityAlertResponse = transactionSecurityAlertResponses?.[id];
+  if (securityAlertResponse) {
+    blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
   }
 
   return blockaidParams;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bloackaid spinner is not shown correctly when confirmation requests are batched.

Previously we only kept result of blockaid validation for only current transaction in redux state, this PR makes change to keep validation result of all recent transaction in state.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/10514

## **Manual testing steps**

1. Go to test dapp
2. Submit batched malicious request
3. Blockaid alert banner should appear correctly

## **Screenshots/Recordings**
https://github.com/user-attachments/assets/645bcd71-6fb8-45fa-a254-407a15195e0b

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
