### PR TITLE
chore: Move PotfolioBalance above TabView

### DIFF
--- a/app/components/UI/Tokens/TokenList/PortfolioBalance/index.test.tsx
+++ b/app/components/UI/Tokens/TokenList/PortfolioBalance/index.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { BN } from 'ethereumjs-util';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
+import AppConstants from '../../../../../../app/core/AppConstants';
+import Routes from '../../../../../../app/constants/navigation/Routes';
+import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
+import { PortfolioBalance } from '.';
+
+jest.mock('../../../../../core/Engine', () => ({
+  getTotalFiatAccountBalance: jest.fn(),
+  context: {
+    TokensController: {
+      ignoreTokens: jest.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+const initialState = {
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      TokensController: {
+        tokens: [
+          {
+            name: 'Ethereum',
+            symbol: 'ETH',
+            address: '0x0',
+            decimals: 18,
+            isETH: true,
+
+            balanceFiat: '< $0.01',
+            iconUrl: '',
+          },
+          {
+            name: 'Bat',
+            symbol: 'BAT',
+            address: '0x01',
+            decimals: 18,
+            balanceFiat: '$0',
+            iconUrl: '',
+          },
+          {
+            name: 'Link',
+            symbol: 'LINK',
+            address: '0x02',
+            decimals: 18,
+            balanceFiat: '$0',
+            iconUrl: '',
+          },
+        ],
+      },
+      TokenRatesController: {
+        marketData: {
+          '0x1': {
+            '0x0': { price: 0.005 },
+            '0x01': { price: 0.005 },
+            '0x02': { price: 0.005 },
+          },
+        },
+      },
+      CurrencyRateController: {
+        currentCurrency: 'USD',
+        currencyRates: {
+          ETH: {
+            conversionRate: 1,
+          },
+        },
+      },
+      TokenBalancesController: {
+        contractBalances: {
+          '0x00': new BN(2),
+          '0x01': new BN(2),
+          '0x02': new BN(0),
+        },
+      },
+    },
+  },
+  settings: {
+    primaryCurrency: 'usd',
+    hideZeroBalanceTokens: true,
+  },
+  security: {
+    dataCollectionForMarketing: true,
+  },
+};
+
+const mockNavigate = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      push: mockPush,
+    }),
+  };
+});
+
+// TODO: Replace "any" with type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderPortfolioBalance = (state: any = {}) =>
+  renderWithProvider(<PortfolioBalance />, { state });
+
+describe('PortfolioBalance', () => {
+  afterEach(() => {
+    mockNavigate.mockClear();
+    mockPush.mockClear();
+  });
+
+  it('fiat balance must be defined', () => {
+    const { getByTestId } = renderPortfolioBalance(initialState);
+    expect(
+      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT),
+    ).toBeDefined();
+  });
+
+  it('portfolio button should render correctly', () => {
+    const { getByTestId } = renderPortfolioBalance(initialState);
+
+    expect(getByTestId(WalletViewSelectorsIDs.PORTFOLIO_BUTTON)).toBeDefined();
+  });
+
+  it('navigates to Portfolio url when portfolio button is pressed', () => {
+    const { getByTestId } = renderPortfolioBalance(initialState);
+
+    const expectedUrl = `${AppConstants.PORTFOLIO.URL}/?metamaskEntry=mobile&metricsEnabled=false&marketingEnabled=${initialState.security.dataCollectionForMarketing}`;
+
+    fireEvent.press(getByTestId(WalletViewSelectorsIDs.PORTFOLIO_BUTTON));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+      params: {
+        newTabUrl: expectedUrl,
+        timestamp: 123,
+      },
+      screen: Routes.BROWSER.VIEW,
+    });
+  });
+});

