### PR TITLE
chore: cherrypick do not show staked eth balance when balance is zero on homepage or asset detail

### DIFF
--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
@@ -166,7 +166,7 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
 
   return (
     <View>
-      {hasStakedPositions && (
+      {hasEthToUnstake && (
         <AssetElement
           asset={asset}
           mainBalance={stakedBalanceETH}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -514,10 +514,12 @@ const Wallet = ({
       } as any;
       assets.push(nativeAsset);
 
-      let stakedAsset;
-      if (accountBalanceByChainId.stakedBalance) {
+      if (
+        accountBalanceByChainId.stakedBalance &&
+        !hexToBN(accountBalanceByChainId.stakedBalance).isZero()
+      ) {
         stakedBalance = renderFromWei(accountBalanceByChainId.stakedBalance);
-        stakedAsset = {
+        const stakedAsset = {
           ...nativeAsset,
           nativeAsset,
           name: 'Staked Ethereum',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

1. What is the reason for the change?

We have decided that we should hide the staked ethereum balance if it is 0 on mobile.

3. What is the improvement/solution?

Ensure that the staked ethereum asset does not show when the balance is zero on the homepage and on the ETH asset detail page.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/STAKE-874

## **Manual testing steps**

1. On this branch 
2. If you have a zero Staked ETH balance, you should see no Staked Ethereum asset on the homepage or on the ETH asset detail page after clicking the ETH asset on homepage.
3. If you do have Staked ETH already, then you should see that ETH on the homepage and on the ETH asset detail page as well. Unstake Max ETH and wait for transaction to confirm. When you check homepage and ETH asset detail page, there should be no Staked Ethereum listed as balance is now 0.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/04e475ad-f8c0-49f1-aaeb-a5a8df25e44b

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/35ea9834-ff42-4667-87d2-cc510ff91155

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->
