### PR TITLE
fix: gas fee edit from swaps

### DIFF
--- a/app/components/UI/EditGasFee1559/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/EditGasFee1559/__snapshots__/index.test.tsx.snap
@@ -135,7 +135,40 @@ exports[`EditGasFee1559 should render correctly 1`] = `
             <View>
               <HorizontalSelector
                 onPress={[Function]}
-                options={[Function]}
+                options={
+                  [
+                    {
+                      "label": <Text
+                        bold={true}
+                        primary={false}
+                      >
+                        Low
+                      </Text>,
+                      "name": "low",
+                      "topLabel": false,
+                    },
+                    {
+                      "label": <Text
+                        bold={true}
+                        primary={false}
+                      >
+                        Market
+                      </Text>,
+                      "name": "medium",
+                      "topLabel": false,
+                    },
+                    {
+                      "label": <Text
+                        bold={true}
+                        primary={false}
+                      >
+                        Aggressive
+                      </Text>,
+                      "name": "high",
+                      "topLabel": false,
+                    },
+                  ]
+                }
               />
             </View>
             <View

--- a/app/components/UI/EditGasFee1559/index.js
+++ b/app/components/UI/EditGasFee1559/index.js
@@ -398,7 +398,7 @@ const EditGasFee1559 = ({
           <HorizontalSelector
             selected={selectedOption}
             onPress={selectOption}
-            options={renderOptions}
+            options={renderOptions()}
           />
         </View>
         <View style={styles.advancedOptionsContainer}>


### PR DESCRIPTION
## **Description**

Prevent crash when editing gas fee during swap.

## **Related issues**

Fixes: #12387  #12457

## **Manual testing steps**

See issue.

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/6dd625b2-f18f-496d-9843-118575ed9166

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
