### PR TITLE
fix: add contractBalances as dependency

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -99,6 +99,7 @@ import { useAccountSyncing } from '../../../util/notifications/hooks/useAccountS
 import { PortfolioBalance } from '../../UI/Tokens/TokenList/PortfolioBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
+import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
@@ -182,6 +183,7 @@ const Wallet = ({
    * ETH to current currency conversion rate
    */
   const conversionRate = useSelector(selectConversionRate);
+  const contractBalances = useSelector(selectContractBalances);
   /**
    * Currency code of the currently-active currency
    */
@@ -589,6 +591,7 @@ const Wallet = ({
         </>
       </View>
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     tokens,
     accountBalanceByChainId,
@@ -604,6 +607,7 @@ const Wallet = ({
     ticker,
     conversionRate,
     currentCurrency,
+    contractBalances,
   ]);
   const renderLoader = useCallback(
     () => (


### PR DESCRIPTION
## **Description**

This PR forces UI to rerender when contractBalances change in state.

When a user switches from account A to account B; the value of [contractBalances](https://github.com/MetaMask/metamask-mobile/blob/d112027e57343f8447ded38b33b794e14ed928dc/app/core/Engine.ts#L2010) would still have the state values from accountA;
If account A and accountB have some tokens in common (exp both hold USDC) you would see the total = native fiat value + USDC value;
Also; When a user switches accounts, the tokensStateChange [subscription](https://github.com/MetaMask/core/blob/b27a5d7f9652a0a145b2a5ed0e72abb6d29c55ba/packages/assets-controllers/src/TokenBalancesController.ts#L145) is fired; except that by the time it got to update the contractBalances in state; the UI has already rendered the total fiat value;
The reason why after a while, it would update to the correct total value; is because the [conversionRate](https://github.com/MetaMask/metamask-mobile/blob/d112027e57343f8447ded38b33b794e14ed928dc/app/components/Views/Wallet/index.tsx#L184) in state would change forcing the UI to re-render the component;
My fix [here](https://github.com/MetaMask/metamask-mobile/pull/12205) is adding contractBalances as a dependency which will force the array to rerender once contractBalances in state are updated;

## **Related issues**

Fixes:

## **Manual testing steps**

1. Import two accounts with native and ERC20 balances
2. Switch between accounts; 
3. You should see the correct total balance in fiat


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/af618c18-0da1-4121-a98f-2c338aa08ef9



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/d4bc13c1-0229-4025-8d24-5ecc99860797



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
