### PR TITLE
chore: fix flipper pod compilation with pika 15.3 toolchain

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -116,11 +116,25 @@ target 'MetaMask-Flask' do
 end
 
 post_install do |installer|
+  # fix flipper with pika 15.3 toolchain
+  installer.pods_project.targets.each do |target|
+    if target.name == 'Flipper'
+      file_path = 'ios/Pods/Flipper/xplat/Flipper/FlipperTransportTypes.h'
+      contents = File.read(file_path)
+      unless contents.include?('#include <functional>')
+        File.open(file_path, 'w') do |file|
+          file.puts('#include <functional>')
+          file.puts(contents)
+        end
+      end
+    end
+  end
+
   react_native_post_install(
     installer,
     # Set `mac_catalyst_enabled` to `true` in order to apply patches
     # necessary for Mac Catalyst builds
     :mac_catalyst_enabled => false
-  )  
+  )
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -120,6 +120,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     if target.name == 'Flipper'
       file_path = 'ios/Pods/Flipper/xplat/Flipper/FlipperTransportTypes.h'
+      system("chmod +w " + file_path)
       contents = File.read(file_path)
       unless contents.include?('#include <functional>')
         File.open(file_path, 'w') do |file|

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "./scripts/build.sh watcher watch",
     "watch:clean": "./scripts/build.sh watcher clean",
     "clean:ios": "rm -rf ios/build",
-    "pod:install": "command -v pod && (cd ios/ && bundle exec pod install && cd ..) || echo \"Skipping pod install\"",
+    "pod:install": "command -v pod && bundle exec pod install --project-directory=ios || echo \"pod command not found. Skipping pod install\"",
     "clean:ppom": "rm -rf ppom/dist ppom/node_modules app/lib/ppom/ppom.html.js",
     "clean:android": "rm -rf android/app/build",
     "clean:node": "rm -rf node_modules && yarn --frozen-lockfile",


### PR DESCRIPTION
add pod post install script to include required import 
see more https://github.com/facebook/flipper/commit/b3dcdb87f930dbbc9dbacb53ad60996e0111e7d8
https://github.com/facebook/react-native/issues/43335#issuecomment-1980708164

NOTE: to install ios pods run `yarn pod:install`. It will execute ` bundle exec pod install --project-directory=ios` within the project root directory. 
Running  `pod install`  inside `ios` folder will error out

