### PR TITLE
chore: bump rbenv, ruby-build

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -40,8 +40,8 @@ ENV BUNDLE_PATH=/home/node/.bundle
 ENV HOME=/home/node
 # distro rbenv and ruby are out of date - install rbenv from git and manage ruby
 # RUBY_BUILD_VERSION=v20240501
-ARG RBENV_COMMIT=c3ba994ec2daccf4d160aea7f55dd5cc6fc873ef
-ARG RUBY_BUILD_COMMIT=263640c9fe1d44e6fc8f86fc56a67ee58e7b22f7
+ARG RBENV_COMMIT=3bac268cdb81dd745ce13a1cf6ff4a286336ab3b
+ARG RUBY_BUILD_COMMIT=aab1b8d0e7e814f200320749501ba57e2fae20d0
 RUN (mkdir /home/node/.rbenv \
     && curl -sL https://github.com/rbenv/rbenv/archive/${RBENV_COMMIT}.tar.gz \
     | tar --strip-components=1 -C /home/node/.rbenv/ -xzf - \


### PR DESCRIPTION

## **Description**

Address following build error:

    ruby-build: definition not found: 3.1.6
    See all available versions with `rbenv install --list-all'.
    If the version you need is missing, try upgrading ruby-build.

## **Related issues**

- #11847
- #11843
- #11846

## **Manual testing steps**

1. `docker build -t metamask-mobile-builder`
2. `docker run --rm -it metamask-mobile-builder`

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
