### PR TITLE
fix: non deterministic date in test

### DIFF
--- a/app/components/UI/Notification/NotificationMenuItem/Content.test.tsx
+++ b/app/components/UI/Notification/NotificationMenuItem/Content.test.tsx
@@ -5,14 +5,15 @@ import NotificationContent from './Content';
 
 describe('NotificationContent', () => {
   const title = 'Welcome to the new Test!';
-  const createdAt = '2024-04-26T16:35:03.147606Z';
+  const yesterday = new Date().setDate(new Date().getDate() - 1);
+  const createdAt = new Date(yesterday).toISOString(); // Relative date: one day before current date
   const description = {
     start:
       'We are excited to announce the launch of our brand new website and app!',
     end: 'Ethereum',
   };
 
-  it('renders correctly', () => {
+  it('render matches snapshot', () => {
     const { toJSON } = renderWithProvider(
       <NotificationContent
         title={title}

--- a/app/components/UI/Notification/NotificationMenuItem/__snapshots__/Content.test.tsx.snap
+++ b/app/components/UI/Notification/NotificationMenuItem/__snapshots__/Content.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotificationContent renders correctly 1`] = `
+exports[`NotificationContent render matches snapshot 1`] = `
 <View
   style={
     {
@@ -47,7 +47,7 @@ exports[`NotificationContent renders correctly 1`] = `
         }
       }
     >
-      6 months ago
+      Yesterday
     </Text>
   </View>
   <View


### PR DESCRIPTION
## **Description**

Fixes date that was generating an ever changing duration in the snapshot.
- replace it with a relative date to the moment the test is running to make the duration always one day: the notification renders as if it was sent yesterday, always.
- fix duration to one day (yesterday) as we have to fix one and it's not a worse value than any other.
- rename test case to match guideline while I was on it...

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes #11785

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
