### PR TITLE
fix(3245): vertical positioning of the matching password green checkmark icon

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -194,8 +194,8 @@ const createStyles = (colors) =>
     },
     showMatchingPasswords: {
       position: 'absolute',
-      top: 52,
-      right: 17,
+      top: 36,
+      right: 10,
       alignSelf: 'flex-end',
     },
   });
@@ -693,7 +693,7 @@ class ChoosePassword extends PureComponent {
                     keyboardAppearance={themeAppearance}
                   />
                   <View style={styles.showMatchingPasswords}>
-                    {passwordsMatch ? (
+                    {true ? (
                       <Icon
                         name="check"
                         size={16}

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -693,7 +693,7 @@ class ChoosePassword extends PureComponent {
                     keyboardAppearance={themeAppearance}
                   />
                   <View style={styles.showMatchingPasswords}>
-                    {true ? (
+                    {passwordsMatch ? (
                       <Icon
                         name="check"
                         size={16}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently the green checkmark seems to be positioned at the bottom, it should probably be centered
Screenshots below were on iphone 15, should be tested on smaller, and bigger iphones, as well as on Android before merging.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3245

Currently the green checkmark seems to be positioned at the bottom, it should probably be centered

### Scenario

1. create a new wallet
2. on the choose password screen choose matching passwords, the green checkmark should be centered vertically but it is not

### Design

| Not OK       | OK        |
|--------------|--------------|
| <img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/c7f6643f-eed8-4fc7-8f75-3f9743744782"> |<img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/ac56e515-5797-4129-922d-bb205be834c1"> |

| Not OK       | OK        |
|--------------|--------------|
| <img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/49443880-8fcc-415c-9ef3-abf3db6adb1b"> |<img width="350" alt="Screenshot 2024-04-18 at 3 56 43 PM" src="https://github.com/user-attachments/assets/701221a5-d774-46fe-86ca-82c214b94c7b"> |


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
