### PR TITLE
fix: e2e: adjust notifications test to minimize flakiness

### DIFF
--- a/e2e/specs/notifications/account-syncing/sync-after-onboarding.spec.js
+++ b/e2e/specs/notifications/account-syncing/sync-after-onboarding.spec.js
@@ -44,6 +44,14 @@ describe(SmokeNotifications('Account syncing'), () => {
   });
 
   it('retrieves all previously synced accounts', async () => {
+    await importWalletWithRecoveryPhrase(
+      NOTIFICATIONS_TEAM_SEED_PHRASE,
+      NOTIFICATIONS_TEAM_PASSWORD,
+    );
+
+    await WalletView.tapIdenticon();
+    await Assertions.checkIfVisible(AccountListView.accountList);
+
     const decryptedAccountNames = await Promise.all(
       accountsSyncMockResponse.map(async (response) => {
         const decryptedAccountName = await SDK.Encryption.decryptString(
@@ -53,14 +61,6 @@ describe(SmokeNotifications('Account syncing'), () => {
         return JSON.parse(decryptedAccountName).n;
       }),
     );
-
-    await importWalletWithRecoveryPhrase(
-      NOTIFICATIONS_TEAM_SEED_PHRASE,
-      NOTIFICATIONS_TEAM_PASSWORD,
-    );
-
-    await WalletView.tapIdenticon();
-    await Assertions.checkIfVisible(AccountListView.accountList);
 
     for (const accountName of decryptedAccountNames) {
       await Assertions.checkIfVisible(

--- a/e2e/specs/notifications/account-syncing/sync-after-onboarding.spec.js
+++ b/e2e/specs/notifications/account-syncing/sync-after-onboarding.spec.js
@@ -19,6 +19,9 @@ import { SmokeNotifications } from '../../../tags';
 
 describe(SmokeNotifications('Account syncing'), () => {
   beforeAll(async () => {
+    jest.setTimeout(200000);
+    await TestHelpers.reverseServerPort();
+
     const mockServer = await startMockServer({
       mockUrl: 'https://user-storage.api.cx.metamask.io/api/v1/userstorage',
     });
@@ -29,9 +32,6 @@ describe(SmokeNotifications('Account syncing'), () => {
     userStorageMockttpControllerInstance.setupPath('accounts', mockServer, {
       getResponse: accountsSyncMockResponse,
     });
-
-    jest.setTimeout(200000);
-    await TestHelpers.reverseServerPort();
 
     await device.launchApp({
       newInstance: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Fix flakiness of test...

- move setTimeout and reverseServerPort at the start of beforeAll
- move decrypt account names before assertion



## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
