### PR TITLE
chore: Remove obsolete CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,6 @@ jobs:
           bundler-cache: true
         env:
           BUNDLE_GEMFILE: ios/Gemfile
-      - name: Determine whether the current PR is a draft
-        id: set-is-draft
-        if: github.event_name == 'pull_request' && github.event.pull_request.number
-        run: echo "IS_DRAFT=$(gh pr view --json isDraft --jq '.isDraft' "${PR_NUMBER}")" >> "$GITHUB_OUTPUT"
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup registry config for using package previews on draft PRs
-        if: github.event_name == 'pull_request' && steps.set-is-draft.outputs.IS_DRAFT == 'true'
-        run: printf '%s\n\n%s' '@metamask:registry=https://npm.pkg.github.com' "//npm.pkg.github.com/:_authToken=${PACKAGE_READ_TOKEN}" > .npmrc
-        env:
-          PACKAGE_READ_TOKEN: ${{ secrets.PACKAGE_READ_TOKEN }}
       - run: yarn setup
       - name: Require clean working directory
         shell: bash
@@ -179,14 +167,14 @@ jobs:
         with:
           name: ios-bundle
           path: ios/main.jsbundle
-      
+
   ship-js-bundle-size-check:
     runs-on: ubuntu-latest
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Download iOS bundle
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## **Description**

CI has a step where it sets up an alternative registry for `@metamask`- scoped packages specifically for draft PRs. This was intended to support the older stype of `MetaMask/core` preview builds, which used an alternative npm registry. Preview builds today now use the normal npm registry, so this step is no longer needed.

## **Related issues**

Originally added here: https://github.com/MetaMask/metamask-mobile/pull/5270
Some related changes here: https://github.com/MetaMask/metamask-mobile/pull/5807 (these were already removed)

The old preview build method was replaced here: https://github.com/MetaMask/core/pull/1622

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
