### PR TITLE
fix: accounts notifications switch

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/__snapshots__/index.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`NotificationOptionToggle should render correctly 1`] = `
   >
     <RCTSwitch
       accessibilityRole="switch"
-      disabled={false}
       onChange={[Function]}
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}

--- a/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.test.tsx
@@ -25,8 +25,6 @@ describe('NotificationOptionToggle', () => {
         address={'0x123123123'}
         title={'0x123123123'}
         isEnabled
-        isLoading={false}
-        disabledSwitch={false}
         refetchAccountSettings={() => Promise.resolve()}
       />,
     );

--- a/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.tsx
@@ -32,8 +32,6 @@ interface NotificationOptionsToggleProps {
   testId?: string;
 
   isEnabled: boolean;
-  isLoading?: boolean;
-  disabledSwitch?: boolean;
   refetchAccountSettings: () => Promise<void>;
 }
 
@@ -72,8 +70,6 @@ const NotificationOptionToggle = ({
   type,
   testId,
   isEnabled,
-  disabledSwitch,
-  isLoading,
 }: NotificationOptionsToggleProps) => {
   const theme = useTheme();
   const { colors } = theme;
@@ -122,7 +118,9 @@ const NotificationOptionToggle = ({
         )}
       </View>
       <View style={styles.switchElement}>
-        {!isLoading ? (
+      {isEnabled === undefined ? (
+          <ActivityIndicator />
+        ) : (
           <Switch
             value={status}
             onChange={onPress}
@@ -133,11 +131,8 @@ const NotificationOptionToggle = ({
             thumbColor={theme.brandColors.white}
             style={styles.switch}
             ios_backgroundColor={colors.border.muted}
-            disabled={disabledSwitch}
             {...generateTestId(Platform, testId)}
           />
-        ) : (
-          <ActivityIndicator />
         )}
       </View>
     </View>

--- a/app/components/Views/Settings/NotificationsSettings/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.test.tsx
@@ -7,6 +7,22 @@ import NotificationsSettings from '.';
 import { Props } from './NotificationsSettings.types';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsControllerTestUtils';
 
+// Mock store.getState
+let mockGetState: jest.Mock;
+jest.mock('../../../../store', () => {
+  mockGetState = jest.fn();
+  mockGetState.mockImplementation(() => ({
+    notifications: {},
+  }));
+
+  return {
+    store: {
+      getState: mockGetState,
+      dispatch: jest.fn(),
+    },
+  };
+});
+
 const mockInitialState = {
   settings: {
     useBlockieIcon: false,
@@ -26,6 +42,9 @@ const setOptions = jest.fn();
 
 describe('NotificationsSettings', () => {
   it('should render correctly', () => {
+    mockGetState.mockImplementation(() => ({
+      notifications: {},
+    }));
     const { toJSON } = renderWithProvider(
       <NotificationsSettings
         navigation={

--- a/app/core/redux/slices/notifications/index.ts
+++ b/app/core/redux/slices/notifications/index.ts
@@ -1,0 +1,39 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+export const REFECHING_ACCOUNTS_STATES = 'loading';
+
+export interface NotificationsAccountsState {
+  [address: string]: boolean;
+}
+
+export const initialState: NotificationsAccountsState = {};
+
+const name = 'notificationsAccountsProvider';
+
+const slice = createSlice({
+  name,
+  initialState,
+  reducers: {
+    /**
+     * Updates the local accounts state based on external notifications source.
+     * @param state - The current state of the notificationsAccountsProvider slice.
+     * @param action - An action with the new accounts states as payload.
+     */
+
+    updateAccountState: (
+      state,
+      action: PayloadAction<NotificationsAccountsState>,
+    ) => {
+      if (JSON.stringify(state) !== JSON.stringify(action.payload)) {
+        return action.payload;
+      }
+      return state;
+    },
+  },
+});
+
+const { actions, reducer } = slice;
+
+export default reducer;
+
+export const { updateAccountState } = actions;

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -29,6 +29,7 @@ import inpageProviderReducer from '../core/redux/slices/inpageProvider';
 import smartTransactionsReducer from '../core/redux/slices/smartTransactions';
 import transactionMetricsReducer from '../core/redux/slices/transactionMetrics';
 import originThrottlingReducer from '../core/redux/slices/originThrottling';
+import notificationsAccountsProvider from '../core/redux/slices/notifications';
 
 /**
  * Infer state from a reducer
@@ -120,6 +121,7 @@ export interface RootState {
   inpageProvider: StateFromReducer<typeof inpageProviderReducer>;
   transactionMetrics: StateFromReducer<typeof transactionMetricsReducer>;
   originThrottling: StateFromReducer<typeof originThrottlingReducer>;
+  notifications: StateFromReducer<typeof notificationsAccountsProvider>;
 }
 
 // TODO: Fix the Action type. It's set to `any` now because some of the
@@ -158,6 +160,7 @@ const rootReducer = combineReducers<RootState, any>({
   inpageProvider: inpageProviderReducer,
   transactionMetrics: transactionMetricsReducer,
   originThrottling: originThrottlingReducer,
+  notifications: notificationsAccountsProvider,
 });
 
 export default rootReducer;

--- a/app/util/notifications/hooks/useSwitchNotifications.test.tsx
+++ b/app/util/notifications/hooks/useSwitchNotifications.test.tsx
@@ -151,8 +151,15 @@ describe('useAccountSettingsProps', () => {
       .spyOn(Selectors, 'selectIsUpdatingMetamaskNotificationsAccount')
       .mockReturnValue([]);
 
+      const isMetamaskNotificationsEnabled = jest
+      .spyOn(Selectors,
+        'selectIsMetamaskNotificationsEnabled',
+      )
+      .mockReturnValue(true);
+
     return {
       selectIsUpdatingMetamaskNotificationsAccount,
+      isMetamaskNotificationsEnabled
     };
   }
 

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -48,6 +48,7 @@ const initialRootState: RootState = {
   inpageProvider: initialInpageProvider,
   transactionMetrics,
   originThrottling,
+  notifications: {},
 };
 
 export default initialRootState;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fix some performance issues on notifications settings screen and add a loading state for each account switch while support for local state for accounts. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
