### PR TITLE
feat: multichain currency rate polling

### DIFF
--- a/app/components/UI/NetworkModal/index.tsx
+++ b/app/components/UI/NetworkModal/index.tsx
@@ -317,11 +317,9 @@ const NetworkModals = (props: NetworkProps) => {
   };
 
   const switchNetwork = async () => {
-    const { NetworkController, CurrencyRateController } = Engine.context;
+    const { NetworkController } = Engine.context;
     const url = new URLPARSE(rpcUrl);
     const existingNetwork = networkConfigurationByChainId[chainId];
-
-    CurrencyRateController.updateExchangeRate([ticker]);
 
     if (!isPrivateConnection(url.hostname)) {
       url.set('protocol', 'https:');

--- a/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.test.tsx
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.test.tsx
@@ -303,18 +303,6 @@ describe('NetworkSwitcher View', () => {
         ],
       ]
     `);
-    expect(
-      (Engine.context.CurrencyRateController.updateExchangeRate as jest.Mock)
-        .mock.calls,
-    ).toMatchInlineSnapshot(`
-      [
-        [
-          [
-            "POL",
-          ],
-        ],
-      ]
-    `);
   });
 
   it('renders correctly with errors', async () => {

--- a/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/NetworkSwitcher.tsx
@@ -153,14 +153,13 @@ function NetworkSwitcher() {
 
   const switchNetwork = useCallback(
     (networkConfiguration) => {
-      const { CurrencyRateController, NetworkController } = Engine.context;
+      const { NetworkController } = Engine.context;
       const config = Object.values(networkConfigurations).find(
         ({ chainId }) => chainId === networkConfiguration.chainId,
       );
 
       if (config) {
         const {
-          nativeCurrency: ticker,
           rpcEndpoints,
           defaultRpcEndpointIndex,
         } = config;
@@ -168,7 +167,6 @@ function NetworkSwitcher() {
         const { networkClientId } =
           rpcEndpoints?.[defaultRpcEndpointIndex] ?? {};
 
-        CurrencyRateController.updateExchangeRate([ticker]);
         NetworkController.setActiveNetwork(networkClientId);
         navigateToGetStarted();
       }

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -238,7 +238,6 @@ const NetworkSelector = () => {
 
   const onSetRpcTarget = async (networkConfiguration: NetworkConfiguration) => {
     const {
-      CurrencyRateController,
       NetworkController,
       SelectedNetworkController,
     } = Engine.context;
@@ -251,7 +250,6 @@ const NetworkSelector = () => {
       const {
         name: nickname,
         chainId,
-        nativeCurrency: ticker,
         rpcEndpoints,
         defaultRpcEndpointIndex,
       } = networkConfiguration;
@@ -365,7 +363,6 @@ const NetworkSelector = () => {
     });
     const {
       NetworkController,
-      CurrencyRateController,
       AccountTrackerController,
       SelectedNetworkController,
     } = Engine.context;

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -37,9 +37,7 @@ import Networks, {
 } from '../../../util/networks';
 import {
   LINEA_MAINNET,
-  LINEA_SEPOLIA,
   MAINNET,
-  SEPOLIA,
 } from '../../../constants/network';
 import Button from '../../../component-library/components/Buttons/Button/Button';
 import {
@@ -65,7 +63,6 @@ import createStyles from './NetworkSelector.styles';
 import {
   BUILT_IN_NETWORKS,
   InfuraNetworkType,
-  TESTNET_TICKER_SYMBOLS,
 } from '@metamask/controller-utils';
 import InfoModal from '../../../../app/components/UI/Swaps/components/InfoModal';
 import hideKeyFromUrl from '../../../util/hideKeyFromUrl';
@@ -268,8 +265,6 @@ const NetworkSelector = () => {
           networkConfigurationId,
         );
       } else {
-        CurrencyRateController.updateExchangeRate([ticker]);
-
         const { networkClientId } = rpcEndpoints[defaultRpcEndpointIndex];
 
         await NetworkController.setActiveNetwork(networkClientId);
@@ -378,13 +373,6 @@ const NetworkSelector = () => {
     if (domainIsConnectedDapp && process.env.MULTICHAIN_V1) {
       SelectedNetworkController.setNetworkClientIdForDomain(origin, type);
     } else {
-      let ticker = type;
-      if (type === LINEA_SEPOLIA) {
-        ticker = TESTNET_TICKER_SYMBOLS.LINEA_SEPOLIA as InfuraNetworkType;
-      }
-      if (type === SEPOLIA) {
-        ticker = TESTNET_TICKER_SYMBOLS.SEPOLIA as InfuraNetworkType;
-      }
 
       const networkConfiguration =
         networkConfigurations[BUILT_IN_NETWORKS[type].chainId];
@@ -394,7 +382,6 @@ const NetworkSelector = () => {
           networkConfiguration.defaultRpcEndpointIndex
         ].networkClientId ?? type;
 
-      CurrencyRateController.updateExchangeRate([ticker]);
       NetworkController.setActiveNetwork(clientId);
       closeRpcModal();
       AccountTrackerController.refresh();

--- a/app/components/Views/Root/index.js
+++ b/app/components/Views/Root/index.js
@@ -12,6 +12,7 @@ import { useAppTheme, ThemeContext } from '../../../util/theme';
 import { ToastContextWrapper } from '../../../component-library/components/Toast';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { isTest } from '../../../util/test/utils';
+import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 
 /**
  * Top level of the component hierarchy
@@ -85,9 +86,11 @@ const ConnectedRoot = () => {
     <SafeAreaProvider>
       <ThemeContext.Provider value={theme}>
         <ToastContextWrapper>
-          <ErrorBoundary view="Root">
-            <App />
-          </ErrorBoundary>
+          <AssetPollingProvider>
+            <ErrorBoundary view="Root">
+              <App />
+            </ErrorBoundary>
+          </AssetPollingProvider>
         </ToastContextWrapper>
       </ThemeContext.Provider>
     </SafeAreaProvider>

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -822,14 +822,13 @@ export class NetworkSettings extends PureComponent {
     shouldNetworkSwitchPopToWallet,
     navigation,
   }) => {
-    const { NetworkController, CurrencyRateController } = Engine.context;
+    const { NetworkController } = Engine.context;
 
     const url = new URL(rpcUrl);
     if (!isPrivateConnection(url.hostname)) {
       url.set('protocol', 'https:');
     }
 
-    CurrencyRateController.updateExchangeRate([ticker]);
     const existingNetwork = this.props.networkConfigurations[chainId];
 
     const indexRpc = rpcUrls.findIndex(({ url }) => url === rpcUrl);
@@ -1530,7 +1529,7 @@ export class NetworkSettings extends PureComponent {
   };
 
   switchToMainnet = () => {
-    const { NetworkController, CurrencyRateController } = Engine.context;
+    const { NetworkController } = Engine.context;
     const { networkConfigurations } = this.props;
 
     const { networkClientId } =
@@ -1538,7 +1537,6 @@ export class NetworkSettings extends PureComponent {
         networkConfigurations.defaultRpcEndpointIndex
       ] ?? {};
 
-    CurrencyRateController.updateExchangeRate([NetworksTicker.mainnet]);
     NetworkController.setActiveNetwork(networkClientId);
 
     setTimeout(async () => {

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -1538,7 +1538,7 @@ export class NetworkSettings extends PureComponent {
         networkConfigurations.defaultRpcEndpointIndex
       ] ?? {};
 
-    CurrencyRateController.updateExchangeRate(NetworksTicker.mainnet);
+    CurrencyRateController.updateExchangeRate([NetworksTicker.mainnet]);
     NetworkController.setActiveNetwork(networkClientId);
 
     setTimeout(async () => {

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -188,7 +188,7 @@ class NetworksSettings extends PureComponent {
   switchToMainnet = () => {
     const { NetworkController, CurrencyRateController } = Engine.context;
 
-    CurrencyRateController.updateExchangeRate(NetworksTicker.mainnet);
+    CurrencyRateController.updateExchangeRate([NetworksTicker.mainnet]);
     NetworkController.setProviderType(MAINNET);
 
     setTimeout(async () => {

--- a/app/components/Views/Settings/NetworksSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/index.js
@@ -186,9 +186,8 @@ class NetworksSettings extends PureComponent {
   };
 
   switchToMainnet = () => {
-    const { NetworkController, CurrencyRateController } = Engine.context;
+    const { NetworkController } = Engine.context;
 
-    CurrencyRateController.updateExchangeRate([NetworksTicker.mainnet]);
     NetworkController.setProviderType(MAINNET);
 
     setTimeout(async () => {

--- a/app/components/hooks/AssetPolling/AssetPollingProvider.tsx
+++ b/app/components/hooks/AssetPolling/AssetPollingProvider.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from 'react';
+import useCurrencyRatePolling from './useCurrencyRatePolling';
+
+// This provider is a step towards making controller polling fully UI based.
+// Eventually, individual UI components will call the use*Polling hooks to
+// poll and return particular data. This polls globally in the meantime.
+export const AssetPollingProvider = ({ children }: { children: ReactNode }) => {
+  useCurrencyRatePolling();
+
+  return <>{children}</>;
+};

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
@@ -1,0 +1,42 @@
+import useCurrencyRatePolling from './useCurrencyRatePolling';
+import { renderHookWithProvider } from '../../../util/test/renderWithProvider';
+import Engine from '../../../core/Engine';
+
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    CurrencyRateController: {
+      startPolling: jest.fn(),
+      stopPollingByPollingToken: jest.fn(),
+    },
+  },
+}));
+
+describe('useCurrencyRatePolling', () => {
+
+  it('Should poll by the native currencies in network state', async () => {
+
+    const state = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              '0x1': {
+                nativeCurrency: 'ETH',
+              },
+              '0x89': {
+                nativeCurrency: 'POL',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useCurrencyRatePolling(), {state});
+
+      expect(
+        jest.mocked(Engine.context.CurrencyRateController.startPolling)
+      ).toHaveBeenCalledWith({nativeCurrencies: ['ETH', 'POL']});
+
+  });
+});

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+import usePolling from '../usePolling';
+import { selectNetworkConfigurations } from '../../../selectors/networkController';
+import Engine from '../../../core/Engine';
+import { selectConversionRate, selectCurrencyRates } from '../../../selectors/currencyRateController';
+
+// Polls native currency prices across networks.
+const useCurrencyRatePolling = () => {
+
+  // Selectors to determine polling input
+  const networkConfigurations = useSelector(selectNetworkConfigurations);
+
+  // Selectors returning state updated by the polling
+  const conversionRate = useSelector(selectConversionRate);
+  const currencyRates = useSelector(selectCurrencyRates);
+
+  const nativeCurrencies = [
+    ...new Set(
+      Object.values(networkConfigurations).map((n) => n.nativeCurrency),
+    ),
+  ];
+
+  const { CurrencyRateController } = Engine.context;
+
+  usePolling({
+    startPolling:
+      CurrencyRateController.startPolling.bind(CurrencyRateController),
+    stopPollingByPollingToken:
+      CurrencyRateController.stopPollingByPollingToken.bind(CurrencyRateController),
+    input: [{nativeCurrencies}],
+  });
+
+  return {
+    conversionRate,
+    currencyRates,
+  };
+};
+
+export default useCurrencyRatePolling;

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -706,15 +706,7 @@ export class Engine {
       }),
       state: initialState.CurrencyRateController,
     });
-    const currentNetworkConfig =
-      networkController.getNetworkConfigurationByNetworkClientId(
-        networkController?.state.selectedNetworkClientId,
-      );
-    currencyRateController.startPolling({
-      nativeCurrencies: currentNetworkConfig?.nativeCurrency
-        ? [currentNetworkConfig?.nativeCurrency]
-        : [],
-    });
+
     const gasFeeController = new GasFeeController({
       // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
       messenger: this.controllerMessenger.getRestricted({

--- a/app/core/RPCMethods/lib/ethereum-chain-utils.js
+++ b/app/core/RPCMethods/lib/ethereum-chain-utils.js
@@ -207,7 +207,6 @@ export async function switchToNetwork({
   isAddNetworkFlow = false,
 }) {
   const {
-    CurrencyRateController,
     NetworkController,
     PermissionController,
     SelectedNetworkController,
@@ -300,7 +299,6 @@ export async function switchToNetwork({
       networkConfigurationId || networkConfiguration.networkType,
     );
   } else {
-    CurrencyRateController.updateExchangeRate(requestData.ticker);
     NetworkController.setActiveNetwork(
       networkConfigurationId || networkConfiguration.networkType,
     );

--- a/app/core/RPCMethods/wallet_addEthereumChain.test.js
+++ b/app/core/RPCMethods/wallet_addEthereumChain.test.js
@@ -393,7 +393,6 @@ describe('RPC Method - wallet_addEthereumChain', () => {
       }),
     );
     expect(spyOnSetActiveNetwork).toHaveBeenCalledTimes(1);
-    expect(spyOnUpdateExchangeRate).toHaveBeenCalledTimes(1);
   });
 
   it('should not add a networkConfiguration that has a chainId that already exists in wallet state, and should switch to the existing network', async () => {
@@ -432,7 +431,6 @@ describe('RPC Method - wallet_addEthereumChain', () => {
 
     expect(spyOnAddNetwork).not.toHaveBeenCalled();
     expect(spyOnSetActiveNetwork).toHaveBeenCalledTimes(1);
-    expect(spyOnUpdateExchangeRate).toHaveBeenCalledTimes(1);
   });
 
   describe('MM_CHAIN_PERMISSIONS is enabled', () => {

--- a/app/selectors/currencyRateController.ts
+++ b/app/selectors/currencyRateController.ts
@@ -34,3 +34,10 @@ export const selectCurrentCurrency = createSelector(
   (currencyRateControllerState: CurrencyRateState) =>
     currencyRateControllerState?.currentCurrency,
 );
+
+export const selectCurrencyRates = createSelector(
+  selectCurrencyRateControllerState,
+  (
+    currencyRateControllerState: CurrencyRateState,
+  ) => currencyRateControllerState?.currencyRates,
+);

--- a/app/util/networks/handleNetworkSwitch.test.ts
+++ b/app/util/networks/handleNetworkSwitch.test.ts
@@ -137,9 +137,6 @@ describe('useHandleNetworkSwitch', () => {
     const nickname = handleNetworkSwitch('1338');
 
     expect(
-      mockEngine.context.CurrencyRateController.updateExchangeRate,
-    ).toBeCalledWith(['TEST']);
-    expect(
       mockEngine.context.NetworkController.setActiveNetwork,
     ).toBeCalledWith('networkId1');
     expect(
@@ -153,10 +150,6 @@ describe('useHandleNetworkSwitch', () => {
 
     const networkType = handleNetworkSwitch('11155111');
 
-    // TODO: This is a bug, it should be set to SepoliaETH
-    expect(
-      mockEngine.context.CurrencyRateController.updateExchangeRate,
-    ).toBeCalledWith(['ETH']);
     expect(
       mockEngine.context.NetworkController.setProviderType,
     ).not.toBeCalledWith();

--- a/app/util/networks/handleNetworkSwitch.ts
+++ b/app/util/networks/handleNetworkSwitch.ts
@@ -1,4 +1,3 @@
-import { CurrencyRateController } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { NetworkController } from '@metamask/network-controller';
 import Engine from '../../core/Engine';
@@ -22,8 +21,6 @@ const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
     return;
   }
 
-  const currencyRateController = Engine.context
-    .CurrencyRateController as CurrencyRateController;
   const networkController = Engine.context
     .NetworkController as NetworkController;
   const chainId = selectChainId(store.getState());
@@ -44,13 +41,11 @@ const handleNetworkSwitch = (switchToChainId: string): string | undefined => {
       ,
       {
         name: nickname,
-        nativeCurrency: ticker,
         rpcEndpoints,
         defaultRpcEndpointIndex,
       },
     ] = entry;
 
-    currencyRateController.updateExchangeRate([ticker]);
     const { networkClientId } = rpcEndpoints[defaultRpcEndpointIndex];
 
     networkController.setActiveNetwork(networkClientId);


### PR DESCRIPTION
## **Description**

This PR uses the `CurrencyRateController` to poll native currency prices across chains.  This will keep prices updated in state across all networks.

Because we're polling across all networks, it's no longer necessary to trigger updates when switching chains, so these places have been removed.  Once we start showing tokens across all networks, "switching chains" will become a less relevant action.

## **Related issues**


## **Manual testing steps**

1. Verify fiat prices are correct for the native currency on a network
2. Switch to a network with a different native currency, 
3. Verify fiat prices are correct for that network

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

No visual changes, but native token prices should still be accurate across networks and when changing currencies.


https://github.com/user-attachments/assets/d77d3413-d773-43fc-afaf-1af44aedd5ee



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
