### PR TITLE
chore: improve typescript on accounts controller selector

### DIFF
--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -62,7 +62,7 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
  */
 export const selectSelectedInternalAccountChecksummedAddress = createSelector(
   selectSelectedInternalAccount,
-  (account): string => {
+  (account) => {
     const selectedAddress = account.address;
     return toChecksumHexAddress(selectedAddress);
   },

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -52,7 +52,6 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
         `selectSelectedInternalAccount: Account with ID ${accountId} not found.`,
       );
       captureException(err);
-      return undefined;
     }
     return account;
   },
@@ -63,8 +62,8 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
  */
 export const selectSelectedInternalAccountChecksummedAddress = createSelector(
   selectSelectedInternalAccount,
-  (account) => {
-    const selectedAddress = account?.address;
-    return selectedAddress ? toChecksumHexAddress(selectedAddress) : undefined;
+  (account): string => {
+    const selectedAddress = account.address;
+    return toChecksumHexAddress(selectedAddress);
   },
 );


### PR DESCRIPTION
## **Description**
`selectedAddress` variable should not be undefined or the account when that data is requested, if turns out to be undefined, the app will not behave as expected.
The typescript will flag `selectedAddress` on multiple places if the variable is possibly `undefined`

This proposal solution aims for us to keep the best of both worlds:
* Typescript assertion, `selectedAddress` being defined on the consumers of `selectSelectedInternalAccountChecksummedAddress`
* thrown an error to Sentry so we caught any unexpected behavior

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
