### PR TITLE
test: Fix swap smoke tests

### DIFF
--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -37,11 +37,11 @@ class SwapView {
 
   async swipeToSwap() {
     const percentage = device.getPlatform() === 'ios' ? 0.72 : 0.95;
-    // Wait for counter to go down to 0:05
-    // as the flashing gas fees happening when counter is 0:15
-    // will disables the swipe button
-    await Assertions.checkIfTextIsDisplayed('New quotes in 0:05');
+    // Two swipes are needed because the flashing gas fee
+    // could interupt the first swipe
     await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
+    await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
+    await Assertions.checkIfTextIsDisplayed('Swap!');
   }
 
   swapCompleteLabel(sourceTokenSymbol, destTokenSymbol) {

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -54,7 +54,7 @@ class SwapView {
 
   async tapIUnderstandPriceWarning() {
     try {
-      await Gestures.waitAndTap(this.iUnderstandLabel);
+      await Gestures.waitAndTap(this.iUnderstandLabel, 5000);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(`Price warning not displayed: ${e}`);

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -5,7 +5,6 @@ import {
 
 import Matchers from '../../utils/Matchers';
 import Gestures from '../../utils/Gestures';
-import TestHelpers from '../../helpers';
 
 class SwapView {
   get quoteSummary() {
@@ -42,7 +41,6 @@ class SwapView {
     // and that's when the swipe button becomes disabled
     // that's the need to retry
     await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
-    await TestHelpers.delay(4000);
     await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
   }
 

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -41,12 +41,9 @@ class SwapView {
     // Swipe could happen at the same time when gas fees are falshing
     // and that's when the swipe button becomes disabled
     // that's the need to retry
-    let swapCompleteted
-    do {
-      await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
-      await TestHelpers.delay(1000);
-      swapCompleteted = await Matchers.getElementByText('Swap!')
-    } while (!swapCompleteted)
+    await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
+    await TestHelpers.delay(4000);
+    await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
   }
 
   swapCompleteLabel(sourceTokenSymbol, destTokenSymbol) {

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -5,7 +5,7 @@ import {
 
 import Matchers from '../../utils/Matchers';
 import Gestures from '../../utils/Gestures';
-import Assertions from '../../utils/Assertions';
+import TestHelpers from '../../helpers';
 
 class SwapView {
   get quoteSummary() {
@@ -37,11 +37,16 @@ class SwapView {
 
   async swipeToSwap() {
     const percentage = device.getPlatform() === 'ios' ? 0.72 : 0.95;
-    // Two swipes are needed because the flashing gas fee
-    // could interupt the first swipe
-    await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
-    await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
-    await Assertions.checkIfTextIsDisplayed('Swap!');
+
+    // Swipe could happen at the same time when gas fees are falshing
+    // and that's when the swipe button becomes disabled
+    // that's the need to retry
+    let swapCompleteted
+    do {
+      await Gestures.swipe(this.swipeToSwapButton, 'right', 'fast', percentage);
+      await TestHelpers.delay(1000);
+      swapCompleteted = await Matchers.getElementByText('Swap!')
+    } while (!swapCompleteted)
   }
 
   swapCompleteLabel(sourceTokenSymbol, destTokenSymbol) {

--- a/e2e/utils/Gestures.js
+++ b/e2e/utils/Gestures.js
@@ -51,9 +51,9 @@ class Gestures {
    * Wait for an element to be visible and then tap it.
    *
    * @param {Promise<Detox.IndexableNativeElement>} elementID - ID of the element to tap
-   * @param {number} timeout - Timeout for waiting (default: 10000ms)
+   * @param {number} timeout - Timeout for waiting (default: 8000ms)
    */
-  static async waitAndTap(elementID, timeout = 10000) {
+  static async waitAndTap(elementID, timeout = 15000) {
     const element = await elementID;
     await waitFor(element).toBeVisible().withTimeout(timeout);
     await element.tap();
@@ -132,7 +132,6 @@ class Gestures {
   static async swipe(elementID, direction, speed, percentage, xStart, yStart) {
     const element = await elementID;
 
-    await waitFor(element).toBeVisible();
     await element.swipe(direction, speed, percentage, xStart, yStart);
   }
 

--- a/e2e/utils/Gestures.js
+++ b/e2e/utils/Gestures.js
@@ -132,6 +132,7 @@ class Gestures {
   static async swipe(elementID, direction, speed, percentage, xStart, yStart) {
     const element = await elementID;
 
+    await waitFor(element).toBeVisible();
     await element.swipe(direction, speed, percentage, xStart, yStart);
   }
 

--- a/e2e/utils/Gestures.js
+++ b/e2e/utils/Gestures.js
@@ -51,9 +51,9 @@ class Gestures {
    * Wait for an element to be visible and then tap it.
    *
    * @param {Promise<Detox.IndexableNativeElement>} elementID - ID of the element to tap
-   * @param {number} timeout - Timeout for waiting (default: 8000ms)
+   * @param {number} timeout - Timeout for waiting (default: 10000ms)
    */
-  static async waitAndTap(elementID, timeout = 15000) {
+  static async waitAndTap(elementID, timeout = 10000) {
     const element = await elementID;
     await waitFor(element).toBeVisible().withTimeout(timeout);
     await element.tap();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This is to address the Swap smoke test failures. 

The problem happens because:
- it takes about 15 second for the button to receive the swipe gesture not sure really why. I tried a few things but I cannot seem to change that
- But the real problem happens when the gas fee start flashing which also happens also around 15 second after the the quite is displayed. During that the swipe button becomes disabled and the swipe gesture doesn’t take effect

Fix in this PR.
- I have reduced  the standard time defined for detox to wait for the elements to be displayed to 10 secs instead of 15. 
- I have added one more swipe gesture as it used to help before

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