--- a/app/components/UI/Tokens/TokenList/index.tsx
+++ b/app/components/UI/Tokens/TokenList/index.tsx
@@ -71,7 +71,7 @@ export const TokenList = ({
 
   return tokens?.length ? (
     <FlatList
-      ListHeaderComponent={<PortfolioBalance />}
+      ListHeaderComponent={<>{/* TODO: TokenListControlBar will go here */}</>}
       data={tokens}
       renderItem={({ item }) => (
         <TokenListItem

--- a/app/components/UI/Tokens/TokenList/index.tsx
+++ b/app/components/UI/Tokens/TokenList/index.tsx
@@ -16,7 +16,6 @@ import createStyles from '../styles';
 import Text from '../../../../component-library/components/Texts/Text';
 import { TokenI } from '../types';
 import { strings } from '../../../../../locales/i18n';
-import { PortfolioBalance } from './PortfolioBalance';
 import { TokenListFooter } from './TokenListFooter';
 import { TokenListItem } from './TokenListItem';
 

--- a/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`Tokens should hide zero balance tokens when setting is on 1`] = `
                             }
                           />
                         }
-                        ListHeaderComponent={<PortfolioBalance />}
+                        ListHeaderComponent={<React.Fragment />}
                         data={
                           [
                             {
@@ -395,128 +395,7 @@ exports[`Tokens should hide zero balance tokens when setting is on 1`] = `
                           <View
                             collapsable={false}
                             onLayout={[Function]}
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-between",
-                                  "marginHorizontal": 16,
-                                  "marginVertical": 24,
-                                }
-                              }
-                            >
-                              <View>
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 32,
-                                      "fontWeight": "500",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 40,
-                                    }
-                                  }
-                                  testID="total-balance-text"
-                                >
-                                  0 USD
-                                </Text>
-                                <View
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "flexDirection": "row",
-                                    }
-                                  }
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  />
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  >
-                                    (+0.00%)
-                                  </Text>
-                                </View>
-                              </View>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "transparent",
-                                    "borderColor": "#0376c9",
-                                    "borderRadius": 20,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "height": 40,
-                                    "justifyContent": "center",
-                                    "marginVertical": 5,
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
-                                testID="portfolio-button"
-                              >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#0376c9",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
-                                  }
-                                >
-                                  Portfolio
-                                </Text>
-                                <SvgMock
-                                  color="#0376c9"
-                                  height={16}
-                                  name="Export"
-                                  style={
-                                    {
-                                      "height": 16,
-                                      "marginLeft": 8,
-                                      "width": 16,
-                                    }
-                                  }
-                                  width={16}
-                                />
-                              </TouchableOpacity>
-                            </View>
-                          </View>
+                          />
                           <View
                             onFocusCapture={[Function]}
                             onLayout={[Function]}
@@ -1589,7 +1468,7 @@ exports[`Tokens should render correctly 1`] = `
                             }
                           />
                         }
-                        ListHeaderComponent={<PortfolioBalance />}
+                        ListHeaderComponent={<React.Fragment />}
                         data={
                           [
                             {
@@ -1644,128 +1523,7 @@ exports[`Tokens should render correctly 1`] = `
                           <View
                             collapsable={false}
                             onLayout={[Function]}
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-between",
-                                  "marginHorizontal": 16,
-                                  "marginVertical": 24,
-                                }
-                              }
-                            >
-                              <View>
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 32,
-                                      "fontWeight": "500",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 40,
-                                    }
-                                  }
-                                  testID="total-balance-text"
-                                >
-                                  0 USD
-                                </Text>
-                                <View
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "flexDirection": "row",
-                                    }
-                                  }
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  />
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  >
-                                    (+0.00%)
-                                  </Text>
-                                </View>
-                              </View>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "transparent",
-                                    "borderColor": "#0376c9",
-                                    "borderRadius": 20,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "height": 40,
-                                    "justifyContent": "center",
-                                    "marginVertical": 5,
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
-                                testID="portfolio-button"
-                              >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#0376c9",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
-                                  }
-                                >
-                                  Portfolio
-                                </Text>
-                                <SvgMock
-                                  color="#0376c9"
-                                  height={16}
-                                  name="Export"
-                                  style={
-                                    {
-                                      "height": 16,
-                                      "marginLeft": 8,
-                                      "width": 16,
-                                    }
-                                  }
-                                  width={16}
-                                />
-                              </TouchableOpacity>
-                            </View>
-                          </View>
+                          />
                           <View
                             onFocusCapture={[Function]}
                             onLayout={[Function]}
