### PR TITLE
fix: token list after switching networks

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -683,7 +683,7 @@ class Engine {
       // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
       messenger: this.controllerMessenger.getRestricted({
         name: 'TokenListController',
-        allowedActions: [],
+        allowedActions: [`${networkController.name}:getNetworkClientById`],
         allowedEvents: [`${networkController.name}:stateChange`],
       }),
     });

--- a/patches/@metamask+assets-controllers+31.0.0.patch
+++ b/patches/@metamask+assets-controllers+31.0.0.patch
@@ -598,6 +598,28 @@ index f7509a1..52bc67e 100644
  var TokenBalancesController_default = TokenBalancesController;
  
  
+diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-JUI3XNEF.js b/node_modules/@metamask/assets-controllers/dist/chunk-JUI3XNEF.js
+index 44804c8..911a6e6 100644
+--- a/node_modules/@metamask/assets-controllers/dist/chunk-JUI3XNEF.js
++++ b/node_modules/@metamask/assets-controllers/dist/chunk-JUI3XNEF.js
+@@ -247,10 +247,15 @@ var TokenListController = class extends _pollingcontroller.StaticIntervalPolling
+ };
+ _onNetworkControllerStateChange = new WeakSet();
+ onNetworkControllerStateChange_fn = async function(networkControllerState) {
+-  if (this.chainId !== networkControllerState.providerConfig.chainId) {
++  const selectedNetworkClient = this.messagingSystem.call(
++    "NetworkController:getNetworkClientById",
++    networkControllerState.selectedNetworkClientId
++  );
++  const { chainId } = selectedNetworkClient.configuration;
++  if (this.chainId !== chainId) {
+     this.abortController.abort();
+     this.abortController = new AbortController();
+-    this.chainId = networkControllerState.providerConfig.chainId;
++    this.chainId = chainId;
+     if (this.state.preventPollingOnNetworkRestart) {
+       this.clearingTokenListData();
+     } else {
 diff --git a/node_modules/@metamask/assets-controllers/dist/chunk-QFDTOEYR.js b/node_modules/@metamask/assets-controllers/dist/chunk-QFDTOEYR.js
 index 5335fa5..ae37683 100644
 --- a/node_modules/@metamask/assets-controllers/dist/chunk-QFDTOEYR.js


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where after switching networks, importing a token populates search results from the old network.

The fix is to patch https://github.com/MetaMask/core/pull/4316, which will be introduced in asset controllers version 33.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/11696

## **Manual testing steps**

1. Force close MM app
2. Open MM
3. Switch networks
4. click import tokens
5. search for a token by name, like usdt
6. the imported token should have prices available and have the correct contract address

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
