### PR TITLE
fix: Remove unnecessary re renders activity view

### DIFF
--- a/app/selectors/accountTrackerController.ts
+++ b/app/selectors/accountTrackerController.ts
@@ -16,7 +16,7 @@ export const selectAccounts = createDeepEqualSelector(
   (accountTrackerControllerState: AccountTrackerControllerState) =>
     accountTrackerControllerState.accounts,
 );
-export const selectAccountsByChainId = createSelector(
+export const selectAccountsByChainId = createDeepEqualSelector(
   selectAccountTrackerControllerState,
   (accountTrackerControllerState: AccountTrackerControllerState) =>
     accountTrackerControllerState.accountsByChainId,


### PR DESCRIPTION
## **Description**

Activity view and every component that uses the selector `selectAccountsByChainId` was re rendering when the state was [updating with the same value ](https://github.com/MetaMask/core/blob/c970faff01eae893bc32ae7c7a513fbb31495182/packages/assets-controllers/src/AccountTrackerController.ts#L327).

We should aim to only update the state when there is changes. [Draft created](https://github.com/MetaMask/core/pull/4837)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/6871de37-09ee-4452-b2b1-79e0286c1e4c



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/eeb62987-d2c0-40d8-aa33-0aefce309e50



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
