### PR TITLE
feat: reject connection properly

### DIFF
--- a/app/core/SDKConnect/Connection/Connection.ts
+++ b/app/core/SDKConnect/Connection/Connection.ts
@@ -317,7 +317,7 @@ export class Connection extends EventEmitter2 {
     this.trigger = trigger;
   }
 
-  disconnect({ terminate, context }: { terminate: boolean; context?: string }) {
+  disconnect({ terminate, context }: { terminate: boolean; context?: string }): Promise<boolean> {
     return disconnect({ instance: this, terminate, context });
   }
 

--- a/app/core/SDKConnect/Connection/Connection.ts
+++ b/app/core/SDKConnect/Connection/Connection.ts
@@ -272,12 +272,15 @@ export class Connection extends EventEmitter2 {
   public connect({
     withKeyExchange,
     authorized,
+    rejected,
   }: {
     authorized: boolean;
+    rejected?: boolean;
     withKeyExchange: boolean;
   }) {
     return connect({
       instance: this,
+      rejected,
       withKeyExchange,
       authorized,
     });

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/connect.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/connect.ts
@@ -7,6 +7,7 @@ async function connect({
   authorized,
 }: {
   withKeyExchange: boolean;
+  rejected?: boolean;
   instance: Connection;
   authorized: boolean;
 }) {

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.test.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.test.ts
@@ -17,7 +17,7 @@ describe('disconnect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockRemoteSendMessage.mockResolvedValue(undefined);
+    mockRemoteSendMessage.mockResolvedValue(true);
 
     mockConnection = {
       channelId: 'testChannelId',
@@ -29,45 +29,74 @@ describe('disconnect', () => {
     } as unknown as Connection;
   });
 
-  it('should log the disconnect action with channel ID, context, and terminate flag', () => {
-    disconnect({ instance: mockConnection, terminate: true, context: 'test' });
+  it('should log the disconnect action with channel ID, context, and terminate flag', async () => {
+    await disconnect({ instance: mockConnection, terminate: true, context: 'test' });
 
-    expect(DevLogger.log).toHaveBeenCalledTimes(1);
-    expect(DevLogger.log).toHaveBeenCalledWith(
+    expect(DevLogger.log).toHaveBeenCalledTimes(3);
+    expect(DevLogger.log).toHaveBeenNthCalledWith(
+      1,
       `Connection::disconnect() context=test id=testChannelId terminate=true`,
+    );
+    expect(DevLogger.log).toHaveBeenNthCalledWith(
+      2,
+      `Connection::disconnect() context=test id=testChannelId terminate=true sending terminate`,
+    );
+    expect(DevLogger.log).toHaveBeenNthCalledWith(
+      3,
+      `Connection::disconnect() context=test id=testChannelId terminate=true sent terminate=true`,
     );
   });
 
-  it('should reset receivedClientsReady to false', () => {
-    disconnect({ instance: mockConnection, terminate: true });
+  it('should reset receivedClientsReady to false', async () => {
+    await disconnect({ instance: mockConnection, terminate: true });
 
     expect(mockConnection.receivedClientsReady).toBe(false);
   });
 
   describe('When terminate is true', () => {
-    it('should send a TERMINATE message to the remote', () => {
-      disconnect({ instance: mockConnection, terminate: true });
+    it('should send a TERMINATE message to the remote', async () => {
+      await disconnect({ instance: mockConnection, terminate: true });
 
       expect(mockRemoteSendMessage).toHaveBeenCalledTimes(1);
       expect(mockRemoteSendMessage).toHaveBeenCalledWith({
         type: MessageType.TERMINATE,
       });
     });
-  });
 
-  describe('Disconnecting the remote', () => {
-    it('should call disconnect on the remote', () => {
-      disconnect({ instance: mockConnection, terminate: true });
+    it('should call disconnect on the remote when terminated successfully', async () => {
+      await disconnect({ instance: mockConnection, terminate: true });
 
       expect(mockRemoteDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call disconnect on the remote when termination fails', async () => {
+      mockRemoteSendMessage.mockResolvedValue(false);
+      await disconnect({ instance: mockConnection, terminate: true });
+
+      expect(mockRemoteDisconnect).not.toHaveBeenCalled();
     });
   });
 
   describe('When terminate is false', () => {
-    it('should not send a TERMINATE message to the remote', () => {
-      disconnect({ instance: mockConnection, terminate: false });
+    it('should not send a TERMINATE message to the remote', async () => {
+      await disconnect({ instance: mockConnection, terminate: false });
 
       expect(mockRemoteSendMessage).not.toHaveBeenCalled();
     });
+
+    it('should not call disconnect on the remote', async () => {
+      await disconnect({ instance: mockConnection, terminate: false });
+
+      expect(mockRemoteDisconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should return the terminated status', async () => {
+    const result = await disconnect({ instance: mockConnection, terminate: true });
+    expect(result).toBe(true);
+
+    mockRemoteSendMessage.mockResolvedValue(false);
+    const falseResult = await disconnect({ instance: mockConnection, terminate: true });
+    expect(falseResult).toBe(false);
   });
 });

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.ts
@@ -1,10 +1,9 @@
-import Logger from '../../../../util/Logger';
 
 import { MessageType } from '@metamask/sdk-communication-layer';
 import DevLogger from '../../utils/DevLogger';
 import { Connection } from '../Connection';
 
-function disconnect({
+async function disconnect({
   terminate,
   context,
   instance,
@@ -12,21 +11,24 @@ function disconnect({
   instance: Connection;
   terminate: boolean;
   context?: string;
-}) {
+}): Promise<boolean> {
   DevLogger.log(
     `Connection::disconnect() context=${context} id=${instance.channelId} terminate=${terminate}`,
   );
   instance.receivedClientsReady = false;
+  let terminated = false;
   if (terminate) {
-    instance.remote
+    DevLogger.log(`Connection::disconnect() context=${context} id=${instance.channelId} terminate=${terminate} sending terminate`);
+    terminated = await instance.remote
       .sendMessage({
         type: MessageType.TERMINATE,
-      })
-      .catch((err) => {
-        Logger.log(err, `Connection failed to send terminate`);
       });
+    DevLogger.log(`Connection::disconnect() context=${context} id=${instance.channelId} terminate=${terminate} sent terminate=${terminated}`);
   }
-  instance.remote.disconnect();
+  if(terminated) {
+    instance.remote.disconnect();
+  }
+  return terminated;
 }
 
 export default disconnect;

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/removeConnection.test.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/removeConnection.test.ts
@@ -9,7 +9,7 @@ describe('removeConnection', () => {
   let mockConnection: Connection;
 
   const mockDisapprove = jest.fn();
-  const mockDisconnect = jest.fn();
+  const mockDisconnect = jest.fn().mockImplementation(() => Promise.resolve(true));
   const mockOnDisconnect = jest.fn();
   const mockSetLoading = jest.fn();
 
@@ -28,64 +28,70 @@ describe('removeConnection', () => {
       },
       setLoading: mockSetLoading,
     } as unknown as Connection;
+
+    // Reset the mock implementation to return true by default
+    mockDisconnect.mockImplementation(() => Promise.resolve(true));
   });
 
-  it('should set isReady to false', () => {
-    removeConnection({
+  it('should set isReady to false when disconnected', async () => {
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(true);
     expect(mockConnection.isReady).toBe(false);
   });
 
-  it('should reset lastAuthorized to 0', () => {
-    removeConnection({
+  it('should reset lastAuthorized to 0 when disconnected', async () => {
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(true);
     expect(mockConnection.lastAuthorized).toBe(0);
   });
 
-  it('should set authorizedSent to false', () => {
-    removeConnection({
+  it('should set authorizedSent to false when disconnected', async () => {
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(true);
     expect(mockConnection.authorizedSent).toBe(false);
   });
 
-  it('should log the removal action with context and channel ID', () => {
-    removeConnection({
+  it('should log the removal action with context, channel ID, and disconnected status', async () => {
+    await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
-    expect(DevLogger.log).toHaveBeenCalledTimes(1);
     expect(DevLogger.log).toHaveBeenCalledWith(
-      `Connection::removeConnection() context=test id=testChannelId`,
+      'Connection::removeConnection() context=test id=testChannelId disconnected=true',
     );
   });
 
-  it('should call disapprove with the channel ID', () => {
-    removeConnection({
+  it('should call disapprove with the channel ID when disconnected', async () => {
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(true);
     expect(mockDisapprove).toHaveBeenCalledTimes(1);
     expect(mockDisapprove).toHaveBeenCalledWith(mockConnection.channelId);
   });
 
-  it('should call disconnect with terminate flag and specific context', () => {
-    removeConnection({
+  it('should call disconnect with terminate flag and specific context', async () => {
+    await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
@@ -98,24 +104,43 @@ describe('removeConnection', () => {
     });
   });
 
-  it('should trigger onDisconnect of the backgroundBridge if it exists', () => {
-    removeConnection({
+  it('should trigger onDisconnect of the backgroundBridge if it exists and disconnected', async () => {
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(true);
     expect(mockOnDisconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('should set loading to false', () => {
-    removeConnection({
+  it('should set loading to false regardless of disconnect result', async () => {
+    mockDisconnect.mockImplementation(() => Promise.resolve(false)); // Mock unsuccessful disconnect
+    const result = await removeConnection({
       instance: mockConnection,
       terminate: true,
       context: 'test',
     });
 
+    expect(result).toBe(false);
     expect(mockSetLoading).toHaveBeenCalledTimes(1);
     expect(mockSetLoading).toHaveBeenCalledWith(false);
+  });
+
+  it('should not modify connection properties if disconnect fails', async () => {
+    mockDisconnect.mockImplementation(() => Promise.resolve(false)); // Mock unsuccessful disconnect
+    const result = await removeConnection({
+      instance: mockConnection,
+      terminate: true,
+      context: 'test',
+    });
+
+    expect(result).toBe(false);
+    expect(mockConnection.isReady).toBe(true);
+    expect(mockConnection.lastAuthorized).not.toBe(0);
+    expect(mockConnection.authorizedSent).toBe(true);
+    expect(mockDisapprove).not.toHaveBeenCalled();
+    expect(mockOnDisconnect).not.toHaveBeenCalled();
   });
 });

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/removeConnection.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/removeConnection.ts
@@ -1,7 +1,7 @@
 import DevLogger from '../../utils/DevLogger';
 import { Connection } from '../Connection';
 
-function removeConnection({
+async function removeConnection({
   terminate,
   context,
   instance,
@@ -9,18 +9,23 @@ function removeConnection({
   instance: Connection;
   terminate: boolean;
   context?: string;
-}) {
-  instance.isReady = false;
-  instance.lastAuthorized = 0;
-  instance.authorizedSent = false;
-  DevLogger.log(
-    `Connection::removeConnection() context=${context} id=${instance.channelId}`,
-  );
-  instance.disapprove(instance.channelId);
-  instance.disconnect({ terminate, context: 'Connection::removeConnection' });
-  instance.backgroundBridge?.onDisconnect();
+}): Promise<boolean> {
+
+  const disconnected = await instance.disconnect({ terminate, context: 'Connection::removeConnection' });
+  DevLogger.log(`Connection::removeConnection() context=${context} id=${instance.channelId} disconnected=${disconnected}`);
+  if (disconnected) {
+    instance.backgroundBridge?.onDisconnect();
+    instance.isReady = false;
+    instance.lastAuthorized = 0;
+    instance.authorizedSent = false;
+    DevLogger.log(
+      `Connection::removeConnection() context=${context} id=${instance.channelId}`,
+    );
+    instance.disapprove(instance.channelId);
+  }
   instance.approvalPromise = undefined;
   instance.setLoading(false);
+  return disconnected;
 }
 
 export default removeConnection;

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
@@ -136,6 +136,11 @@ async function connectToChannel({
       });
       authorized = true;
     } catch (error) {
+      // TODO: send rejected event
+
+      // first needs to connect without key exchange to send the event
+      await instance.state.connected[id].remote.reject({channelId: id});
+
       instance.removeChannel({ channelId: id, sendTerminate: true });
       // cleanup connection
       await wait(100); // Add delay for connect modal to be fully closed

--- a/app/core/SDKConnect/ConnectionManagement/removeAll.ts
+++ b/app/core/SDKConnect/ConnectionManagement/removeAll.ts
@@ -6,33 +6,58 @@ import {
 import { store } from '../../../../app/store';
 import SDKConnect from '../SDKConnect';
 
-async function removeAll(instance: SDKConnect) {
-  for (const id in instance.state.connections) {
-    instance.removeChannel({
-      channelId: id,
-      sendTerminate: true,
-    });
+async function removeAll(instance: SDKConnect): Promise<boolean> {
+  const removeChannels = async (connections: Record<string, unknown>): Promise<boolean> => {
+    try {
+      await Promise.all(
+        Object.keys(connections).map(id =>
+          instance.removeChannel({
+            channelId: id,
+            sendTerminate: true,
+          })
+        )
+      );
+      return true;
+    } catch (error) {
+      console.error('Error removing channels:', error);
+      return false;
+    }
+  };
+
+  try {
+    // Remove current connections and dapp connections in parallel
+    const [currentRemoved, dappRemoved] = await Promise.all([
+      removeChannels(instance.state.connections),
+      removeChannels(await instance.loadDappConnections()),
+    ]);
+
+    if (currentRemoved && dappRemoved) {
+      // Reset state
+      instance.state = {
+        ...instance.state,
+        approvedHosts: {},
+        disabledHosts: {},
+        connections: {},
+        dappConnections: {},
+        connected: {},
+        connecting: {},
+        paused: false,
+      };
+
+      // Dispatch reset actions
+      store.dispatch(resetConnections({}));
+      store.dispatch(resetApprovedHosts({}));
+      store.dispatch(resetDappConnections({}));
+
+      return true;
+    }
+      console.error('Failed to remove all connections');
+      return false;
+
+  } catch (error) {
+    console.error('Error in removeAll:', error);
+    return false;
   }
-
-  for (const id in await instance.loadDappConnections()) {
-    instance.removeChannel({
-      channelId: id,
-      sendTerminate: true,
-    });
-  }
-
-  // Also remove approved hosts that may have been skipped.
-  instance.state.approvedHosts = {};
-  instance.state.disabledHosts = {};
-  instance.state.connections = {};
-  instance.state.dappConnections = {};
-  instance.state.connected = {};
-  instance.state.connecting = {};
-  instance.state.paused = false;
-
-  store.dispatch(resetConnections({}));
-  store.dispatch(resetApprovedHosts({}));
-  store.dispatch(resetDappConnections({}));
 }
 
 export default removeAll;

--- a/app/core/SDKConnect/SDKConnect.test.ts
+++ b/app/core/SDKConnect/SDKConnect.test.ts
@@ -94,7 +94,7 @@ describe('SDKConnect', () => {
   >;
 
   const mockRemoveAll = removeAll as jest.MockedFunction<typeof removeAll>;
-  mockRemoveAll.mockResolvedValue(Promise.resolve());
+  mockRemoveAll.mockResolvedValue(true);
 
   const mockInvalidateChannel = invalidateChannel as jest.MockedFunction<
     typeof invalidateChannel

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@metamask/react-native-webview": "^14.0.3",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/scure-bip39": "^2.1.0",
-    "@metamask/sdk-communication-layer": "^0.28.1",
+    "@metamask/sdk-communication-layer": "0.29.0-wallet",
     "@metamask/selected-network-controller": "^15.0.2",
     "@metamask/signature-controller": "^17.0.0",
     "@metamask/slip44": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,10 +5085,10 @@
     "@noble/hashes" "~1.3.2"
     "@scure/base" "~1.1.3"
 
-"@metamask/sdk-communication-layer@^0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.28.1.tgz#fa7ba2529359603071fcc5c593149609694ec663"
-  integrity sha512-dH3dR7E35KM+2JNYYa1k39xdPyKejRASRCA3tt/iHo3KvFRC3JDRJyzi+JFYP4JUaCtp7HmDL6GGspQHiBudTQ==
+"@metamask/sdk-communication-layer@0.29.0-wallet":
+  version "0.29.0-wallet"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.29.0-wallet.tgz#05b8589fc731e5a92e22607c8b63dd7f71d58081"
+  integrity sha512-GgBzSNijpu+Utm5/joiI+uzzCgB0CpK7ZBFkQvn7NGguWGJKiHPexDNDLGlwViw3X5QpFHmY7hNBMWoDIby2HA==
   dependencies:
     bufferutil "^4.0.8"
     date-fns "^2.29.3"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is an update to the SDK communication protocol that allows the following:
- prevent deleting connection until server confirmation
- emit rejection event 

## **Related issues**

- https://github.com/MetaMask/metamask-sdk/pull/1020
- https://github.com/MetaMask/metamask-sdk/pull/1022

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
