### PR TITLE
feat: adding footer section to confirmation page

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -3,12 +3,13 @@ import { Text, View } from 'react-native';
 
 import BottomModal from '../../../../components/UI/BottomModal';
 import { useTheme } from '../../../../util/theme';
-import useRedesignEnabled from '../hooks/useRedesignEnabled';
+import Footer from '../components/Confirm/Footer';
+import useConfirmationRedesignEnabled from '../hooks/useConfirmationRedesignEnabled';
 import createStyles from './style';
 
 const Confirm = () => {
   const { colors } = useTheme();
-  const { isRedesignedEnabled } = useRedesignEnabled();
+  const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
 
   if (!isRedesignedEnabled) {
     return null;
@@ -20,6 +21,7 @@ const Confirm = () => {
     <BottomModal>
       <View style={styles.container}>
         <Text>TODO</Text>
+        <Footer />
       </View>
     </BottomModal>
   );

--- a/app/components/Views/confirmations/Confirm/__snapshots__/Confirm.test.tsx.snap
+++ b/app/components/Views/confirmations/Confirm/__snapshots__/Confirm.test.tsx.snap
@@ -130,6 +130,131 @@ exports[`Confirm should match snapshot for personal sign 1`] = `
       <Text>
         TODO
       </Text>
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "padding": 16,
+          }
+        }
+      >
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessible={true}
+          activeOpacity={0.2}
+          onPress={[Function]}
+          style={
+            [
+              [
+                {
+                  "borderRadius": 100,
+                  "justifyContent": "center",
+                  "padding": 15,
+                },
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#0376c9",
+                  "borderWidth": 1,
+                },
+                {
+                  "flex": 1,
+                },
+              ],
+              null,
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#007aff",
+                  "fontSize": 17,
+                  "fontWeight": "500",
+                  "textAlign": "center",
+                },
+                null,
+                [
+                  {
+                    "fontFamily": "EuclidCircularB-Bold",
+                    "fontSize": 14,
+                    "fontWeight": "600",
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#0376c9",
+                  },
+                  undefined,
+                ],
+                null,
+              ]
+            }
+          >
+            Reject
+          </Text>
+        </TouchableOpacity>
+        <View
+          style={
+            {
+              "width": 8,
+            }
+          }
+        />
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessible={true}
+          activeOpacity={0.2}
+          onPress={[Function]}
+          style={
+            [
+              [
+                {
+                  "borderRadius": 100,
+                  "justifyContent": "center",
+                  "padding": 15,
+                },
+                {
+                  "backgroundColor": "#0376c9",
+                  "minHeight": 50,
+                },
+                {
+                  "flex": 1,
+                },
+              ],
+              null,
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#007aff",
+                  "fontSize": 17,
+                  "fontWeight": "500",
+                  "textAlign": "center",
+                },
+                null,
+                [
+                  {
+                    "fontFamily": "EuclidCircularB-Bold",
+                    "fontSize": 14,
+                    "fontWeight": "600",
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#ffffff",
+                  },
+                  undefined,
+                ],
+                null,
+              ]
+            }
+          >
+            Confirm
+          </Text>
+        </TouchableOpacity>
+      </View>
     </View>
   </View>
 </Modal>

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { personalSignatureConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
+import Footer from './index';
+import { fireEvent } from '@testing-library/react-native';
+
+const mockConfirmSpy = jest.fn();
+const mockRejectSpy = jest.fn();
+jest.mock('../../../hooks/useApprovalRequest', () => () => ({
+  onConfirm: mockConfirmSpy,
+  onReject: mockRejectSpy,
+}));
+
+describe('Footer', () => {
+  it('should match snapshot for personal sign', async () => {
+    const container = renderWithProvider(<Footer />, {
+      state: personalSignatureConfirmationState,
+    });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should call onConfirm when confirm button is clicked', async () => {
+    const { getByText } = renderWithProvider(<Footer />, {
+      state: personalSignatureConfirmationState,
+    });
+    fireEvent.press(getByText('Confirm'));
+    expect(mockConfirmSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onReject when reject button is clicked', async () => {
+    const { getByText } = renderWithProvider(<Footer />, {
+      state: personalSignatureConfirmationState,
+    });
+    fireEvent.press(getByText('Reject'));
+    expect(mockRejectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import { strings } from '../../../../../../../locales/i18n';
+import StyledButton from '../../../../../../components/UI/StyledButton';
+import { useTheme } from '../../../../../../util/theme';
+import useApprovalRequest from '../../../hooks/useApprovalRequest';
+import createStyles from './style';
+
+const Footer = () => {
+  const { onConfirm, onReject } = useApprovalRequest();
+  const { colors } = useTheme();
+
+  const styles = createStyles(colors);
+
+  return (
+    <View style={styles.buttonsContainer}>
+      <StyledButton
+        onPress={onReject}
+        containerStyle={styles.fill}
+        type={'normal'}
+      >
+        {strings('confirm.reject')}
+      </StyledButton>
+      <View style={styles.buttonDivider} />
+      <StyledButton
+        onPress={onConfirm}
+        containerStyle={styles.fill}
+        type={'confirm'}
+      >
+        {strings('confirm.confirm')}
+      </StyledButton>
+    </View>
+  );
+};
+
+export default Footer;

--- a/app/components/Views/confirmations/components/Confirm/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/app/components/Views/confirmations/components/Confirm/Footer/__snapshots__/Footer.test.tsx.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer should match snapshot for personal sign 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "row",
+      "padding": 16,
+    }
+  }
+>
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessible={true}
+    activeOpacity={0.2}
+    onPress={[MockFunction]}
+    style={
+      [
+        [
+          {
+            "borderRadius": 100,
+            "justifyContent": "center",
+            "padding": 15,
+          },
+          {
+            "backgroundColor": "#ffffff",
+            "borderColor": "#0376c9",
+            "borderWidth": 1,
+          },
+          {
+            "flex": 1,
+          },
+        ],
+        null,
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#007aff",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "textAlign": "center",
+          },
+          null,
+          [
+            {
+              "fontFamily": "EuclidCircularB-Bold",
+              "fontSize": 14,
+              "fontWeight": "600",
+              "textAlign": "center",
+            },
+            {
+              "color": "#0376c9",
+            },
+            undefined,
+          ],
+          null,
+        ]
+      }
+    >
+      Reject
+    </Text>
+  </TouchableOpacity>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessible={true}
+    activeOpacity={0.2}
+    onPress={[MockFunction]}
+    style={
+      [
+        [
+          {
+            "borderRadius": 100,
+            "justifyContent": "center",
+            "padding": 15,
+          },
+          {
+            "backgroundColor": "#0376c9",
+            "minHeight": 50,
+          },
+          {
+            "flex": 1,
+          },
+        ],
+        null,
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#007aff",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "textAlign": "center",
+          },
+          null,
+          [
+            {
+              "fontFamily": "EuclidCircularB-Bold",
+              "fontSize": 14,
+              "fontWeight": "600",
+              "textAlign": "center",
+            },
+            {
+              "color": "#ffffff",
+            },
+            undefined,
+          ],
+          null,
+        ]
+      }
+    >
+      Confirm
+    </Text>
+  </TouchableOpacity>
+</View>
+`;

--- a/app/components/Views/confirmations/components/Confirm/Footer/index.ts
+++ b/app/components/Views/confirmations/components/Confirm/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/app/components/Views/confirmations/components/Confirm/Footer/style.ts
+++ b/app/components/Views/confirmations/components/Confirm/Footer/style.ts
@@ -1,0 +1,23 @@
+import { StyleSheet } from 'react-native';
+
+import { Colors } from '../../../../../../util/theme/models';
+
+const createStyles = (colors: Colors) =>
+  StyleSheet.create({
+    fill: {
+      flex: 1,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: colors.border.muted,
+    },
+    buttonsContainer: {
+      flexDirection: 'row',
+      padding: 16,
+    },
+    buttonDivider: {
+      width: 8,
+    },
+  });
+
+export default createStyles;

--- a/app/components/Views/confirmations/components/SignatureRequest/Root/Root.tsx
+++ b/app/components/Views/confirmations/components/SignatureRequest/Root/Root.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import setSignatureRequestSecurityAlertResponse from '../../../../../../actions/signatureRequest';
 import { store } from '../../../../../../store';
 import { useTheme } from '../../../../../../util/theme';
-import useRedesignEnabled from '../../../hooks/useRedesignEnabled';
+import useConfirmationRedesignEnabled from '../../../hooks/useConfirmationRedesignEnabled';
 import PersonalSign from '../../PersonalSign';
 import TypedSign from '../../TypedSign';
 import { MessageParams } from '../types';
@@ -40,7 +40,7 @@ const Root = ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (reduxState: any) => reduxState.modals.signMessageModalVisible,
   );
-  const { isRedesignedEnabled } = useRedesignEnabled();
+  const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
 
   const toggleExpandedMessage = () =>
     setShowExpandedMessage(!showExpandedMessage);

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 
 import { ApprovalTypes } from '../../../../core/RPCMethods/RPCMethodMiddleware';
-import useApprovalRequest from '../hooks/useApprovalRequest';
+import useApprovalRequest from './useApprovalRequest';
 
-const useRedesignEnabled = () => {
+const useConfirmationRedesignEnabled = () => {
   const { approvalRequest } = useApprovalRequest();
   const approvalRequestType = approvalRequest?.type;
 
@@ -18,4 +18,4 @@ const useRedesignEnabled = () => {
   return { isRedesignedEnabled };
 };
 
-export default useRedesignEnabled;
+export default useConfirmationRedesignEnabled;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3398,5 +3398,9 @@
       "title": "Reward rate",
       "tooltip": "Expected yearly increase in the value of your stake, based on the reward rate over the past week."
     }
+  },
+  "confirm": {
+    "reject": "Reject",
+    "confirm": "Confirm"
   }
 }


### PR DESCRIPTION
## **Description**

Adding generic footer section to confirmation page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/11434

## **Manual testing steps**

1. Locally enable `export REDESIGNED_SIGNATURE_REQUEST="true"`
2. Go to test dapp and submit personal sign request
3. New confirmation page with footer should be visible

## **Screenshots/Recordings**
<img width="403" alt="Screenshot 2024-09-27 at 5 41 43 PM" src="https://github.com/user-attachments/assets/f4c9ccef-6afe-4029-8217-49b6bc1c2b1d">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
