### PR TITLE
fix: fix native tokens filter when all networks is selected

### DIFF
--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -653,48 +653,282 @@ describe('Tokens', () => {
       expect(queryByText('MATIC')).toBeNull();
     });
 
-    it('should filter zero balance tokens when hideZeroBalanceTokens is enabled', () => {
-      const stateWithZeroBalances = {
-        ...initialState,
-        settings: {
-          hideZeroBalanceTokens: true,
-        },
-        engine: {
-          backgroundState: {
-            ...initialState.engine.backgroundState,
-            TokensController: {
-              allTokens: {
-                '0x1': {
-                  [selectedAddress]: [
-                    {
-                      address: '0x123',
-                      symbol: 'ZERO',
-                      decimals: 18,
-                      balance: '0',
-                      balanceFiat: '$0',
-                      isNative: false,
-                      chainId: '0x1',
+    describe('When hideZeroBalance is enabled', () => {
+      describe('When currentNetwork is selected', () => {
+        it('should show zero balance native token and hide zero balance ERC20 token', () => {
+          const stateWithZeroBalances = {
+            ...initialState,
+            settings: {
+              hideZeroBalanceTokens: true,
+            },
+            engine: {
+              backgroundState: {
+                ...initialState.engine.backgroundState,
+                PreferencesController: {
+                  selectedAddress,
+                  tokenSortConfig: { key: 'symbol', order: 'asc' },
+                  tokenNetworkFilter: {
+                    '0x1': true,
+                  },
+                },
+                TokenBalancesController: {
+                  tokenBalances: {
+                    [selectedAddress]: {
+                      '0x1': {
+                        '0x456': '1000000000000000000',
+                        '0x5555': '0x0',
+                      },
                     },
-                    {
-                      address: '0x456',
-                      symbol: 'NON_ZERO',
-                      decimals: 18,
-                      balance: '1000000000000000000',
-                      balanceFiat: '$100',
-                      isNative: false,
-                      chainId: '0x1',
+                  },
+                },
+                TokensController: {
+                  allTokens: {
+                    '0x1': {
+                      [selectedAddress]: [
+                        {
+                          address: '0x123',
+                          symbol: 'ZERO',
+                          decimals: 18,
+                          balance: '0',
+                          balanceFiat: '$0',
+                          isNative: true,
+                          chainId: '0x1',
+                        },
+                        {
+                          address: '0x456',
+                          symbol: 'NON_ZERO_ERC20',
+                          decimals: 18,
+                          balance: '1000000000000000000',
+                          balanceFiat: '$100',
+                          isNative: false,
+                          chainId: '0x1',
+                        },
+                        {
+                          address: '0x5555',
+                          symbol: 'ZERO_ERC20',
+                          decimals: 18,
+                          balance: '0',
+                          balanceFiat: '0',
+                          isNative: false,
+                          chainId: '0x1',
+                        },
+                      ],
                     },
-                  ],
+                  },
+                },
+              },
+            },
+          };
+
+          const { queryByText } = renderComponent(stateWithZeroBalances);
+          expect(queryByText('ZERO')).toBeDefined();
+          expect(queryByText('NON_ZERO_ERC20')).toBeDefined();
+          expect(queryByText('ZERO_ERC20')).toBeNull();
+        });
+      });
+
+      describe('When allNetworks is selected', () => {
+        it('should hide zero balance ERC20 tokens and native tokens', () => {
+          const stateWithZeroBalances = {
+            ...initialState,
+            settings: {
+              hideZeroBalanceTokens: true,
+            },
+            engine: {
+              backgroundState: {
+                ...initialState.engine.backgroundState,
+                PreferencesController: {
+                  selectedAddress,
+                  tokenSortConfig: { key: 'symbol', order: 'asc' },
+                  tokenNetworkFilter: {
+                    '0x1': true,
+                    '0xe705': true,
+                  },
+                },
+                TokenBalancesController: {
+                  tokenBalances: {
+                    [selectedAddress]: {
+                      '0x1': {
+                        NON_ZERO_ERC20_1: '1000000000000000000',
+                      },
+                      '0xe705': {
+                        '0x4565': '1000000000000000000',
+                        '0x45654444': '0x0',
+                      },
+                    },
+                  },
+                },
+                TokensController: {
+                  allTokens: {
+                    '0x1': {
+                      [selectedAddress]: [
+                        {
+                          address: '0x123',
+                          symbol: 'ZERO_1',
+                          decimals: 18,
+                          balance: '0',
+                          balanceFiat: '$0',
+                          isNative: true,
+                          chainId: '0x1',
+                        },
+                        {
+                          address: '0x456',
+                          symbol: 'NON_ZERO_ERC20_1',
+                          decimals: 18,
+                          balance: '1000000000000000000',
+                          balanceFiat: '$100',
+                          isNative: false,
+                          chainId: '0x1',
+                        },
+                      ],
+                    },
+                    '0xe705': {
+                      [selectedAddress]: [
+                        {
+                          address: '0x1233',
+                          symbol: 'ZERO_2',
+                          decimals: 18,
+                          balance: '2233333',
+                          balanceFiat: '$344',
+                          isNative: true,
+                          chainId: '0xe705',
+                        },
+                        {
+                          address: '0x4565',
+                          symbol: 'NON_ZERO_ERC20_2',
+                          decimals: 18,
+                          balance: '1000000000000000000',
+                          balanceFiat: '$100',
+                          isNative: false,
+                          chainId: '0xe705',
+                        },
+                        {
+                          address: '0x45654444',
+                          symbol: 'NON_ZERO_ERC20_3',
+                          decimals: 18,
+                          balance: '0',
+                          balanceFiat: '0',
+                          isNative: false,
+                          chainId: '0xe705',
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          };
+          const { queryByText } = renderComponent(stateWithZeroBalances);
+          expect(queryByText('ZERO_1')).toBeNull();
+          expect(queryByText('ZERO_2')).toBeDefined();
+
+          expect(queryByText('NON_ZERO_ERC20_1')).toBeDefined();
+          expect(queryByText('NON_ZERO_ERC20_2')).toBeDefined();
+          expect(queryByText('NON_ZERO_ERC20_3')).toBeNull();
+        });
+      });
+    });
+
+    describe('When hideZeroBalance is disabled', () => {
+      it('should show zero balance native and ERC20 tokens', () => {
+        const stateWithZeroBalances = {
+          ...initialState,
+          settings: {
+            hideZeroBalanceTokens: false,
+          },
+          engine: {
+            backgroundState: {
+              ...initialState.engine.backgroundState,
+              PreferencesController: {
+                selectedAddress,
+                tokenSortConfig: { key: 'symbol', order: 'asc' },
+                tokenNetworkFilter: {
+                  '0x1': true,
+                  '0xe705': true,
+                },
+              },
+              TokenBalancesController: {
+                tokenBalances: {
+                  [selectedAddress]: {
+                    '0x1': {
+                      NON_ZERO_ERC20_1: '1000000000000000000',
+                    },
+                    '0xe705': {
+                      '0x4565': '1000000000000000000',
+                      '0x45654444': '0x0',
+                    },
+                  },
+                },
+              },
+              TokensController: {
+                allTokens: {
+                  '0x1': {
+                    [selectedAddress]: [
+                      {
+                        address: '0x123',
+                        symbol: 'ZERO_1',
+                        decimals: 18,
+                        balance: '0',
+                        balanceFiat: '$0',
+                        isNative: true,
+                        chainId: '0x1',
+                      },
+                      {
+                        address: '0x456',
+                        symbol: 'NON_ZERO_ERC20_1',
+                        decimals: 18,
+                        balance: '1000000000000000000',
+                        balanceFiat: '$100',
+                        isNative: false,
+                        chainId: '0x1',
+                      },
+                    ],
+                  },
+                  '0xe705': {
+                    [selectedAddress]: [
+                      {
+                        address: '0x1233',
+                        symbol: 'ZERO_2',
+                        decimals: 18,
+                        balance: '2233333',
+                        balanceFiat: '$344',
+                        isNative: true,
+                        chainId: '0xe705',
+                      },
+                      {
+                        address: '0x4565',
+                        symbol: 'NON_ZERO_ERC20_2',
+                        decimals: 18,
+                        balance: '1000000000000000000',
+                        balanceFiat: '$100',
+                        isNative: false,
+                        chainId: '0xe705',
+                      },
+                      {
+                        address: '0x45654444',
+                        symbol: 'NON_ZERO_ERC20_3',
+                        decimals: 18,
+                        balance: '0',
+                        balanceFiat: '0',
+                        isNative: false,
+                        chainId: '0xe705',
+                      },
+                    ],
+                  },
                 },
               },
             },
           },
-        },
-      };
+        };
 
-      const { queryByText } = renderComponent(stateWithZeroBalances);
-      expect(queryByText('ZERO')).toBeNull();
-      expect(queryByText('NON_ZERO')).toBeDefined();
+        const { queryByText } = renderComponent(stateWithZeroBalances);
+        expect(queryByText('ZERO_1')).toBeDefined();
+        expect(queryByText('ZERO_2')).toBeDefined();
+
+        expect(queryByText('NON_ZERO_ERC20_1')).toBeDefined();
+        expect(queryByText('NON_ZERO_ERC20_2')).toBeDefined();
+        expect(queryByText('NON_ZERO_ERC20_3')).toBeDefined();
+      });
     });
   });
 });

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -30,6 +30,7 @@ import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletV
 import { strings } from '../../../../locales/i18n';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import {
+  selectIsTokenNetworkFilterEqualCurrentNetwork,
   selectTokenNetworkFilter,
   selectTokenSortConfig,
 } from '../../../selectors/preferencesController';
@@ -104,6 +105,9 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
   const hideZeroBalanceTokens = useSelector(
     (state: RootState) => state.settings.hideZeroBalanceTokens,
   );
+  const isUserOnCurrentNetwork = useSelector(
+    selectIsTokenNetworkFilterEqualCurrentNetwork,
+  );
 
   const tokenExchangeRates = useSelector(selectContractExchangeRates);
   const currentCurrency = useSelector(selectCurrentCurrency);
@@ -144,17 +148,36 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
         selectedAccountTokensChains,
       ).flat() as TokenI[];
 
-      // First filter zero balance tokens if setting is enabled
-      const tokensToDisplay = hideZeroBalanceTokens
-        ? allTokens.filter((curToken) => {
+      /*
+        If hideZeroBalanceTokens is ON and user is on "all Networks" we respect the setting and filter native and ERC20 tokens when zero
+        If user is on "current Network" we want to show native tokens, even with zero balance
+      */
+      let tokensToDisplay = [];
+      if (hideZeroBalanceTokens) {
+        if (isUserOnCurrentNetwork) {
+          tokensToDisplay = allTokens.filter((curToken) => {
             const multiChainTokenBalances =
               multiChainTokenBalance?.[selectedInternalAccountAddress as Hex]?.[
                 curToken.chainId as Hex
               ];
             const balance = multiChainTokenBalances?.[curToken.address as Hex];
             return !isZero(balance) || curToken.isNative || curToken.isStaked;
-          })
-        : allTokens;
+          });
+        } else {
+          tokensToDisplay = allTokens.filter((curToken) => {
+            const multiChainTokenBalances =
+              multiChainTokenBalance?.[selectedInternalAccountAddress as Hex]?.[
+                curToken.chainId as Hex
+              ];
+            const balance =
+              multiChainTokenBalances?.[curToken.address as Hex] ||
+              curToken.balance;
+            return !isZero(balance) || curToken.isStaked;
+          });
+        }
+      } else {
+        tokensToDisplay = allTokens;
+      }
 
       // Then apply network filters
       const filteredAssets = filterAssets(tokensToDisplay, [
@@ -273,6 +296,7 @@ const Tokens: React.FC<TokensI> = ({ tokens }) => {
     multiChainTokenBalance,
     networkConfigurationsByChainId,
     selectedInternalAccountAddress,
+    isUserOnCurrentNetwork,
   ]);
 
   const showRemoveMenu = (token: TokenI) => {


### PR DESCRIPTION
## **Description**

when the user has "all Networks" selected we want to filter out native tokens when the balance is zero and when hideZeroBalance setting is ON

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/4d395a89-4671-4e78-93d3-b3cf44f16d93



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/fd514b31-3c38-43a4-894d-5f929336b154



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
