### PR TITLE
perf: Remove costly reduce operation for generating Engine context

### DIFF
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1486,10 +1486,10 @@ export class Engine {
       getMetaMetricsProps: () => Promise.resolve({}), // Return MetaMetrics props once we enable HW wallets for smart transactions.
     });
 
-    const controllers: Controllers[keyof Controllers][] = [
-      this.keyringController,
-      accountTrackerController,
-      new AddressBookController({
+    this.context = {
+      KeyringController: this.keyringController,
+      AccountTrackerController: accountTrackerController,
+      AddressBookController: new AddressBookController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'AddressBookController',
           allowedActions: [],
@@ -1497,11 +1497,11 @@ export class Engine {
         }),
         state: initialState.AddressBookController,
       }),
-      assetsContractController,
-      nftController,
-      tokensController,
-      tokenListController,
-      new TokenDetectionController({
+      AssetsContractController: assetsContractController,
+      NftController: nftController,
+      TokensController: tokensController,
+      TokenListController: tokenListController,
+      TokenDetectionController: new TokenDetectionController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'TokenDetectionController',
           allowedActions: [
@@ -1547,8 +1547,7 @@ export class Engine {
         useAccountsAPI: true,
         disabled: false
       }),
-
-      new NftDetectionController({
+      NftDetectionController: new NftDetectionController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'NftDetectionController',
           allowedEvents: [
@@ -1567,11 +1566,11 @@ export class Engine {
         addNft: nftController.addNft.bind(nftController),
         getNftState: () => nftController.state,
       }),
-      currencyRateController,
-      networkController,
-      phishingController,
-      preferencesController,
-      new TokenBalancesController({
+      CurrencyRateController: currencyRateController,
+      NetworkController: networkController,
+      PhishingController: phishingController,
+      PreferencesController: preferencesController,
+      TokenBalancesController: new TokenBalancesController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'TokenBalancesController',
           allowedActions: [
@@ -1587,7 +1586,7 @@ export class Engine {
         ],
         state: initialState.TokenBalancesController,
       }),
-      new TokenRatesController({
+      TokenRatesController: new TokenRatesController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'TokenRatesController',
           allowedActions: [
@@ -1607,9 +1606,9 @@ export class Engine {
         interval: 30 * 60 * 1000,
         state: initialState.TokenRatesController || { marketData: {} },
       }),
-      this.transactionController,
-      this.smartTransactionsController,
-      new SwapsController({
+      TransactionController: this.transactionController,
+      SmartTransactionsController: this.smartTransactionsController,
+      SwapsController: new SwapsController({
         clientId: AppConstants.SWAPS.CLIENT_ID,
         fetchAggregatorMetadataThreshold:
           AppConstants.SWAPS.CACHE_AGGREGATOR_METADATA_THRESHOLD,
@@ -1646,11 +1645,11 @@ export class Engine {
         // @ts-expect-error TODO: Resolve mismatch between gas fee and swaps controller types
         fetchEstimatedMultiLayerL1Fee,
       }),
-      gasFeeController,
-      approvalController,
-      permissionController,
-      selectedNetworkController,
-      new SignatureController({
+      GasFeeController: gasFeeController,
+      ApprovalController: approvalController,
+      PermissionController: permissionController,
+      SelectedNetworkController: selectedNetworkController,
+      SignatureController: new SignatureController({
         messenger: this.controllerMessenger.getRestricted({
           name: 'SignatureController',
           allowedActions: [
@@ -1666,17 +1665,17 @@ export class Engine {
         // This casting expected due to mismatch of browser and react-native version of Sentry traceContext
         trace: trace as unknown as SignatureControllerOptions['trace'],
       }),
-      loggingController,
+      LoggingController: loggingController,
       ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-      this.snapController,
-      this.subjectMetadataController,
-      authenticationController,
-      userStorageController,
-      notificationServicesController,
-      notificationServicesPushController,
+      SnapController: this.snapController,
+      SubjectMetadataController: this.subjectMetadataController,
+      AuthenticationController: authenticationController,
+      UserStorageController: userStorageController,
+      NotificationServicesController: notificationServicesController,
+      NotificationServicesPushController: notificationServicesPushController,
       ///: END:ONLY_INCLUDE_IF
-      accountsController,
-      new PPOMController({
+      AccountsController: accountsController,
+      PPOMController: new PPOMController({
         chainId: networkController.getNetworkClientById(
           networkController?.state.selectedNetworkClientId,
         ).configuration.chainId,
@@ -1710,7 +1709,7 @@ export class Engine {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         nativeCrypto: Crypto as any,
       }),
-    ];
+    };
 
     // set initial state
     // TODO: Pass initial state into each controller constructor instead
@@ -1719,7 +1718,7 @@ export class Engine {
     //
     // The check for `controller.subscribe !== undefined` is to filter out BaseControllerV2
     // controllers. They should be initialized via the constructor instead.
-    for (const controller of controllers) {
+    for (const controller of Object.values(this.context)) {
       if (
         hasProperty(initialState, controller.name) &&
         // Use `in` operator here because the `subscribe` function is one level up the prototype chain
@@ -1734,16 +1733,9 @@ export class Engine {
 
     this.datamodel = new ComposableController(
       // @ts-expect-error The ComposableController needs to be updated to support BaseControllerV2
-      controllers,
+      Object.values(this.context),
       this.controllerMessenger,
     );
-    this.context = controllers.reduce<Partial<typeof this.context>>(
-      (context, controller) => ({
-        ...context,
-        [controller.name]: controller,
-      }),
-      {},
-    ) as typeof this.context;
 
     const { NftController: nfts } = this.context;
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1711,9 +1711,23 @@ export class Engine {
       }),
     };
 
+    // Avoiding `Object.values` and `getKnownPropertyNames` for performance benefits: https://www.measurethat.net/Benchmarks/Show/7173/0/objectvalues-vs-reduce
+    const controllers = (
+      Object.keys(this.context) as (keyof Controllers)[]
+    ).reduce<Controllers[keyof Controllers][]>(
+      (controllers, controllerName) => {
+        const controller = this.context[controllerName];
+        if (controller) {
+          controllers.push(controller);
+        }
+        return controllers;
+      },
+      [],
+    );
+
     this.datamodel = new ComposableController(
-      // @ts-expect-error The ComposableController needs to be updated to support BaseControllerV2
-      Object.values(this.context),
+      // @ts-expect-error TODO: Filter out non-controller instances
+      controllers,
       this.controllerMessenger,
     );
 

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1711,26 +1711,6 @@ export class Engine {
       }),
     };
 
-    // set initial state
-    // TODO: Pass initial state into each controller constructor instead
-    // This is being set post-construction for now to ensure it's functionally equivalent with
-    // how the `ComponsedController` used to set initial state.
-    //
-    // The check for `controller.subscribe !== undefined` is to filter out BaseControllerV2
-    // controllers. They should be initialized via the constructor instead.
-    for (const controller of Object.values(this.context)) {
-      if (
-        hasProperty(initialState, controller.name) &&
-        // Use `in` operator here because the `subscribe` function is one level up the prototype chain
-        'subscribe' in controller &&
-        controller.subscribe !== undefined
-      ) {
-        // The following type error can be addressed by passing initial state into controller constructors instead
-        // @ts-expect-error No type-level guarantee that the correct state is being applied to the correct controller here.
-        controller.update(initialState[controller.name]);
-      }
-    }
-
     this.datamodel = new ComposableController(
       // @ts-expect-error The ComposableController needs to be updated to support BaseControllerV2
       Object.values(this.context),


### PR DESCRIPTION
## Overview

Optimizes an expensive operation from the Engine initialization process. 

A custom span for measuring this process was added in https://github.com/MetaMask/metamask-mobile/pull/11579.

## Motivation

Currently, the Engine's context object is created using a `Array.prototype.reduce()` operation on a large `controllers` array. This reduce call is also written to create a temporary object on every iteration.

Benchmarks show that this particular implementation of reduce runs significantly slower than other means of creating an object, and compared to reduce calls that are written to re-use the output object the difference is in four orders of magnitude (1555.6 Ops/sec vs. 0.2 Ops/sec).
> https://www.measurethat.net/Benchmarks/Show/21554/0/objectfromentries-vs-reduce-vs-assign

A simple fix would be to refactor the reduce operation so it doesn't rely on temporary objects and spreading:

```diff
diff --git a/app/core/Engine.ts b/app/core/Engine.ts
index decf28da51..1ba63ed106 100644
--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -1738,10 +1738,10 @@ export class Engine {
       this.controllerMessenger,
     );
     this.context = controllers.reduce<Partial<typeof this.context>>(
-      (context, controller) => ({
-        ...context,
-        [controller.name]: controller,
-      }),
+      (context, controller) => {
+        context[controller.name] = controller;
+        return context;
+      },
       {},
     ) as typeof this.context;
```

However, we can also avoid the cost of running reduce altogether simply by creating a controller name-keyed object to assign to the Engine's context field. This is also the approach taken in the Extension `MetamaskController`.

## **Description**

- Replaces `controllers` array in the Engine class with a corresponding object that is directly assigned to `context`.
- Optimize `Object.values` for deriving ComposableController input with `Object.keys` and `reduce` (re-uses object).
  > https://www.measurethat.net/Benchmarks/Show/7173/0/objectvalues-vs-reduce
- Removes for-loop that sets initial state for V1 controllers now that all mobile controllers have been updated to V2.

## **Related issues**

- Contributes to https://github.com/MetaMask/mobile-planning/issues/1095
- Related https://www.notion.so/metamask-consensys/Refactor-Engine-Init-to-only-include-minimum-controllers-for-logging-in-on-startup-23ee10636dcc44d480a93a63361abb5b

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
