### PR TITLE
chore: cicd e2e hardening

### DIFF
--- a/.github/scripts/bitrise/run-bitrise-e2e-check.ts
+++ b/.github/scripts/bitrise/run-bitrise-e2e-check.ts
@@ -76,6 +76,9 @@ async function main(): Promise<void> {
   console.log(`event: ${context.eventName}`);
   console.log(`pullRequestNumber: ${pullRequestNumber}`);
 
+  const mergeQueue = (context.eventName === 'merge_group')
+  const mqCommitHash = context.payload?.merge_group?.head_sha;
+
 
   const octokit: InstanceType<typeof GitHub> = getOctokit(githubToken);
 
@@ -85,17 +88,17 @@ async function main(): Promise<void> {
     pull_number: pullRequestNumber,
   });
 
-  const docs = prData.title.startsWith("docs:");
-
   // Get the latest commit hash
-  const latestCommitHash = prData.head.sha;
+  const prCommitHash = prData?.head?.sha;
+  // Determine the latest commit hash depending if it's a PR or MQ
+  const latestCommitHash = mergeQueue ? mqCommitHash : prCommitHash;
 
-  // Grab flags and labels
-  const labels = prData.labels;
+  // Grab flags & labels
+  const labels = prData?.labels ?? [];
   const hasSmokeTestLabel = labels.some((label) => label.name === e2eLabel);
   const hasAntiLabel = labels.some((label) => label.name === antiLabel);
   const fork = context.payload.pull_request?.head.repo.fork || false;
-  const mergeQueue = (context.eventName === 'merge_group')
+  const docs = mergeQueue ? false : prData.title.startsWith("docs:");
 
 
   console.log(`Docs: ${docs}`);
@@ -107,8 +110,8 @@ async function main(): Promise<void> {
   const [shouldRun, reason] = shouldRunBitriseE2E(hasAntiLabel, hasSmokeTestLabel, docs, fork, mergeQueue);
   console.log(`Should run: ${shouldRun}, Reason: ${reason}`);
 
-  // One of these two labels must exist if not we bomb out
-  if (!hasSmokeTestLabel && !hasAntiLabel) {
+  // One of these two labels must exist for pull_request type
+  if (!mergeQueue && !hasSmokeTestLabel && !hasAntiLabel) {
 
     // Fail Status due to missing labels
     const createStatusCheckResponse = await octokit.rest.checks.create({

--- a/.github/scripts/bitrise/run-bitrise-e2e-check.ts
+++ b/.github/scripts/bitrise/run-bitrise-e2e-check.ts
@@ -149,6 +149,7 @@ async function main(): Promise<void> {
       `Skipping Bitrise status check. due to the following reason: ${reason}`,
     );
 
+    
     // Post success status (skipped)
     const createStatusCheckResponse = await octokit.rest.checks.create({
       owner,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Handle scenarios where MQ and PR context is different when executing in the merge queue context

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:
The E2E Bitrise status from not being in a completed state when in the MQ

## **Manual testing steps**

Tested in alternate repo replicating setup
https://github.com/MetaMask/temp-gh-action-testing/actions/runs/12169779361/job/33943429158 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A CICD Only

### **After**

<!-- [screenshots/recordings] -->
N/A CICD Only

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
