### PR TITLE
chore: demonstrate event tracking bug

### DIFF
--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
@@ -19,8 +19,12 @@ import styleSheet from './StakeInputView.styles';
 import useStakingInputHandlers from '../../hooks/useStakingInput';
 import useBalance from '../../hooks/useBalance';
 import InputDisplay from '../../components/InputDisplay';
+import { useMetrics, MetaMetricsEvents } from '../../../../hooks/useMetrics';
+import { MetaMetrics } from '../../../../../core/Analytics';
+import Logger from '../../../../../util/Logger';
 
 const StakeInputView = () => {
+  const { trackEvent, createEventBuilder } = useMetrics()
   const title = strings('stake.stake_eth');
   const navigation = useNavigation();
   const { styles, theme } = useStyles(styleSheet, {});
@@ -64,6 +68,24 @@ const StakeInputView = () => {
         annualRewardRate,
       },
     });
+    const metrics = MetaMetrics.getInstance();
+    Logger.log('Should fire event')
+    // Working code
+    metrics.trackEvent(MetaMetricsEvents.REVIEW_STAKE_BUTTON_CLICKED, {
+      blah: 'test'
+    })
+    // Broken code
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.REVIEW_STAKE_BUTTON_CLICKED)
+      .addProperties({
+        blah: 'test 1'
+      })
+      .build(),
+    );
+    // Also broken code
+    trackEvent(MetaMetricsEvents.REVIEW_STAKE_BUTTON_CLICKED, {
+      blah: 'test 2'
+    })
   }, [
     navigation,
     amountWei,

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -275,6 +275,7 @@ enum EVENT_NAME {
 
   // Stake
   STAKE_BUTTON_CLICKED = 'Stake Button Clicked',
+  REVIEW_STAKE_BUTTON_CLICKED = 'Review Stake Button Clicked',
 
   // Force Upgrade | Automatic Security Checks
   FORCE_UPGRADE_UPDATE_NEEDED_PROMPT_VIEWED = 'Force Upgrade Update Needed Prompt Viewed',
@@ -1242,6 +1243,11 @@ const legacyMetaMetricsEvents = {
     ACTIONS.STAKE,
     DESCRIPTION.STAKE,
   ),
+  REVIEW_STAKE_BUTTON_CLICKED: generateOpt(
+    EVENT_NAME.REVIEW_STAKE_BUTTON_CLICKED,
+    ACTIONS.STAKE,
+    DESCRIPTION.STAKE
+  )
 };
 
 const MetaMetricsEvents = { ...events, ...legacyMetaMetricsEvents };


### PR DESCRIPTION
## **Description**

Code to demonstrate the event event tracking bug

## **Related issues**

Related issue: https://github.com/MetaMask/metamask-mobile/issues/12117

## **Manual testing steps**

1. Click on staking badge (need to set `MM_POOLED_STAKING_UI_ENABLED=true`)
2. Enter staking input amount
3. Click Review
4. Three duplicate events should be fired with different property values
5. Only the legacy style event is called 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
