### PR TITLE
fix(11482): incorrect QR code error

### DIFF
--- a/app/core/DeeplinkManager/ParseManager/parseDeeplink.ts
+++ b/app/core/DeeplinkManager/ParseManager/parseDeeplink.ts
@@ -10,6 +10,7 @@ import handleUniversalLink from './handleUniversalLink';
 import connectWithWC from './connectWithWC';
 import { Alert } from 'react-native';
 import { strings } from '../../../../locales/i18n';
+import AppConstants from '../../../core/AppConstants';
 
 function parseDeeplink({
   deeplinkManager: instance,
@@ -98,8 +99,14 @@ function parseDeeplink({
         error as Error,
         'DeepLinkManager:parse error parsing deeplink',
       );
-
-      Alert.alert(strings('deeplink.invalid'), `Invalid URL: ${url}`);
+      if (origin === AppConstants.DEEPLINKS.ORIGIN_QR_CODE) {
+        Alert.alert(
+          strings('qr_scanner.unrecognized_address_qr_code_title'),
+          strings('qr_scanner.unrecognized_address_qr_code_desc'),
+        );
+      } else {
+        Alert.alert(strings('deeplink.invalid'), `Invalid URL: ${url}`);
+      }
     }
 
     return false;


### PR DESCRIPTION
## **Description**

When scanning a invalid QR code you're given a deeplink error instead of a QR code error.

## **Related issues**

Fixes: [#11482 ](https://github.com/MetaMask/metamask-mobile/issues/11482)

## **Manual testing steps**

1.  Goto the wallet homepage
2. Click on the QR code icon at the top right
3. Scan a incorrect QR code (a QR account that isn't associated with any address)
4. View [issue](https://github.com/MetaMask/metamask-mobile/issues/11482) to see recording if needed

## **Screenshots/Recordings**

| Before  | After |
|:---:|:---:|
|![before](https://github.com/user-attachments/assets/e811b492-e6f1-45e7-b8a6-229ac18203d6)|![after](https://github.com/user-attachments/assets/303d5aea-c186-47b8-9699-1629ab99d84d)|
### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
