### PR TITLE
feat: Add yarn flipper script

### DIFF
--- a/docs/readme/debugging.md
+++ b/docs/readme/debugging.md
@@ -14,7 +14,7 @@ The prerequisite for debugging is to ensure that the mobile app is up and runnin
 - `yarn watch` - Start the metro bundler, which serves the JS bundle to the native app
 - `yarn start:android` or `yarn start:ios`, which builds the app and installs it in the simulator
 
-Run [Flipper](https://fbflipper.com/docs/getting-started/) using `yarn flipper` (verified working with v0.263.0)
+Run [Flipper](https://fbflipper.com/docs/getting-started/) using `yarn start:flipper` (verified working with v0.263.0)
 
 - May be prompted to install Flipper for first time users
 

--- a/docs/readme/debugging.md
+++ b/docs/readme/debugging.md
@@ -14,7 +14,9 @@ The prerequisite for debugging is to ensure that the mobile app is up and runnin
 - `yarn watch` - Start the metro bundler, which serves the JS bundle to the native app
 - `yarn start:android` or `yarn start:ios`, which builds the app and installs it in the simulator
 
-Install and run [Flipper](https://fbflipper.com/docs/getting-started/) using `npx flipper-server` (verified working with v0.263.0)
+Run [Flipper](https://fbflipper.com/docs/getting-started/) using `yarn flipper` (verified working with v0.263.0)
+
+- May be prompted to install Flipper for first time users
 
 - If there are warnings on the `Troubleshoot` tab, follow the `Setup Doctor` to resolve all of the checks
 

--- a/docs/readme/debugging.md
+++ b/docs/readme/debugging.md
@@ -17,6 +17,7 @@ The prerequisite for debugging is to ensure that the mobile app is up and runnin
 Run [Flipper](https://fbflipper.com/docs/getting-started/) using `yarn start:flipper` (verified working with v0.263.0)
 
 - May be prompted to install Flipper for first time users
+- Flipper app runs in the web browser
 
 - If there are warnings on the `Troubleshoot` tab, follow the `Setup Doctor` to resolve all of the checks
 
@@ -59,3 +60,5 @@ To enable Redux debugging: in Flipper, select the `More` tab -> `Plugin` and add
 - Trouble installing `idb` with `pip3.6`
   - An alternative is to use [`pipx`](https://pipx.pypa.io/stable/) to install `idb`
   - Ensure that `pipx` path is added to your terminal's profile file using `pipx ensurepath`
+- `Flipper` not detecting open simulator when `Flipper` is started
+  - Try both refreshing the web page and the simulator

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "patch:approval": "./scripts/patch-approval-controller.sh",
     "storybook-generate": "sb-rn-get-stories",
     "storybook-watch": "sb-rn-watcher",
-    "flipper": "npx flipper-server"
+    "start:flipper": "npx flipper-server"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "patch:assets": "./scripts/patch-assets-controllers.sh",
     "patch:approval": "./scripts/patch-approval-controller.sh",
     "storybook-generate": "sb-rn-get-stories",
-    "storybook-watch": "sb-rn-watcher"
+    "storybook-watch": "sb-rn-watcher",
+    "flipper": "npx flipper-server"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds `yarn start:flipper` , which runs `npx flipper-server` under the hood

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/10738

## **Manual testing steps**

Run `yarn start:flipper` while simulator is running the MM mobile app
Flipper should pick up the app and we should see logs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/486af828-6eae-418b-b07b-eaa086692d75


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
