### PR TITLE
chore: Update naming for returning a txHash asap for smart transactions

### DIFF
--- a/app/reducers/swaps/index.js
+++ b/app/reducers/swaps/index.js
@@ -89,7 +89,15 @@ export const swapsSmartTxFlagEnabled = createSelector(
 export const selectSwapsChainFeatureFlags = createSelector(
   swapsStateSelector,
   chainIdSelector,
-  (swapsState, chainId) => swapsState[chainId].featureFlags,
+  (swapsState, chainId) => {
+    return {
+      ...swapsState[chainId].featureFlags,
+      smartTransactions: {
+        ...swapsState[chainId].featureFlags.smartTransactions,
+        ...swapsState.featureFlags.smartTransactions,
+      },
+    };
+  },
 );
 
 /**

--- a/app/reducers/swaps/index.js
+++ b/app/reducers/swaps/index.js
@@ -89,15 +89,13 @@ export const swapsSmartTxFlagEnabled = createSelector(
 export const selectSwapsChainFeatureFlags = createSelector(
   swapsStateSelector,
   chainIdSelector,
-  (swapsState, chainId) => {
-    return {
-      ...swapsState[chainId].featureFlags,
-      smartTransactions: {
-        ...swapsState[chainId].featureFlags.smartTransactions,
-        ...swapsState.featureFlags.smartTransactions,
-      },
-    };
-  },
+  (swapsState, chainId) => ({
+    ...swapsState[chainId].featureFlags,
+    smartTransactions: {
+      ...(swapsState[chainId].featureFlags?.smartTransactions || {}),
+      ...(swapsState.featureFlags?.smartTransactions || {}),
+    },
+  }),
 );
 
 /**

--- a/app/reducers/swaps/swaps.test.ts
+++ b/app/reducers/swaps/swaps.test.ts
@@ -24,7 +24,7 @@ const DEFAULT_FEATURE_FLAGS = {
     smartTransactions: {
       expectedDeadline: 45,
       maxDeadline: 150,
-      returnTxHashAsap: false,
+      mobileReturnTxHashAsap: false,
     },
   },
   bsc: {
@@ -90,7 +90,7 @@ describe('swaps reducer', () => {
         smartTransactions: {
           expectedDeadline: 45,
           maxDeadline: 150,
-          returnTxHashAsap: false,
+          mobileReturnTxHashAsap: false,
         },
       };
 
@@ -122,7 +122,7 @@ describe('swaps reducer', () => {
         smartTransactions: {
           expectedDeadline: 45,
           maxDeadline: 150,
-          returnTxHashAsap: false,
+          mobileReturnTxHashAsap: false,
         },
       };
 
@@ -154,7 +154,7 @@ describe('swaps reducer', () => {
         smartTransactions: {
           expectedDeadline: 45,
           maxDeadline: 150,
-          returnTxHashAsap: false,
+          mobileReturnTxHashAsap: false,
         },
       };
 
@@ -226,7 +226,7 @@ describe('swaps reducer', () => {
             smartTransactions: {
               expectedDeadline: 45,
               maxDeadline: 150,
-              returnTxHashAsap: false,
+              mobileReturnTxHashAsap: false,
             },
           },
         },
@@ -281,7 +281,7 @@ describe('swaps reducer', () => {
             smartTransactions: {
               expectedDeadline: 45,
               maxDeadline: 150,
-              returnTxHashAsap: false,
+              mobileReturnTxHashAsap: false,
             },
           },
         },

--- a/app/selectors/smartTransactionsController.test.ts
+++ b/app/selectors/smartTransactionsController.test.ts
@@ -37,7 +37,7 @@ const getDefaultState = () => {
           smartTransactions: {
             expectedDeadline: 45,
             maxDeadline: 160,
-            returnTxHashAsap: false,
+            mobileReturnTxHashAsap: false,
           },
         },
       },

--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -200,7 +200,7 @@ function withRequest<ReturnValue>(
       smartTransactions: {
         expectedDeadline: 45,
         maxDeadline: 150,
-        returnTxHashAsap: false,
+        mobileReturnTxHashAsap: false,
       },
       mobile_active: true,
       extension_active: true,
@@ -231,7 +231,7 @@ describe('submitSmartTransactionHook', () => {
 
   it('returns a txHash asap if the feature flag requires it', async () => {
     withRequest(async ({ request }) => {
-      request.featureFlags.smartTransactions.returnTxHashAsap = true;
+      request.featureFlags.smartTransactions.mobileReturnTxHashAsap = true;
       const result = await submitSmartTransactionHook(request);
       expect(result).toEqual({ transactionHash });
     });

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -52,7 +52,7 @@ export interface SubmitSmartTransactionRequest {
       | {
           expectedDeadline: number;
           maxDeadline: number;
-          returnTxHashAsap: boolean;
+          mobileReturnTxHashAsap: boolean;
         }
       | Record<string, never>;
   };
@@ -74,7 +74,7 @@ class SmartTransactionHook {
     smartTransactions: {
       expectedDeadline?: number;
       maxDeadline?: number;
-      returnTxHashAsap?: boolean;
+      mobileReturnTxHashAsap?: boolean;
     };
   };
   #shouldUseSmartTransaction: boolean;
@@ -262,10 +262,10 @@ class SmartTransactionHook {
     uuid: string,
   ) => {
     let transactionHash: string | undefined | null;
-    const returnTxHashAsap =
-      this.#featureFlags?.smartTransactions?.returnTxHashAsap;
+    const mobileReturnTxHashAsap =
+      this.#featureFlags?.smartTransactions?.mobileReturnTxHashAsap;
 
-    if (returnTxHashAsap && submitTransactionResponse?.txHash) {
+    if (mobileReturnTxHashAsap && submitTransactionResponse?.txHash) {
       transactionHash = submitTransactionResponse.txHash;
     } else {
       transactionHash = await this.#waitForTransactionHash({


### PR DESCRIPTION
## **Description**
This PR updates naming for returning a txHash asap and also merges shared feature flags for smart transactions with network specific ones.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Once the new feature flag is enabled on backend, the mobile app will return a txHash asap after submitting a transaction.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
