### PR TITLE
chore: Add option to skip pod install setup step

### DIFF
--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -9,6 +9,7 @@ const IS_OSX = process.platform === 'darwin';
 // iOS builds are enabled by default on macOS only but can be enabled or disabled explicitly
 let BUILD_IOS = IS_OSX;
 let IS_NODE = false;
+let INSTALL_PODS;
 const args = process.argv.slice(2) || [];
 for (const arg of args) {
   switch (arg) {
@@ -18,12 +19,24 @@ for (const arg of args) {
     case '--no-build-ios':
       BUILD_IOS = false;
       continue;
+    case '--install-pods':
+      INSTALL_PODS = true;
+      continue;
+    case '--no-install-pods':
+      INSTALL_PODS = false;
+      continue;
     case '--node':
       IS_NODE = true;
       continue;
     default:
       throw new Error(`Unrecognized CLI arg ${arg}`);
   }
+}
+if (INSTALL_PODS === undefined) {
+  INSTALL_PODS = BUILD_IOS;
+}
+if (INSTALL_PODS && !BUILD_IOS) {
+  throw new Error('Cannot install pods if iOS setup has been skipped');
 }
 
 const rendererOptions = {
@@ -143,34 +156,39 @@ const setupIosTask = {
       return task.skip('Skipping iOS set up.');
     }
 
+    const tasks = [
+      {
+        title: 'Install bundler gem',
+        task: async () => {
+          await $`gem install bundler -v 2.5.8`;
+        },
+      },
+      {
+        title: 'Install gems',
+        task: async () => {
+          await $`yarn gem:bundle:install`;
+        },
+      },
+      {
+        title: 'Create xcconfig files',
+        task: async () => {
+          fs.writeFileSync('ios/debug.xcconfig', '');
+          fs.writeFileSync('ios/release.xcconfig', '');
+        },
+      },
+    ];
+
+    if (INSTALL_PODS) {
+      tasks.push({
+        title: 'Install CocoaPods',
+        task: async () => {
+          await $`yarn pod:install`;
+        },
+      });
+    }
+
     return task.newListr(
-      [
-        {
-          title: 'Install bundler gem',
-          task: async () => {
-            await $`gem install bundler -v 2.5.8`;
-          },
-        },
-        {
-          title: 'Install gems',
-          task: async () => {
-            await $`yarn gem:bundle:install`;
-          },
-        },
-        {
-          title: 'Create xcconfig files',
-          task: async () => {
-            fs.writeFileSync('ios/debug.xcconfig', '');
-            fs.writeFileSync('ios/release.xcconfig', '');
-          },
-        },
-        {
-          title: 'Install CocoaPods',
-          task: async () => {
-            await $`yarn pod:install`;
-          },
-        },
-      ],
+      tasks,
       {
         concurrent: false,
         exitOnError: true,


### PR DESCRIPTION
## **Description**

Add `--pod-install` and `--no-pod-install` options to the setup script. This allows skipping the pod installation. This is required as a temporary workaround for `pod install` being broken at the moment in the docker workflow.

## **Related issues**

N/A

## **Manual testing steps**

On macOS:
* Run `yarn setup`, and confirm that the pod install step is run
* Run `yarn setup --install-pods --no-build-ios`,  and confirm that an error is thrown
* Run `yarn setup --no-install-pods`, and confirm that the pod install step is not run.

On non-macOS:
* Run `yarn setup`, and confirm that the pod install step is not run
* Run `yarn setup --install-pods`,  and confirm that an error is thrown
* Run `yarn setup --build-ios --no-install-pods`, and confirm that the iOS build steps are run but not the pod install step.



## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