@@ -2846,7 +2604,7 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                             }
                           />
                         }
-                        ListHeaderComponent={<PortfolioBalance />}
+                        ListHeaderComponent={<React.Fragment />}
                         data={
                           [
                             {
@@ -2909,128 +2667,7 @@ exports[`Tokens should show all balance tokens when hideZeroBalanceTokens settin
                           <View
                             collapsable={false}
                             onLayout={[Function]}
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-between",
-                                  "marginHorizontal": 16,
-                                  "marginVertical": 24,
-                                }
-                              }
-                            >
-                              <View>
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 32,
-                                      "fontWeight": "500",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 40,
-                                    }
-                                  }
-                                  testID="total-balance-text"
-                                >
-                                  0 USD
-                                </Text>
-                                <View
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "flexDirection": "row",
-                                    }
-                                  }
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  />
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 14,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 22,
-                                      }
-                                    }
-                                  >
-                                    (+0.00%)
-                                  </Text>
-                                </View>
-                              </View>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "transparent",
-                                    "borderColor": "#0376c9",
-                                    "borderRadius": 20,
-                                    "borderWidth": 1,
-                                    "flexDirection": "row",
-                                    "height": 40,
-                                    "justifyContent": "center",
-                                    "marginVertical": 5,
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
-                                testID="portfolio-button"
-                              >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#0376c9",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
-                                  }
-                                >
-                                  Portfolio
-                                </Text>
-                                <SvgMock
-                                  color="#0376c9"
-                                  height={16}
-                                  name="Export"
-                                  style={
-                                    {
-                                      "height": 16,
-                                      "marginLeft": 8,
-                                      "width": 16,
-                                    }
-                                  }
-                                  width={16}
-                                />
-                              </TouchableOpacity>
-                            </View>
-                          </View>
+                          />
                           <View
                             onFocusCapture={[Function]}
                             onLayout={[Function]}

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -178,32 +178,6 @@ describe('Tokens', () => {
     expect(getByTestId(WalletViewSelectorsIDs.TOKENS_CONTAINER)).toBeDefined();
   });
 
-  it('fiat balance must be defined', () => {
-    const { getByTestId } = renderComponent(initialState);
-
-    expect(
-      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT),
-    ).toBeDefined();
-  });
-  it('portfolio button should render correctly', () => {
-    const { getByTestId } = renderComponent(initialState);
-
-    expect(getByTestId(WalletViewSelectorsIDs.PORTFOLIO_BUTTON)).toBeDefined();
-  });
-  it('navigates to Portfolio url when portfolio button is pressed', () => {
-    const { getByTestId } = renderComponent(initialState);
-
-    const expectedUrl = `${AppConstants.PORTFOLIO.URL}/?metamaskEntry=mobile&metricsEnabled=false&marketingEnabled=${initialState.security.dataCollectionForMarketing}`;
-
-    fireEvent.press(getByTestId(WalletViewSelectorsIDs.PORTFOLIO_BUTTON));
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
-      params: {
-        newTabUrl: expectedUrl,
-        timestamp: 123,
-      },
-      screen: Routes.BROWSER.VIEW,
-    });
-  });
   it('should display unable to find conversion rate', async () => {
     const state = {
       engine: {

--- a/app/components/UI/Tokens/styles.ts
+++ b/app/components/UI/Tokens/styles.ts
@@ -99,7 +99,7 @@ const createStyles = (colors: Colors) =>
       alignItems: 'center',
       marginHorizontal: 16,
       justifyContent: 'space-between',
-      marginVertical: 24,
+      paddingTop: 24,
     },
     fiatBalance: {
       ...fontStyles.normal,

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -479,463 +479,408 @@ exports[`Wallet should render correctly 1`] = `
                       }
                     }
                   >
-                    <View
+                    <RNCSafeAreaView
                       style={
                         {
+                          "backgroundColor": "#ffffff",
                           "flex": 1,
                         }
                       }
                     >
-                      <View
+                      <RCTScrollView
+                        collapsable={false}
+                        onGestureHandlerEvent={[Function]}
+                        onGestureHandlerStateChange={[Function]}
                         style={
                           {
-                            "backgroundColor": "#ffffff",
                             "flex": 1,
+                            "paddingHorizontal": 24,
                           }
                         }
-                        testID="wallet-screen"
                       >
-                        <View
-                          style={
-                            {
-                              "marginTop": 20,
-                              "paddingHorizontal": 16,
-                              "widht": "80%",
+                        <View>
+                          <View
+                            style={
+                              {
+                                "alignItems": "center",
+                              }
                             }
-                          }
-                        >
+                          >
+                            <Image
+                              source={
+                                {
+                                  "default": {
+                                    "uri": "MockImage",
+                                  },
+                                }
+                              }
+                              style={
+                                {
+                                  "height": 50,
+                                  "marginTop": 24,
+                                  "width": 50,
+                                }
+                              }
+                            />
+                            <Text
+                              style={
+                                {
+                                  "color": "#141618",
+                                  "fontFamily": "EuclidCircularB-Bold",
+                                  "fontSize": 24,
+                                  "fontWeight": "600",
+                                  "lineHeight": 34,
+                                }
+                              }
+                            >
+                              An error occurred
+                            </Text>
+                            <Text
+                              style={
+                                {
+                                  "color": "#6a737d",
+                                  "fontFamily": "EuclidCircularB-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": "400",
+                                  "lineHeight": 20,
+                                  "marginTop": 8,
+                                  "textAlign": "center",
+                                }
+                              }
+                            >
+                              Your information can't be shown. Don’t worry, your wallet and funds are safe.
+                            </Text>
+                          </View>
                           <View
                             style={
                               {
                                 "backgroundColor": "#d738471a",
-                                "borderColor": "#d73847",
-                                "borderLeftWidth": 4,
-                                "borderRadius": 4,
-                                "flexDirection": "row",
-                                "padding": 12,
-                                "paddingLeft": 8,
+                                "borderRadius": 8,
+                                "marginTop": 24,
                               }
                             }
-                            testID="banneralert"
                           >
-                            <View
+                            <Text
                               style={
                                 {
-                                  "marginRight": 8,
+                                  "color": "#141618",
+                                  "fontFamily": "EuclidCircularB-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": "400",
+                                  "lineHeight": 20,
+                                  "padding": 8,
                                 }
                               }
                             >
-                              <SvgMock
-                                color="#d73847"
-                                height={24}
-                                name="Danger"
-                                style={
-                                  {
-                                    "height": 24,
-                                    "width": 24,
-                                  }
-                                }
-                                width={24}
-                              />
-                            </View>
-                            <View
+                              View: Wallet
+TypeError: Cannot read properties of undefined (reading 'tabs')
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "alignItems": "center",
+                              }
+                            }
+                          >
+                            <TouchableOpacity
+                              onPress={[Function]}
                               style={
                                 {
-                                  "flex": 1,
+                                  "borderColor": "#0376c9",
+                                  "borderRadius": 50,
+                                  "borderWidth": 1,
+                                  "marginTop": 24,
+                                  "padding": 12,
+                                  "paddingHorizontal": 34,
                                 }
                               }
                             >
                               <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#141618",
-                                    "fontFamily": "EuclidCircularB-Medium",
-                                    "fontSize": 16,
-                                    "fontWeight": "500",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                              >
-                                Basic functionality is off
-                              </Text>
-                              <Text
-                                accessibilityRole="text"
-                                onPress={[Function]}
                                 style={
                                   {
                                     "color": "#0376c9",
                                     "fontFamily": "EuclidCircularB-Regular",
-                                    "fontSize": 14,
                                     "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 22,
-                                  }
-                                }
-                              >
-                                Turn on basic functionality
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "borderColor": "#bbc0c5",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
-                              "marginHorizontal": 16,
-                              "marginTop": 28,
-                            }
-                          }
-                        >
-                          <TouchableOpacity
-                            onPress={[Function]}
-                            style={
-                              {
-                                "alignItems": "center",
-                                "backgroundColor": "#ffffff",
-                                "borderColor": "#bbc0c5",
-                                "borderRadius": 8,
-                                "borderWidth": 0,
-                                "flexDirection": "row",
-                                "padding": 16,
-                              }
-                            }
-                            testID="account-picker"
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flex": 1,
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "backgroundColor": "#ffffff",
-                                    "borderRadius": 16,
-                                    "height": 32,
-                                    "marginRight": 16,
-                                    "overflow": "hidden",
-                                    "width": 32,
-                                  }
-                                }
-                              >
-                                <View
-                                  style={
-                                    [
-                                      {
-                                        "overflow": "hidden",
-                                      },
-                                      {
-                                        "backgroundColor": "#C7144F",
-                                        "borderRadius": 16,
-                                        "height": 32,
-                                        "width": 32,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <RNSVGSvgView
-                                    bbHeight={32}
-                                    bbWidth={32}
-                                    focusable={false}
-                                    height={32}
-                                    style={
-                                      [
-                                        {
-                                          "backgroundColor": "transparent",
-                                          "borderWidth": 0,
-                                        },
-                                        {
-                                          "flex": 0,
-                                          "height": 32,
-                                          "width": 32,
-                                        },
-                                      ]
-                                    }
-                                    width={32}
-                                  >
-                                    <RNSVGGroup
-                                      fill={
-                                        {
-                                          "payload": 4278190080,
-                                          "type": 0,
-                                        }
-                                      }
-                                    >
-                                      <RNSVGRect
-                                        fill={
-                                          {
-                                            "payload": 4294711651,
-                                            "type": 0,
-                                          }
-                                        }
-                                        height={32}
-                                        matrix={
-                                          [
-                                            0.46329603511986217,
-                                            0.8862035792312145,
-                                            -0.8862035792312145,
-                                            0.46329603511986217,
-                                            29.06767649409735,
-                                            -8.290603334655817,
-                                          ]
-                                        }
-                                        propList={
-                                          [
-                                            "fill",
-                                          ]
-                                        }
-                                        width={32}
-                                        x={0}
-                                        y={0}
-                                      />
-                                      <RNSVGRect
-                                        fill={
-                                          {
-                                            "payload": 4280576225,
-                                            "type": 0,
-                                          }
-                                        }
-                                        height={32}
-                                        matrix={
-                                          [
-                                            -0.5778576243835052,
-                                            0.8161375900801603,
-                                            -0.8161375900801603,
-                                            -0.5778576243835052,
-                                            51.62016714634118,
-                                            17.239003094412087,
-                                          ]
-                                        }
-                                        propList={
-                                          [
-                                            "fill",
-                                          ]
-                                        }
-                                        width={32}
-                                        x={0}
-                                        y={0}
-                                      />
-                                      <RNSVGRect
-                                        fill={
-                                          {
-                                            "payload": 4278407261,
-                                            "type": 0,
-                                          }
-                                        }
-                                        height={32}
-                                        matrix={
-                                          [
-                                            0.7046342099635947,
-                                            -0.7095707365365209,
-                                            0.7095707365365209,
-                                            0.7046342099635947,
-                                            -25.225718686778755,
-                                            -4.611026307883787,
-                                          ]
-                                        }
-                                        propList={
-                                          [
-                                            "fill",
-                                          ]
-                                        }
-                                        width={32}
-                                        x={0}
-                                        y={0}
-                                      />
-                                    </RNSVGGroup>
-                                  </RNSVGSvgView>
-                                </View>
-                              </View>
-                              <View
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-start",
+                                    "textAlign": "center",
                                   }
                                 }
                               >
                                 <Text
-                                  accessibilityRole="text"
+                                  allowFontScaling={false}
                                   style={
-                                    {
-                                      "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Medium",
-                                      "fontSize": 14,
-                                      "fontWeight": "500",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
+                                    [
+                                      {
+                                        "color": undefined,
+                                        "fontSize": 15,
+                                      },
+                                      undefined,
+                                      {
+                                        "fontFamily": "FontAwesome",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      {},
+                                    ]
                                   }
-                                  testID="account-label"
                                 >
-                                  Account 1
+                                  
                                 </Text>
-                              </View>
-                            </View>
-                            <SvgMock
-                              color="#141618"
-                              height={20}
-                              name="ArrowDown"
-                              style={
-                                {
-                                  "height": 20,
-                                  "marginLeft": 16,
-                                  "width": 20,
-                                }
-                              }
-                              width={20}
-                            />
-                          </TouchableOpacity>
+                                  
+                                Try again
+                              </Text>
+                            </TouchableOpacity>
+                          </View>
                           <View
                             style={
                               {
-                                "borderColor": "#bbc0c5",
-                                "borderTopWidth": 1,
-                                "marginHorizontal": 16,
-                              }
-                            }
-                          />
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "backgroundColor": "#ffffff",
-                                "borderColor": "#bbc0c5",
-                                "borderRadius": 8,
-                                "borderWidth": 0,
-                                "flexDirection": "row",
-                                "justifyContent": "space-between",
-                                "padding": 16,
+                                "marginTop": 24,
                               }
                             }
                           >
+                            <Text
+                              style={
+                                {
+                                  "color": "#141618",
+                                  "fontFamily": "EuclidCircularB-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": "400",
+                                  "lineHeight": 20,
+                                }
+                              }
+                            >
+                              <Text>
+                                Please report this issue so we can fix it:
+                              </Text>
+                            </Text>
                             <View
                               style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
+                                  "marginBottom": 24,
+                                  "marginTop": 16,
+                                  "paddingLeft": 14,
                                 }
                               }
                             >
                               <Text
