### PR TITLE
chore: cherry pick 12074

### DIFF
--- a/app/components/Views/OnboardingSuccess/OnboardingAssetsSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/OnboardingSuccess/OnboardingAssetsSettings/__snapshots__/index.test.tsx.snap
@@ -739,7 +739,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
                   "uri": "MockImage",
                 },
               },
-              "name": "Mainnet",
+              "name": "Ethereum Mainnet",
               "variant": "Network",
             }
           }
@@ -754,7 +754,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
             }
           }
           testID="celldisplay"
-          title="Mainnet"
+          title="Ethereum Mainnet"
         >
           <View
             style={
@@ -820,7 +820,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
                 }
                 testID="cellbase-avatar-title"
               >
-                Mainnet
+                Ethereum Mainnet
               </Text>
               <Text
                 accessibilityRole="text"
@@ -1452,7 +1452,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
                   "uri": "MockImage",
                 },
               },
-              "name": "Linea Mainnet",
+              "name": "Linea",
               "variant": "Network",
             }
           }
@@ -1467,7 +1467,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
             }
           }
           testID="celldisplay"
-          title="Linea Mainnet"
+          title="Linea"
         >
           <View
             style={
@@ -1533,7 +1533,7 @@ exports[`OnboardingAssetSettings should render correctly 1`] = `
                 }
                 testID="cellbase-avatar-title"
               >
-                Linea Mainnet
+                Linea
               </Text>
               <Text
                 accessibilityRole="text"

--- a/app/components/Views/Settings/IncomingTransactionsSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/IncomingTransactionsSettings/__snapshots__/index.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
               "uri": "MockImage",
             },
           },
-          "name": "Mainnet",
+          "name": "Ethereum Mainnet",
           "variant": "Network",
         }
       }
@@ -356,7 +356,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
         }
       }
       testID="celldisplay"
-      title="Mainnet"
+      title="Ethereum Mainnet"
     >
       <View
         style={
@@ -422,7 +422,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
             }
             testID="cellbase-avatar-title"
           >
-            Mainnet
+            Ethereum Mainnet
           </Text>
           <Text
             accessibilityRole="text"
@@ -1054,7 +1054,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
               "uri": "MockImage",
             },
           },
-          "name": "Linea Mainnet",
+          "name": "Linea",
           "variant": "Network",
         }
       }
@@ -1069,7 +1069,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
         }
       }
       testID="celldisplay"
-      title="Linea Mainnet"
+      title="Linea"
     >
       <View
         style={
@@ -1135,7 +1135,7 @@ exports[`IncomingTransactionsSettings should render correctly 1`] = `
             }
             testID="cellbase-avatar-title"
           >
-            Linea Mainnet
+            Linea
           </Text>
           <Text
             accessibilityRole="text"

--- a/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
+++ b/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
@@ -1844,7 +1844,7 @@ exports[`SecuritySettings should render correctly 1`] = `
                     "uri": "MockImage",
                   },
                 },
-                "name": "Mainnet",
+                "name": "Ethereum Mainnet",
                 "variant": "Network",
               }
             }
@@ -1859,7 +1859,7 @@ exports[`SecuritySettings should render correctly 1`] = `
               }
             }
             testID="celldisplay"
-            title="Mainnet"
+            title="Ethereum Mainnet"
           >
             <View
               style={
@@ -1925,7 +1925,7 @@ exports[`SecuritySettings should render correctly 1`] = `
                   }
                   testID="cellbase-avatar-title"
                 >
-                  Mainnet
+                  Ethereum Mainnet
                 </Text>
                 <Text
                   accessibilityRole="text"
@@ -2557,7 +2557,7 @@ exports[`SecuritySettings should render correctly 1`] = `
                     "uri": "MockImage",
                   },
                 },
-                "name": "Linea Mainnet",
+                "name": "Linea",
                 "variant": "Network",
               }
             }
@@ -2572,7 +2572,7 @@ exports[`SecuritySettings should render correctly 1`] = `
               }
             }
             testID="celldisplay"
-            title="Linea Mainnet"
+            title="Linea"
           >
             <View
               style={
@@ -2638,7 +2638,7 @@ exports[`SecuritySettings should render correctly 1`] = `
                   }
                   testID="cellbase-avatar-title"
                 >
-                  Linea Mainnet
+                  Linea
                 </Text>
                 <Text
                   accessibilityRole="text"

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Wallet should render correctly 1`] = `
                     }
                     testID="open-networks-text"
                   >
-                    Mainnet
+                    Ethereum Mainnet
                   </Text>
                   <SvgMock
                     color="#141618"

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -64,7 +64,7 @@
         "blockExplorerUrls": [],
         "chainId": "0x1",
         "defaultRpcEndpointIndex": 0,
-        "name": "Mainnet",
+        "name": "Ethereum Mainnet",
         "nativeCurrency": "ETH",
         "rpcEndpoints": [
           {
@@ -134,7 +134,7 @@
         "blockExplorerUrls": [],
         "chainId": "0xe708",
         "defaultRpcEndpointIndex": 0,
-        "name": "Linea Mainnet",
+        "name": "Linea",
         "nativeCurrency": "ETH",
         "rpcEndpoints": [
           {

--- a/patches/@metamask+controller-utils+11.3.0.patch
+++ b/patches/@metamask+controller-utils+11.3.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@metamask/controller-utils/dist/types.cjs b/node_modules/@metamask/controller-utils/dist/types.cjs
+index b8c00f2..6268fb0 100644
+--- a/node_modules/@metamask/controller-utils/dist/types.cjs
++++ b/node_modules/@metamask/controller-utils/dist/types.cjs
+@@ -97,11 +97,11 @@ exports.BlockExplorerUrl = {
+     [BuiltInNetworkName.LineaMainnet]: 'https://lineascan.build',
+ };
+ exports.NetworkNickname = {
+-    [BuiltInNetworkName.Mainnet]: 'Mainnet',
++    [BuiltInNetworkName.Mainnet]: 'Ethereum Mainnet',
+     [BuiltInNetworkName.Goerli]: 'Goerli',
+     [BuiltInNetworkName.Sepolia]: 'Sepolia',
+     [BuiltInNetworkName.LineaGoerli]: 'Linea Goerli',
+     [BuiltInNetworkName.LineaSepolia]: 'Linea Sepolia',
+-    [BuiltInNetworkName.LineaMainnet]: 'Linea Mainnet',
++    [BuiltInNetworkName.LineaMainnet]: 'Linea',
+ };
+ //# sourceMappingURL=types.cjs.map


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The network names for Ethereum mainnet and Linea mainnet should be standardized as "Ethereum Mainnet" and "Linea" to align with our third-party provider.

core PR: [adjust network names](https://github.com/MetaMask/core/pull/4865) 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #11895 

## **Manual testing steps**

1. Move from v7.33 ( or any previous release version ) to this branch
2. Check the name of Ethereum mainnet and Linea

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
