### PR TITLE
chore: fail status when on no labels for retro-label changes

### DIFF
--- a/.github/scripts/bitrise/run-bitrise-e2e-check.ts
+++ b/.github/scripts/bitrise/run-bitrise-e2e-check.ts
@@ -125,8 +125,6 @@ async function main(): Promise<void> {
       },
     });
 
-    console.log(createStatusCheckResponse)
-
     if (createStatusCheckResponse.status === 201) {
       console.log(
         `Created '${statusCheckName}' check with failed status for commit ${latestCommitHash}`,

--- a/.github/scripts/bitrise/run-bitrise-e2e-check.ts
+++ b/.github/scripts/bitrise/run-bitrise-e2e-check.ts
@@ -125,6 +125,8 @@ async function main(): Promise<void> {
       },
     });
 
+    console.log(createStatusCheckResponse)
+
     if (createStatusCheckResponse.status === 201) {
       console.log(
         `Created '${statusCheckName}' check with failed status for commit ${latestCommitHash}`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Addresses a scenario where a commit has been evaluated already with label existence but we want to re-evaluate the status check if the labels change. Fail the E2E Status Check when there's no label present.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

Some edge-cases where labels may be retro-actively changed or removed after a status check has been evaluated already

## **Manual testing steps**

CI/CD Testing PR scenario

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A CICD Only

### **After**

N/A CICD Only

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
