### PR TITLE
fix: quick fix on feature flag & notification state

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1014,8 +1014,9 @@ export function getWalletNavbarOptions(
     ),
     headerRight: () => (
       <View style={styles.leftButtonContainer}>
-        {isNotificationEnabled && isNotificationsFeatureEnabled() && (
-          <View style={styles.notificationsWrapper}>
+
+        <View style={styles.notificationsWrapper}>
+          {isNotificationsFeatureEnabled() && (
             <ButtonIcon
               iconColor={IconColor.Primary}
               onPress={handleNotificationOnPress}
@@ -1024,6 +1025,8 @@ export function getWalletNavbarOptions(
               testID={WalletViewSelectorsIDs.WALLET_NOTIFICATIONS_BUTTON}
               style={styles.notificationButton}
             />
+          )}
+          {isNotificationEnabled && (
             <View
               style={[
                 styles.notificationsBadge,
@@ -1033,9 +1036,9 @@ export function getWalletNavbarOptions(
                     : themeColors.background.transparent,
                 },
               ]}
-            />
-          </View>
-        )}
+            />)}
+        </View>
+
 
         <ButtonIcon
           iconColor={IconColor.Primary}

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -260,6 +260,16 @@ exports[`Wallet should render correctly 1`] = `
                   }
                 }
               >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                      "position": "relative",
+                    }
+                  }
+                />
                 <TouchableOpacity
                   accessible={true}
                   activeOpacity={1}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This Pr adds a quick fix on how to render Notification unread/read dot on top of in App bell icon.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