-                                accessibilityRole="text"
                                 style={
                                   {
                                     "color": "#141618",
-                                    "fontFamily": "EuclidCircularB-Bold",
-                                    "fontSize": 12,
-                                    "fontWeight": "700",
-                                    "letterSpacing": 0,
+                                    "fontFamily": "EuclidCircularB-Regular",
+                                    "fontSize": 14,
+                                    "fontWeight": "400",
                                     "lineHeight": 20,
                                   }
                                 }
                               >
-                                Address
-                                :
+                                <Text
+                                  allowFontScaling={false}
+                                  style={
+                                    [
+                                      {
+                                        "color": undefined,
+                                        "fontSize": 20,
+                                      },
+                                      undefined,
+                                      {
+                                        "fontFamily": "FontAwesome",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                                  
+                                Take a screenshot of this screen.
                               </Text>
-                              <RNGestureHandlerButton
-                                collapsable={false}
-                                onGestureEvent={[Function]}
-                                onGestureHandlerEvent={[Function]}
-                                onGestureHandlerStateChange={[Function]}
-                                onHandlerStateChange={[Function]}
-                                rippleColor={0}
-                                testID="wallet-account-copy-button"
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "marginTop": 14,
+                                    },
+                                    {
+                                      "color": "#141618",
+                                      "fontFamily": "EuclidCircularB-Regular",
+                                      "fontSize": 14,
+                                      "fontWeight": "400",
+                                      "lineHeight": 20,
+                                    },
+                                  ]
+                                }
                               >
