### PR TITLE
chore: add new track events for enabling/disabling basic functionality

### DIFF
--- a/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
@@ -74,7 +74,7 @@ const BasicFunctionalityModal = ({ route }: Props) => {
     bottomSheetRef.current?.onCloseBottomSheet(() => {
       dispatch(toggleBasicFunctionality(!isEnabled));
       trackEvent(
-        isEnabled
+        !isEnabled
           ? MetaMetricsEvents.BASIC_FUNCTIONALITY_ENABLED
           : MetaMetricsEvents.BASIC_FUNCTIONALITY_DISABLED,
       );

--- a/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
@@ -30,7 +30,9 @@ import {
   asyncAlert,
   requestPushNotificationsPermission,
 } from '../../../../util/notifications';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useEnableNotifications } from '../../../../util/notifications/hooks/useNotifications';
+import { useMetrics } from '../../../hooks/useMetrics';
 
 interface Props {
   route: {
@@ -41,6 +43,7 @@ interface Props {
 }
 
 const BasicFunctionalityModal = ({ route }: Props) => {
+  const { trackEvent } = useMetrics();
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const bottomSheetRef = useRef<BottomSheetRef>(null);
@@ -68,9 +71,14 @@ const BasicFunctionalityModal = ({ route }: Props) => {
   }, [enableNotifications]);
 
   const closeBottomSheet = async () => {
-    bottomSheetRef.current?.onCloseBottomSheet(() =>
-      dispatch(toggleBasicFunctionality(!isEnabled)),
-    );
+    bottomSheetRef.current?.onCloseBottomSheet(() => {
+      dispatch(toggleBasicFunctionality(!isEnabled));
+      trackEvent(
+        isEnabled
+          ? MetaMetricsEvents.BASIC_FUNCTIONALITY_ENABLED
+          : MetaMetricsEvents.BASIC_FUNCTIONALITY_DISABLED,
+      );
+    });
 
     if (
       route.params.caller === Routes.SETTINGS.NOTIFICATIONS ||

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -159,6 +159,8 @@ enum EVENT_NAME {
 
   // Security & Privacy Settings
   VIEW_SECURITY_SETTINGS = 'Views Security & Privacy',
+  BASIC_FUNCTIONALITY_ENABLED = 'Basic Functionality Enabled',
+  BASIC_FUNCTIONALITY_DISABLED = 'Basic Functionality Disabled',
 
   // Settings
   SETTINGS_VIEWED = 'Settings Viewed',
@@ -576,6 +578,12 @@ const events = {
   DAPP_VIEWED: generateOpt(EVENT_NAME.DAPP_VIEWED),
   // Security & Privacy Settings
   VIEW_SECURITY_SETTINGS: generateOpt(EVENT_NAME.VIEW_SECURITY_SETTINGS),
+  BASIC_FUNCTIONALITY_ENABLED: generateOpt(
+    EVENT_NAME.BASIC_FUNCTIONALITY_ENABLED,
+  ),
+  BASIC_FUNCTIONALITY_DISABLED: generateOpt(
+    EVENT_NAME.BASIC_FUNCTIONALITY_DISABLED,
+  ),
   // Reveal SRP
   REVEAL_SRP_CTA: generateOpt(EVENT_NAME.REVEAL_SRP_CTA),
   REVEAL_SRP_SCREEN: generateOpt(EVENT_NAME.REVEAL_SRP_SCREEN),


### PR DESCRIPTION
## **Description**

Added new events that track when users enable or disable their basic functionality. The goal is to measure the usage of this feature.

## **Related issues**

Fixes: [#3242](https://github.com/MetaMask/MetaMask-planning/issues/3242)

## **Manual testing steps**

1. Go to the Settings screen
2. Tap on "Security & Privacy" button
3. Scroll down to the "Privacy" section
4. In "General", disable and enable the "Basic Functionality" toggle (you will be prompted with bottom sheet modals to confirm these actions)
5. View new track events in the logs

## **Screenshots/Recordings**

![logs](https://github.com/user-attachments/assets/69399feb-d7b6-41f5-850f-88a2b5ce396f)

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests (if applicable)
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format (if applicable)
- [x] I've applied the appropriate labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g., pulled and built branch, run the app, tested changed code)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes
- [ ] I've verified the necessary testing evidence (recordings and/or screenshots) is included
- [ ] The code follows the project's style guidelines and best practices
- [ ] The changes are adequately documented (comments, JSDoc, README updates if needed)
- [ ] The PR includes appropriate unit and/or integration tests (if applicable)
