### PR TITLE
chore: rename `isprivateConnection` to `isPrivateConnection `

### DIFF
--- a/app/components/UI/NetworkModal/index.tsx
+++ b/app/components/UI/NetworkModal/index.tsx
@@ -7,7 +7,7 @@ import NetworkDetails from './NetworkDetails';
 import NetworkAdded from './NetworkAdded';
 import Engine from '../../../core/Engine';
 import {
-  isprivateConnection,
+  isPrivateConnection,
   toggleUseSafeChainsListValidation,
 } from '../../../util/networks';
 import getDecimalChainId from '../../../util/networks/getDecimalChainId';
@@ -186,7 +186,7 @@ const NetworkModals = (props: NetworkProps) => {
   const closeModal = () => {
     const { NetworkController } = Engine.context;
     const url = new URLPARSE(rpcUrl);
-    !isprivateConnection(url.hostname) && url.set('protocol', 'https:');
+    !isPrivateConnection(url.hostname) && url.set('protocol', 'https:');
     NetworkController.upsertNetworkConfiguration(
       {
         rpcUrl: url.href,
@@ -209,7 +209,7 @@ const NetworkModals = (props: NetworkProps) => {
     const { NetworkController, CurrencyRateController } = Engine.context;
     const url = new URLPARSE(rpcUrl);
     CurrencyRateController.updateExchangeRate(ticker);
-    !isprivateConnection(url.hostname) && url.set('protocol', 'https:');
+    !isPrivateConnection(url.hostname) && url.set('protocol', 'https:');
     NetworkController.upsertNetworkConfiguration(
       {
         rpcUrl: url.href,

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -17,7 +17,7 @@ import {
 import { getNavigationOptionsTitle } from '../../../../UI/Navbar';
 import { strings } from '../../../../../../locales/i18n';
 import Networks, {
-  isprivateConnection,
+  isPrivateConnection,
   getAllNetworks,
   getIsNetworkOnboarded,
 } from '../../../../../util/networks';
@@ -656,7 +656,7 @@ export class NetworkSettings extends PureComponent {
     if (this.validateRpcUrl() && isNetworkExists.length === 0) {
       const url = new URL(rpcUrl);
 
-      !isprivateConnection(url.hostname) && url.set('protocol', 'https:');
+      !isPrivateConnection(url.hostname) && url.set('protocol', 'https:');
       CurrencyRateController.updateExchangeRate(ticker);
       // Remove trailing slashes
       NetworkController.upsertNetworkConfiguration(
@@ -747,7 +747,7 @@ export class NetworkSettings extends PureComponent {
       });
     }
     const url = new URL(rpcUrl);
-    const privateConnection = isprivateConnection(url.hostname);
+    const privateConnection = isPrivateConnection(url.hostname);
     if (!privateConnection && url.protocol === 'http:') {
       this.setState({
         warningRpcUrl: strings('app_settings.invalid_rpc_prefix'),

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -284,7 +284,7 @@ export function hasBlockExplorer(key) {
   return key.toLowerCase() !== RPC;
 }
 
-export function isprivateConnection(hostname) {
+export function isPrivateConnection(hostname) {
   return hostname === 'localhost' || regex.localNetwork.test(hostname);
 }
 

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -12,6 +12,7 @@ import {
   convertNetworkId,
   deprecatedGetNetworkId,
   fetchEstimatedMultiLayerL1Fee,
+  isPrivateConnection,
 } from '.';
 import {
   MAINNET,
@@ -436,6 +437,48 @@ describe('network-utils', () => {
 
       expect(layer1GasFee.startsWith('0x')).toEqual(false);
       expect(layer1GasFee).toEqual('0a25339d61');
+    });
+  });
+
+  describe('isPrivateConnection', () => {
+    test('returns true for localhost', () => {
+      expect(isPrivateConnection('localhost')).toBe(true);
+    });
+
+    test('returns true for 127.0.0.1', () => {
+      expect(isPrivateConnection('127.0.0.1')).toBe(true);
+    });
+
+    test('returns true for 192.168.x.x', () => {
+      expect(isPrivateConnection('192.168.1.1')).toBe(true);
+    });
+
+    test('returns true for 10.x.x.x', () => {
+      expect(isPrivateConnection('10.0.0.1')).toBe(true);
+    });
+
+    test('returns true for 172.16.x.x', () => {
+      expect(isPrivateConnection('172.16.0.1')).toBe(true);
+    });
+
+    test('returns true for for 172.31.x.x', () => {
+      expect(isPrivateConnection('172.31.255.255')).toBe(true);
+    });
+
+    test('returns false for a public IP', () => {
+      expect(isPrivateConnection('8.8.8.8')).toBe(false);
+    });
+
+    test('returns false for a non-IP hostname', () => {
+      expect(isPrivateConnection('example.com')).toBe(false);
+    });
+
+    test('returns true for edge case within 172 range', () => {
+      expect(isPrivateConnection('172.20.0.1')).toBe(true);
+    });
+
+    test('returns false for an IP not in private ranges', () => {
+      expect(isPrivateConnection('192.169.0.1')).toBe(false);
     });
   });
 });

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -441,43 +441,43 @@ describe('network-utils', () => {
   });
 
   describe('isPrivateConnection', () => {
-    test('returns true for localhost', () => {
+    it('returns true for localhost', () => {
       expect(isPrivateConnection('localhost')).toBe(true);
     });
 
-    test('returns true for 127.0.0.1', () => {
+    it('returns true for 127.0.0.1', () => {
       expect(isPrivateConnection('127.0.0.1')).toBe(true);
     });
 
-    test('returns true for 192.168.x.x', () => {
+    it('returns true for 192.168.x.x', () => {
       expect(isPrivateConnection('192.168.1.1')).toBe(true);
     });
 
-    test('returns true for 10.x.x.x', () => {
+    it('returns true for 10.x.x.x', () => {
       expect(isPrivateConnection('10.0.0.1')).toBe(true);
     });
 
-    test('returns true for 172.16.x.x', () => {
+    it('returns true for 172.16.x.x', () => {
       expect(isPrivateConnection('172.16.0.1')).toBe(true);
     });
 
-    test('returns true for for 172.31.x.x', () => {
+    it('returns true for for 172.31.x.x', () => {
       expect(isPrivateConnection('172.31.255.255')).toBe(true);
     });
 
-    test('returns false for a public IP', () => {
+    it('returns false for a public IP', () => {
       expect(isPrivateConnection('8.8.8.8')).toBe(false);
     });
 
-    test('returns false for a non-IP hostname', () => {
+    it('returns false for a non-IP hostname', () => {
       expect(isPrivateConnection('example.com')).toBe(false);
     });
 
-    test('returns true for edge case within 172 range', () => {
+    it('returns true for edge case within 172 range', () => {
       expect(isPrivateConnection('172.20.0.1')).toBe(true);
     });
 
-    test('returns false for an IP not in private ranges', () => {
+    it('returns false for an IP not in private ranges', () => {
       expect(isPrivateConnection('192.169.0.1')).toBe(false);
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR corrects a typo in `isPrivateConnection`, which was previously named `isprivateConnection`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
