### PR TITLE
fix(12550): adding popular network no longer switches network filter

### DIFF
--- a/app/components/UI/NetworkModal/index.tsx
+++ b/app/components/UI/NetworkModal/index.tsx
@@ -24,7 +24,10 @@ import {
 import { useTheme } from '../../../util/theme';
 import { networkSwitched } from '../../../actions/onboardNetwork';
 import { NetworkApprovalBottomSheetSelectorsIDs } from '../../../../e2e/selectors/Network/NetworkApprovalBottomSheet.selectors';
-import { selectUseSafeChainsListValidation } from '../../../selectors/preferencesController';
+import {
+  selectTokenNetworkFilter,
+  selectUseSafeChainsListValidation,
+} from '../../../selectors/preferencesController';
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../component-library/components/BottomSheets/BottomSheetFooter';
@@ -36,7 +39,10 @@ import { useMetrics } from '../../../components/hooks/useMetrics';
 import { toHex } from '@metamask/controller-utils';
 import { rpcIdentifierUtility } from '../../../components/hooks/useSafeChains';
 import Logger from '../../../util/Logger';
-import { selectNetworkConfigurations } from '../../../selectors/networkController';
+import {
+  selectNetworkConfigurations,
+  selectIsAllNetworks,
+} from '../../../selectors/networkController';
 import {
   NetworkConfiguration,
   RpcEndpointType,
@@ -87,6 +93,7 @@ const NetworkModals = (props: NetworkProps) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [networkAdded, setNetworkAdded] = React.useState(false);
   const [showCheckNetwork, setShowCheckNetwork] = React.useState(false);
+  const tokenNetworkFilter = useSelector(selectTokenNetworkFilter);
   const [alerts, setAlerts] = React.useState<
     {
       alertError: string;
@@ -98,6 +105,7 @@ const NetworkModals = (props: NetworkProps) => {
   const isCustomNetwork = true;
   const showDetailsModal = () => setShowDetails(!showDetails);
   const showCheckNetworkModal = () => setShowCheckNetwork(!showCheckNetwork);
+  const isAllNetworks = useSelector(selectIsAllNetworks);
 
   const { colors } = useTheme();
   const styles = createNetworkModalStyles(colors);
@@ -121,10 +129,17 @@ const NetworkModals = (props: NetworkProps) => {
 
   const onUpdateNetworkFilter = useCallback(() => {
     const { PreferencesController } = Engine.context;
-    PreferencesController.setTokenNetworkFilter({
-      [customNetworkInformation.chainId]: true,
-    });
-  }, [customNetworkInformation.chainId]);
+    if (!isAllNetworks) {
+      PreferencesController.setTokenNetworkFilter({
+        [customNetworkInformation.chainId]: true,
+      });
+    } else {
+      PreferencesController.setTokenNetworkFilter({
+        ...tokenNetworkFilter,
+        [customNetworkInformation.chainId]: true,
+      });
+    }
+  }, [customNetworkInformation.chainId, isAllNetworks, tokenNetworkFilter]);
 
   const addNetwork = async () => {
     const isValidUrl = validateRpcUrl(rpcUrl);

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -12,6 +12,7 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import Logger from '../../../util/Logger';
 import {
   selectChainId,
+  selectIsAllNetworks,
   selectNetworkConfigurations,
 } from '../../../selectors/networkController';
 import {
@@ -46,7 +47,6 @@ import {
 import ButtonBase from '../../../component-library/components/Buttons/Button/foundation/ButtonBase';
 import { selectNetworkName } from '../../../selectors/networkInfos';
 import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
-import { enableAllNetworksFilter } from './util/enableAllNetworksFilter';
 import { selectAccountTokensAcrossChains } from '../../../selectors/multichain';
 import { filterAssets } from './util/filterAssets';
 
@@ -111,7 +111,6 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
       ),
     ),
   ];
-  const allNetworks = useSelector(selectNetworkConfigurations);
   const selectedAccountTokensChains = useSelector(
     selectAccountTokensAcrossChains,
   );
@@ -120,10 +119,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const [tokenToRemove, setTokenToRemove] = useState<TokenI>();
   const [refreshing, setRefreshing] = useState(false);
   const [isAddTokenEnabled, setIsAddTokenEnabled] = useState(true);
-  const allNetworksEnabled = useMemo(
-    () => enableAllNetworksFilter(allNetworks),
-    [allNetworks],
-  );
+  const isAllNetworks = useSelector(selectIsAllNetworks);
 
   const styles = createStyles(colors);
 
@@ -341,10 +337,6 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const onActionSheetPress = (index: number) =>
     index === 0 ? removeToken() : null;
 
-  const allNetworksFilterShown =
-    Object.keys(tokenNetworkFilter).length !==
-    Object.keys(allNetworksEnabled).length;
-
   useEffect(() => {
     const { PreferencesController } = Engine.context;
     if (isTestNet(currentChainId)) {
@@ -365,9 +357,9 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
             <ButtonBase
               label={
                 <Text style={styles.controlButtonText} numberOfLines={1}>
-                  {allNetworksFilterShown
-                    ? networkName ?? strings('wallet.current_network')
-                    : strings('wallet.all_networks')}
+                  {isAllNetworks
+                    ? strings('wallet.all_networks')
+                    : networkName ?? strings('wallet.current_network')}
                 </Text>
               }
               isDisabled={isTestNet(currentChainId)}


### PR DESCRIPTION
## **Description**

Fixed an issue where adding a popular network switches the network filter. For example if the user is on "All Networks" and they add a popular network such as Avalanche, the network switcher reverts to that network, instead it should stay at "All Networks"

## **Related issues**

Fixes: [#12550](https://github.com/MetaMask/metamask-mobile/issues/12550)

## **Manual testing steps**

1. Click on "All Networks" filter
2. Click on the network tab, then add a popular network such as Avalanche
3. Make sure the network filter stays at "All Networks"

## **Screenshots/Recordings**

NA

### **Before**

See video of before in [issue](https://github.com/MetaMask/metamask-mobile/issues/12550)

### **After**

https://github.com/user-attachments/assets/49577d3d-d329-4cfd-8341-dee70c33d754

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
