### PR TITLE
chore(build): let adb server live between builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -178,8 +178,6 @@ prebuild_ios(){
 }
 
 prebuild_android(){
-	adb kill-server
-	adb start-server
 	prebuild
 	# Copy JS files for injection
 	yes | cp -rf app/core/InpageBridgeWeb3.js android/app/src/main/assets/.


### PR DESCRIPTION
## Description

Introduced on https://github.com/MetaMask/metamask-mobile/pull/244/commits/8fd7eb25097d867bcd3fcbce481b71e7e9b04379 

It breaks wireless adb connection, adb logcat, and any process that attaches to the running adb-server

Running adb server should not influence the ability to build

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/11135

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
