### PR TITLE
test: replaced TestHelpers function call with equivalent from Assertions 

### DIFF
--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -5,7 +5,7 @@ import {
 
 import Matchers from '../../utils/Matchers';
 import Gestures from '../../utils/Gestures';
-import TestHelpers from '../../helpers';
+import Assertions from '../../utils/Assertions';
 
 class SwapView {
   get quoteSummary() {
@@ -40,7 +40,7 @@ class SwapView {
     // Wait for counter to go down to 0:05
     // as the flashing gas fees happening when counter is 0:15
     // will disables the swipe button
-    await TestHelpers.checkIfElementWithTextIsVisible('New quotes in 0:05');
+    await Assertions.checkIfTextIsDisplayed('New quotes in 0:05');
     await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
   }
 


### PR DESCRIPTION


## **Description**

Replaced `TestHelpers.checkIfElementWithTextIsVisible()` call  with `Assertions.checkIfTextIsDisplayed()` as we are slowly deprecating TestHelpers file as part of our page object refactor.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
