### PR TITLE
fix(action): github action to apply release label is broken

### DIFF
--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -16,7 +16,7 @@ VERSION_BRANCHES=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | gr
 VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
 
 # Get the version from package.json
-VERSION_PACKAGE=$(node -p "require('./package.json').version")
+VERSION_PACKAGE=$(node -p "require('../../package.json').version")
 
 # Compare versions and keep the highest one
 HIGHEST_VERSION=$(printf "%s\n%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" "$VERSION_PACKAGE" | sort --version-sort | tail -n 1)


### PR DESCRIPTION
## **Description**

This fixes Github action that was broken on Sep 27th with this PR: https://github.com/MetaMask/metamask-mobile/pull/10917

A tentative fix was made on Oct 10th with this PR, but it didn't succeed: https://github.com/MetaMask/metamask-mobile/pull/11745

## **Related issues**

Fixes https://github.com/MetaMask/MetaMask-planning/issues/3493

Here's also the corresponding [Slack thread](https://consensys.slack.com/archives/C02U025CVU4/p1728917197927679?thread_ts=1728583769.556839&cid=C02U025CVU4)

## **Manual testing steps**

Before this PR is merged:
1. Clone the repo
2. Run the following CLI commands
````
cd .github/scripts
node -p "require('../../package.json').version"
````
3. Check that the release version printed corresponds to the one indicated in [main package.json](https://github.com/MetaMask/metamask-mobile/blob/main/package.json#L3)

Once this PR will be merged:
1. Go to metamask-mobile repo's Github action
2. Check that [Add release label to PR and linked issues when PR gets merged](https://github.com/MetaMask/metamask-mobile/actions/workflows/add-release-label.yml) executions are back to green

## **Screenshots/Recordings**

- None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
