### PR TITLE
feat: Hide the smart transaction status page if we return a txHash asap

### DIFF
--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -283,37 +283,53 @@ describe('Smart Transactions utils', () => {
   });
   describe('getShouldStartFlow', () => {
     it('returns true for Send transaction', () => {
-      const res = getShouldStartApprovalRequest(false, true, false, false);
+      const res = getShouldStartApprovalRequest(false, true, false, false, false);
       expect(res).toBe(true);
+    });
+    it('returns false for Send transaction when mobileReturnTxHashAsap is true', () => {
+      const res = getShouldStartApprovalRequest(false, true, false, false, true);
+      expect(res).toBe(false);
     });
     it('returns true for Dapp transaction', () => {
-      const res = getShouldStartApprovalRequest(true, false, false, false);
+      const res = getShouldStartApprovalRequest(true, false, false, false, false);
       expect(res).toBe(true);
     });
+    it('returns false for Dapp transaction when mobileReturnTxHashAsap is true', () => {
+      const res = getShouldStartApprovalRequest(true, false, false, false, true);
+      expect(res).toBe(false);
+    });
     it('returns true for Swap approve transaction', () => {
-      const res = getShouldStartApprovalRequest(false, false, true, false);
+      const res = getShouldStartApprovalRequest(false, false, true, false, false);
       expect(res).toBe(true);
     });
     it('returns false for Swap transaction', () => {
-      const res = getShouldStartApprovalRequest(false, false, false, true);
+      const res = getShouldStartApprovalRequest(false, false, false, true, false);
       expect(res).toBe(false);
     });
   });
   describe('getShouldUpdateFlow', () => {
     it('returns true for Send transaction', () => {
-      const res = getShouldUpdateApprovalRequest(false, true, false);
+      const res = getShouldUpdateApprovalRequest(false, true, false, false);
       expect(res).toBe(true);
+    });
+    it('returns false for Send transaction when mobileReturnTxHashAsap is true', () => {
+      const res = getShouldUpdateApprovalRequest(false, true, false, true);
+      expect(res).toBe(false);
     });
     it('returns true for Dapp transaction', () => {
-      const res = getShouldUpdateApprovalRequest(true, false, false);
+      const res = getShouldUpdateApprovalRequest(true, false, false, false);
       expect(res).toBe(true);
     });
+    it('returns false for Dapp transaction when mobileReturnTxHashAsap is true', () => {
+      const res = getShouldUpdateApprovalRequest(true, false, false, true);
+      expect(res).toBe(false);
+    });
     it('returns true for Swap transaction', () => {
-      const res = getShouldUpdateApprovalRequest(false, false, true);
+      const res = getShouldUpdateApprovalRequest(false, false, true, false);
       expect(res).toBe(true);
     });
     it('returns false for Swap approve transaction', () => {
-      const res = getShouldUpdateApprovalRequest(false, false, false);
+      const res = getShouldUpdateApprovalRequest(false, false, false, false);
       expect(res).toBe(false);
     });
   });

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -69,14 +69,18 @@ export const getShouldStartApprovalRequest = (
   isSend: boolean,
   isSwapApproveTx: boolean,
   hasPendingApprovalForSwapApproveTx: boolean,
+  mobileReturnTxHashAsap: boolean,
 ): boolean =>
-  isDapp || isSend || isSwapApproveTx || !hasPendingApprovalForSwapApproveTx;
+  !mobileReturnTxHashAsap &&
+  (isDapp || isSend || isSwapApproveTx || !hasPendingApprovalForSwapApproveTx);
 
 export const getShouldUpdateApprovalRequest = (
   isDapp: boolean,
   isSend: boolean,
   isSwapTransaction: boolean,
-): boolean => isDapp || isSend || isSwapTransaction;
+  mobileReturnTxHashAsap: boolean,
+): boolean =>
+  !mobileReturnTxHashAsap && (isDapp || isSend || isSwapTransaction);
 
 const waitForSmartTransactionConfirmationDone = (
   controllerMessenger: ControllerMessenger,

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -94,6 +94,7 @@ class SmartTransactionHook {
 
   #shouldStartApprovalRequest: boolean;
   #shouldUpdateApprovalRequest: boolean;
+  #mobileReturnTxHashAsap: boolean;
 
   constructor(request: SubmitSmartTransactionRequest) {
     const {
@@ -116,6 +117,8 @@ class SmartTransactionHook {
     this.#chainId = transactionMeta.chainId;
     this.#txParams = transactionMeta.txParams;
     this.#controllerMessenger = controllerMessenger;
+    this.#mobileReturnTxHashAsap =
+      this.#featureFlags?.smartTransactions?.mobileReturnTxHashAsap ?? false;
 
     const {
       isDapp,
@@ -143,11 +146,13 @@ class SmartTransactionHook {
       this.#isSend,
       this.#isSwapApproveTx,
       Boolean(approvalIdForPendingSwapApproveTx),
+      this.#mobileReturnTxHashAsap,
     );
     this.#shouldUpdateApprovalRequest = getShouldUpdateApprovalRequest(
       this.#isDapp,
       this.#isSend,
       this.#isSwapTransaction,
+      this.#mobileReturnTxHashAsap,
     );
   }
 
@@ -221,9 +226,7 @@ class SmartTransactionHook {
       );
       throw error;
     } finally {
-      const mobileReturnTxHashAsap =
-        this.#featureFlags?.smartTransactions?.mobileReturnTxHashAsap;
-      if (!mobileReturnTxHashAsap) {
+      if (!this.#mobileReturnTxHashAsap) {
         this.#cleanup();
       }
     }
@@ -266,10 +269,8 @@ class SmartTransactionHook {
     uuid: string,
   ) => {
     let transactionHash: string | undefined | null;
-    const mobileReturnTxHashAsap =
-      this.#featureFlags?.smartTransactions?.mobileReturnTxHashAsap;
 
-    if (mobileReturnTxHashAsap && submitTransactionResponse?.txHash) {
+    if (this.#mobileReturnTxHashAsap && submitTransactionResponse?.txHash) {
       transactionHash = submitTransactionResponse.txHash;
     } else {
       transactionHash = await this.#waitForTransactionHash({


### PR DESCRIPTION
## **Description**
We want to hide the smart transaction status page if we return a txHash asap, which we want to do always going forward. Once we verify it works as expected and no fallback is needed, we can remove the STX status page from the codebase.

## **Related issues**

Fixes: TXL-538

## **Manual testing steps**

1. Be on Ethereum Mainnet + smart transactions enabled in Advanced Settings
2. Do a transaction
3. You will not see the STX status page, only a Toast notification as we do for regular (non-STX) transactions

## **Screenshots/Recordings**

Smart transaction is submitted:
![image](https://github.com/user-attachments/assets/fc04d632-1254-45e1-8c27-2cc56beb6d22)

Smart transaction is completed:
![image](https://github.com/user-attachments/assets/18de1f4c-3adc-446e-b5fe-973c1d48a89b)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
