### PR TITLE
fix: Decrease unlock time

### DIFF
--- a/app/core/Encryptor/lib.ts
+++ b/app/core/Encryptor/lib.ts
@@ -52,6 +52,8 @@ class AesEncryptionLibrary implements EncryptionLibrary {
 
   decrypt = async (data: string, key: string, iv: unknown): Promise<string> =>
     await Aes.decrypt(data, key, iv, CipherAlgorithm.cbc);
+
+  pbkdf2 = Aes.pbkdf2;
 }
 
 class AesForkedEncryptionLibrary implements EncryptionLibrary {
@@ -87,6 +89,8 @@ class AesForkedEncryptionLibrary implements EncryptionLibrary {
 
   decrypt = async (data: string, key: string, iv: unknown): Promise<string> =>
     await AesForked.decrypt(data, key, iv);
+
+  pbkdf2 = AesForked.pbkdf2;
 }
 
 // Those wrappers are stateless, we can build them only once!

--- a/app/core/Engine.ts
+++ b/app/core/Engine.ts
@@ -161,7 +161,11 @@ import {
   LedgerMobileBridge,
   LedgerTransportMiddleware,
 } from '@metamask/eth-ledger-bridge-keyring';
-import { Encryptor, LEGACY_DERIVATION_OPTIONS } from './Encryptor';
+import {
+  ENCRYPTION_LIBRARY,
+  Encryptor,
+  LEGACY_DERIVATION_OPTIONS,
+} from './Encryptor';
 import {
   isMainnetByChainId,
   fetchEstimatedMultiLayerL1Fee,
@@ -270,6 +274,7 @@ import { trace } from '../util/trace';
 import { MetricsEventBuilder } from './Analytics/MetricsEventBuilder';
 import { JsonMap } from './Analytics/MetaMetrics.types';
 import { isPooledStakingFeatureEnabled } from '../components/UI/Stake/constants';
+import { getEncryptionLibrary } from './Encryptor/lib';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -824,6 +829,8 @@ export class Engine {
       state: initialKeyringState || initialState.KeyringController,
       // @ts-expect-error To Do: Update the type of QRHardwareKeyring to Keyring<Json>
       keyringBuilders: additionalKeyrings,
+      pbkdf2MobileNative: getEncryptionLibrary(ENCRYPTION_LIBRARY.original)
+        .pbkdf2,
     });
 
     ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)

