### PR TITLE
chore: Cache node installed via nvm on Bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -312,6 +312,7 @@ workflows:
             - key: node-{{ getenv "NODE_VERSION" }}-{{ .OS }}-{{ .Arch }}
             - paths: |-
                 ../.nvm/
+                ../../../root/.nvm/
   install_applesimutils:
     steps:
       - script@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -255,7 +255,7 @@ workflows:
       - restore-cache@2:
           title: Restore Node
           inputs:
-            - key: node-${{ getenv "NODE_VERSION" }}-{{ .OS }}-{{ .Arch }}
+            - key: node-{{ getenv "NODE_VERSION" }}-{{ .OS }}-{{ .Arch }}
       - script@1:
           title: node, yarn, corepack installation
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -252,6 +252,10 @@ workflows:
           title: Yarn Setup
   prep_environment:
     steps:
+      - restore-cache@2:
+          title: Restore Node
+          inputs:
+            - key: node-${{ getenv "NODE_VERSION" }}-{{ .OS }}-{{ .Arch }}
       - script@1:
           title: node, yarn, corepack installation
           inputs:
@@ -302,6 +306,12 @@ workflows:
                 npm i -g "corepack@$COREPACK_VERSION"
                 echo "Corepack enabling $YARN_VERSION"
                 corepack enable
+      - save-cache@1:
+          title: Save Node
+          inputs:
+            - key: node-{{ getenv "NODE_VERSION" }}-{{ .OS }}-{{ .Arch }}
+            - paths: |-
+                ../.nvm/
   install_applesimutils:
     steps:
       - script@1:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds steps to the `prep_environment` workflow for both restoring and saving the installed version of node. First, we attempt to restore the cached node file path. Then the install nvm step will attempt to install node if it doesn't exist. If it does, it will use the cached version of node. Then, we cache the downloaded version of node (if there is one)

At the time of writing, node is installed to the following paths
- iOS - `/Users/vagrant/.nvm`
- Android - `/root/.nvm`

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2029

## **Manual testing steps**

1. On Bitrise, run `pr_smoke_e2e_pipeline`
2. On initial run, the `Restore Node` step in `prep_environment` workflow should not have any node to cache
3. nvm will then install node
4. The `Save Node` step will then cache node
5. Upon re-running the `pr_smoke_e2e_pipeline` again, `Restore Node` will now be able to restore the cached version of node
6. The nvm install step will then detect that a version exists and use the cached version

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
Build with node cache enabled - https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/6598b4fb-e88a-4252-9d57-5e8421226ea5?tab=workflows

In this build, both `ios_e2e_build` and `android_e2e_build` does not yet have node cached, so it downloads it on the respective machines and then caches it. For E2E tests - The restore node step successfully detects that node already exists via nvm and uses that instead of downloading it again

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
