### PR TITLE
fix: fix block explorer return button

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -2065,6 +2065,7 @@ export class NetworkSettings extends PureComponent {
               <View style={styles.dropDownInput}>
                 <Cell
                   key={rpcUrl}
+                  testID={NetworksViewSelectorsIDs.ICON_BUTTON_BLOCK_EXPLORER}
                   variant={CellVariant.SelectWithMenu}
                   title={blockExplorerUrl}
                   isSelected={false}
@@ -2233,7 +2234,9 @@ export class NetworkSettings extends PureComponent {
                   )}
                   testID={NetworksViewSelectorsIDs.BLOCK_EXPLORER_INPUT}
                   placeholderTextColor={colors.text.muted}
-                  onSubmitEditing={this.toggleNetworkDetailsModal}
+                  onSubmitEditing={() => {
+                    this.onBlockExplorerItemAdd(blockExplorerUrlForm);
+                  }}
                   keyboardAppearance={themeAppearance}
                 />
                 {blockExplorerUrl &&
@@ -2247,6 +2250,7 @@ export class NetworkSettings extends PureComponent {
                 <View style={styles.addRpcNameButton}>
                   <ButtonPrimary
                     label={strings('app_settings.add_block_explorer_url')}
+                    testID={NetworksViewSelectorsIDs.ADD_BLOCK_EXPLORER}
                     size={ButtonSize.Lg}
                     onPress={() => {
                       this.onBlockExplorerItemAdd(blockExplorerUrlForm);
@@ -2324,6 +2328,7 @@ export class NetworkSettings extends PureComponent {
                       this.openAddBlockExplorerForm();
                       this.closeBlockExplorerModal();
                     }}
+                    testID={NetworksViewSelectorsIDs.ADD_BLOCK_EXPLORER}
                     width={ButtonWidthTypes.Auto}
                     labelTextVariant={TextVariant.DisplayMD}
                   />

--- a/e2e/pages/Settings/NetworksView.js
+++ b/e2e/pages/Settings/NetworksView.js
@@ -27,6 +27,16 @@ class NetworkView {
     return Matchers.getElementByID(NetworksViewSelectorsIDs.ICON_BUTTON_RPC);
   }
 
+  get addBlockExplorerDropDownButton() {
+    return Matchers.getElementByID(
+      NetworksViewSelectorsIDs.ICON_BUTTON_BLOCK_EXPLORER,
+    );
+  }
+
+  get addBlockExplorerButton() {
+    return Matchers.getElementByID(NetworksViewSelectorsIDs.ADD_BLOCK_EXPLORER);
+  }
+
   get addRpcButton() {
     return Matchers.getElementByID(NetworksViewSelectorsIDs.ADD_RPC_BUTTON);
   }
@@ -91,6 +101,12 @@ class NetworkView {
     );
   }
 
+  get networkBlockExplorerInput() {
+    return Matchers.getElementByID(
+      NetworksViewSelectorsIDs.BLOCK_EXPLORER_INPUT,
+    );
+  }
+
   get rpcAddButton() {
     return Matchers.getElementByID(
       NetworksViewSelectorsIDs.ADD_CUSTOM_NETWORK_BUTTON,
@@ -136,6 +152,14 @@ class NetworkView {
 
   async tapRpcDropDownButton() {
     await Gestures.waitAndTap(this.addRpcDropDownButton);
+  }
+
+  async tapBlockExplorerDownButton() {
+    await Gestures.waitAndTap(this.addBlockExplorerDropDownButton);
+  }
+
+  async tapBlockExplorerButton() {
+    await Gestures.waitAndTap(this.addBlockExplorerButton);
   }
 
   async tapAddRpcButton() {
@@ -189,6 +213,13 @@ class NetworkView {
     await Gestures.typeTextAndHideKeyboard(
       this.networkSymbolInput,
       networkSymbol,
+    );
+  }
+
+  async typeInNetworkBlockExplorer(networkBlockExplorer) {
+    await Gestures.typeTextAndHideKeyboard(
+      this.networkBlockExplorerInput,
+      networkBlockExplorer,
     );
   }
 

--- a/e2e/resources/networks.e2e.js
+++ b/e2e/resources/networks.e2e.js
@@ -1,4 +1,4 @@
-import { toHex } from '@metamask/controller-utils';
+import { BlockExplorerUrl, toHex } from '@metamask/controller-utils';
 
 /* eslint-disable @typescript-eslint/no-require-imports, import/no-commonjs */
 const InfuraKey = process.env.MM_INFURA_PROJECT_ID;
@@ -109,6 +109,7 @@ const CustomNetworks = {
       rpcUrl: 'https://rpc.gnosischain.com',
       nickname: 'Gnosis',
       ticker: 'xDAI',
+      BlockExplorerUrl: 'https://gnosisscan.io',
     },
   },
 };

--- a/e2e/selectors/Settings/NetworksView.selectors.js
+++ b/e2e/selectors/Settings/NetworksView.selectors.js
@@ -6,6 +6,7 @@ export const NetworksViewSelectorsIDs = {
   ADD_NETWORKS_BUTTON: 'add-network-button',
   NETWORK_NAME_INPUT: 'input-network-name',
   BLOCK_EXPLORER_INPUT: 'block-explorer',
+  ADD_BLOCK_EXPLORER: 'add-block-explorer-button',
   RPC_URL_INPUT: 'input-rpc-url',
   CHAIN_INPUT: 'input-chain-id',
   NETWORKS_SYMBOL_INPUT: 'input-network-symbol',
@@ -20,6 +21,7 @@ export const NetworksViewSelectorsIDs = {
   SEARCH_NETWORK_INPUT_BOX_ID: 'network-search-input',
   CONTAINER: 'network-form-container',
   ICON_BUTTON_RPC: 'drop-down-rpc-menu',
+  ICON_BUTTON_BLOCK_EXPLORER: 'drop-down-block-explorer-menu',
   ADD_RPC_BUTTON: 'add-rpc-button',
   RPC_NAME_INPUT: 'input-rpc-name',
 };

--- a/e2e/specs/networks/add-custom-rpc.spec.js
+++ b/e2e/specs/networks/add-custom-rpc.spec.js
@@ -17,8 +17,6 @@ import { getFixturesServerPort } from '../../fixtures/utils';
 import FixtureServer from '../../fixtures/fixture-server';
 import Assertions from '../../utils/Assertions';
 import { CustomNetworks } from '../../resources/networks.e2e';
-import Gestures from '../../utils/Gestures';
-import Matchers from '../../utils/Matchers';
 
 const fixtureServer = new FixtureServer();
 
@@ -74,6 +72,12 @@ describe(Regression('Custom RPC Tests'), () => {
     );
 
     await NetworkView.tapChainIDLabel(); // Focus outside of text input field
+
+    await NetworkView.tapBlockExplorerDownButton();
+    await NetworkView.tapBlockExplorerButton();
+    await NetworkView.typeInNetworkBlockExplorer(
+      `${CustomNetworks.Gnosis.providerConfig.BlockExplorerUrl}\n`,
+    );
 
     if (device.getPlatform() === 'ios') {
       await NetworkView.tapChainIDLabel(); // Focus outside of text input field


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After trying to add a block explorer the Add Custom Network modal pops-up. I am adding block explorer by using device keypad enter button because the Add Block Explorer URL button is not reachable, keypad in the way. May be because of the keypad that is causing this.

Have not been able to successfully add a block explorer.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #11992 

## **Manual testing steps**

1. Go to add network form
2. fill the form
3. when you fill the block explorer form click on return keyboard button

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
