### PR TITLE
chore: explicitely make platform team owners of metrics system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@ app/component-library/               @MetaMask/design-system-engineers
 patches/                             @MetaMask/mobile-platform
 app/core/Engine.ts                   @MetaMask/mobile-platform
 app/core/Engine.test.js              @MetaMask/mobile-platform
+app/core/Analytics/                  @MetaMask/mobile-platform
+app/util/metrics/                    @MetaMask/mobile-platform
+app/components/hooks/useMetrics/     @MetaMask/mobile-platform
 
 # Supply Chain Team
 bitrise.yml                          @MetaMask/supply-chain @MetaMask/mobile-platform


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

explicitely make platform team owners of metrics system

## **Related issues**

Fixes risk of PRs changing the metrics system without platform team review

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A
### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
