### PR TITLE
fix: gas never loading during send + high gas fee after deep link

### DIFF
--- a/app/components/Views/confirmations/Send/index.js
+++ b/app/components/Views/confirmations/Send/index.js
@@ -331,7 +331,6 @@ class Send extends PureComponent {
         newTxMeta = {
           symbol: 'ETH',
           assetType: 'ETH',
-          type: 'ETHER_TRANSACTION',
           paymentRequest: true,
           selectedAsset: { symbol: 'ETH', isETH: true },
           ...txRecipient,

--- a/app/util/custom-gas/index.js
+++ b/app/util/custom-gas/index.js
@@ -111,7 +111,7 @@ export async function getGasLimit(transaction, resetGas = false) {
   let estimation;
   try {
     const newTransactionObj = resetGas
-      ? { ...transaction, gas: undefined }
+      ? { ...transaction, gas: undefined, gasPrice: undefined }
       : transaction;
 
     estimation = await estimateGas(newTransactionObj);


### PR DESCRIPTION
## **Description**

Resolves two overlapping gas issues that were causing the gas fee to never finish loading during some wallet initiated send transactions, and for the gas fee estimate to be too high after using a deep link or QR code.

The gas fee estimates (and simulation details) were not loading as the simulation and gas fee polling in the `TransactionController` was silently failing due to recently added validations that were not compatible with the legacy `ETHER_TRANSACTION` type still being set in the `Send` view.

The resulting gas fee estimate was too high for deep links as the `estimateGas` call to the provider had an invalid value of `0` for the `gasPrice` which was resulting in an error response, and in turn setting the `gasLimit` to the fallback value of `95%` of the block gas limit.

Additional error logging will be added to the `TransactionController` in future.

## **Related issues**

Fixes: #10895 #10281

## **Manual testing steps**

See issues.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
