### PR TITLE
fix: sev "HIGH" `dset` vulnerability

### DIFF
--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -300,7 +300,7 @@ describe('RPC Method - wallet_addEthereumChain', () => {
         ...otherOptions,
       });
 
-      expect(Engine.context.ApprovalController.clear).toBeCalledTimes(2);
+      expect(Engine.context.ApprovalController.clear).toBeCalledTimes(1);
     });
   });
 });

--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -300,7 +300,7 @@ describe('RPC Method - wallet_addEthereumChain', () => {
         ...otherOptions,
       });
 
-      expect(Engine.context.ApprovalController.clear).toBeCalledTimes(1);
+      expect(Engine.context.ApprovalController.clear).toBeCalledTimes(2);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "react-native/ws": "^6.2.3",
     "socket.io-client/engine.io-client/ws": "^8.17.1",
     "micromatch": "4.0.8",
-    "send": "0.19.0"
+    "send": "0.19.0",
+    "dset": "^3.1.4"
   },
   "dependencies": {
     "@consensys/on-ramp-sdk": "1.28.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15762,10 +15762,10 @@ drbg.js@^1.0.1:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
 
-dset@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.3.tgz#c194147f159841148e8e34ca41f638556d9542d2"
-  integrity sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==
+dset@^3.1.1, dset@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"
+  integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==
 
 dtrace-provider@~0.8:
   version "0.8.8"


### PR DESCRIPTION
## **Description**

Fixes https://github.com/MetaMask/metamask-mobile/security/dependabot/142 (sev "HIGH")
- Causes `yarn audit:ci` to fail:
  - First observed: https://github.com/MetaMask/metamask-mobile/actions/runs/10821626483/job/30024202594
- Pinned yarn resolution for `dset` to patched version (`^3.1.4`).
  - Relying on yarn resolution was unavoidable, because the latest versions of `dset`'s upstream packages `@segment/analytics-react-native`, `@segment/tsub` aren't using the patched version yet.

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
