### PR TITLE
fix: fix detect tokens performance

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -388,9 +388,8 @@ const Wallet = ({
   useEffect(
     () => {
       requestAnimationFrame(async () => {
-        const { TokenDetectionController, AccountTrackerController } =
+        const { AccountTrackerController } =
           Engine.context;
-        TokenDetectionController.detectTokens();
         AccountTrackerController.refresh();
       });
     },

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1678,7 +1678,6 @@ class Engine {
     const {
       AccountTrackerController,
       AssetsContractController,
-      TokenDetectionController,
       NetworkController,
       SwapsController,
     } = this.context;
@@ -1700,7 +1699,6 @@ class Engine {
       ).configuration.chainId,
       pollCountLimit: AppConstants.SWAPS.POLL_COUNT_LIMIT,
     });
-    TokenDetectionController.detectTokens();
     AccountTrackerController.refresh();
   }
 

--- a/patches/@metamask+assets-controllers+30.0.0.patch
+++ b/patches/@metamask+assets-controllers+30.0.0.patch
@@ -381,7 +381,7 @@ index ee6155c..06a3a04 100644
  };
  var NftDetectionController_default = NftDetectionController;
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
-index 76e3362..586b15e 100644
+index 76e3362..6f79cf7 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 +++ b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 @@ -34,7 +34,7 @@ var STATIC_MAINNET_TOKEN_LIST = Object.entries(
@@ -440,7 +440,17 @@ index 76e3362..586b15e 100644
          await _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _restartTokenDetection, restartTokenDetection_fn).call(this, {
            selectedAddress: _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress)
          });
-@@ -324,7 +326,7 @@ getSlicesOfTokensToDetect_fn = function({
+@@ -241,7 +243,8 @@ registerEventListeners_fn = function() {
+     async ({ address: newSelectedAddress }) => {
+       const isSelectedAddressChanged = _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress) !== newSelectedAddress;
+       if (isSelectedAddressChanged) {
+-        _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _selectedAddress, newSelectedAddress);
++        const newSelectedAddressChecksummed = _controllerutils.toChecksumHexAddress.call(void 0, newSelectedAddress)
++        _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _selectedAddress, newSelectedAddressChecksummed);
+         await _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _restartTokenDetection, restartTokenDetection_fn).call(this, {
+           selectedAddress: _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress)
+         });
+@@ -324,7 +327,7 @@ getSlicesOfTokensToDetect_fn = function({
    chainId,
    selectedAddress
  }) {

--- a/patches/@metamask+assets-controllers+30.0.0.patch
+++ b/patches/@metamask+assets-controllers+30.0.0.patch
@@ -381,7 +381,7 @@ index ee6155c..06a3a04 100644
  };
  var NftDetectionController_default = NftDetectionController;
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
-index 76e3362..6f79cf7 100644
+index 76e3362..057c90e 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 +++ b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 @@ -34,7 +34,7 @@ var STATIC_MAINNET_TOKEN_LIST = Object.entries(
@@ -417,7 +417,18 @@ index 76e3362..6f79cf7 100644
      _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _trackMetaMetricsEvent, trackMetaMetricsEvent);
      const { isUnlocked } = this.messagingSystem.call(
        "KeyringController:getState"
-@@ -203,6 +206,7 @@ _isDetectionEnabledFromPreferences = new WeakMap();
+@@ -165,7 +168,9 @@ var TokenDetectionController = class extends _pollingcontroller.StaticIntervalPo
+     if (!this.isActive) {
+       return;
+     }
+-    const addressAgainstWhichToDetect = selectedAddress ?? _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress);
++    const currentAddress = _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress);
++    const currentAddressChecksum = _controllerutils.toChecksumHexAddress.call(void 0, currentAddress)
++    const addressAgainstWhichToDetect = _controllerutils.toChecksumHexAddress.call(void 0, selectedAddress) ?? currentAddressChecksum;
+     const { chainId, networkClientId: selectedNetworkClientId } = _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _getCorrectChainIdAndNetworkClientId, getCorrectChainIdAndNetworkClientId_fn).call(this, networkClientId);
+     const chainIdAgainstWhichToDetect = chainId;
+     const networkClientIdAgainstWhichToDetect = selectedNetworkClientId;
+@@ -203,6 +208,7 @@ _isDetectionEnabledFromPreferences = new WeakMap();
  _isDetectionEnabledForNetwork = new WeakMap();
  _getBalancesInSingleCall = new WeakMap();
  _trackMetaMetricsEvent = new WeakMap();
