### PR TITLE
feat: update input colors and text formatting

### DIFF
--- a/app/components/UI/Stake/Views/StakeInputView/__snapshots__/StakeInputView.test.tsx.snap
+++ b/app/components/UI/Stake/Views/StakeInputView/__snapshots__/StakeInputView.test.tsx.snap
@@ -426,7 +426,7 @@ exports[`StakeInputView render matches snapshot 1`] = `
                               accessibilityRole="text"
                               style={
                                 {
-                                  "color": "#9fa6ae",
+                                  "color": "#141618",
                                   "fontFamily": "EuclidCircularB-Bold",
                                   "fontSize": 32,
                                   "fontWeight": "700",

--- a/app/components/UI/Stake/Views/UnstakeInputView/__snapshots__/UnstakeInputView.test.tsx.snap
+++ b/app/components/UI/Stake/Views/UnstakeInputView/__snapshots__/UnstakeInputView.test.tsx.snap
@@ -426,7 +426,7 @@ exports[`UnstakeInputView render matches snapshot 1`] = `
                               accessibilityRole="text"
                               style={
                                 {
-                                  "color": "#9fa6ae",
+                                  "color": "#141618",
                                   "fontFamily": "EuclidCircularB-Bold",
                                   "fontSize": 32,
                                   "fontWeight": "700",

--- a/app/components/UI/Stake/components/InputDisplay.tsx
+++ b/app/components/UI/Stake/components/InputDisplay.tsx
@@ -43,7 +43,6 @@ const InputDisplay = ({
   isOverMaximum,
   balanceText,
   balanceValue,
-  isNonZeroAmount,
   isEth,
   amountEth,
   fiatAmount,
@@ -70,10 +69,7 @@ const InputDisplay = ({
         )}
       </View>
       <View style={styles.amountRow}>
-        <Text
-          color={isNonZeroAmount ? TextColor.Default : TextColor.Muted}
-          variant={TextVariant.DisplayMD}
-        >
+        <Text color={TextColor.Default} variant={TextVariant.DisplayMD}>
           {isEth ? amountEth : fiatAmount}
         </Text>
         <Text color={TextColor.Muted} variant={TextVariant.DisplayMD}>

--- a/app/components/UI/Stake/components/StakingBalance/StakingCta/StakingCta.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingCta/StakingCta.tsx
@@ -30,12 +30,12 @@ const StakingCta = ({ estimatedRewardRate, style }: StakingCtaProps) => {
     });
     trackEvent(
       createEventBuilder(MetaMetricsEvents.STAKE_LEARN_MORE_CLICKED)
-      .addProperties({
-        selected_provider: 'consensys',
-        text: 'Learn More',
-        location: 'Token Details'
-      })
-      .build()
+        .addProperties({
+          selected_provider: 'consensys',
+          text: 'Learn More',
+          location: 'Token Details',
+        })
+        .build(),
     );
   };
 
@@ -51,7 +51,7 @@ const StakingCta = ({ estimatedRewardRate, style }: StakingCtaProps) => {
         <Text style={styles.rightPad} color={TextColor.Success}>
           {estimatedRewardRate}
         </Text>
-        <Text>{strings('stake.stake_your_eth_cta.annually')}</Text>
+        <Text>{`${strings('stake.stake_your_eth_cta.annually')} `}</Text>
         <Button
           label={strings('stake.stake_your_eth_cta.learn_more_with_period')}
           variant={ButtonVariants.Link}

--- a/app/components/UI/Stake/components/StakingBalance/StakingCta/__snapshots__/StakingCta.test.tsx.snap
+++ b/app/components/UI/Stake/components/StakingBalance/StakingCta/__snapshots__/StakingCta.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`StakingCta render matches snapshot 1`] = `
         }
       }
     >
-      annually.
+      annually. 
     </Text>
     <Text
       accessibilityRole="link"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3570,7 +3570,7 @@
     },
     "unstaking_time": {
       "title": "Unstaking time",
-      "tooltip": "It can take between 1 and 11 days for your unstaking request to be processed. The exact duration depends on ETH staking activity."
+      "tooltip": "It typically takes less than 3 days to unstake your ETH, but it can take up to 11 days to process. The exact duration depends on the amount you unstake and ETH staking activity"
     }
   },
   "confirm": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the staking UI components and text to improve visual consistency and clarity:

- Updated input text color from `muted` to `deafult` in both stake and unstake input views for better readability
- Simplified text color logic in `InputDisplay` by removing conditional coloring based on amount
- Enhanced unstaking tooltip text to be more precise


## **Related issues**

Fixes: [STAKE-863](https://consensyssoftware.atlassian.net/browse/STAKE-863)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[STAKE-863]: https://consensyssoftware.atlassian.net/browse/STAKE-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