--- a/patches/@metamask+eth-hd-keyring+7.0.4.patch
+++ b/patches/@metamask+eth-hd-keyring+7.0.4.patch
@@ -1,0 +1,62 @@
+diff --git a/node_modules/@metamask/eth-hd-keyring/index.js b/node_modules/@metamask/eth-hd-keyring/index.js
+index 46a634e..58dd033 100644
+--- a/node_modules/@metamask/eth-hd-keyring/index.js
++++ b/node_modules/@metamask/eth-hd-keyring/index.js
+@@ -26,15 +26,17 @@ const hdPathString = `m/44'/60'/0'/0`;
+ const type = 'HD Key Tree';
+ 
+ class HdKeyring {
++  pbkdf2MobileNative = undefined;
+   /* PUBLIC METHODS */
+-  constructor(opts = {}) {
++  constructor(pbkdf2MobileNative) {
+     this.type = type;
+     this._wallets = [];
+-    this.deserialize(opts);
++    this.deserialize();
++    this.pbkdf2MobileNative = pbkdf2MobileNative;
+   }
+ 
+-  generateRandomMnemonic() {
+-    this._initFromMnemonic(bip39.generateMnemonic(wordlist));
++  async generateRandomMnemonic() {
++   await this._initFromMnemonic(bip39.generateMnemonic(wordlist));
+   }
+ 
+   _uint8ArrayToString(mnemonic) {
+@@ -92,7 +94,7 @@ class HdKeyring {
+     });
+   }
+ 
+-  deserialize(opts = {}) {
++  async deserialize(opts = {}) {    
+     if (opts.numberOfAccounts && !opts.mnemonic) {
+       throw new Error(
+         'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
+@@ -111,7 +113,7 @@ class HdKeyring {
+     this.hdPath = opts.hdPath || hdPathString;
+ 
+     if (opts.mnemonic) {
+-      this._initFromMnemonic(opts.mnemonic);
++      await this._initFromMnemonic(opts.mnemonic);
+     }
+ 
+     if (opts.numberOfAccounts) {
+@@ -277,7 +279,7 @@ class HdKeyring {
+    * as a string, an array of UTF-8 bytes, or a Buffer. Mnemonic input
+    * passed as type buffer or array of UTF-8 bytes must be NFKD normalized.
+    */
+-  _initFromMnemonic(mnemonic) {
++ async _initFromMnemonic(mnemonic) {
+     if (this.root) {
+       throw new Error(
+         'Eth-Hd-Keyring: Secret recovery phrase already provided',
+@@ -295,7 +297,7 @@ class HdKeyring {
+     }
+     
+     // eslint-disable-next-line n/no-sync
+-    const seed = bip39.mnemonicToSeedSync(this.mnemonic, wordlist);
++    const seed = await bip39.mnemonicToSeedSync(this.mnemonic, wordlist, '', this.pbkdf2MobileNative);
+     this.hdWallet = HDKey.fromMasterSeed(seed);
+     this.root = this.hdWallet.derive(this.hdPath);
+   }

--- a/patches/@metamask+keyring-controller+17.3.1.patch
+++ b/patches/@metamask+keyring-controller+17.3.1.patch
@@ -1,0 +1,68 @@
+diff --git a/node_modules/@metamask/keyring-controller/dist/KeyringController.cjs b/node_modules/@metamask/keyring-controller/dist/KeyringController.cjs
+index a12a342..bf66879 100644
+--- a/node_modules/@metamask/keyring-controller/dist/KeyringController.cjs
++++ b/node_modules/@metamask/keyring-controller/dist/KeyringController.cjs
+@@ -118,15 +118,21 @@ var SignTypedDataVersion;
+  * @param KeyringConstructor - The Keyring class for the builder.
+  * @returns A builder function for the given Keyring.
+  */
+-function keyringBuilderFactory(KeyringConstructor) {
+-    const builder = () => new KeyringConstructor();
++function keyringBuilderFactory(KeyringConstructor, pbkdf2MobileNative) {
++let builder = undefined
++    if(pbkdf2MobileNative){
++     builder = () => new KeyringConstructor(pbkdf2MobileNative);
++    }else{
++     builder = () => new KeyringConstructor();
++    }
+     builder.type = KeyringConstructor.type;
++    
+     return builder;
+ }
+ exports.keyringBuilderFactory = keyringBuilderFactory;
+-const defaultKeyringBuilders = [
++const defaultKeyringBuilders = (pbkdf2MobileNative) => [
+     keyringBuilderFactory(eth_simple_keyring_1.default),
+-    keyringBuilderFactory(eth_hd_keyring_1.default),
++    pbkdf2MobileNative ?  keyringBuilderFactory(eth_hd_keyring_1.default, pbkdf2MobileNative) : keyringBuilderFactory(eth_hd_keyring_1.default),
+ ];
+ const getDefaultKeyringState = () => {
+     return {
+@@ -256,7 +262,7 @@ class KeyringController extends base_controller_1.BaseController {
+      * @param options.state - Initial state to set on this controller.
+      */
+     constructor(options) {
+-        const { encryptor = encryptorUtils, keyringBuilders, messenger, state, } = options;
++        const { encryptor = encryptorUtils, keyringBuilders, messenger, state, pbkdf2MobileNative } = options;
+         super({
+             name,
+             metadata: {
+@@ -283,8 +289,8 @@ class KeyringController extends base_controller_1.BaseController {
+         _KeyringController_cacheEncryptionKey.set(this, void 0);
+         _KeyringController_qrKeyringStateListener.set(this, void 0);
+         __classPrivateFieldSet(this, _KeyringController_keyringBuilders, keyringBuilders
+-            ? keyringBuilders.concat(defaultKeyringBuilders)
+-            : defaultKeyringBuilders, "f");
++            ? keyringBuilders.concat(defaultKeyringBuilders(pbkdf2MobileNative))
++            : defaultKeyringBuilders(pbkdf2MobileNative), "f");
+         __classPrivateFieldSet(this, _KeyringController_encryptor, encryptor, "f");
+         __classPrivateFieldSet(this, _KeyringController_keyrings, [], "f");
+         __classPrivateFieldSet(this, _KeyringController_unsupportedKeyrings, [], "f");
+@@ -1388,6 +1394,7 @@ async function _KeyringController_newKeyring(type, data) {
+     const keyring = keyringBuilder();
+     // @ts-expect-error Enforce data type after updating clients
+     await keyring.deserialize(data);
++    
+     if (keyring.init) {
+         await keyring.init();
+     }
+@@ -1395,7 +1402,8 @@ async function _KeyringController_newKeyring(type, data) {
+         if (!keyring.generateRandomMnemonic) {
+             throw new Error(constants_1.KeyringControllerError.UnsupportedGenerateRandomMnemonic);
+         }
+-        keyring.generateRandomMnemonic();
++
++        await keyring.generateRandomMnemonic();
+         await keyring.addAccounts(1);
+     }
+     await __classPrivateFieldGet(this, _KeyringController_instances, "m", _KeyringController_checkForDuplicate).call(this, type, await keyring.getAccounts());

--- a/patches/@metamask+scure-bip39+2.1.1.patch
+++ b/patches/@metamask+scure-bip39+2.1.1.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/@metamask/scure-bip39/dist/index.js b/node_modules/@metamask/scure-bip39/dist/index.js
+index e0c500c..e4d99e9 100644
+--- a/node_modules/@metamask/scure-bip39/dist/index.js
++++ b/node_modules/@metamask/scure-bip39/dist/index.js
+@@ -1,6 +1,7 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.mnemonicToSeedSync = exports.mnemonicToSeed = exports.validateMnemonic = exports.entropyToMnemonic = exports.mnemonicToEntropy = exports.generateMnemonic = void 0;
++const { bytesToString, hexToBytes } = require("@metamask/utils");
+ /*! scure-bip39 - MIT License (c) 2022 Patricio Palladino, Paul Miller (paulmillr.com) */
+ const _assert_1 = require("@noble/hashes/_assert");
+ const pbkdf2_1 = require("@noble/hashes/pbkdf2");
+@@ -146,8 +147,18 @@ exports.mnemonicToSeed = mnemonicToSeed;
+  * mnemonicToSeedSync(mnem, 'password');
+  * // new Uint8Array([...64 bytes])
+  */
+-function mnemonicToSeedSync(mnemonic, wordlist, passphrase = '') {
++async function mnemonicToSeedSync(mnemonic, wordlist, passphrase = '', pbkdf2MobileNative = undefined) {
+     const encodedMnemonicUint8Array = encodeMnemonicForSeedDerivation(mnemonic, wordlist);
++    if(pbkdf2MobileNative){
++        const key =  await pbkdf2MobileNative(bytesToString(encodedMnemonicUint8Array),
++        'mnemonic',
++        2048,
++        512,
++        'sha512');
++        const keyInbytes = hexToBytes(key);        
++        return keyInbytes;
++    }
++
+     return (0, pbkdf2_1.pbkdf2)(sha512_1.sha512, encodedMnemonicUint8Array, salt(passphrase), { c: 2048, dkLen: 64 });
+ }
+ exports.mnemonicToSeedSync = mnemonicToSeedSync;


### PR DESCRIPTION
## **Description**

THIS PR IMPROVED THE UNLOCK TIME (AFTER USER PRESSES UNLOCK UNTIL THE WALLET VIEW), OF 18 SECONDS (debug mode)
Previous unlock duration: ~25 seconds
New unlock duration: ~7 seconds
And from ~10 seconds to ~4 seconds 
(Android QA build)! 
Previous unlock duration: ~10 seconds
New unlock duration: ~4 seconds

We will be able to drop our baseline on our performance E2E testing, seeing results in this [build](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/b59e9827-b897-4769-8fee-9b0c50a65992?tab=workflows) time that it takes for a cold app start to the wallet view, reducing 30% (1.4 seconds) of the time, compared to last main build  (Android)

This PR patch scure-bip39, eth-hd-keyring and keyring controller to use the native aes module instead.

This patch will be replaced for ongoing work on Keyring Controller,  key-tree, and eth-hd-keyring

These are the next steps that need to be taken to ship this:
* Reviews & merge https://github.com/MetaMask/accounts/pull/100
* Release [key-tree](https://github.com/MetaMask/key-tree) last version
* Update https://github.com/MetaMask/accounts/pull/102 with key-tree last version
* Refine Keyring Controller with the necessary changes to use the new eth-hd-keyring or create a keyring builder from mobile when [concat](https://github.com/MetaMask/core/blob/5f6b020693b6497c40728e80c281b5cc3028c542/packages/keyring-controller/src/KeyringController.ts#L649) issue is fixed to be able to override hd-keyring from the Keyring Controller consumer
* We can use this bump [PR](https://github.com/MetaMask/metamask-mobile/pull/12339) of KeyringController to bring those changes to mbile



PR smoke e2e pipeline: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/2fe81597-0389-43e3-87f1-b74b905707f2?tab=workflows

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

(DEBUG)
https://github.com/user-attachments/assets/0d58ae22-84bb-463d-8948-da06649cd303

(QA)

https://github.com/user-attachments/assets/706ae004-6c12-44a6-ad3f-b976fe0d7333



### **After**

(DEBUG)
https://github.com/user-attachments/assets/009f2ef4-5239-4944-979a-bd57adcc1d26

(QA)
https://github.com/user-attachments/assets/3e264ce5-0842-480b-b9bf-cfd8c6d34258



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
