### PR TITLE
fix(431-2): active network icon has too much margin and adding optional prop

### DIFF
--- a/app/components/UI/NavbarTitle/index.js
+++ b/app/components/UI/NavbarTitle/index.js
@@ -144,7 +144,9 @@ class NavbarTitle extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
 
-    if (providerConfig.nickname) {
+    if (networkName) {
+      name = networkName;
+    } else if (providerConfig.nickname) {
       name = providerConfig.nickname;
     } else {
       name =
@@ -153,19 +155,6 @@ class NavbarTitle extends PureComponent {
     }
 
     const realTitle = translate ? strings(title) : title;
-    let displayName = networkName;
-
-    if (!displayName) {
-      if (providerConfig.nickname) {
-        displayName = providerConfig.nickname;
-      } else {
-        displayName =
-          (Networks[providerConfig.type] &&
-            Networks[providerConfig.type].name) ||
-          { ...Networks.rpc, color: null }.name;
-      }
-    }
-
     return (
       <TouchableOpacity
         onPress={this.openNetworkList}
@@ -193,7 +182,7 @@ class NavbarTitle extends PureComponent {
               ]}
             />
             <Text numberOfLines={1} style={styles.networkName}>
-              {displayName || name}
+              {name}
             </Text>
           </View>
         ) : null}

