### PR TITLE
chore: Modify gitignore to include generated ios/plist files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ docs/assets/termsOfUse.html
 
 # build metadata
 android/app/src/main/assets/modules.json
+
+# Google firebase base64 derived configs
+ios/GoogleService-Info.plist
+ios/GoogleServices/GoogleService-Info.plist

--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,4 @@ docs/assets/termsOfUse.html
 android/app/src/main/assets/modules.json
 
 # Google firebase base64 derived configs
-ios/GoogleService-Info.plist
-ios/GoogleServices/GoogleService-Info.plist
+**/GoogleService-Info.plist


### PR DESCRIPTION
## **Description**

Update gitignore so that we don't need to remember to stash ios configuration after setup.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
