### PR TITLE
ci: disable security e2e tests

### DIFF
--- a/e2e/specs/confirmations/security-alert-send-eth.mock.spec.js
+++ b/e2e/specs/confirmations/security-alert-send-eth.mock.spec.js
@@ -1,6 +1,4 @@
 'use strict';
-
-import { SmokeConfirmations } from '../../tags';
 import TestHelpers from '../../helpers';
 
 import AmountView from '../../pages/Send/AmountView';
@@ -10,13 +8,11 @@ import { loginToApp } from '../../viewHelper';
 import TabBarComponent from '../../pages/TabBarComponent';
 import WalletActionsModal from '../../pages/modals/WalletActionsModal';
 import FixtureBuilder from '../../fixtures/fixture-builder';
-import {
-  withFixtures,
-} from '../../fixtures/fixture-helper';
+import { withFixtures } from '../../fixtures/fixture-helper';
 import { mockEvents } from '../../api-mocking/mock-config/mock-events';
 import Assertions from '../../utils/Assertions';
 
-describe(SmokeConfirmations('Security Alert API - Send flow'), () => {
+describe('Security Alert API - Send flow', () => {
   const BENIGN_ADDRESS_MOCK = '0x50587E46C5B96a3F6f9792922EC647F13E6EFAE4';
 
   beforeAll(async () => {
@@ -52,10 +48,8 @@ describe(SmokeConfirmations('Security Alert API - Send flow'), () => {
 
   it('should not show security alerts for benign requests', async () => {
     const testSpecificMock = {
-      GET: [
-        mockEvents.GET.securityAlertApiSupportedChains,
-      ],
-      POST: [mockEvents.POST.securityAlertApiValidate,]
+      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      POST: [mockEvents.POST.securityAlertApiValidate],
     };
 
     await runTest(testSpecificMock, async () => {
@@ -72,19 +66,19 @@ describe(SmokeConfirmations('Security Alert API - Send flow'), () => {
 
   it('should show security alerts for malicious request', async () => {
     const testSpecificMock = {
-      GET: [
-        mockEvents.GET.securityAlertApiSupportedChains,
-      ],
-      POST: [{
-        ...mockEvents.POST.securityAlertApiValidate,
-        response: {
-          block: 20733277,
-          result_type: 'Malicious',
-          reason: 'transfer_farming',
-          description: '',
-          features: ['Interaction with a known malicious address'],
+      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      POST: [
+        {
+          ...mockEvents.POST.securityAlertApiValidate,
+          response: {
+            block: 20733277,
+            result_type: 'Malicious',
+            reason: 'transfer_farming',
+            description: '',
+            features: ['Interaction with a known malicious address'],
+          },
         },
-      }]
+      ],
     };
 
     await runTest(testSpecificMock, async () => {
@@ -98,19 +92,22 @@ describe(SmokeConfirmations('Security Alert API - Send flow'), () => {
     const testSpecificMock = {
       GET: [
         mockEvents.GET.securityAlertApiSupportedChains,
-        { 
-          urlEndpoint: 'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json',
-          responseCode: 500
-        }
-      ],
-      POST: [{
-        ...mockEvents.POST.securityAlertApiValidate,
-        response: {
-          error: 'Internal Server Error',
-          message: 'An unexpected error occurred on the server.'
+        {
+          urlEndpoint:
+            'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json',
+          responseCode: 500,
         },
-        responseCode: 500
-      }]
+      ],
+      POST: [
+        {
+          ...mockEvents.POST.securityAlertApiValidate,
+          response: {
+            error: 'Internal Server Error',
+            message: 'An unexpected error occurred on the server.',
+          },
+          responseCode: 500,
+        },
+      ],
     };
 
     await runTest(testSpecificMock, async () => {

--- a/e2e/specs/confirmations/signatures/security-alert-typed-sign.mock.spec.js
+++ b/e2e/specs/confirmations/signatures/security-alert-typed-sign.mock.spec.js
@@ -5,16 +5,13 @@ import { loginToApp } from '../../../viewHelper';
 import SigningBottomSheet from '../../../pages/Browser/SigningBottomSheet';
 import TestDApp from '../../../pages/Browser/TestDApp';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
-import {
-  withFixtures,
-} from '../../../fixtures/fixture-helper';
-import { SmokeConfirmations } from '../../../tags';
+import { withFixtures } from '../../../fixtures/fixture-helper';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
 import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 import ConfirmationView from '../../../pages/Confirmation/ConfirmationView';
 
-describe(SmokeConfirmations('Security Alert API - Typed Sign'), () => {
+describe('Security Alert API - Typed Sign', () => {
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -53,27 +50,29 @@ describe(SmokeConfirmations('Security Alert API - Typed Sign'), () => {
     params: [
       [
         { type: 'string', name: 'Message', value: 'Hi, Alice!' },
-        { type: 'uint32', name: 'A number', value: '1337' }
+        { type: 'uint32', name: 'A number', value: '1337' },
       ],
-      '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3'
+      '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
     ],
     origin: 'localhost',
   };
 
   it('should sign typed message', async () => {
     const testSpecificMock = {
-      GET: [
-        mockEvents.GET.securityAlertApiSupportedChains,
+      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      POST: [
+        {
+          ...mockEvents.POST.securityAlertApiValidate,
+          requestBody: typedSignRequestBody,
+        },
       ],
-      POST: [{
-        ...mockEvents.POST.securityAlertApiValidate,
-        requestBody: typedSignRequestBody,
-      }]
     };
 
     await runTest(testSpecificMock, async () => {
       try {
-        await Assertions.checkIfNotVisible(ConfirmationView.securityAlertBanner);
+        await Assertions.checkIfNotVisible(
+          ConfirmationView.securityAlertBanner,
+        );
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('The banner alert is not visible');
@@ -83,20 +82,20 @@ describe(SmokeConfirmations('Security Alert API - Typed Sign'), () => {
 
   it('should show security alert for malicious request', async () => {
     const testSpecificMock = {
-      GET: [
-        mockEvents.GET.securityAlertApiSupportedChains,
-      ],
-      POST: [{
-        ...mockEvents.POST.securityAlertApiValidate,
-        requestBody: typedSignRequestBody,
-        response: {
-          block: 20733277,
-          result_type: 'Malicious',
-          reason: 'malicious_domain',
-          description: `You're interacting with a malicious domain. If you approve this request, you might lose your assets.`,
-          features: [],
+      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      POST: [
+        {
+          ...mockEvents.POST.securityAlertApiValidate,
+          requestBody: typedSignRequestBody,
+          response: {
+            block: 20733277,
+            result_type: 'Malicious',
+            reason: 'malicious_domain',
+            description: `You're interacting with a malicious domain. If you approve this request, you might lose your assets.`,
+            features: [],
+          },
         },
-      }]
+      ],
     };
 
     await runTest(testSpecificMock, async () => {
@@ -109,23 +108,28 @@ describe(SmokeConfirmations('Security Alert API - Typed Sign'), () => {
       GET: [
         mockEvents.GET.securityAlertApiSupportedChains,
         {
-          urlEndpoint: 'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json',
-          responseCode: 500
-        }
-      ],
-      POST: [{
-        ...mockEvents.POST.securityAlertApiValidate,
-        requestBody: typedSignRequestBody,
-        response: {
-          error: 'Internal Server Error',
-          message: 'An unexpected error occurred on the server.'
+          urlEndpoint:
+            'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json',
+          responseCode: 500,
         },
-        responseCode: 500
-      }]
+      ],
+      POST: [
+        {
+          ...mockEvents.POST.securityAlertApiValidate,
+          requestBody: typedSignRequestBody,
+          response: {
+            error: 'Internal Server Error',
+            message: 'An unexpected error occurred on the server.',
+          },
+          responseCode: 500,
+        },
+      ],
     };
 
     await runTest(testSpecificMock, async () => {
-      await Assertions.checkIfVisible(ConfirmationView.securityAlertResponseFailedBanner);
+      await Assertions.checkIfVisible(
+        ConfirmationView.securityAlertResponseFailedBanner,
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The purpose of this PR is to temporarily disable the e2e tests added [here](https://github.com/MetaMask/metamask-mobile/pull/12288) as it introduces instability within the smoke pipeline.  

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
