### PR TITLE
feat: disable wallet buttons for accounts that cannot sign transactions

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -258,10 +258,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
   }
 
   return (
-    <View
-      style={styles.wrapper}
-      testID={TokenOverviewSelectorsIDs.CONTAINER}
-    >
+    <View style={styles.wrapper} testID={TokenOverviewSelectorsIDs.CONTAINER}>
       {asset.hasBalanceError ? (
         renderWarning()
       ) : (

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -390,16 +390,27 @@ exports[`AssetOverview should render correctly 1`] = `
         }
       >
         <TouchableOpacity
+          disabled={false}
           onPress={[Function]}
           style={
-            {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-              "paddingTop": 16,
-              "paddingVertical": 2,
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingVertical": 16,
+                "width": "100%",
+              },
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingTop": 16,
+                "paddingVertical": 2,
+                "width": "100%",
+              },
+              false,
+            ]
           }
           testID="token-buy-button"
         >
@@ -485,16 +496,27 @@ exports[`AssetOverview should render correctly 1`] = `
         }
       >
         <TouchableOpacity
+          disabled={false}
           onPress={[Function]}
           style={
-            {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-              "paddingTop": 16,
-              "paddingVertical": 2,
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingVertical": 16,
+                "width": "100%",
+              },
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingTop": 16,
+                "paddingVertical": 2,
+                "width": "100%",
+              },
+              false,
+            ]
           }
           testID="token-swap-button"
         >
@@ -580,16 +602,27 @@ exports[`AssetOverview should render correctly 1`] = `
         }
       >
         <TouchableOpacity
+          disabled={false}
           onPress={[Function]}
           style={
-            {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-              "paddingTop": 16,
-              "paddingVertical": 2,
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingVertical": 16,
+                "width": "100%",
+              },
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingTop": 16,
+                "paddingVertical": 2,
+                "width": "100%",
+              },
+              false,
+            ]
           }
           testID="token-bridge-button"
         >
@@ -675,16 +708,27 @@ exports[`AssetOverview should render correctly 1`] = `
         }
       >
         <TouchableOpacity
+          disabled={false}
           onPress={[Function]}
           style={
-            {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-              "paddingTop": 16,
-              "paddingVertical": 2,
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingVertical": 16,
+                "width": "100%",
+              },
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingTop": 16,
+                "paddingVertical": 2,
+                "width": "100%",
+              },
+              false,
+            ]
           }
           testID="token-send-button"
         >
