### PR TITLE
chore: extend dsl component functionality

### DIFF
--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories.tsx
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories.tsx
@@ -30,8 +30,20 @@ const CellSelectWithMenuMeta = {
       control: { type: 'boolean' },
       defaultValue: SAMPLE_CELLSELECT_WITH_BUTTON_PROPS.isDisabled,
     },
+    withAvatar: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+    },
+    showSecondaryTextIcon: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+    },
+    onTextClick: {
+      action: 'clicked',
+    },
   },
 };
+
 export default CellSelectWithMenuMeta;
 
 export const CellMultiSelectWithMenu = {

--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.styles.ts
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.styles.ts
@@ -55,6 +55,9 @@ const styleSheet = (params: {
     tagLabel: {
       marginTop: 4,
     },
+    selectedTag: {
+      backgroundColor: colors.primary.muted,
+    },
     containerRow: {
       flexDirection: 'row',
       alignItems: 'flex-start',

--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
@@ -6,6 +6,7 @@ import { TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
+import Tag from '../../../component-library/components/Tags/Tag';
 
 // Internal dependencies.
 import styleSheet from './CellSelectWithMenu.styles';
@@ -34,6 +35,7 @@ const CellSelectWithMenu = ({
   isSelected = false,
   children,
   withAvatar = true,
+  showSecondaryTextIcon = true,
   ...props
 }: CellSelectWithMenuProps) => {
   const { styles } = useStyles(styleSheet, { style });
@@ -77,13 +79,26 @@ const CellSelectWithMenu = ({
                 >
                   {secondaryText}
                 </Text>
-                <Icon
-                  name={IconName.ArrowDown}
-                  size={IconSize.Xss}
-                  style={styles.arrowStyle}
-                />
+                {showSecondaryTextIcon && (
+                  <Icon
+                    name={IconName.ArrowDown}
+                    size={IconSize.Xss}
+                    style={styles.arrowStyle}
+                  />
+                )}
               </TouchableOpacity>
             </TouchableWithoutFeedback>
+          )}
+          {!!tagLabel && (
+            <Tag
+              testID={CellModalSelectorsIDs.TAG_LABEL}
+              label={tagLabel}
+              style={
+                isSelected
+                  ? [styles.tagLabel, styles.selectedTag]
+                  : styles.tagLabel
+              }
+            />
           )}
         </View>
         {children && <View style={styles.optionalAccessory}>{children}</View>}

--- a/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
+++ b/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
@@ -280,6 +280,36 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
                 width={10}
               />
             </TouchableOpacity>
+            <View
+              style={
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#bbc0c5",
+                  "borderRadius": 10,
+                  "borderWidth": 1,
+                  "height": 24,
+                  "justifyContent": "center",
+                  "marginTop": 4,
+                  "paddingHorizontal": 4,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#141618",
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Imported
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -288,7 +318,7 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
   <View
     style={
       {
-        "paddingHorizontal": 20,
+        "paddingRight": 20,
       }
     }
   >

--- a/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
+++ b/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
@@ -293,6 +293,7 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
                   "paddingHorizontal": 4,
                 }
               }
+              testID="celltag-label"
             >
               <Text
                 accessibilityRole="text"

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories.tsx
@@ -14,7 +14,11 @@ import Text, {
 
 // Internal dependencies.
 import { default as ListItemSelectWithButtonComponent } from './ListItemMultiSelectButton';
-import { SAMPLE_LISTITEMMULTISELECT_PROPS } from './ListItemMultiSelectButton.constants';
+import {
+  BUTTON_TEST_ID,
+  DEFAULT_LISTITEMMULTISELECT_GAP,
+  SAMPLE_LISTITEMMULTISELECT_PROPS,
+} from './ListItemMultiSelectButton.constants';
 import { ListItemMultiSelectButtonProps } from './ListItemMultiSelectButton.types';
 
 const ListItemSelectWithButtonMeta = {
@@ -28,6 +32,27 @@ const ListItemSelectWithButtonMeta = {
     isDisabled: {
       control: { type: 'boolean' },
       defaultValue: SAMPLE_LISTITEMMULTISELECT_PROPS.isDisabled,
+    },
+    showButtonIcon: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+    },
+    buttonIcon: {
+      control: { type: 'select' },
+      options: Object.values(IconName),
+      defaultValue: IconName.MoreVertical,
+    },
+    gap: {
+      control: { type: 'number' },
+      defaultValue: DEFAULT_LISTITEMMULTISELECT_GAP,
+    },
+    buttonProps: {
+      control: 'object',
+      defaultValue: {
+        textButton: '',
+        onButtonClick: () => null,
+        buttonTestId: BUTTON_TEST_ID,
+      },
     },
   },
 };

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
@@ -85,7 +85,7 @@ const styleSheet = (params: {
       paddingTop: 32,
     },
     buttonIcon: {
-      paddingHorizontal: 20,
+      paddingRight: 20,
     },
   });
 };

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
@@ -68,7 +68,7 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
           <ButtonIcon
             iconName={buttonIcon}
             iconColor={IconColor.Default}
-            testID={BUTTON_TEST_ID}
+            testID={buttonProps?.buttonTestId || BUTTON_TEST_ID}
             onPress={buttonProps?.onButtonClick}
             accessibilityRole="button"
           />

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.types.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.types.ts
@@ -41,6 +41,9 @@ export interface ListItemMultiSelectButtonProps
    */
   showButtonIcon?: boolean;
 
+  /**
+   * Optional button props
+   */
   buttonProps?: {
     /**
      * Optional button onClick function
@@ -50,6 +53,16 @@ export interface ListItemMultiSelectButtonProps
      * Optional property to show text button
      */
     textButton?: string | null;
+
+    /**
+     * Optional property to show button icon
+     */
+    showButtonIcon?: boolean;
+
+    /**
+     * Optional property for button test ID
+     */
+    buttonTestId?: string;
   };
 }
 

--- a/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`ListItemMultiSelectButton should render correctly with default props 1`
   <View
     style={
       {
-        "paddingHorizontal": 20,
+        "paddingRight": 20,
       }
     }
   >

--- a/app/component-library/components/Cells/Cell/foundation/CellBase/CellBase.types.ts
+++ b/app/component-library/components/Cells/Cell/foundation/CellBase/CellBase.types.ts
@@ -37,6 +37,11 @@ export interface CellBaseProps {
    * Optional prop to control the style of the CellBase.
    */
   style?: StyleProp<ViewStyle> | undefined;
+
+  /**
+   * Optional prop to control the visibility of the secondary text icon.
+   */
+  showSecondaryTextIcon?: boolean;
 }
 
 /**

--- a/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
@@ -1928,7 +1928,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >
@@ -2150,7 +2150,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >
@@ -2374,7 +2374,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >
@@ -2598,7 +2598,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >
@@ -2822,7 +2822,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >
@@ -3044,7 +3044,7 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                   <View
                                     style={
                                       {
-                                        "paddingHorizontal": 20,
+                                        "paddingRight": 20,
                                       }
                                     }
                                   >

--- a/e2e/selectors/Modals/CellModal.selectors.js
+++ b/e2e/selectors/Modals/CellModal.selectors.js
@@ -5,4 +5,5 @@ export const CellModalSelectorsIDs = {
   BASE_TITLE: 'cellbase-avatar-title',
   BASE_AVATAR: 'cellbase-avatar',
   SELECT_WITH_MENU: 'select-with-menu',
+  TAG_LABEL: 'celltag-label',
 };


### PR DESCRIPTION
## **Description**

Extending functionality for the design system library components below (while not introducing any visible changes)

### CellSelectWithMenu

The `showSecondaryTextIcon` prop is needed so that in future use cases; the developer can opt out of showing the caret icon. I am using this component in the [Header Update PR](https://github.com/MetaMask/metamask-mobile/pull/11763) and this what it looks like and without the prop. Here is the  [Figma](https://www.figma.com/design/DFLO6VVgikalwAFyOln3Cb/Mobile-account-picker-update?node-id=34-4156&m=dev) as well

| Before  | After  |
|:---:|:---:|
|![Screenshot 2024-10-31 at 5 39 21 PM](https://github.com/user-attachments/assets/22d6d446-2fbe-4560-8231-01f935015868)|![Screenshot 2024-11-04 at 1 29 13 PM](https://github.com/user-attachments/assets/2d1cacf8-e799-45a4-8425-f97c4b3fa46b)|

The caret icon is currently used in the  `NetworkSelector` and remains unaffected by this change

<img src="https://github.com/user-attachments/assets/1c13162a-caf4-4ffd-9551-d696eea84169" width="500" >

The `Tag` component is introduced here because we need to show which account is imported in the [Header Update](https://github.com/MetaMask/metamask-mobile/pull/11763). View the stories screenshots at the bottom of the description to see the. change

### ListItemMultiSelectButton

The `paddingHorizontal` change to `paddingRight` is needed because with it the UI doesn't match the [Figma](https://www.figma.com/design/DFLO6VVgikalwAFyOln3Cb/Mobile-account-picker-update?node-id=34-4156&m=dev) for the Header Update and for future use cases it wouldn't make sense to have the elements so far apart from each other. These changes have no affect in where its currently used, in this case the `NetworkSelector`

| Before  | After  |
|:---:|:---:|
|![ListItemMultiSelector_before](https://github.com/user-attachments/assets/3dc8bfb8-8717-4dbe-b1fb-6449d1f3324c)|![ListItemMultiSelector_after](https://github.com/user-attachments/assets/3e0f9218-f496-4edb-bda9-5cb376c26de5)|

The test id `buttonTestId` prop has been introduced so that we can target a specific component during e2e tests. Currently its using only `BUTTON_TEST_ID` which works for unit tests but not e2e tests especially when its mapped out into a list. There is no direct way to target the component

### Stories
| ListItemMultiSelectButton  | CellSelectWithMenu  |
|:---:|:---:|
|![Simulator Screenshot - iPhone 15 - 2024-11-04 at 14 09 36](https://github.com/user-attachments/assets/4fb80c7e-745c-4bf8-86dc-ad5c5e80713a)|![Simulator Screenshot - iPhone 15 - 2024-11-04 at 14 08 33](https://github.com/user-attachments/assets/b5024b88-ea14-42a1-9c9a-2fe06cee6d5c)


## **Related issues**

Related:

## **Manual testing steps**

1. Launch Storybook
2.
3.

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
