### PR TITLE
fix: replace end of navigation init and UIStartup span

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -610,6 +610,13 @@ const App = (props) => {
 
   useEffect(() => {
     if (prevNavigator.current || !navigator) return;
+
+    endTrace({ name: TraceName.NavInit });
+    endTrace({ name: TraceName.UIStartup });
+  }, [navigator]);
+
+  useEffect(() => {
+    if (prevNavigator.current || !navigator) return;
     const appTriggeredAuth = async () => {
       const existingUser = await StorageWrapper.getItem(EXISTING_USER);
       setOnboarded(!!existingUser);
@@ -650,15 +657,9 @@ const App = (props) => {
         );
       }
     };
-    appTriggeredAuth()
-      .catch((error) => {
-        Logger.error(error, 'App: Error in appTriggeredAuth');
-      })
-      .finally(() => {
-        endTrace({ name: TraceName.NavInit });
-
-        endTrace({ name: TraceName.UIStartup });
-      });
+    appTriggeredAuth().catch((error) => {
+      Logger.error(error, 'App: Error in appTriggeredAuth');
+    });
   }, [navigator, queueOfHandleDeeplinkFunctions]);
 
   const handleDeeplink = useCallback(({ error, params, uri }) => {


### PR DESCRIPTION
## **Description**

Replace navigation init and UIStartup Span

* It seems that the span was ending in the finally of appTriggeredAuth, which means that it was ending after Byometrics of the user which was causing this [issue](https://metamask.sentry.io/performance/trace/55c4f7b831bc4c74a6324cfadaeddd1c/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&fov=0%2C300086&name=All%20Errors&node=txn-85cea569b7044459912c0421a46b4ed9&project=2299799&query=&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=24h&timestamp=1732831856&yAxis=count%28%29) (5 minutes long span)

* Moving it to an useEffect that will only trigger the end of the span when the navigator is defined  and there is no prevNavigator ref will means that the traces will end when the biometrics are actually triggered instead of when it is completed

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
