### PR TITLE
fix: infinite gas fee loading during send

### DIFF
--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -112,9 +112,9 @@ import CustomGasModal from './components/CustomGasModal';
 import { ResultType } from '../../components/BlockaidBanner/BlockaidBanner.types';
 import { withMetricsAwareness } from '../../../../../components/hooks/useMetrics';
 import {
-  selectTransactionGasFeeEstimates,
   selectCurrentTransactionMetadata,
   selectCurrentTransactionSecurityAlertResponse,
+  selectGasFeeEstimates,
 } from '../../../../../selectors/confirmTransaction';
 import { selectGasFeeControllerEstimateType } from '../../../../../selectors/gasFeeController';
 import { createBuyNavigationDetails } from '../../../../UI/Ramp/routes/utils';
@@ -1468,7 +1468,7 @@ const mapStateToProps = (state) => ({
   selectedAsset: state.transaction.selectedAsset,
   transactionState: state.transaction,
   primaryCurrency: state.settings.primaryCurrency,
-  gasFeeEstimates: selectTransactionGasFeeEstimates(state),
+  gasFeeEstimates: selectGasFeeEstimates(state),
   gasEstimateType: selectGasFeeControllerEstimateType(state),
   isPaymentRequest: state.transaction.paymentRequest,
   isNativeTokenBuySupported: isNetworkRampNativeTokenSupported(

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1559,6 +1559,7 @@ class Engine {
     this.configureControllersOnNetworkChange();
     this.startPolling();
     this.handleVaultBackup();
+    this.transactionController.clearUnapprovedTransactions();
 
     Engine.instance = this;
   }

--- a/app/selectors/confirmTransaction.ts
+++ b/app/selectors/confirmTransaction.ts
@@ -26,11 +26,6 @@ const selectCurrentTransactionGasFeeEstimatesStrict = createSelector(
   (transactionMetadata) => transactionMetadata?.gasFeeEstimates,
 );
 
-const selectCurrentTransactionGasFeeEstimatesLoaded = createSelector(
-  selectCurrentTransactionMetadata,
-  (transactionMetadata) => transactionMetadata?.gasFeeEstimatesLoaded,
-);
-
 export const selectCurrentTransactionGasFeeEstimates = createDeepEqualSelector(
   selectCurrentTransactionGasFeeEstimatesStrict,
   (gasFeeEstimates) => gasFeeEstimates,
@@ -51,11 +46,4 @@ export const selectGasFeeEstimates = createSelector(
 
     return gasFeeControllerEstimates;
   },
-);
-
-export const selectTransactionGasFeeEstimates = createSelector(
-  selectCurrentTransactionGasFeeEstimatesLoaded,
-  selectGasFeeEstimates,
-  (transactionGasFeeEstimatesLoaded, gasFeeEstimates) =>
-    transactionGasFeeEstimatesLoaded ? gasFeeEstimates : undefined,
 );


### PR DESCRIPTION
## **Description**

Additional fixes required to prevent infinite or delayed gas fee loading when creating transfers from the wallet.

The core of the problem is as follows:

1. Following the recent upgrade to version `35.0.0` of the `TransactionController`, the `networkClientId` is automatically set in the transaction metadata when adding a transaction.
2. This meant legacy transactions already in the wallet before upgrade did not have this value set.
3. When the `GasFeePoller` polls automatically in the `TransactionController`, it needs to determine the `networkClientId` of each transaction in order to retrieve the correct estimates from the `GasFeeController`.
4. If the `networkClientId` is not in the transaction metadata, this is derived using the `NetworkController:findNetworkClientIdByChainId` messenger action which was not defined as an allowed action for the `TransactionController` in the mobile client until a recent PR.
5. Send transactions are unique in that they exclusively used the gas fee estimates from the transaction metadata, and do not fallback to the network gas fee estimates provided by the `GasFeeController` state directly.
6. All of the above ultimately meant that if a user attempted to create a send transaction and had `unapproved` transactions in their state from a previous release, then the gas fee polling would consistently fail (due to the disallowed action) meaning transaction gas fee estimates were never updated and therefore the UI would never load and never allow confirmation of the transaction.

The core issue has unknowingly already been resolved by the PR #10936 

For added stability, this PR also:

1. Updates send confirmations to also fallback to the network gas fee estimates to increase their stability in the face of errors and not block transactions.
2. Clears all unapproved transactions on startup, since they are never displayed and provide no benefit while needlessly increasing state size, background processing, and callouts.

Further logging and modular error handling will also be added to the `TransactionController` going forward.

## **Related issues**

Fixes: #10895 

## **Manual testing steps**

To re-create the original issue:

1. Install or checkout version `7.27.0`.
2. Add a transaction but hard reset / close the app while the confirmation is visible.
4. Install or checkout version `7.28.0` or later.
5. Start a transfer.
6. Note that the gas fee never loads.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
