### PR TITLE
fix: Fix unwanted `IncompleteAssetDisplayed` events

### DIFF
--- a/app/components/UI/SimulationDetails/useBalanceChanges.ts
+++ b/app/components/UI/SimulationDetails/useBalanceChanges.ts
@@ -98,13 +98,12 @@ const fetchTokenExchangeRates = async (
   chainId: Hex,
 ) => {
   try {
-    const x = await fetchTokenContractExchangeRates({
+    return await fetchTokenContractExchangeRates({
       tokenPricesService: new CodefiTokenPricesServiceV2(),
       nativeCurrency,
       tokenAddresses,
       chainId,
     });
-    return x;
   } catch (err) {
     return {};
   }
@@ -201,7 +200,7 @@ export default function useBalanceChanges(
     [JSON.stringify(erc20TokenAddresses), chainId, fiatCurrency],
   );
 
-  if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData) {
+  if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData ) {
     return { pending: true, value: [] };
   }
 

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -593,7 +593,7 @@ class TransactionReview extends PureComponent {
                       primaryCurrency={primaryCurrency}
                       chainId={chainId}
                     />
-                    {useTransactionSimulations && (
+                    {useTransactionSimulations && transactionSimulationData && (
                       <View style={styles.transactionSimulations}>
                         <SimulationDetails
                           simulationData={transactionSimulationData}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to stop `IncompleteAssetDisplayed` events appearing in the mix panel even the token is known by the API.

For more information please see the mixpanel link https://mixpanel.com/project/1979229/view/132079/app/events#H35NJuByTVqi

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3362

## **Manual testing steps**

No QA needed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
