### PR TITLE
fix: Android: Splash screen always showing behind other screens

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -493,7 +493,6 @@ const MainFlow = () => (
     mode={'modal'}
     screenOptions={{
       headerShown: false,
-      cardStyle: { backgroundColor: importedColors.transparent },
     }}
   >
     <Stack.Screen name={'Main'} component={ConnectedMain} />


### PR DESCRIPTION
## **Description**

### Cause of the issue
The splash screen has been reworked recently for performances and replaced by an Android window background. But this is visible quickly between screen changes as nav stack has been reorganised.

### Fix
- remove the transparent background on MainFlow stack navigator to prevent the window background to be visible behind it

## **Related issues**

Fixes #11697

## **Manual testing steps**

```gherkin
Feature: Navigate between screens without splash screen visible
  Scenario: go to token detail screen
    Given wallet is ready
    And some tokens are available in the list (load from a test address)
    When user touches the token title or icon
    Then detail screen opens
    And no splash screen fox is visible even very quicly.
```

>[!NOTE]
> The issue was on Android but do not hesitate to also test iOS to make sure nothing is broken.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See recording in #11697

### **After**

[android.webm](https://github.com/user-attachments/assets/98585c9a-942d-406a-ae87-6d440e5f9ec3)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
