### PR TITLE
chore: add new `keyring-snaps` code fence

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -17,6 +17,7 @@ const availableFeatures = new Set([
   'preinstalled-snaps',
   'external-snaps',
   'beta',
+  'keyring-snaps',
 ]);
 
 const mainFeatureSet = new Set(['preinstalled-snaps']);
@@ -24,6 +25,7 @@ const flaskFeatureSet = new Set([
   'flask',
   'preinstalled-snaps',
   'external-snaps',
+  'keyring-snaps',
 ]);
 
 /**


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- To enable the development of `keyring-snaps` (accounts that are created from external snaps) without interfering with the main build.
- we have been using code fences to develop other features like `preinstalled-snaps` and `beta` for a while now.
- We are using an entirely new flag for this feature because some features will be `keyring-snaps` specific that will not need to be included in the `preinstalled-snaps` or `external-snaps` build
- `keyring-snaps` will only be available on flask for now
- One could argue that we do not need a new flag, instead we could use the `external-snaps` flag, however by creating a new flag, this allows us to ship feature related to `external-saps` while not worrying about accidentally releasing `keyring-snaps`
2. What is the improvement/solution?
- created the `keyring-snaps` flag in the `metro.transform` file 
- added `keyring-snaps` as a feature to be included in the flask build

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/568

## **Manual testing steps**

This change is not user facing so there is no need for qa. instead if the linter, tests and e2e pass we can confidently say this is working.

1. Build the application
2. Import/create a wallet
3. navigate to settings
4. there should be no snaps settings

5. navigate to .js.env
6. set `export METAMASK_BUILD_TYPE=flask`
7. rebuild the app
8. open wallet
9. there should be a snaps settings section


## **Screenshots/Recordings**


### **Before**

N/A

### **After**



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
