### PR TITLE
test: disable sonar on E2E folder

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectName=MetaMask Mobile Project
 #sonar.projectVersion=1.0
 
 # Root for sonar analysis.
-sonar.sources=app/,e2e/
+sonar.sources=app/
 
 # Excluded project files from analysis.
 sonar.exclusions=**.stories.**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Right now, sonar is treating the[ e2e folder as app code,](https://sonarcloud.io/component_measures?metric=new_coverage&selected=metamask-mobile%3Ae2e%2Fpages&pullRequest=10714&id=metamask-mobile) which expects unit test coverage whenever new code is added or changed in the e2e folder. This doesn’t make sense because why would we need unit test coverage for e2e tests. 

The initial idea for having sonar analysis done on the e2e folder was to identify code smells within it. A year ago, the e2e folder was filled with code smells, but the smells decreased as we refactored the code. There are three minor code smells in the viewHelpers file, which are comments. Furthermore, we have best practices to catch these smells before merging. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
