### PR TITLE
fix(11215): show error message when user selects a new ledger device

### DIFF
--- a/app/components/Views/LedgerConnect/index.styles.ts
+++ b/app/components/Views/LedgerConnect/index.styles.ts
@@ -50,6 +50,10 @@ const createStyles = (colors: Colors) =>
       flex: 1,
       marginTop: Device.getDeviceHeight() * 0.025,
     },
+    bodyContainerWhithErrorMessage: {
+      flex: 1,
+      marginTop: Device.getDeviceHeight() * 0.01,
+    },
     textContainer: {
       marginTop: Device.getDeviceHeight() * 0.05,
     },

--- a/app/components/Views/LedgerConnect/index.test.tsx
+++ b/app/components/Views/LedgerConnect/index.test.tsx
@@ -372,7 +372,7 @@ describe('LedgerConnect', () => {
   it('shows error message about multiple devices support', async () => {
     isSendingLedgerCommands = true;
     isAppLaunchConfirmationNeeded = false;
-    const { findByTestId } = renderWithProvider(
+    const { getByTestId } = renderWithProvider(
       <LedgerConnect
         onConnectLedger={onConfirmationComplete}
         isSendingLedgerCommands={isSendingLedgerCommands}
@@ -384,7 +384,7 @@ describe('LedgerConnect', () => {
       />,
     );
     await waitFor(() => {
-      expect(findByTestId('multiple-devices-error-message')).toBeDefined();
+      expect(getByTestId('multiple-devices-error-message')).toBeDefined();
     });
   });
 });

--- a/app/components/Views/LedgerConnect/index.tsx
+++ b/app/components/Views/LedgerConnect/index.tsx
@@ -87,7 +87,8 @@ const LedgerConnect = ({
   const onDeviceSelected = (currentDevice: BluetoothDevice | undefined) => {
     const getStoredDeviceId = async () => {
       const storedDeviceId = await getDeviceId();
-      const isMatchingDeviceId = currentDevice?.id === storedDeviceId;
+      const isMatchingDeviceId =
+        !storedDeviceId || currentDevice?.id === storedDeviceId;
       setHasMatchingDeviceId(isMatchingDeviceId);
 
       if (isMatchingDeviceId) {
@@ -127,6 +128,11 @@ const LedgerConnect = ({
       },
     });
   };
+
+  const getStylesWithMultipleDevicesErrorMessage = () =>
+    hasMatchingDeviceId
+      ? styles.bodyContainer
+      : styles.bodyContainerWhithErrorMessage;
 
   useEffect(() => {
     if (ledgerError) {
@@ -272,13 +278,12 @@ const LedgerConnect = ({
             </Text>
           )}
           {!hasMatchingDeviceId && (
-            <Text red small>
-              Mutiple devices not supported yet, please forget your previous
-              device first before adding a new one
+            <Text red small testID={'multiple-devices-error-message'}>
+              {strings('ledger.multiple_devices_error_message')}
             </Text>
           )}
         </View>
-        <View style={styles.bodyContainer}>
+        <View style={getStylesWithMultipleDevicesErrorMessage()}>
           {!isAppLaunchConfirmationNeeded ? (
             <Scan
               onDeviceSelected={onDeviceSelected}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3367,7 +3367,7 @@
     "blind_sign_error_message": "Blind signing is not enabled on your Ledger device. Please enable it in the settings.",
     "user_reject_transaction": "User rejected the transaction",
     "user_reject_transaction_message": "The user has rejected the transaction on the Ledger device.",
-    "multiple_devices_error_message": "Mutiple devices not supported yet, please forget your previous device first before adding a new one"
+    "multiple_devices_error_message": "Multiple devices aren’t supported yet. To add a new Ledger device, you’ll need to remove an older one."
   },
   "account_actions": {
     "edit_name": "Edit account name",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3366,7 +3366,8 @@
     "blind_sign_error": "Blind signing error",
     "blind_sign_error_message": "Blind signing is not enabled on your Ledger device. Please enable it in the settings.",
     "user_reject_transaction": "User rejected the transaction",
-    "user_reject_transaction_message": "The user has rejected the transaction on the Ledger device."
+    "user_reject_transaction_message": "The user has rejected the transaction on the Ledger device.",
+    "multiple_devices_error_message": "Mutiple devices not supported yet, please forget your previous device first before adding a new one"
   },
   "account_actions": {
     "edit_name": "Edit account name",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

As discussed with @AlexJupiter, to prevent users to add multiple ledger devices, we decided to show an error message when deviceId would not match with the device already added.
This is a temporary solution until proper mutliple devices support is implemented.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/11215

## **Manual testing steps**
⚠️ These steps require at least two different ledger devices
1. Add a new hardware account, select Ledger device n°1 and import an account
2. Add a new hardware account, select Ledger device n°2
3. See that error message is displayed
4. Select Ledger device n°1, see that error message is not displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/2280f18a-ed10-4095-90e8-5ed8d7a52847



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
