### PR TITLE
fix: Add `preferContractSymbol` to Name components

### DIFF
--- a/app/components/UI/Name/Name.tsx
+++ b/app/components/UI/Name/Name.tsx
@@ -47,11 +47,21 @@ const UnknownEthereumAddress: React.FC<{ address: string }> = ({ address }) => {
   );
 };
 
-const Name: React.FC<NameProperties> = ({ type, value }) => {
+const Name: React.FC<NameProperties> = ({
+  chainId,
+  preferContractSymbol,
+  type,
+  value,
+}) => {
   if (type !== NameType.EthereumAddress) {
     throw new Error('Unsupported NameType: ' + type);
   }
-  const displayName = useDisplayName(type, value);
+  const displayName = useDisplayName(
+    type,
+    value,
+    chainId,
+    preferContractSymbol,
+  );
   const { styles } = useStyles(styleSheet, {
     displayNameVariant: displayName.variant,
   });

--- a/app/components/UI/Name/Name.types.ts
+++ b/app/components/UI/Name/Name.types.ts
@@ -1,4 +1,5 @@
 import { ViewProps } from 'react-native';
+import { Hex } from '@metamask/utils';
 
 /**
  * The name types supported by the NameController.
@@ -11,6 +12,8 @@ export enum NameType {
 }
 
 export interface NameProperties extends ViewProps {
+  chainId?: Hex;
+  preferContractSymbol?: boolean;
   type: NameType;
   value: string;
 }

--- a/app/components/UI/SimulationDetails/AssetPill/AssetPill.tsx
+++ b/app/components/UI/SimulationDetails/AssetPill/AssetPill.tsx
@@ -63,9 +63,10 @@ const AssetPill: React.FC<AssetPillProperties> = ({ asset }) => {
         <NativeAssetPill />
       ) : (
         <Name
+          preferContractSymbol
           testID="simulation-details-asset-pill-name"
           type={NameType.EthereumAddress}
-          value={asset.address as Hex}
+          value={asset.address as Hex}          
         />
       )}
     </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds `preferContractSymbol` property to name components which used in simulations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3494

## **Manual testing steps**

1. Uniswap in in-app browser
2. Try swap from / to `DAI`
3. In simulations instead of `Dai stablecoin` see `DAI`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="520" alt="Screenshot 2024-10-14 at 11 16 25" src="https://github.com/user-attachments/assets/f3e9ced7-532b-4b92-aa22-d2b60941f743">


### **After**

<img width="564" alt="Screenshot 2024-10-14 at 11 10 29" src="https://github.com/user-attachments/assets/81f386f9-77ea-4170-8024-540f9e3c86b3">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
