### PR TITLE
chore: update release action to not create the release branch but just open PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -43,14 +43,10 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable
-      - name: Set Versions
-        id: set-versions
-        shell: bash
-        run: SEMVER_VERSION=${{ github.event.inputs.semver-version }} VERSION_NUMBER=${{ github.event.inputs.version-number }} yarn set-version
-      - name: Create Release PR
-        id: create-release-pr
+      - name: Create Release & Changelog PR
+        id: create-release-changelog-pr
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./scripts/create-release-pr.sh ${{ github.event.inputs.previous-version-tag }} ${{ github.event.inputs.semver-version }}
+          ./scripts/create-release-pr.sh ${{ github.event.inputs.previous-version-tag }} ${{ github.event.inputs.semver-version }} ${{ github.event.inputs.version-number }}

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -15,20 +15,27 @@ fi
 
 RELEASE_BRANCH_NAME="${RELEASE_BRANCH_PREFIX}${NEW_VERSION}"
 CHANGELOG_BRANCH_NAME="chore/${NEW_VERSION}-Changelog"
-RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}. The changelog will be found in another PR ${CHANGELOG_BRANCH_NAME}."
+RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}. The changelog will be found in another PR ${CHANGELOG_BRANCH_NAME}.
+
+  # Team sign-off checklist
+  - [] team-security
+  - [] team-platform
+  - [] team-snaps-platform
+  - [] team-sdk
+  - [] team-assets
+  - [] team-notifications
+  - [] team-confirmations
+  - [] team-design-system
+  - [] team-tiger
+  - [] team-wallet-framework
+  - [] team-stake
+  - [] team-accounts
+
+  # Reference
+  - Testing plan sheet - https://docs.google.com/spreadsheets/d/1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ/edit?gid=404070372#gid=404070372"
 
 git config user.name metamaskbot
 git config user.email metamaskbot@users.noreply.github.com
-
-git checkout -b "${RELEASE_BRANCH_NAME}"
-
-if ! (git add . && git commit -m "${NEW_VERSION}");
-then
-    echo "Error: No changes detected."
-    exit 1
-fi
-
-git push --set-upstream origin "${RELEASE_BRANCH_NAME}"
 
 gh pr create \
   --draft \
@@ -36,9 +43,7 @@ gh pr create \
   --body "${RELEASE_BODY}" \
   --head "${RELEASE_BRANCH_NAME}";
 
-
 git checkout -b "${CHANGELOG_BRANCH_NAME}"
-
 
 #Generate changelog and test plan csv
 node ./scripts/generate-rc-commits.mjs "${PREVIOUS_VERSION}" "${RELEASE_BRANCH_NAME}" 

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -19,18 +19,18 @@ CHANGELOG_BRANCH_NAME="chore/${NEW_VERSION}-Changelog"
 RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}. The changelog will be found in another PR ${CHANGELOG_BRANCH_NAME}.
 
   # Team sign-off checklist
-  - [] team-security
-  - [] team-platform
-  - [] team-snaps-platform
-  - [] team-sdk
-  - [] team-assets
-  - [] team-notifications
-  - [] team-confirmations
-  - [] team-design-system
-  - [] team-tiger
-  - [] team-wallet-framework
-  - [] team-stake
-  - [] team-accounts
+  - [ ] team-accounts
+  - [ ] team-assets
+  - [ ] team-confirmations
+  - [ ] team-design-system
+  - [ ] team-notifications
+  - [ ] team-platform
+  - [ ] team-security
+  - [ ] team-snaps-platform
+  - [ ] team-sdk
+  - [ ] team-stake
+  - [ ] team-tiger
+  - [ ] team-wallet-framework
 
   # Reference
   - Testing plan sheet - https://docs.google.com/spreadsheets/d/1tsoodlAlyvEUpkkcNcbZ4PM9HuC9cEM80RZeoVv5OCQ/edit?gid=404070372#gid=404070372"

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 PREVIOUS_VERSION="${1}"
 NEW_VERSION="${2}"
+NEW_VERSION_NUMBER="${3}"
 RELEASE_BRANCH_PREFIX="release/"
 
 if [[ -z $NEW_VERSION ]]; then
@@ -44,6 +45,9 @@ gh pr create \
   --head "${RELEASE_BRANCH_NAME}";
 
 git checkout -b "${CHANGELOG_BRANCH_NAME}"
+
+#Bump versions for the release"
+SEMVER_VERSION="${NEW_VERSION}" VERSION_NUMBER="${NEW_VERSION_NUMBER}" yarn set-version
 
 #Generate changelog and test plan csv
 node ./scripts/generate-rc-commits.mjs "${PREVIOUS_VERSION}" "${RELEASE_BRANCH_NAME}" 

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -43,8 +43,13 @@ gh pr create \
   --title "feat: ${NEW_VERSION}" \
   --body "${RELEASE_BODY}" \
   --head "${RELEASE_BRANCH_NAME}";
+echo "Release PR Created"
+
+git checkout "${RELEASE_BRANCH_NAME}"
+echo "Release Branch Checked Out"
 
 git checkout -b "${CHANGELOG_BRANCH_NAME}"
+echo "Changelog Branch Created"
 
 #Bump versions for the release"
 SEMVER_VERSION="${NEW_VERSION}" VERSION_NUMBER="${NEW_VERSION_NUMBER}" yarn set-version


### PR DESCRIPTION
## **Description**

This PR makes a minor change to make the release action depend on an existing release branch before running the action. The new action will create a PR for the release branch and creating a PR for the changelog and version bump against the release branch.  

## **Related issues**

Fixes:

## **Manual testing steps**

1. Confirm there is a release branch
2. Run the GH action
3. See successful run and 2 PRs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**
- Example PR: https://github.com/MetaMask/metamask-mobile/pull/11887
- Example Changelog PR: https://github.com/MetaMask/metamask-mobile/pull/11888
- Successful Action Run: https://github.com/MetaMask/metamask-mobile/actions/runs/11411806607

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
