### PR TITLE
test: Update swap test to handle the details modal

### DIFF
--- a/e2e/specs/swaps/swap-action-regression.spec.js
+++ b/e2e/specs/swaps/swap-action-regression.spec.js
@@ -110,25 +110,29 @@ describe(Regression('Multiple Swaps from Actions'), () => {
       await Assertions.checkIfVisible(
         ActivitiesView.swapActivity(sourceTokenSymbol, destTokenSymbol),
       );
-      await TestHelpers.delay(5000);
       await ActivitiesView.tapOnSwapActivity(
         sourceTokenSymbol,
         destTokenSymbol,
       );
 
-      if (device.getPlatform() === 'android') {
+      try {
         await Assertions.checkIfVisible(DetailsModal.title);
-        await Assertions.checkIfElementToHaveText(
-          DetailsModal.title,
-          DetailsModal.generateExpectedTitle(
-            sourceTokenSymbol,
-            destTokenSymbol,
-          ),
+      } catch (e) {
+        await ActivitiesView.tapOnSwapActivity(
+          sourceTokenSymbol,
+          destTokenSymbol,
         );
-        await Assertions.checkIfVisible(DetailsModal.statusConfirmed);
-        await DetailsModal.tapOnCloseIcon();
-        await Assertions.checkIfNotVisible(DetailsModal.title);
+        await Assertions.checkIfVisible(DetailsModal.title);
       }
+
+      await Assertions.checkIfVisible(DetailsModal.title);
+      await Assertions.checkIfElementToHaveText(
+        DetailsModal.title,
+        DetailsModal.generateExpectedTitle(sourceTokenSymbol, destTokenSymbol),
+      );
+      await Assertions.checkIfVisible(DetailsModal.statusConfirmed);
+      await DetailsModal.tapOnCloseIcon();
+      await Assertions.checkIfNotVisible(DetailsModal.title);
     },
   );
 });

--- a/e2e/specs/swaps/swap-action-smoke.spec.js
+++ b/e2e/specs/swaps/swap-action-smoke.spec.js
@@ -109,12 +109,20 @@ describe(SmokeSwaps('Swap from Actions'), () => {
       await Assertions.checkIfVisible(
         ActivitiesView.swapActivity(sourceTokenSymbol, destTokenSymbol),
       );
-      await TestHelpers.delay(5000);
       await ActivitiesView.tapOnSwapActivity(
         sourceTokenSymbol,
         destTokenSymbol,
       );
-      await Assertions.checkIfVisible(DetailsModal.title);
+
+      try {
+        await Assertions.checkIfVisible(DetailsModal.title);
+      } catch (e) {
+        await ActivitiesView.tapOnSwapActivity(
+          sourceTokenSymbol,
+          destTokenSymbol,
+        );
+        await Assertions.checkIfVisible(DetailsModal.title);
+      }
       await Assertions.checkIfElementToHaveText(
         DetailsModal.title,
         DetailsModal.generateExpectedTitle(sourceTokenSymbol, destTokenSymbol),

--- a/e2e/specs/swaps/swap-token-chart.spec.js
+++ b/e2e/specs/swaps/swap-token-chart.spec.js
@@ -18,8 +18,8 @@ import FixtureServer from '../../fixtures/fixture-server';
 import { getFixturesServerPort } from '../../fixtures/utils';
 import { Regression } from '../../tags';
 import Assertions from '../../utils/Assertions';
-import ActivitiesView from "../../pages/ActivitiesView";
-import DetailsModal from "../../pages/modals/DetailsModal";
+import ActivitiesView from '../../pages/ActivitiesView';
+import DetailsModal from '../../pages/modals/DetailsModal';
 
 const fixtureServer = new FixtureServer();
 

--- a/e2e/specs/swaps/swap-token-chart.spec.js
+++ b/e2e/specs/swaps/swap-token-chart.spec.js
@@ -18,6 +18,8 @@ import FixtureServer from '../../fixtures/fixture-server';
 import { getFixturesServerPort } from '../../fixtures/utils';
 import { Regression } from '../../tags';
 import Assertions from '../../utils/Assertions';
+import ActivitiesView from "../../pages/ActivitiesView";
+import DetailsModal from "../../pages/modals/DetailsModal";
 
 const fixtureServer = new FixtureServer();
 
@@ -81,5 +83,26 @@ describe(Regression('Swap from Token view'), () => {
       console.log(`Toast message is slow to appear or did not appear: ${e}`);
     }
     await device.enableSynchronization();
+    await TestHelpers.delay(5000);
+    await TabBarComponent.tapActivity();
+    await Assertions.checkIfVisible(ActivitiesView.title);
+    await Assertions.checkIfVisible(ActivitiesView.swapActivity('LINK', 'DAI'));
+    await ActivitiesView.tapOnSwapActivity('LINK', 'DAI');
+
+    try {
+      await Assertions.checkIfVisible(DetailsModal.title);
+    } catch (e) {
+      await ActivitiesView.tapOnSwapActivity('LINK', 'DAI');
+      await Assertions.checkIfVisible(DetailsModal.title);
+    }
+
+    await Assertions.checkIfVisible(DetailsModal.title);
+    await Assertions.checkIfElementToHaveText(
+      DetailsModal.title,
+      DetailsModal.generateExpectedTitle('LINK', 'DAI'),
+    );
+    await Assertions.checkIfVisible(DetailsModal.statusConfirmed);
+    await DetailsModal.tapOnCloseIcon();
+    await Assertions.checkIfNotVisible(DetailsModal.title);
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In some occasion, the Swap action detox test fail when trying to inspect the Detail Modal on the Transaction View. The objective for this task would to add some logic so the test could resolve the issue of the detail modal not appearing and making the test fail even thought the swap was successful.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
