### PR TITLE
feat: conditionally display stake/earn text based on pooled staking feature flag (#12261)

### DIFF
--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -83,7 +83,9 @@ const StakeButtonContent = ({ asset }: StakeButtonProps) => {
       <Text variant={TextVariant.BodyLGMedium}>
         {' • '}
         <Text color={TextColor.Primary} variant={TextVariant.BodyLGMedium}>
-          {`${strings('stake.earn')} `}
+          {isPooledStakingFeatureEnabled()
+            ? `${strings('stake.earn')} `
+            : `${strings('stake.stake')} `}
         </Text>
       </Text>
       <Icon


### PR DESCRIPTION
## **Description**

Updates StakeButton component to show different text based on whether pooled staking is enabled. Shows "earn" when pooled staking is active, and "stake" when using traditional staking.

## **Manual testing steps**

1. Set export MM_POOLED_STAKING_UI_ENABLED=true in your local .js.env
file
2. Go to Homepage and you should see 'Earn' CTA 
3. Disable the flag in .js.env and then go to homepage , and now you
should see 'Stake' CTA

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**

<img width="349" alt="image"
src="https://github.com/user-attachments/assets/475c7593-6c79-4aca-afff-a4be635dd8ea">

### **After**

<img width="346" alt="image"
src="https://github.com/user-attachments/assets/c06ca319-13c8-4e73-9bcf-bbbaaff4fa00">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.