@@ -770,16 +814,27 @@ exports[`AssetOverview should render correctly 1`] = `
         }
       >
         <TouchableOpacity
+          disabled={false}
           onPress={[Function]}
           style={
-            {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "justifyContent": "flex-start",
-              "paddingTop": 16,
-              "paddingVertical": 2,
-              "width": "100%",
-            }
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingVertical": 16,
+                "width": "100%",
+              },
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+                "paddingTop": 16,
+                "paddingVertical": 2,
+                "width": "100%",
+              },
+              false,
+            ]
           }
           testID="token-receive-button"
         >

--- a/app/components/UI/WalletAction/WalletAction.styles.ts
+++ b/app/components/UI/WalletAction/WalletAction.styles.ts
@@ -26,6 +26,9 @@ const styleSheet = (params: { theme: Theme }) => {
     descriptionLabel: {
       color: colors.text.alternative,
     },
+    disabled: {
+      opacity: 0.5,
+    },
   });
 };
 

--- a/app/components/UI/WalletAction/WalletAction.tsx
+++ b/app/components/UI/WalletAction/WalletAction.tsx
@@ -8,9 +8,14 @@ import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../component-library/hooks';
+import { strings } from '../../../../locales/i18n';
 
 // Internal dependencies.
-import { walletActionDetails, WalletActionProps } from './WalletAction.types';
+import {
+  WalletActionDetail,
+  WalletActionProps,
+  WalletActionType,
+} from './WalletAction.types';
 import styleSheet from './WalletAction.styles';
 import Avatar, {
   AvatarVariant,
@@ -27,6 +32,39 @@ const WalletAction = ({
   disabled,
   ...props
 }: WalletActionProps) => {
+  const walletActionDetails: Record<WalletActionType, WalletActionDetail> = {
+    [WalletActionType.Buy]: {
+      title: strings('asset_overview.buy_button'),
+      description: strings('asset_overview.buy_description'),
+      disabledDescription: strings('asset_overview.disabled_button.buy'),
+    },
+    [WalletActionType.Sell]: {
+      title: strings('asset_overview.sell_button'),
+      description: strings('asset_overview.sell_description'),
+      disabledDescription: strings('asset_overview.disabled_button.sell'),
+    },
+    [WalletActionType.Swap]: {
+      title: strings('asset_overview.swap'),
+      description: strings('asset_overview.swap_description'),
+      disabledDescription: strings('asset_overview.disabled_button.swap'),
+    },
+    [WalletActionType.Bridge]: {
+      title: strings('asset_overview.bridge'),
+      description: strings('asset_overview.bridge_description'),
+      disabledDescription: strings('asset_overview.disabled_button.bridge'),
+    },
+    [WalletActionType.Send]: {
+      title: strings('asset_overview.send_button'),
+      description: strings('asset_overview.send_description'),
+      disabledDescription: strings('asset_overview.disabled_button.send'),
+    },
+    [WalletActionType.Receive]: {
+      title: strings('asset_overview.receive_button'),
+      description: strings('asset_overview.receive_description'),
+      disabledDescription: strings('asset_overview.disabled_button.receive'),
+    },
+  };
+
   const actionStrings = actionType ? walletActionDetails[actionType] : null;
   const actionTitle = actionStrings?.title ?? '';
   const actionDescription = actionStrings?.description;

--- a/app/components/UI/WalletAction/WalletAction.tsx
+++ b/app/components/UI/WalletAction/WalletAction.tsx
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import React, { useMemo } from 'react';
+import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { lightTheme } from '@metamask/design-tokens';
 
@@ -33,14 +33,6 @@ const WalletAction = ({
   const { colors } = lightTheme;
   const { styles } = useStyles(styleSheet, {});
 
-  const avatarStyle = useMemo(
-    () => ({
-      ...iconStyle,
-      backgroundColor: disabled ? colors.primary.muted : colors.primary.default,
-    }),
-    [disabled, colors, iconStyle],
-  );
-
   const touchableStyles = [
     styles.base,
     containerStyle,
@@ -57,9 +49,10 @@ const WalletAction = ({
     >
       <Avatar
         variant={AvatarVariant.Icon}
-        style={avatarStyle}
+        style={iconStyle}
         size={iconSize}
         name={iconName}
+        backgroundColor={colors.primary.default}
         iconColor={colors.background.default}
       />
       <View>

--- a/app/components/UI/WalletAction/WalletAction.tsx
+++ b/app/components/UI/WalletAction/WalletAction.tsx
@@ -1,6 +1,6 @@
 // Third party dependencies.
-import React from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import React, { useMemo } from 'react';
+import { TouchableOpacity, View } from 'react-native';
 import { lightTheme } from '@metamask/design-tokens';
 
 // External dependencies.
@@ -8,39 +8,58 @@ import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../component-library/hooks';
+
 // Internal dependencies.
-import { WalletActionProps } from './WalletAction.types';
+import { walletActionDetails, WalletActionProps } from './WalletAction.types';
 import styleSheet from './WalletAction.styles';
 import Avatar, {
   AvatarVariant,
 } from '../../../component-library/components/Avatars/Avatar';
 
 const WalletAction = ({
-  actionTitle,
-  actionDescription,
+  actionType,
   iconName,
   iconSize,
   onPress,
   containerStyle,
   iconStyle,
   actionID,
+  disabled,
   ...props
 }: WalletActionProps) => {
+  const actionStrings = actionType ? walletActionDetails[actionType] : null;
+  const actionTitle = actionStrings?.title ?? '';
+  const actionDescription = actionStrings?.description;
   const { colors } = lightTheme;
   const { styles } = useStyles(styleSheet, {});
+
+  const avatarStyle = useMemo(
+    () => ({
+      ...iconStyle,
+      backgroundColor: disabled ? colors.primary.muted : colors.primary.default,
+    }),
+    [disabled, colors, iconStyle],
+  );
+
+  const touchableStyles = [
+    styles.base,
+    containerStyle,
+    disabled && styles.disabled,
+  ];
+
   return (
     <TouchableOpacity
-      style={{ ...styles.base, ...containerStyle }}
+      style={touchableStyles}
       onPress={onPress}
       testID={actionID}
+      disabled={disabled}
       {...props}
     >
       <Avatar
         variant={AvatarVariant.Icon}
-        style={iconStyle}
+        style={avatarStyle}
         size={iconSize}
         name={iconName}
-        backgroundColor={colors.primary.default}
         iconColor={colors.background.default}
       />
       <View>

--- a/app/components/UI/WalletAction/WalletAction.types.ts
+++ b/app/components/UI/WalletAction/WalletAction.types.ts
@@ -1,7 +1,6 @@
 import { ImageStyle, ViewStyle } from 'react-native';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
-import { strings } from '../../../../locales/i18n';
 
 export enum WalletActionType {
   Buy = 'Buy',
@@ -17,40 +16,6 @@ export interface WalletActionDetail {
   description: string;
   disabledDescription: string;
 }
-
-export const walletActionDetails: Record<WalletActionType, WalletActionDetail> =
-  {
-    [WalletActionType.Buy]: {
-      title: strings('asset_overview.buy_button'),
-      description: strings('asset_overview.buy_description'),
-      disabledDescription: strings('asset_overview.disabled_button.buy'),
-    },
-    [WalletActionType.Sell]: {
-      title: strings('asset_overview.sell_button'),
-      description: strings('asset_overview.sell_description'),
-      disabledDescription: strings('asset_overview.disabled_button.sell'),
-    },
-    [WalletActionType.Swap]: {
-      title: strings('asset_overview.swap'),
-      description: strings('asset_overview.swap_description'),
-      disabledDescription: strings('asset_overview.disabled_button.swap'),
-    },
-    [WalletActionType.Bridge]: {
-      title: strings('asset_overview.bridge'),
-      description: strings('asset_overview.bridge_description'),
-      disabledDescription: strings('asset_overview.disabled_button.bridge'),
-    },
-    [WalletActionType.Send]: {
-      title: strings('asset_overview.send_button'),
-      description: strings('asset_overview.send_description'),
-      disabledDescription: strings('asset_overview.disabled_button.send'),
-    },
-    [WalletActionType.Receive]: {
-      title: strings('asset_overview.receive_button'),
-      description: strings('asset_overview.receive_description'),
-      disabledDescription: strings('asset_overview.disabled_button.receive'),
-    },
-  };
 
 export interface WalletActionProps {
   actionType?: WalletActionType;

--- a/app/components/UI/WalletAction/WalletAction.types.ts
+++ b/app/components/UI/WalletAction/WalletAction.types.ts
@@ -1,14 +1,64 @@
 import { ImageStyle, ViewStyle } from 'react-native';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
+import { strings } from '../../../../locales/i18n';
+
+export enum WalletActionType {
+  Buy = 'Buy',
+  Sell = 'Sell',
+  Swap = 'Swap',
+  Bridge = 'Bridge',
+  Send = 'Send',
+  Receive = 'Receive',
+}
+
+export interface WalletActionDetail {
+  title: string;
+  description: string;
+  disabledDescription: string;
+}
+
+export const walletActionDetails: Record<WalletActionType, WalletActionDetail> =
+  {
+    [WalletActionType.Buy]: {
+      title: strings('asset_overview.buy_button'),
+      description: strings('asset_overview.buy_description'),
+      disabledDescription: strings('asset_overview.disabled_button.buy'),
+    },
+    [WalletActionType.Sell]: {
+      title: strings('asset_overview.sell_button'),
+      description: strings('asset_overview.sell_description'),
+      disabledDescription: strings('asset_overview.disabled_button.sell'),
+    },
+    [WalletActionType.Swap]: {
+      title: strings('asset_overview.swap'),
+      description: strings('asset_overview.swap_description'),
+      disabledDescription: strings('asset_overview.disabled_button.swap'),
+    },
+    [WalletActionType.Bridge]: {
+      title: strings('asset_overview.bridge'),
+      description: strings('asset_overview.bridge_description'),
+      disabledDescription: strings('asset_overview.disabled_button.bridge'),
+    },
+    [WalletActionType.Send]: {
+      title: strings('asset_overview.send_button'),
+      description: strings('asset_overview.send_description'),
+      disabledDescription: strings('asset_overview.disabled_button.send'),
+    },
+    [WalletActionType.Receive]: {
+      title: strings('asset_overview.receive_button'),
+      description: strings('asset_overview.receive_description'),
+      disabledDescription: strings('asset_overview.disabled_button.receive'),
+    },
+  };
 
 export interface WalletActionProps {
-  actionTitle?: string;
-  actionDescription?: string;
+  actionType?: WalletActionType;
   iconName: IconName;
   iconSize: AvatarSize;
   onPress: () => void;
   containerStyle?: ViewStyle;
   iconStyle?: ImageStyle;
   actionID?: string;
+  disabled?: boolean;
 }

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { fireEvent } from '@testing-library/react-native';
 import AssetDetailsActions from './AssetDetailsActions';
 import { strings } from '../../../../../locales/i18n';
 import { TokenOverviewSelectorsIDs } from '../../../../../e2e/selectors/TokenOverview.selectors';
+import {
+  expectedUuid2,
+  MOCK_ACCOUNTS_CONTROLLER_STATE,
+} from '../../../../util/test/accountsControllerTestUtils';
+import { EthMethod } from '@metamask/keyring-api';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import initialRootState from '../../../../util/test/initial-root-state';
 
 describe('AssetDetailsActions', () => {
   const mockOnBuy = jest.fn();
@@ -26,12 +33,18 @@ describe('AssetDetailsActions', () => {
   });
 
   it('should render correctly', () => {
-    const { toJSON } = render(<AssetDetailsActions {...defaultProps} />);
+    const { toJSON } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
     expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders correctly with all buttons displayed', () => {
-    const { getByText } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByText } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     expect(getByText(strings('asset_overview.buy_button'))).toBeTruthy();
     expect(getByText(strings('asset_overview.swap'))).toBeTruthy();
@@ -41,53 +54,111 @@ describe('AssetDetailsActions', () => {
   });
 
   it('calls onBuy when the buy button is pressed', () => {
-    const { getByTestId } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.BUY_BUTTON));
     expect(mockOnBuy).toHaveBeenCalled();
   });
 
   it('calls goToSwaps when the swap button is pressed', () => {
-    const { getByTestId } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.SWAP_BUTTON));
     expect(mockGoToSwaps).toHaveBeenCalled();
   });
 
   it('calls goToBridge when the bridge button is pressed', () => {
-    const { getByTestId } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.BRIDGE_BUTTON));
     expect(mockGoToBridge).toHaveBeenCalled();
   });
 
   it('calls onSend when the send button is pressed', () => {
-    const { getByTestId } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.SEND_BUTTON));
     expect(mockOnSend).toHaveBeenCalled();
   });
 
   it('calls onReceive when the receive button is pressed', () => {
-    const { getByTestId } = render(<AssetDetailsActions {...defaultProps} />);
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state: initialRootState },
+    );
 
     fireEvent.press(getByTestId(TokenOverviewSelectorsIDs.RECEIVE_BUTTON));
     expect(mockOnReceive).toHaveBeenCalled();
   });
 
   it('does not render the buy button when displayBuyButton is false', () => {
-    const { queryByText } = render(
+    const { queryByText } = renderWithProvider(
       <AssetDetailsActions {...defaultProps} displayBuyButton={false} />,
+      { state: initialRootState },
     );
 
     expect(queryByText(strings('asset_overview.buy_button'))).toBeNull();
   });
 
   it('does not render the swap button when displaySwapsButton is false', () => {
-    const { queryByText } = render(
+    const { queryByText } = renderWithProvider(
       <AssetDetailsActions {...defaultProps} displaySwapsButton={false} />,
+      { state: initialRootState },
     );
 
     expect(queryByText(strings('asset_overview.swap'))).toBeNull();
+  });
+
+  it('disables buttons when the account cannot sign transactions', () => {
+    const mockState = { ...MOCK_ACCOUNTS_CONTROLLER_STATE };
+    mockState.internalAccounts.accounts[expectedUuid2].methods = Object.values(
+      EthMethod,
+    ).filter((method) => method !== EthMethod.SignTransaction);
+
+    const initialState = {
+      ...initialRootState,
+      engine: {
+        ...initialRootState.engine,
+        backgroundState: {
+          ...initialRootState.engine.backgroundState,
+          AccountsController: mockState,
+        },
+      },
+    };
+
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      {
+        state: initialState,
+      },
+    );
+
+    const buttons = [
+      TokenOverviewSelectorsIDs.BUY_BUTTON,
+      TokenOverviewSelectorsIDs.SWAP_BUTTON,
+      TokenOverviewSelectorsIDs.BRIDGE_BUTTON,
+      TokenOverviewSelectorsIDs.SEND_BUTTON,
+    ];
+
+    buttons.forEach((buttonTestId) => {
+      expect(getByTestId(buttonTestId).props.disabled).toBe(true);
+    });
+
+    // The receive button should always be enabled
+    expect(
+      getByTestId(TokenOverviewSelectorsIDs.RECEIVE_BUTTON).props.disabled,
+    ).toBe(false);
   });
 });

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
@@ -10,6 +10,8 @@ import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
 import { TokenOverviewSelectorsIDs } from '../../../../../e2e/selectors/TokenOverview.selectors';
+import { useSelector } from 'react-redux';
+import { selectCanSignTransactions } from '../../../../selectors/accountsController';
 
 export interface AssetDetailsActionsProps {
   displayBuyButton: boolean | undefined;
@@ -31,6 +33,7 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
   onReceive,
 }) => {
   const { styles } = useStyles(styleSheet, {});
+  const canSignTransactions = useSelector(selectCanSignTransactions);
 
   return (
     <View style={styles.activitiesButton}>
@@ -38,10 +41,11 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
         <View style={styles.buttonWrapper}>
           <WalletAction
             iconName={IconName.Add}
-            iconSize={AvatarSize.Lg}
             onPress={onBuy}
             iconStyle={styles.icon}
             containerStyle={styles.containerStyle}
+            iconSize={AvatarSize.Lg}
+            disabled={!canSignTransactions}
             actionID={TokenOverviewSelectorsIDs.BUY_BUTTON}
           />
           <Text variant={TextVariant.BodyMD}>
@@ -49,15 +53,15 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
           </Text>
         </View>
       )}
-
       {displaySwapsButton && (
         <View style={styles.buttonWrapper}>
           <WalletAction
             iconName={IconName.SwapHorizontal}
-            iconSize={AvatarSize.Lg}
             onPress={goToSwaps}
             iconStyle={styles.icon}
             containerStyle={styles.containerStyle}
+            iconSize={AvatarSize.Lg}
+            disabled={!canSignTransactions}
             actionID={TokenOverviewSelectorsIDs.SWAP_BUTTON}
           />
           <Text variant={TextVariant.BodyMD}>
@@ -65,14 +69,14 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
           </Text>
         </View>
       )}
-
       <View style={styles.buttonWrapper}>
         <WalletAction
           iconName={IconName.Bridge}
-          iconSize={AvatarSize.Lg}
           onPress={goToBridge}
           iconStyle={styles.icon}
           containerStyle={styles.containerStyle}
+          iconSize={AvatarSize.Lg}
+          disabled={!canSignTransactions}
           actionID={TokenOverviewSelectorsIDs.BRIDGE_BUTTON}
         />
         <Text variant={TextVariant.BodyMD}>
@@ -82,10 +86,11 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
       <View style={styles.buttonWrapper}>
         <WalletAction
           iconName={IconName.Arrow2Upright}
-          iconSize={AvatarSize.Lg}
           onPress={onSend}
           iconStyle={styles.icon}
           containerStyle={styles.containerStyle}
+          iconSize={AvatarSize.Lg}
+          disabled={!canSignTransactions}
           actionID={TokenOverviewSelectorsIDs.SEND_BUTTON}
         />
         <Text variant={TextVariant.BodyMD}>
@@ -95,10 +100,11 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
       <View style={styles.buttonWrapper}>
         <WalletAction
           iconName={IconName.QrCode}
-          iconSize={AvatarSize.Lg}
           onPress={onReceive}
           iconStyle={styles.icon}
           containerStyle={styles.containerStyle}
+          iconSize={AvatarSize.Lg}
+          disabled={false}
           actionID={TokenOverviewSelectorsIDs.RECEIVE_BUTTON}
         />
         <Text variant={TextVariant.BodyMD}>

--- a/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
@@ -21,16 +21,29 @@ exports[`AssetDetailsActions should render correctly 1`] = `
     }
   >
     <TouchableOpacity
