### PR TITLE
chore: Remove unnecessary event prop

### DIFF
--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -337,7 +337,6 @@ describe('Smart Transactions utils', () => {
       const transactionMeta = { hash: '0x123' } as TransactionMeta;
       const smartTransaction = {
         statusMetadata: {
-          duplicated: true,
           timedOut: false,
           proxied: true,
         },
@@ -353,7 +352,6 @@ describe('Smart Transactions utils', () => {
         controllerMessenger,
       );
       expect(result).toEqual({
-        smart_transaction_duplicated: true,
         smart_transaction_timed_out: false,
         smart_transaction_proxied: true,
       });
@@ -363,7 +361,6 @@ describe('Smart Transactions utils', () => {
       const transactionMeta = { hash: '0x123' } as TransactionMeta;
       const smartTransaction = {
         statusMetadata: {
-          duplicated: false,
           timedOut: true,
           proxied: false,
         },
@@ -389,7 +386,6 @@ describe('Smart Transactions utils', () => {
         controllerMessenger,
       );
       expect(result).toEqual({
-        smart_transaction_duplicated: false,
         smart_transaction_timed_out: true,
         smart_transaction_proxied: false,
       });
@@ -430,7 +426,6 @@ describe('Smart Transactions utils', () => {
       const transactionMeta = { hash: '0x123' } as TransactionMeta;
       const smartTransaction = {
         statusMetadata: {
-          duplicated: true,
           timedOut: false,
           proxied: true,
         },
@@ -446,7 +441,6 @@ describe('Smart Transactions utils', () => {
         controllerMessenger,
       );
       expect(result).toEqual({
-        smart_transaction_duplicated: true,
         smart_transaction_timed_out: false,
         smart_transaction_proxied: true,
       });

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -116,9 +116,8 @@ export const getSmartTransactionMetricsProperties = async (
   if (!smartTransaction?.statusMetadata) {
     return {};
   }
-  const { duplicated, timedOut, proxied } = smartTransaction.statusMetadata;
+  const { timedOut, proxied } = smartTransaction.statusMetadata;
   return {
-    smart_transaction_duplicated: duplicated,
     smart_transaction_timed_out: timedOut,
     smart_transaction_proxied: proxied,
   };


### PR DESCRIPTION
## **Description**

Removes an unnecessary event prop smart_transaction_duplicated, as we did in the extension: https://github.com/MetaMask/metamask-extension/pull/28546

## **Related issues**

Fixes:

## **Manual testing steps**

1. This event prop won't be available anymore in some events after submitting a smart transaction.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
