### PR TITLE
fix: fix multi rpc modal design

### DIFF
--- a/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
+++ b/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
@@ -7,8 +7,6 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
       "alignItems": "center",
       "backgroundColor": "#ffffff",
       "flexDirection": "row",
-      "paddingRight": 20,
-      "width": "100%",
     }
   }
 >
@@ -16,10 +14,10 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
     disabled={false}
     style={
       {
+        "flex": 1,
         "opacity": 1,
         "padding": 16,
         "position": "relative",
-        "width": "90%",
         "zIndex": 1,
       }
     }

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
@@ -25,10 +25,10 @@ const styleSheet = (params: {
   return StyleSheet.create({
     base: Object.assign(
       {
+        flex: 1,
         position: 'relative',
         opacity: isDisabled ? 0.5 : 1,
         padding: 16,
-        width: '90%',
         zIndex: 1,
       } as ViewStyle,
       style,
@@ -71,10 +71,8 @@ const styleSheet = (params: {
       backgroundColor: isSelected
         ? colors.primary.muted
         : colors.background.default,
-      paddingRight: 20,
       flexDirection: 'row',
       alignItems: 'center',
-      width: '100%',
     },
     itemColumn: {
       display: 'flex',

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
@@ -42,7 +42,8 @@ describe('ListItemMultiSelectButton', () => {
       <ListItemMultiSelectButton
         onPress={mockOnPress}
         buttonProps={{
-          onButtonClick: mockOnPress,
+          label: '',
+          onPress: mockOnPress,
         }}
       >
         <View />
@@ -67,7 +68,8 @@ describe('ListItemMultiSelectButton', () => {
       <ListItemMultiSelectButton
         buttonIcon={IconName.Check}
         buttonProps={{
-          onButtonClick: mockOnButtonClick,
+          label: '',
+          onPress: mockOnButtonClick,
         }}
       >
         <View />

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
@@ -69,20 +69,20 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
             iconName={buttonIcon}
             iconColor={IconColor.Default}
             testID={BUTTON_TEST_ID}
-            onPress={buttonProps?.onButtonClick}
+            onPress={buttonProps?.onPress}
             accessibilityRole="button"
           />
         </View>
       ) : null}
-      {buttonProps?.textButton ? (
+      {buttonProps?.label ? (
         <View>
           <Button
             variant={ButtonVariants.Link}
-            onPress={buttonProps?.onButtonClick as () => void}
+            onPress={buttonProps?.onPress as () => void}
             labelTextVariant={TextVariant.BodyMD}
             size={ButtonSize.Lg}
             width={ButtonWidthTypes.Auto}
-            label={buttonProps?.textButton}
+            label={buttonProps?.label}
           />
         </View>
       ) : null}

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.types.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.types.ts
@@ -4,7 +4,7 @@ import { TouchableOpacityProps } from 'react-native';
 // External dependencies.
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import { ListItemProps } from '../../../component-library/components/List/ListItem/ListItem.types';
-import { GestureResponderEvent } from 'react-native-modal';
+import { ButtonBaseProps } from '../../../component-library/components/Buttons/Button/foundation/ButtonBase';
 
 /**
  * ListItemMultiSelect component props.
@@ -41,16 +41,10 @@ export interface ListItemMultiSelectButtonProps
    */
   showButtonIcon?: boolean;
 
-  buttonProps?: {
-    /**
-     * Optional button onClick function
-     */
-    onButtonClick?: ((event: GestureResponderEvent) => void) | undefined;
-    /**
-     * Optional property to show text button
-     */
-    textButton?: string | null;
-  };
+  /**
+   * Optional button props
+   */
+  buttonProps?: ButtonBaseProps;
 }
 
 /**

--- a/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
@@ -7,8 +7,6 @@ exports[`ListItemMultiSelectButton should render correctly with default props 1`
       "alignItems": "center",
       "backgroundColor": "#ffffff",
       "flexDirection": "row",
-      "paddingRight": 20,
-      "width": "100%",
     }
   }
 >
@@ -16,10 +14,10 @@ exports[`ListItemMultiSelectButton should render correctly with default props 1`
     disabled={false}
     style={
       {
+        "flex": 1,
         "opacity": 1,
         "padding": 16,
         "position": "relative",
-        "width": "90%",
         "zIndex": 1,
       }
     }

--- a/app/components/Views/MultiRpcModal/MultiRpcModal.tsx
+++ b/app/components/Views/MultiRpcModal/MultiRpcModal.tsx
@@ -105,8 +105,8 @@ const MultiRpcModal = () => {
                   buttonIcon={IconName.MoreVertical}
                   showButtonIcon={false}
                   buttonProps={{
-                    textButton: strings('transaction.edit'),
-                    onButtonClick: () => {
+                    label: strings('transaction.edit'),
+                    onPress: () => {
                       sheetRef.current?.onCloseBottomSheet(() => {
                         navigate(Routes.ADD_NETWORK, {
                           shouldNetworkSwitchPopToWallet: false,

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -387,7 +387,8 @@ const NetworkSelector = () => {
           style={styles.networkCell}
           buttonIcon={IconName.MoreVertical}
           buttonProps={{
-            onButtonClick: () => {
+            label: '',
+            onPress: () => {
               openModal(chainId, false, MAINNET, true);
             },
           }}
@@ -444,7 +445,8 @@ const NetworkSelector = () => {
           buttonIcon={IconName.MoreVertical}
           secondaryText={hideKeyFromUrl(LINEA_DEFAULT_RPC_URL)}
           buttonProps={{
-            onButtonClick: () => {
+            label: '',
+            onPress: () => {
               openModal(chainId, false, LINEA_MAINNET, true);
             },
           }}
@@ -508,7 +510,8 @@ const NetworkSelector = () => {
               buttonIcon={IconName.MoreVertical}
               secondaryText={hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))}
               buttonProps={{
-                onButtonClick: () => {
+                label: '',
+                onPress: () => {
                   openModal(chainId, true, rpcUrl, false);
                 },
               }}
@@ -580,7 +583,8 @@ const NetworkSelector = () => {
             style={styles.networkCell}
             buttonIcon={IconName.MoreVertical}
             buttonProps={{
-              onButtonClick: () => {
+              label: '',
+              onPress: () => {
                 openModal(chainId, false, networkType, true);
               },
             }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fix design ui for the multi rpc modal

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. this Modal is not called yet , it's require the network controller v21 to be used
2. the use of this modal will be done on this [PR](https://github.com/MetaMask/metamask-mobile/pull/11622)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="438" alt="Screenshot 2024-10-04 at 11 44 15" src="https://github.com/user-attachments/assets/f558a5a8-796a-423c-b957-f7e7aee8d0b2">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