+      disabled={true}
       onPress={[MockFunction]}
       style={
-        {
-          "alignItems": "flex-start",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingTop": 16,
-          "paddingVertical": 2,
-          "width": "100%",
-        }
+        [
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingVertical": 16,
+            "width": "100%",
+          },
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingTop": 16,
+            "paddingVertical": 2,
+            "width": "100%",
+          },
+          {
+            "opacity": 0.5,
+          },
+        ]
       }
       testID="token-buy-button"
     >
@@ -38,7 +51,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c9",
+            "backgroundColor": "#0376c91a",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -116,16 +129,29 @@ exports[`AssetDetailsActions should render correctly 1`] = `
     }
   >
     <TouchableOpacity
+      disabled={true}
       onPress={[MockFunction]}
       style={
-        {
-          "alignItems": "flex-start",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingTop": 16,
-          "paddingVertical": 2,
-          "width": "100%",
-        }
+        [
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingVertical": 16,
+            "width": "100%",
+          },
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingTop": 16,
+            "paddingVertical": 2,
+            "width": "100%",
+          },
+          {
+            "opacity": 0.5,
+          },
+        ]
       }
       testID="token-swap-button"
     >
@@ -133,7 +159,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c9",
+            "backgroundColor": "#0376c91a",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -211,16 +237,29 @@ exports[`AssetDetailsActions should render correctly 1`] = `
     }
   >
     <TouchableOpacity