--- a/app/components/UI/NavbarTitle/index.js
+++ b/app/components/UI/NavbarTitle/index.js
@@ -26,6 +26,7 @@ const createStyles = (colors) =>
     },
     network: {
       flexDirection: 'row',
+      alignItems: 'center',
     },
     networkName: {
       fontSize: 11,
@@ -37,7 +38,6 @@ const createStyles = (colors) =>
       height: 5,
       borderRadius: 100,
       marginRight: 5,
-      marginTop: Device.isIos() ? 4 : 5,
     },
     title: {
       fontSize: scale(14),
@@ -91,6 +91,10 @@ class NavbarTitle extends PureComponent {
      */
     showSelectedNetwork: PropTypes.bool,
     /**
+     * Name of the network to display
+     */
+    networkName: PropTypes.string,
+    /**
      * Content to display inside text element
      */
     children: PropTypes.node,
@@ -125,8 +129,14 @@ class NavbarTitle extends PureComponent {
   };
 
   render = () => {
-    const { providerConfig, title, translate, showSelectedNetwork, children } =
-      this.props;
+    const {
+      providerConfig,
+      title,
+      translate,
+      showSelectedNetwork,
+      children,
+      networkName,
+    } = this.props;
     let name = null;
     const color =
       (Networks[providerConfig.type] && Networks[providerConfig.type].color) ||
@@ -143,6 +153,18 @@ class NavbarTitle extends PureComponent {
     }
 
     const realTitle = translate ? strings(title) : title;
+    let displayName = networkName;
+
+    if (!displayName) {
+      if (providerConfig.nickname) {
+        displayName = providerConfig.nickname;
+      } else {
+        displayName =
+          (Networks[providerConfig.type] &&
+            Networks[providerConfig.type].name) ||
+          { ...Networks.rpc, color: null }.name;
+      }
+    }
 
     return (
       <TouchableOpacity
@@ -171,7 +193,7 @@ class NavbarTitle extends PureComponent {
               ]}
             />
             <Text numberOfLines={1} style={styles.networkName}>
-              {name}
+              {displayName || name}
             </Text>
           </View>
         ) : null}

--- a/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -192,7 +193,6 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -882,6 +882,7 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -893,7 +894,6 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1583,6 +1583,7 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1594,7 +1595,6 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -2255,6 +2255,7 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -2266,7 +2267,6 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3203,6 +3203,7 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3214,7 +3215,6 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3875,6 +3875,7 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3886,7 +3887,6 @@ exports[`BuildQuote View Fiat Currency Data renders the loading page when fiats 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4823,6 +4823,7 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4834,7 +4835,6 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -5495,6 +5495,7 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -5506,7 +5507,6 @@ exports[`BuildQuote View Payment Method Data renders the loading page when payme
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6443,6 +6443,7 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6454,7 +6455,6 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -7115,6 +7115,7 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -7126,7 +7127,6 @@ exports[`BuildQuote View Regions data renders the loading page when regions are 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8063,6 +8063,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8074,7 +8075,6 @@ exports[`BuildQuote View renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -11118,6 +11118,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -11129,7 +11130,6 @@ exports[`BuildQuote View renders correctly 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -14153,6 +14153,7 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -14164,7 +14165,6 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -14825,6 +14825,7 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -14836,7 +14837,6 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`GetStarted renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -169,7 +170,6 @@ exports[`GetStarted renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -831,6 +831,7 @@ exports[`GetStarted renders correctly 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -842,7 +843,6 @@ exports[`GetStarted renders correctly 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1504,6 +1504,7 @@ exports[`GetStarted renders correctly when getStarted is true 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1515,7 +1516,6 @@ exports[`GetStarted renders correctly when getStarted is true 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1947,6 +1947,7 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1958,7 +1959,6 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -169,7 +170,6 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1906,6 +1906,7 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1917,7 +1918,6 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3061,6 +3061,7 @@ exports[`NetworkSwitcher View renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3072,7 +3073,6 @@ exports[`NetworkSwitcher View renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4216,6 +4216,7 @@ exports[`NetworkSwitcher View renders correctly 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4227,7 +4228,6 @@ exports[`NetworkSwitcher View renders correctly 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -5371,6 +5371,7 @@ exports[`NetworkSwitcher View renders correctly while loading 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -5382,7 +5383,6 @@ exports[`NetworkSwitcher View renders correctly while loading 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6714,6 +6714,7 @@ exports[`NetworkSwitcher View renders correctly while loading 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6725,7 +6726,6 @@ exports[`NetworkSwitcher View renders correctly while loading 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8057,6 +8057,7 @@ exports[`NetworkSwitcher View renders correctly with errors 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8068,7 +8069,6 @@ exports[`NetworkSwitcher View renders correctly with errors 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8706,6 +8706,7 @@ exports[`NetworkSwitcher View renders correctly with errors 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8717,7 +8718,6 @@ exports[`NetworkSwitcher View renders correctly with errors 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -9355,6 +9355,7 @@ exports[`NetworkSwitcher View renders correctly with no data 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -9366,7 +9367,6 @@ exports[`NetworkSwitcher View renders correctly with no data 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -192,7 +193,6 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1683,6 +1683,7 @@ exports[`OrderDetails renders a completed order 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1694,7 +1695,6 @@ exports[`OrderDetails renders a completed order 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3196,6 +3196,7 @@ exports[`OrderDetails renders a created order 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3207,7 +3208,6 @@ exports[`OrderDetails renders a created order 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4670,6 +4670,7 @@ exports[`OrderDetails renders a failed order 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4681,7 +4682,6 @@ exports[`OrderDetails renders a failed order 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6172,6 +6172,7 @@ exports[`OrderDetails renders a pending order 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6183,7 +6184,6 @@ exports[`OrderDetails renders a pending order 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -7646,6 +7646,7 @@ exports[`OrderDetails renders an empty screen layout if there is no order 1`] = 
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -7657,7 +7658,6 @@ exports[`OrderDetails renders an empty screen layout if there is no order 1`] = 
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8089,6 +8089,7 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8100,7 +8101,6 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8738,6 +8738,7 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8749,7 +8750,6 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -10294,6 +10294,7 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -10305,7 +10306,6 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -11855,6 +11855,7 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -11866,7 +11867,6 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -13329,6 +13329,7 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -13340,7 +13341,6 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/PaymentMethods/__snapshots__/PaymentMethods.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`PaymentMethods View renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -192,7 +193,6 @@ exports[`PaymentMethods View renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1644,6 +1644,7 @@ exports[`PaymentMethods View renders correctly for sell 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1655,7 +1656,6 @@ exports[`PaymentMethods View renders correctly for sell 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3107,6 +3107,7 @@ exports[`PaymentMethods View renders correctly while loading 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3118,7 +3119,6 @@ exports[`PaymentMethods View renders correctly while loading 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4348,6 +4348,7 @@ exports[`PaymentMethods View renders correctly with empty data 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4359,7 +4360,6 @@ exports[`PaymentMethods View renders correctly with empty data 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -5022,6 +5022,7 @@ exports[`PaymentMethods View renders correctly with empty data for sell 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -5033,7 +5034,6 @@ exports[`PaymentMethods View renders correctly with empty data for sell 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -5696,6 +5696,7 @@ exports[`PaymentMethods View renders correctly with error 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -5707,7 +5708,6 @@ exports[`PaymentMethods View renders correctly with error 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6368,6 +6368,7 @@ exports[`PaymentMethods View renders correctly with null data 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6379,7 +6380,6 @@ exports[`PaymentMethods View renders correctly with null data 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -7609,6 +7609,7 @@ exports[`PaymentMethods View renders correctly with payment method with disclaim
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -7620,7 +7621,6 @@ exports[`PaymentMethods View renders correctly with payment method with disclaim
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -9130,6 +9130,7 @@ exports[`PaymentMethods View renders correctly with sdkError 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -9141,7 +9142,6 @@ exports[`PaymentMethods View renders correctly with sdkError 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -9779,6 +9779,7 @@ exports[`PaymentMethods View renders correctly with show back button false 1`] =
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -9790,7 +9791,6 @@ exports[`PaymentMethods View renders correctly with show back button false 1`] =
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -705,6 +705,7 @@ exports[`Quotes renders animation on first fetching 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -716,7 +717,6 @@ exports[`Quotes renders animation on first fetching 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -2944,6 +2944,7 @@ exports[`Quotes renders correctly after animation with quotes 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -2955,7 +2956,6 @@ exports[`Quotes renders correctly after animation with quotes 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4315,6 +4315,7 @@ exports[`Quotes renders correctly after animation with quotes and expanded 2`] =
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4326,7 +4327,6 @@ exports[`Quotes renders correctly after animation with quotes and expanded 2`] =
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6070,6 +6070,7 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6081,7 +6082,6 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6828,6 +6828,7 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6839,7 +6840,6 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -7586,6 +7586,7 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -7597,7 +7598,6 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -8344,6 +8344,7 @@ exports[`Quotes renders quotes expired screen 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -8355,7 +8356,6 @@ exports[`Quotes renders quotes expired screen 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Regions View renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -169,7 +170,6 @@ exports[`Regions View renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -974,6 +974,7 @@ exports[`Regions View renders correctly while loading 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -985,7 +986,6 @@ exports[`Regions View renders correctly while loading 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1585,6 +1585,7 @@ exports[`Regions View renders correctly with error 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1596,7 +1597,6 @@ exports[`Regions View renders correctly with error 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -2234,6 +2234,7 @@ exports[`Regions View renders correctly with no data 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -2245,7 +2246,6 @@ exports[`Regions View renders correctly with no data 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -2845,6 +2845,7 @@ exports[`Regions View renders correctly with sdkError 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -2856,7 +2857,6 @@ exports[`Regions View renders correctly with sdkError 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -3494,6 +3494,7 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -3505,7 +3506,6 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -4308,6 +4308,7 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -4319,7 +4320,6 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -5497,6 +5497,7 @@ exports[`Regions View renders correctly with unsupportedRegion 2`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -5508,7 +5509,6 @@ exports[`Regions View renders correctly with unsupportedRegion 2`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -6686,6 +6686,7 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -6697,7 +6698,6 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/UI/Ramp/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/SendTransaction/__snapshots__/SendTransaction.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`SendTransaction View renders correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -192,7 +193,6 @@ exports[`SendTransaction View renders correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -996,6 +996,7 @@ exports[`SendTransaction View renders correctly for custom action payment method
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1007,7 +1008,6 @@ exports[`SendTransaction View renders correctly for custom action payment method
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {
@@ -1727,6 +1727,7 @@ exports[`SendTransaction View renders correctly for token 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -1738,7 +1739,6 @@ exports[`SendTransaction View renders correctly for token 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/Views/confirmations/Send/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/Send/__snapshots__/index.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`Accounts should render correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -192,7 +193,6 @@ exports[`Accounts should render correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {

--- a/app/components/Views/confirmations/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`Confirm should render correctly 1`] = `
                 <View
                   style={
                     {
+                      "alignItems": "center",
                       "flexDirection": "row",
                     }
                   }
@@ -190,7 +191,6 @@ exports[`Confirm should render correctly 1`] = `
                           "borderRadius": 100,
                           "height": 5,
                           "marginRight": 5,
-                          "marginTop": 4,
                           "width": 5,
                         },
                         {


### PR DESCRIPTION
## **Description**

The active network icon in the header has too much margin and is misaligned with the network title. 

I have also added an optional prop of `networkName`  that allows developers to pass in the network name of their choice. This is in preparation of [multichain](https://github.com/MetaMask/metamask-mobile/pull/12256) support, currently we are showing the selected network name, in multichain we want to be able to pass in a network name and not the selected chain.

## **Related issues**
Fixes: 

## **Manual testing steps**
1. Goto asset details, swaps, or buy. Basically any screen that has the header with network name
2.
3.

## **Screenshots/Recordings**
(green icon at the very top)
| Before  | After  |
|:---:|:---:|
|![asset_details_ios_before](https://github.com/user-attachments/assets/26de61bb-a217-456f-9d40-8bc552f4b1ec)|![asset_details_ios_after](https://github.com/user-attachments/assets/a4d4667b-4b1f-485c-a9f9-ef78872da772)|

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
