### PR TITLE
fix: Remove duplicate notifications controllers entries in `EngineService`

### DIFF
--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -172,18 +172,6 @@ class EngineService {
         name: 'PPOMController',
         key: `${engine.context.PPOMController.name}:stateChange`,
       },
-      {
-        name: 'AuthenticationController',
-        key: `AuthenticationController:stateChange`,
-      },
-      {
-        name: 'UserStorageController',
-        key: `UserStorageController:stateChange`,
-      },
-      {
-        name: 'NotificationServicesController',
-        key: `NotificationServicesController:stateChange`,
-      },
     ];
 
     engine?.datamodel?.subscribe?.(() => {


### PR DESCRIPTION
## **Description**

- The removed lines are duplicated above [in the section wrapped in snaps feature flags](https://github.com/MetaMask/metamask-mobile/pull/12349/files#diff-40a495afa863cded8d434e7fd9ed07803cc1524a8565c445ffcf24739eec47daL142-L153).
  - The removed lines should not be placed outside of the snaps feature flags.
- The removed lines don't have any effect as the controllers they reference are only [instantiated](https://github.com/MetaMask/metamask-mobile/blob/3b269cecf4064269e3f7d6f8a7aa100cb5c13f24/app/core/Engine.ts#L1055-L1351) and [passed into the engine context and datamodel](https://github.com/MetaMask/metamask-mobile/blob/3b269cecf4064269e3f7d6f8a7aa100cb5c13f24/app/core/Engine.ts#L1657-L1664
) when snaps feature flags are active. Otherwise, the `stateChange` events are never defined.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
