### PR TITLE
fix: Fix coachmark error

### DIFF
--- a/app/components/UI/OnboardingWizard/Coachmark/index.js
+++ b/app/components/UI/OnboardingWizard/Coachmark/index.js
@@ -178,9 +178,9 @@ export default class Coachmark extends PureComponent {
      */
     style: PropTypes.object,
     /**
-     * Content text
+     * Content object
      */
-    content: PropTypes.string,
+    content: PropTypes.object,
     /**
      * Title text
      */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change resolves the error regarding invalid prop type that appears with the Coachmark component

## **Related issues**

Fixes:

## **Manual testing steps**

Notice that the Coachmark invalid prop error no longer appears after a fresh install and landing on the wallet screen w/ onboarding wizard

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1001" alt="Screenshot 2024-08-22 at 3 17 25 PM" src="https://github.com/user-attachments/assets/91129096-0112-4861-8e47-71ce1b1d717b">


### **After**

<!-- [screenshots/recordings] -->

<img width="998" alt="image" src="https://github.com/user-attachments/assets/a9156414-8050-48ca-8ae6-09a2f47fdb4e">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
