### PR TITLE
fix: prevent redirect on switch chain error on iOS

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -429,11 +429,8 @@ class WalletConnect2Session {
       return;
     }
 
-    // Android specific logic to prevent automatic redirect on switchChain and let the dapp call wallet_addEthereumChain on error.
-    if (
-      method.toLowerCase() === RPC_WALLET_SWITCHETHEREUMCHAIN.toLowerCase() &&
-      Device.isAndroid()
-    ) {
+    // Specific logic to prevent automatic redirect on switchChain and let the dapp call wallet_addEthereumChain on error.
+    if (method.toLowerCase() === RPC_WALLET_SWITCHETHEREUMCHAIN.toLowerCase()) {
       // extract first chainId param from request array
       const params = requestEvent.params.request.params as [
         { chainId?: string },
@@ -457,7 +454,7 @@ class WalletConnect2Session {
       );
       if (!existingEntry && !existingNetworkDefault) {
         DevLogger.log(
-          `SKIP rpcMiddleWare -- auto rejection is detected android (_chainId=${_chainId})`,
+          `SKIP rpcMiddleWare -- auto rejection is detected (_chainId=${_chainId})`,
         );
         await this.web3Wallet.rejectRequest({
           id: requestEvent.id,


### PR DESCRIPTION
## **Description**
Removed `Device. isAndroid` from a condition that prevents automatic redirection in case switch chain fails.


## **Related issues**

Fixes:

## **Manual testing steps**

1. Connect using a native dapp in mainnet **on iOS**
2. Switch to a chain that is not added in MetaMask
3. See that there's an unnecesary redirection to the dapp back and forth before getting the add chain popup

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/878d72da-e7cd-4499-ae17-a38809f4f96d

### **After**

https://github.com/user-attachments/assets/17a8ee09-af37-4d6c-8687-3b2a094aba11

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
