### PR TITLE
fix: use object styling in Title component

### DIFF
--- a/app/components/Base/Title/Title.tsx
+++ b/app/components/Base/Title/Title.tsx
@@ -18,12 +18,12 @@ const Title: React.FC<TitleProps> = ({
 
   return (
     <Text
-      style={[
-        style.text,
-        centered && style.centered,
-        hero && style.hero,
-        externalStyle,
-      ]}
+      style={{
+        ...style.text,
+        ...(centered ? style.centered : {}),
+        ...(hero ? style.hero : {}),
+        ...(typeof externalStyle === 'object' ? externalStyle : {}),
+      }}
       {...props}
     />
   );

--- a/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -530,24 +530,14 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -1241,24 +1231,14 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -1952,24 +1932,14 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -3582,24 +3552,14 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -5212,24 +5172,14 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -6842,24 +6792,14 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -14562,24 +14502,14 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -15244,24 +15174,14 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
@@ -2296,24 +2296,14 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
@@ -8400,24 +8400,14 @@ exports[`NetworkSwitcher View renders correctly with errors 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -9059,24 +9049,14 @@ exports[`NetworkSwitcher View renders correctly with errors 2`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -9718,24 +9698,14 @@ exports[`NetworkSwitcher View renders correctly with no data 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -8415,24 +8415,14 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
@@ -4697,24 +4697,14 @@ exports[`PaymentMethods View renders correctly with empty data 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -5381,24 +5371,14 @@ exports[`PaymentMethods View renders correctly with empty data for sell 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -6065,24 +6045,14 @@ exports[`PaymentMethods View renders correctly with error 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -9509,24 +9479,14 @@ exports[`PaymentMethods View renders correctly with sdkError 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1095,24 +1095,14 @@ exports[`Quotes renders animation on first fetching 1`] = `
                                 accessibilityRole="text"
                                 style={
                                   {
-                                    "0": {
-                                      "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Bold",
-                                      "fontSize": 18,
-                                      "fontWeight": "600",
-                                      "marginVertical": 3,
-                                    },
-                                    "1": {
-                                      "textAlign": "center",
-                                    },
-                                    "2": undefined,
-                                    "3": undefined,
                                     "color": "#141618",
-                                    "fontFamily": "EuclidCircularB-Regular",
-                                    "fontSize": 14,
-                                    "fontWeight": "400",
+                                    "fontFamily": "EuclidCircularB-Bold",
+                                    "fontSize": 18,
+                                    "fontWeight": "600",
                                     "letterSpacing": 0,
                                     "lineHeight": 22,
+                                    "marginVertical": 3,
+                                    "textAlign": "center",
                                   }
                                 }
                               >
@@ -6515,24 +6505,14 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -7283,24 +7263,14 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -8051,24 +8021,14 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -8819,24 +8779,14 @@ exports[`Quotes renders quotes expired screen 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >

--- a/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
@@ -1934,24 +1934,14 @@ exports[`Regions View renders correctly with error 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >
@@ -3204,24 +3194,14 @@ exports[`Regions View renders correctly with sdkError 1`] = `
                                   accessibilityRole="text"
                                   style={
                                     {
-                                      "0": {
-                                        "color": "#141618",
-                                        "fontFamily": "EuclidCircularB-Bold",
-                                        "fontSize": 18,
-                                        "fontWeight": "600",
-                                        "marginVertical": 3,
-                                      },
-                                      "1": {
-                                        "textAlign": "center",
-                                      },
-                                      "2": undefined,
-                                      "3": undefined,
                                       "color": "#141618",
-                                      "fontFamily": "EuclidCircularB-Regular",
-                                      "fontSize": 14,
-                                      "fontWeight": "400",
+                                      "fontFamily": "EuclidCircularB-Bold",
+                                      "fontSize": 18,
+                                      "fontWeight": "600",
                                       "letterSpacing": 0,
                                       "lineHeight": 22,
+                                      "marginVertical": 3,
+                                      "textAlign": "center",
                                     }
                                   }
                                 >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We need to use object styling instead of an array of styles because the Text component from the design system isn't prepared to receive an array therefore it breaks the views where we apply custom styles to the Title component.

This is a patch for `release 7.34.0`. We will revisit this as an improvement in the Component Library.

Please check screenshots.

## **Related issues**

-

## **Manual testing steps**

-

## **Screenshots/Recordings**

| **Before** | **After** |
|------------|-----------|
| ![Before](https://github.com/user-attachments/assets/992279b8-db80-408d-afea-ed27007f0c10) | ![After](https://github.com/user-attachments/assets/a5215bb6-d6e9-487e-bf01-2da33aa35b86) |

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
