### PR TITLE
fix: Patch swaps controller to expose POL rather than MATIC symbol

### DIFF
--- a/patches/@metamask+swaps-controller+9.0.2.patch
+++ b/patches/@metamask+swaps-controller+9.0.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@metamask/swaps-controller/dist/constants.js b/node_modules/@metamask/swaps-controller/dist/constants.js
+index 4c98522..523f25a 100644
+--- a/node_modules/@metamask/swaps-controller/dist/constants.js
++++ b/node_modules/@metamask/swaps-controller/dist/constants.js
+@@ -129,8 +129,8 @@ exports.BSC_SWAPS_TOKEN_OBJECT = {
+     decimals: 18,
+ };
+ exports.POLYGON_SWAPS_TOKEN_OBJECT = {
+-    symbol: 'MATIC',
+-    name: 'Matic',
++    symbol: 'POL',
++    name: 'Polygon',
+     address: exports.NATIVE_SWAPS_TOKEN_ADDRESS,
+     decimals: 18,
+ };


### PR DESCRIPTION
## **Description**

Patches the SwapsController to rename MATIC to POL token symbol. Previously, this was hardcoded to a MATIC symbol, so it was not properly displaying the POL token during swaps.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Switch to Polygon Network
2. Initiate Swap
3. Ensure that `MATIC` is now `POL` in swap UI

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/5abd28e9-131b-4b19-8a2f-d4a701231d76



<img width="300" alt="Screenshot 2024-08-30 at 1 32 50 PM" src="https://github.com/user-attachments/assets/b7849c5e-fc9d-41d3-814c-89566f3cb32b">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