+      disabled={true}
       onPress={[MockFunction]}
       style={
-        {
-          "alignItems": "flex-start",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingTop": 16,
-          "paddingVertical": 2,
-          "width": "100%",
-        }
+        [
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingVertical": 16,
+            "width": "100%",
+          },
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingTop": 16,
+            "paddingVertical": 2,
+            "width": "100%",
+          },
+          {
+            "opacity": 0.5,
+          },
+        ]
       }
       testID="token-bridge-button"
     >
@@ -228,7 +267,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c9",
+            "backgroundColor": "#0376c91a",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -306,16 +345,29 @@ exports[`AssetDetailsActions should render correctly 1`] = `
     }
   >
     <TouchableOpacity
+      disabled={true}
       onPress={[MockFunction]}
       style={
-        {
-          "alignItems": "flex-start",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingTop": 16,
-          "paddingVertical": 2,
-          "width": "100%",
-        }
+        [
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingVertical": 16,
+            "width": "100%",
+          },
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingTop": 16,
+            "paddingVertical": 2,
+            "width": "100%",
+          },
+          {
+            "opacity": 0.5,
+          },
+        ]
       }
       testID="token-send-button"
     >
@@ -323,7 +375,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c9",
+            "backgroundColor": "#0376c91a",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -401,16 +453,27 @@ exports[`AssetDetailsActions should render correctly 1`] = `
     }
   >
     <TouchableOpacity
