### PR TITLE
chore: updating codeowners to remove mobile-devs from component library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 *                                    @MetaMask/mobile-devs
 
 # Design System Team
-app/component-library/               @MetaMask/design-system-engineers @MetaMask/mobile-platform
+app/component-library/               @MetaMask/design-system-engineers
 
 # Platform Team
 patches/                             @MetaMask/mobile-platform


### PR DESCRIPTION
## **Description**

This PR updates the `CODEOWNERS` file by removing mobile developers from the `component-library` folder. The goal is to:

- **Prevent Prop Bloat**: Streamline components and avoid unnecessary complexity.
- **Maintain Consistency**: Ensure that we achieve 1:1 consistency across Figma, Extension, and Mobile environments.
- **Reduce Tech Debt**: Centralize control over merge permissions to avoid inconsistencies and maintain clean component architecture.

## **Related Issues**

Fixes: N/A

## **Manual Testing Steps**

1. Review the changes made to the `CODEOWNERS` file.
2. Verify that mobile developers no longer have ownership permissions over the `component-library` folder.
3. Confirm that merge permissions reflect the correct teams for maintaining the design system and consistency.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described and includes necessary testing evidence, such as recordings or screenshots.