### PR TITLE
chore: pin react-native-tcp to hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "react-native-svg": "^15.3.0",
     "react-native-svg-charts": "^5.4.0",
     "react-native-swipe-gestures": "1.0.3",
-    "react-native-tcp": "aprock/react-native-tcp#11/head",
+    "react-native-tcp": "aprock/react-native-tcp#98fbc801f0586297f16730b2f4c75eef15dfabcd",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "6.4.2",
     "react-native-video": "5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25065,7 +25065,7 @@ react-native-swipe-gestures@^1.0.5:
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
 
-react-native-tcp@aprock/react-native-tcp#11/head:
+react-native-tcp@aprock/react-native-tcp#98fbc801f0586297f16730b2f4c75eef15dfabcd:
   version "4.0.0"
   resolved "https://codeload.github.com/aprock/react-native-tcp/tar.gz/98fbc801f0586297f16730b2f4c75eef15dfabcd"
   dependencies:


### PR DESCRIPTION
## **Description**

Fix it to the git commit hash we're using (yarn.lock resolved url tar.gz hash),
instead of the latest commit on a contributor's pr branch on the fork (package.json)

i.e. https://github.com/aprock/react-native-tcp/commit/98fbc801f0586297f16730b2f4c75eef15dfabcd
(note: [`master`](https://github.com/aprock/react-native-tcp/commits/master) is few commits ahead)

note: our [`develop`](https://github.com/MetaMask/metamask-mobile/tree/develop) has two more such cases ([1](https://github.com/MetaMask/metamask-mobile/blob/develop/package.json#L169), [2](https://github.com/MetaMask/metamask-mobile/blob/develop/package.json#L209))

## **Related issues**

Fixes: variable commit hashes, if the lockfile were to be removed/regenerated

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
