### PR TITLE
chore: Stop suppressing pod install failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,6 @@ jobs:
             --rm \
             -v "$(pwd):/app" -w /app \
             metamask-mobile-builder:latest \
-            bash -c 'yarn && yarn setup --build-ios'
+            bash -c 'yarn && yarn setup --build-ios --no-install-pods'
             # restore ownership for cleanup
             sudo chown -R "$(id -u):$(id -g)" .

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "./scripts/build.sh watcher watch",
     "watch:clean": "./scripts/build.sh watcher clean",
     "clean:ios": "rm -rf ios/build",
-    "pod:install": "command -v pod && bundle exec pod install --project-directory=ios || echo \"pod command not found. Skipping pod install\"",
+    "pod:install": "bundle exec pod install --project-directory=ios",
     "gem:bundle:install": "bundle install --gemfile=ios/Gemfile",
     "clean:ppom": "rm -rf ppom/dist ppom/node_modules app/lib/ppom/ppom.html.js",
     "clean:android": "rm -rf android/app/build",


### PR DESCRIPTION
## **Description**

Pod install failures were suppressed originally to make cross-platform development easier, as they would fail on Windows and Linux (where you would presumably be developing with Android which does not require this step). However, since the introduction of the new setup script, this step will not run on non-macOS machines by default so this error suppression is no longer needed.

This will make install errors easier to discover, saving developer time.

## **Related issues**

N/A

## **Manual testing steps**

To test that there is no regression, simply run `yarn setup`.

I'm not entirely sure how to induce a pod install error. But if you're in a state where pod install fails, then `yarn setup` should now fail as well, where previously it would succeed.

I simulated a failure by updating `pod:install` to say `bundle exec po install` (i.e. delete the `d` from `pod` so that it's an unrecognized command). This failure showed on the CLI as expected on this branch. On `main` it silently failed.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