-                                <View
-                                  accessible={true}
-                                  collapsable={false}
+                                <Text
+                                  allowFontScaling={false}
+                                  style={
+                                    [
+                                      {
+                                        "color": undefined,
+                                        "fontSize": 14,
+                                      },
+                                      undefined,
+                                      {
+                                        "fontFamily": "FontAwesome",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                                  
+                                <Text
+                                  onPress={[Function]}
                                   style={
                                     {
-                                      "alignItems": "center",
-                                      "backgroundColor": "#0376c91a",
-                                      "borderRadius": 20,
-                                      "flexDirection": "row",
-                                      "marginLeft": 12,
-                                      "opacity": 1,
-                                      "padding": 4,
-                                      "paddingHorizontal": 12,
+                                      "color": "#0376c9",
                                     }
                                   }
                                 >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
+                                  Copy
+                                </Text>
+                                 
+                                the error message to clipboard.
+                              </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "marginTop": 14,
+                                    },
+                                    {
+                                      "color": "#141618",
+                                      "fontFamily": "EuclidCircularB-Regular",
+                                      "fontSize": 14,
+                                      "fontWeight": "400",
+                                      "lineHeight": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  allowFontScaling={false}
+                                  style={
+                                    [
                                       {
-                                        "color": "#0376c9",
-                                        "fontFamily": "EuclidCircularB-Medium",
-                                        "fontSize": 12,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 20,
-                                      }
-                                    }
-                                    testID="wallet-account-address"
-                                  >
-                                    0xC495...D272
-                                  </Text>
-                                  <SvgMock
-                                    color="#0376c9"
-                                    height={16}
-                                    name="Copy"
-                                    style={
+                                        "color": undefined,
+                                        "fontSize": 14,
+                                      },
+                                      undefined,
                                       {
-                                        "height": 16,
-                                        "marginLeft": 4,
-                                        "width": 16,
-                                      }
+                                        "fontFamily": "FontAwesome",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                                  
+                                Submit a ticket
+                                 
+                                <Text
+                                  onPress={[Function]}
+                                  style={
+                                    {
+                                      "color": "#0376c9",
                                     }
-                                    width={16}
-                                  />
-                                </View>
-                              </RNGestureHandlerButton>
+                                  }
+                                >
+                                  here.
+                                </Text>
+                                 
+                                Please include the error message and the screenshot.
+                              </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "marginTop": 14,
+                                    },
+                                    {
+                                      "color": "#141618",
+                                      "fontFamily": "EuclidCircularB-Regular",
+                                      "fontSize": 14,
+                                      "fontWeight": "400",
+                                      "lineHeight": 20,
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  allowFontScaling={false}
+                                  style={
+                                    [
+                                      {
+                                        "color": undefined,
+                                        "fontSize": 14,
+                                      },
+                                      undefined,
+                                      {
+                                        "fontFamily": "FontAwesome",
+                                        "fontStyle": "normal",
+                                        "fontWeight": "normal",
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                >
+                                  
+                                </Text>
+                                  
+                                Send us a bug report
+                                 
+                                <Text
+                                  onPress={[Function]}
+                                  style={
+                                    {
+                                      "color": "#0376c9",
+                                    }
+                                  }
+                                >
+                                  here.
+                                </Text>
+                                 
+                                Please include details about what happened.
+                              </Text>
                             </View>
-                            <TouchableOpacity
-                              accessible={true}
-                              activeOpacity={1}
-                              disabled={false}
-                              onPress={[Function]}
-                              onPressIn={[Function]}
-                              onPressOut={[Function]}
+                            <Text
                               style={
                                 {
-                                  "alignItems": "center",
-                                  "borderRadius": 8,
-                                  "height": 24,
-                                  "justifyContent": "center",
-                                  "opacity": 1,
-                                  "width": 24,
+                                  "color": "#141618",
+                                  "fontFamily": "EuclidCircularB-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": "400",
+                                  "lineHeight": 20,
                                 }
                               }
-                              testID="main-wallet-account-actions"
                             >
-                              <SvgMock
-                                color="#141618"
-                                height={16}
-                                name="MoreHorizontal"
+                              If this error persists,
+                               
+                              <Text
+                                onPress={[Function]}
                                 style={
                                   {
-                                    "height": 16,
-                                    "width": 16,
+                                    "color": "#0376c9",
                                   }
                                 }
-                                width={16}
-                              />
-                            </TouchableOpacity>
+                              >
+                                save your Secret Recovery Phrase
+                              </Text>
+                               
+                              & re-install the app. Note: you can NOT restore your wallet without your Secret Recovery Phrase.
+                            </Text>
                           </View>
                         </View>
-                      </View>
-                    </View>
+                      </RCTScrollView>
+                    </RNCSafeAreaView>
                   </View>
                 </View>
               </View>

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -564,7 +564,7 @@ const Wallet = ({
         {selectedAddress ? (
           <WalletAccount style={styles.walletAccount} ref={walletRef} />
         ) : null}
-        <View>
+        <>
           <PortfolioBalance />
           <ScrollableTabView
             renderTabBar={renderTabBar}
@@ -589,7 +589,7 @@ const Wallet = ({
               navigation={navigation}
             />
           </ScrollableTabView>
-        </View>
+        </>
       </View>
     );
   }, [

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -96,6 +96,7 @@ import {
 } from '../../../selectors/notifications';
 import { ButtonVariants } from '../../../component-library/components/Buttons/Button';
 import { useListNotifications } from '../../../util/notifications/hooks/useNotifications';
+import { PortfolioBalance } from '../../UI/Tokens/TokenList/PortfolioBalance';
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
     base: {
@@ -111,12 +112,11 @@ const createStyles = ({ colors, typography }: Theme) =>
       backgroundColor: colors.primary.default,
     },
     tabStyle: {
-      paddingBottom: 0,
+      paddingBottom: 8,
       paddingVertical: 8,
     },
     tabBar: {
       borderColor: colors.background.default,
-      marginTop: 16,
     },
     textStyle: {
       ...(typography.sBodyMD as TextStyle),
@@ -406,8 +406,7 @@ const Wallet = ({
   useEffect(
     () => {
       requestAnimationFrame(async () => {
-        const { AccountTrackerController } =
-          Engine.context;
+        const { AccountTrackerController } = Engine.context;
         AccountTrackerController.refresh();
       });
     },
@@ -565,29 +564,32 @@ const Wallet = ({
         {selectedAddress ? (
           <WalletAccount style={styles.walletAccount} ref={walletRef} />
         ) : null}
-        <ScrollableTabView
-          renderTabBar={renderTabBar}
-          // eslint-disable-next-line react/jsx-no-bind
-          onChangeTab={onChangeTab}
-        >
-          <Tokens
-            tabLabel={strings('wallet.tokens')}
-            key={'tokens-tab'}
-            navigation={navigation}
-            // TODO - Consolidate into the correct type.
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            tokens={assets}
-          />
-          <CollectibleContracts
-            // TODO - Extend component to support injected tabLabel prop.
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            tabLabel={strings('wallet.collectibles')}
-            key={'nfts-tab'}
-            navigation={navigation}
-          />
-        </ScrollableTabView>
+        <View>
+          <PortfolioBalance />
+          <ScrollableTabView
+            renderTabBar={renderTabBar}
+            // eslint-disable-next-line react/jsx-no-bind
+            onChangeTab={onChangeTab}
+          >
+            <Tokens
+              tabLabel={strings('wallet.tokens')}
+              key={'tokens-tab'}
+              navigation={navigation}
+              // TODO - Consolidate into the correct type.
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              tokens={assets}
+            />
+            <CollectibleContracts
+              // TODO - Extend component to support injected tabLabel prop.
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              tabLabel={strings('wallet.collectibles')}
+              key={'nfts-tab'}
+              navigation={navigation}
+            />
+          </ScrollableTabView>
+        </View>
       </View>
     );
   }, [

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -117,6 +117,7 @@ const createStyles = ({ colors, typography }: Theme) =>
     },
     tabBar: {
       borderColor: colors.background.default,
+      marginBottom: 8,
     },
     textStyle: {
       ...(typography.sBodyMD as TextStyle),


### PR DESCRIPTION
## **Description**

Step 2 of token sorting is to move `PortfolioBalance` above the `TabView`. This PR introduces this UI change, since it can happen separately from the Token sorting task in order to keep PRs small and easy to review / get past CI.

## **Related issues**

Design: https://www.figma.com/design/aMYiscz

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
