### PR TITLE
chore: remove triggers for actions not needed during the merge-queue CI

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -6,8 +6,6 @@ on:
       - main
     types:
       - closed
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   add-release-label:

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -9,8 +9,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   check-pr-labels:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,8 +4,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
-  merge_group:
-    types: [checks_requested]
     
 jobs:
   CLABot:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+  merge_group:
+    types: [checks_requested]
     
 jobs:
   CLABot:

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -6,8 +6,6 @@ on:
       - main
     types:
       - closed
-  merge_group:
-    types: [checks_requested]
     
 jobs:
   close-bug-report:

--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
     types: [opened,edited]
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   pr-title-linter:


### PR DESCRIPTION
## **Description**

This PR remove triggers not necessary for merge-queue validation. [This](https://github.com/MetaMask/metamask-mobile/actions/runs/10908008647) is an example of steps failing due to merge-queue attempting to run. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. NA
2.
3.

## **Screenshots/Recordings**

NA

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
