### PR TITLE
fix: e2e: use different wallet SRP for non accounts tests

### DIFF
--- a/e2e/specs/accounts/import-wallet-account.spec.js
+++ b/e2e/specs/accounts/import-wallet-account.spec.js
@@ -21,7 +21,7 @@ describe(SmokeAccounts('Import account via private to wallet'), () => {
   });
 
   it('should import wallet and go to the wallet view', async () => {
-    await importWalletWithRecoveryPhrase();
+    await importWalletWithRecoveryPhrase(process.env.MM_TEST_WALLET_SRP);
   });
 
   it('should be able to import account', async () => {

--- a/e2e/specs/wallet/send-ERC-token.spec.js
+++ b/e2e/specs/wallet/send-ERC-token.spec.js
@@ -24,7 +24,7 @@ describe(SmokeCore('Send ERC Token'), () => {
   });
 
   it('should import wallet and go to the wallet view', async () => {
-    await importWalletWithRecoveryPhrase();
+    await importWalletWithRecoveryPhrase(process.env.MM_TEST_WALLET_SRP);
   });
 
   it('should add Sepolia testnet to my networks list', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There are some performance issues with the existing e2e due to hundreds of accounts added by default which is causing some non-accounts tests to fail

Update flaky test to override default e2e and use a wallet that doesn't have hundreds of accounts added.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

See E2E results

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
