### PR TITLE
fix: Set NO_FLIPPER to true on ios release

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -166,9 +166,6 @@ prebuild(){
 }
 
 prebuild_ios(){
-	# Disable Flipper
-	NO_FLIPPER="1"
-
 	prebuild
 	# Generate xcconfig files for CircleCI
 	if [ "$PRE_RELEASE" = true ] ; then
@@ -292,11 +289,14 @@ generateArchivePackages() {
 }
 
 buildIosRelease(){
-
-  remapEnvVariableRelease
+  	remapEnvVariableRelease
 
 	# Enable Sentry to auto upload source maps and debug symbols
 	export SENTRY_DISABLE_AUTO_UPLOAD="false"
+
+	# Disable Flipper
+	export NO_FLIPPER="1"
+
 	prebuild_ios
 
 	# Replace release.xcconfig with ENV vars
@@ -319,6 +319,9 @@ buildIosFlaskRelease(){
 	# remap flask env variables to match what the app expects
 	remapFlaskEnvVariables
 
+	# Disable Flipper
+	export NO_FLIPPER="1"
+
 	prebuild_ios
 
 	# Replace release.xcconfig with ENV vars
@@ -338,6 +341,9 @@ buildIosFlaskRelease(){
 }
 
 buildIosReleaseE2E(){
+	# Disable Flipper
+	export NO_FLIPPER="1"
+
 	prebuild_ios
 
 	# Replace release.xcconfig with ENV vars
@@ -358,7 +364,11 @@ buildIosReleaseE2E(){
 }
 
 buildIosQA(){
-  remapEnvVariableQA
+  	remapEnvVariableQA
+	
+	# Disable Flipper
+	export NO_FLIPPER="1"
+
 	prebuild_ios
 
   	echo "Start QA build..."
@@ -382,7 +392,7 @@ buildIosQA(){
 
 
 buildAndroidQA(){
-  remapEnvVariableQA
+  	remapEnvVariableQA
 
 	if [ "$PRE_RELEASE" = false ] ; then
 		adb uninstall io.metamask.qa

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -166,6 +166,9 @@ prebuild(){
 }
 
 prebuild_ios(){
+	# Disable Flipper
+	NO_FLIPPER="1"
+
 	prebuild
 	# Generate xcconfig files for CircleCI
 	if [ "$PRE_RELEASE" = true ] ; then


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR sets NO_FLIPPER to true on iOS release builds, which disables Flipper and fixes the build failures on Bitrise

## **Related issues**

Fixes:

## **Manual testing steps**

- Running `build_all_targets_pipeline` should succeed (no errors on iOS build)
- Running e2e smoke tests should pass (unaffected by these changes)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