+      disabled={false}
       onPress={[MockFunction]}
       style={
-        {
-          "alignItems": "flex-start",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingTop": 16,
-          "paddingVertical": 2,
-          "width": "100%",
-        }
+        [
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingVertical": 16,
+            "width": "100%",
+          },
+          {
+            "alignItems": "flex-start",
+            "flexDirection": "row",
+            "justifyContent": "flex-start",
+            "paddingTop": 16,
+            "paddingVertical": 2,
+            "width": "100%",
+          },
+          false,
+        ]
       }
       testID="token-receive-button"
     >

--- a/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c91a",
+            "backgroundColor": "#0376c9",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -159,7 +159,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c91a",
+            "backgroundColor": "#0376c9",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -267,7 +267,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c91a",
+            "backgroundColor": "#0376c9",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",
@@ -375,7 +375,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#0376c91a",
+            "backgroundColor": "#0376c9",
             "borderRadius": 20,
             "height": 40,
             "justifyContent": "center",

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import React, { useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { swapsUtils } from '@metamask/swaps-controller';
 import { useDispatch, useSelector } from 'react-redux';
@@ -21,7 +21,6 @@ import useGoToBridge from '../../../components/UI/Bridge/utils/useGoToBridge';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { getEther } from '../../../util/transactions';
 import { newAssetTransaction } from '../../../actions/transaction';
-import { strings } from '../../../../locales/i18n';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import WalletAction from '../../../components/UI/WalletAction';
 import { useStyles } from '../../../component-library/hooks';
@@ -39,6 +38,8 @@ import {
   createBuyNavigationDetails,
   createSellNavigationDetails,
 } from '../../UI/Ramp/routes/utils';
+import { selectCanSignTransactions } from '../../../selectors/accountsController';
+import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 
 const WalletActions = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -54,8 +55,17 @@ const WalletActions = () => {
   const [isNetworkRampSupported] = useRampNetwork();
   const { trackEvent } = useMetrics();
 
-  const onReceive = () => {
-    sheetRef.current?.onCloseBottomSheet(() => {
+  const canSignTransactions = useSelector(selectCanSignTransactions);
+
+  const closeBottomSheetAndNavigate = useCallback(
+    (navigateFunc: () => void) => {
+      sheetRef.current?.onCloseBottomSheet(navigateFunc);
+    },
+    [],
+  );
+
+  const onReceive = useCallback(() => {
+    closeBottomSheetAndNavigate(() => {
       navigate(Routes.QR_TAB_SWITCHER, {
         initialScreen: QRTabSwitcherScreens.Receive,
       });
@@ -67,44 +77,55 @@ const WalletActions = () => {
       location: 'TabBar',
       chain_id: getDecimalChainId(chainId),
     });
-  };
+  }, [closeBottomSheetAndNavigate, navigate, trackEvent, chainId]);
 
-  const onBuy = () => {
-    sheetRef.current?.onCloseBottomSheet(() => {
+  const onBuy = useCallback(() => {
+    closeBottomSheetAndNavigate(() => {
       navigate(...createBuyNavigationDetails());
-      trackEvent(MetaMetricsEvents.BUY_BUTTON_CLICKED, {
-        text: 'Buy',
-        location: 'TabBar',
-        chain_id_destination: getDecimalChainId(chainId),
-      });
     });
-  };
 
-  const onSell = () => {
-    sheetRef.current?.onCloseBottomSheet(() => {
-      navigate(...createSellNavigationDetails());
-      trackEvent(MetaMetricsEvents.SELL_BUTTON_CLICKED, {
-        text: 'Sell',
-        location: 'TabBar',
-        chain_id_source: getDecimalChainId(chainId),
-      });
+    trackEvent(MetaMetricsEvents.BUY_BUTTON_CLICKED, {
+      text: 'Buy',
+      location: 'TabBar',
+      chain_id_destination: getDecimalChainId(chainId),
     });
-  };
-  const onSend = () => {
-    sheetRef.current?.onCloseBottomSheet(() => {
+  }, [closeBottomSheetAndNavigate, navigate, trackEvent, chainId]);
+
+  const onSell = useCallback(() => {
+    closeBottomSheetAndNavigate(() => {
+      navigate(...createSellNavigationDetails());
+    });
+
+    trackEvent(MetaMetricsEvents.SELL_BUTTON_CLICKED, {
+      text: 'Sell',
+      location: 'TabBar',
+      chain_id_source: getDecimalChainId(chainId),
+    });
+  }, [closeBottomSheetAndNavigate, navigate, trackEvent, chainId]);
+
+  const onSend = useCallback(() => {
+    closeBottomSheetAndNavigate(() => {
       navigate('SendFlowView');
       ticker && dispatch(newAssetTransaction(getEther(ticker)));
-      trackEvent(MetaMetricsEvents.SEND_BUTTON_CLICKED, {
-        text: 'Send',
-        tokenSymbol: '',
-        location: 'TabBar',
-        chain_id: getDecimalChainId(chainId),
-      });
     });
-  };
 
-  const goToSwaps = () => {
-    sheetRef.current?.onCloseBottomSheet(() => {
+    trackEvent(MetaMetricsEvents.SEND_BUTTON_CLICKED, {
+      text: 'Send',
+      tokenSymbol: '',
+      location: 'TabBar',
+      chain_id: getDecimalChainId(chainId),
+    });
+  }, [
+    closeBottomSheetAndNavigate,
+    navigate,
+    ticker,
+    dispatch,
+    trackEvent,
+    chainId,
+  ]);
+
+  const goToSwaps = useCallback(() => {
+    closeBottomSheetAndNavigate(() => {
       navigate('Swaps', {
         screen: 'SwapsAmountView',
         params: {
@@ -112,87 +133,90 @@ const WalletActions = () => {
           sourcePage: 'MainView',
         },
       });
-      trackEvent(MetaMetricsEvents.SWAP_BUTTON_CLICKED, {
-        text: 'Swap',
-        tokenSymbol: '',
-        location: 'TabBar',
-        chain_id: getDecimalChainId(chainId),
-      });
     });
-  };
+
+    trackEvent(MetaMetricsEvents.SWAP_BUTTON_CLICKED, {
+      text: 'Swap',
+      tokenSymbol: '',
+      location: 'TabBar',
+      chain_id: getDecimalChainId(chainId),
+    });
+  }, [closeBottomSheetAndNavigate, navigate, trackEvent, chainId]);
+
+  const sendIconStyle = useMemo(
+    () => ({
+      transform: [{ rotate: '-45deg' }],
+      ...styles.icon,
+    }),
+    [styles.icon],
+  );
 
   return (
     <BottomSheet ref={sheetRef}>
       <View style={styles.actionsContainer}>
         {isNetworkRampSupported && (
           <WalletAction
-            actionTitle={strings('asset_overview.buy_button')}
-            actionDescription={strings('asset_overview.buy_description')}
+            actionType={WalletActionType.Buy}
             iconName={IconName.Add}
-            iconSize={AvatarSize.Md}
             onPress={onBuy}
-            iconStyle={styles.icon}
             actionID={WalletActionsModalSelectorsIDs.BUY_BUTTON}
+            iconStyle={styles.icon}
+            iconSize={AvatarSize.Md}
+            disabled={!canSignTransactions}
           />
         )}
-
         {isNetworkRampSupported && (
           <WalletAction
-            actionTitle={strings('asset_overview.sell_button')}
-            actionDescription={strings('asset_overview.sell_description')}
+            actionType={WalletActionType.Sell}
             iconName={IconName.MinusBold}
-            iconSize={AvatarSize.Md}
             onPress={onSell}
-            iconStyle={styles.icon}
             actionID={WalletActionsModalSelectorsIDs.SELL_BUTTON}
+            iconStyle={styles.icon}
+            iconSize={AvatarSize.Md}
+            disabled={!canSignTransactions}
           />
         )}
-
         {AppConstants.SWAPS.ACTIVE &&
           swapsIsLive &&
           isSwapsAllowed(chainId) && (
             <WalletAction
-              actionTitle={strings('asset_overview.swap')}
-              actionDescription={strings('asset_overview.swap_description')}
+              actionType={WalletActionType.Swap}
               iconName={IconName.SwapHorizontal}
-              iconSize={AvatarSize.Md}
               onPress={goToSwaps}
-              iconStyle={styles.icon}
               actionID={WalletActionsModalSelectorsIDs.SWAP_BUTTON}
+              iconStyle={styles.icon}
+              iconSize={AvatarSize.Md}
+              disabled={!canSignTransactions}
             />
           )}
-
         {isBridgeAllowed(chainId) && (
           <WalletAction
-            actionTitle={strings('asset_overview.bridge')}
-            actionDescription={strings('asset_overview.bridge_description')}
+            actionType={WalletActionType.Bridge}
             iconName={IconName.Bridge}
-            iconSize={AvatarSize.Md}
             onPress={goToBridge}
-            iconStyle={styles.icon}
             actionID={WalletActionsModalSelectorsIDs.BRIDGE_BUTTON}
+            iconStyle={styles.icon}
+            iconSize={AvatarSize.Md}
+            disabled={!canSignTransactions}
           />
         )}
         <WalletAction
-          actionTitle={strings('asset_overview.send_button')}
-          actionDescription={strings('asset_overview.send_description')}
+          actionType={WalletActionType.Send}
           iconName={IconName.Arrow2Right}
-          iconSize={AvatarSize.Md}
           onPress={onSend}
-          iconStyle={{
-            transform: [{ rotate: '-45deg' }],
-            ...styles.icon,
-          }}
+          iconStyle={sendIconStyle}
           actionID={WalletActionsModalSelectorsIDs.SEND_BUTTON}
+          iconSize={AvatarSize.Md}
+          disabled={!canSignTransactions}
         />
         <WalletAction
-          actionTitle={strings('asset_overview.receive_button')}
-          actionDescription={strings('asset_overview.receive_description')}
+          actionType={WalletActionType.Receive}
           iconName={IconName.Received}
-          iconSize={AvatarSize.Md}
           onPress={onReceive}
-          iconStyle={styles.icon}
           actionID={WalletActionsModalSelectorsIDs.RECEIVE_BUTTON}
+          iconStyle={styles.icon}
+          iconSize={AvatarSize.Md}
+          disabled={false}
         />
       </View>
     </BottomSheet>

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectFlattenedKeyringAccounts } from './keyringController';
-import { InternalAccount } from '@metamask/keyring-api';
+import { EthMethod, InternalAccount } from '@metamask/keyring-api';
 
 /**
  *
@@ -79,4 +79,13 @@ export const selectSelectedInternalAccountAddress = createSelector(
     const selectedAddress = account?.address;
     return selectedAddress || undefined;
   },
+);
+
+/**
+ * A memoized selector that returns whether the selected internal account can sign transactions
+ */
+export const selectCanSignTransactions = createSelector(
+  selectSelectedInternalAccount,
+  (selectedAccount) =>
+    selectedAccount?.methods?.includes(EthMethod.SignTransaction) ?? false,
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1287,6 +1287,14 @@
     "info": "Info",
     "swap": "Swap",
     "bridge": "Bridge",
+    "disabled_button": {
+      "buy": "Buying not supported for this account",
+      "sell": "Selling not supported for this account",
+      "swap": "Swapping not supported for this account",
+      "bridge": "Bridging not supported for this account",
+      "send": "Sending not supported for this account",
+      "action": "This action is not supported for this account"
+    },
     "description": "Description",
     "totalSupply": "Total Supply",
     "address": "Address",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR disables certain buttons in the WalletActions component when the selected account cannot sign transactions. This change improves the user experience by preventing attempts to perform actions that require transaction signing when the account cannot do so.

The reason for the change is to prevent users from attempting actions that their current account cannot perform.
The improvement is that Buy, Sell, Send, Swap, and Bridge buttons are now disabled when the selected account cannot sign transactions, providing clear visual feedback to the user about available actions.

This work is a continuation of Kate's [PR](https://github.com/MetaMask/metamask-mobile/pull/11330#issuecomment-2423304671). Since her departure it was easier to start with a fresh branch than rebase her work. Her pr already went through QA and reviews.

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/570

## **Manual testing steps**

1. Go to the [SSK](https://metamask.github.io/snap-simple-keyring/latest/) and create an account
2. Update the account using this JSON, replacing the address and ID fields with the new account information (this update step removes `eth_signTransaction` from the account's methods)
```json
{
    "id": "your new account ID",
    "address": "you new account address",
    "options": {},
    "methods": [
        "personal_sign",
        "eth_sign",
        "eth_signTypedData_v1",
        "eth_signTypedData_v3",
        "eth_signTypedData_v4"
    ],
    "type": "eip155:eoa"
}
```
3. Switch to the account that cannot sign transactions if not already there
4. Verify that the Buy, Sell, Send, Swap, and Bridge buttons are visually disabled with a message and not clickable
5. Click on the asset details view
6. Verify that the Buy, Sell, Send, Swap, and Bridge buttons are visually disabled and not clickable
7. Switch back to an account that can sign transactions
8. Verify that the buttons are now enabled and functional in wallet view and asset details view

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Wallet view
<img src="https://github.com/user-attachments/assets/d0cdcd63-cec5-4641-95a4-a47450319282" width=350 /> 

Asset details view
<img src="https://github.com/user-attachments/assets/ceac95af-3653-4178-9718-f75ff97e239f" width=350/> 

### **After**

Wallet view

<img src="https://github.com/user-attachments/assets/e254813e-6fcf-40e9-8ba8-222311e27bcc" width=350 /> 

Asset details view
<img src="https://github.com/user-attachments/assets/bdf42f9f-cdb8-41d5-97db-537a1fe19d97" width=350/> 

## QA
This PR is a direct copy of [#11330](https://github.com/MetaMask/metamask-mobile/pull/11330). Kates change went through several rounds of QA with Mike. His first round found a few issues which were outlined [here](https://github.com/MetaMask/metamask-mobile/pull/11330#issuecomment-2401076714). Those issues were addressed in subsequent commits and finally QA passed [here](https://github.com/MetaMask/metamask-mobile/pull/11330#issuecomment-2442972876). All of the code in this PR is a copy of the previous except that I addressed @brianacnguyen's [comments](https://github.com/MetaMask/metamask-mobile/pull/11330#discussion_r1821179342). The extra styles that I removed have no effect on the UX since the opacity of 0.5 (correctly applied) has the desired effect on the buttons and makes them appear disabled. This came from a discussion with Brian during a code review. 

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