@@ -425,7 +436,7 @@ index 76e3362..6f79cf7 100644
  _registerEventListeners = new WeakSet();
  registerEventListeners_fn = function() {
    this.messagingSystem.subscribe("KeyringController:unlock", async () => {
-@@ -224,12 +228,10 @@ registerEventListeners_fn = function() {
+@@ -224,12 +230,10 @@ registerEventListeners_fn = function() {
    );
    this.messagingSystem.subscribe(
      "PreferencesController:stateChange",
@@ -440,17 +451,7 @@ index 76e3362..6f79cf7 100644
          await _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _restartTokenDetection, restartTokenDetection_fn).call(this, {
            selectedAddress: _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress)
          });
-@@ -241,7 +243,8 @@ registerEventListeners_fn = function() {
-     async ({ address: newSelectedAddress }) => {
-       const isSelectedAddressChanged = _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress) !== newSelectedAddress;
-       if (isSelectedAddressChanged) {
--        _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _selectedAddress, newSelectedAddress);
-+        const newSelectedAddressChecksummed = _controllerutils.toChecksumHexAddress.call(void 0, newSelectedAddress)
-+        _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _selectedAddress, newSelectedAddressChecksummed);
-         await _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _restartTokenDetection, restartTokenDetection_fn).call(this, {
-           selectedAddress: _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress)
-         });
-@@ -324,7 +327,7 @@ getSlicesOfTokensToDetect_fn = function({
+@@ -324,7 +328,7 @@ getSlicesOfTokensToDetect_fn = function({
    chainId,
    selectedAddress
  }) {

--- a/patches/@metamask+assets-controllers+30.0.0.patch
+++ b/patches/@metamask+assets-controllers+30.0.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-4ODKGWYQ.js b/node_modules/@metamask/assets-controllers/dist/chunk-4ODKGWYQ.js
-index 542e3f6..6c656aa 100644
+index 542e3f6..af49a85 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-4ODKGWYQ.js
 +++ b/node_modules/@metamask/assets-controllers/dist/chunk-4ODKGWYQ.js
 @@ -69,9 +69,10 @@ var AssetsContractController = class extends _basecontroller.BaseControllerV1 {
@@ -381,7 +381,7 @@ index ee6155c..06a3a04 100644
  };
  var NftDetectionController_default = NftDetectionController;
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
-index 76e3362..5ab79a4 100644
+index 76e3362..586b15e 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 +++ b/node_modules/@metamask/assets-controllers/dist/chunk-HDI4L2DD.js
 @@ -34,7 +34,7 @@ var STATIC_MAINNET_TOKEN_LIST = Object.entries(
@@ -425,7 +425,22 @@ index 76e3362..5ab79a4 100644
  _registerEventListeners = new WeakSet();
  registerEventListeners_fn = function() {
    this.messagingSystem.subscribe("KeyringController:unlock", async () => {
-@@ -324,7 +328,7 @@ getSlicesOfTokensToDetect_fn = function({
+@@ -224,12 +228,10 @@ registerEventListeners_fn = function() {
+   );
+   this.messagingSystem.subscribe(
+     "PreferencesController:stateChange",
+-    async ({ selectedAddress: newSelectedAddress, useTokenDetection }) => {
+-      const isSelectedAddressChanged = _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress) !== newSelectedAddress;
++    async ({ useTokenDetection }) => {
+       const isDetectionChangedFromPreferences = _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _isDetectionEnabledFromPreferences) !== useTokenDetection;
+-      _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _selectedAddress, newSelectedAddress);
+       _chunkZ4BLTVTBjs.__privateSet.call(void 0, this, _isDetectionEnabledFromPreferences, useTokenDetection);
+-      if (isSelectedAddressChanged || isDetectionChangedFromPreferences) {
++      if (isDetectionChangedFromPreferences) {
+         await _chunkZ4BLTVTBjs.__privateMethod.call(void 0, this, _restartTokenDetection, restartTokenDetection_fn).call(this, {
+           selectedAddress: _chunkZ4BLTVTBjs.__privateGet.call(void 0, this, _selectedAddress)
+         });
+@@ -324,7 +326,7 @@ getSlicesOfTokensToDetect_fn = function({
    chainId,
    selectedAddress
  }) {
@@ -826,7 +841,7 @@ index cd8f792..b20db8a 100644
  
  
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-MBCN3MNX.js b/node_modules/@metamask/assets-controllers/dist/chunk-MBCN3MNX.js
-index b8722af..535b648 100644
+index b8722af..dbff48b 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-MBCN3MNX.js
 +++ b/node_modules/@metamask/assets-controllers/dist/chunk-MBCN3MNX.js
 @@ -103,10 +103,14 @@ var TokensController = class extends _basecontroller.BaseControllerV1 {


### PR DESCRIPTION
## **Description**

This PR removes not needed calls in the codebase to `TokenDetectionController.detectTokens(); ` that was making the app slower;

Note: This performance issue is more noticeable on Android than IOS.

This PR remove this [call](https://github.com/MetaMask/metamask-mobile/blob/6fc1d9d3ae3fc2f7e447349f8b110e9520fc9e15/app/core/Engine.ts#L1698) in Engine.ts. This call is executed whenever the user switches networks; I think this is not needed since `TokenDetectionController` in core is already subscribed to `NetworkController:networkDidChange`. 

Similarly, This PR also also removes this [call](https://github.com/MetaMask/metamask-mobile/blob/6fc1d9d3ae3fc2f7e447349f8b110e9520fc9e15/app/components/Views/Wallet/index.tsx#L401) in wallet/index.tsx; 

I have also noticed that switching accounts in android is a bit slow; that was due to calling detectTokens function twice.
One call was made because TokenDetectionController is subscribed to `AccountsController:selectedAccountChange`
the other one was happening because of the subscription to `PreferencesController:stateChange` which is redundant and was happening because this [PR](https://github.com/MetaMask/core/pull/4219/files#diff-3336d65a4d2c1e5af90f22e16feb058f327960796b135308bca9ed8415418f5dR297) update was not patched;


When testing with simulator, after adding logs inside [onNetworkChange](https://github.com/MetaMask/metamask-mobile/blob/726ca826662ea6044cd5da671555c379e19a7864/app/components/Views/NetworkSelector/NetworkSelector.tsx#L191) 
This is how much it take to go from linea to Ethereum network on this PR vs main
<img width="1758" alt="Screenshot 2024-09-19 at 17 29 51" src="https://github.com/user-attachments/assets/7d66d49d-ffdc-4311-9fad-2b14245289f3">

<img width="1800" alt="Screenshot 2024-09-19 at 18 27 51" src="https://github.com/user-attachments/assets/76fe85b6-4413-4a1a-9e4d-e1fc305f8b89">

Testing on physical:


https://github.com/user-attachments/assets/146cee68-75ba-459b-9e80-4b8f9bfb54b6




## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/1927

## **Manual testing steps**

(I found it easier to debug when you add console.log inside detect tokens function to make sure it is not being called multiple times)
1. Go to home page and select Linea network; then go back to Ethereum mainnet; switch back and forth multiple times and you should notice the switch is smoother now; you can check your console.log in your terminal and see that when you switch between networks; you only see it calling detectTokens once.
2. Switch accounts back and forth and it should also be faster; you can also check logs and make sure detectTokens is only triggered once when switching accounts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/721d1f56-6e1e-4940-9544-5d4b5c3232c0



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c6287f8c-3091-4267-b82a-4c6bc02527fb


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
