### PR TITLE
fix: fix network selector

### DIFF
--- a/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Tokens/__snapshots__/index.test.tsx.snap
@@ -365,7 +365,7 @@ exports[`Tokens Portfolio View should match the snapshot when portfolio view is 
                                 }
                               }
                             >
-                              Ethereum Main Network
+                              All Networks
                             </Text>
                             <SvgMock
                               color="#141618"

--- a/app/selectors/networkController.test.ts
+++ b/app/selectors/networkController.test.ts
@@ -110,15 +110,9 @@ describe('networkSelectors', () => {
     expect(selectNetworkClientId(mockState)).toBe('custom-network');
   });
 
-  it('selectIsAllNetworks should return false if tokenNetworkFilter length does not match networkConfigurations length', () => {
+  it('selectIsAllNetworks should return false if tokenNetworkFilter length is greater than 1', () => {
     const tokenNetworkFilter = { '0x1': 'true' };
-    expect(
-      selectIsAllNetworks.resultFunc(
-        mockState.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId,
-        tokenNetworkFilter,
-      ),
-    ).toBe(false);
+    expect(selectIsAllNetworks.resultFunc(tokenNetworkFilter)).toBe(false);
   });
 
   it('selectNetworkConfigurationByChainId should return the network configuration for a given chainId', () => {

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -168,11 +168,13 @@ export const selectIsEIP1559Network = createSelector(
 );
 
 export const selectIsAllNetworks = createSelector(
-  selectNetworkConfigurations,
   (state: RootState) => selectTokenNetworkFilter(state),
-  (networkConfigurations, tokenNetworkFilter) =>
-    Object.keys(tokenNetworkFilter).length ===
-    Object.keys(networkConfigurations).length,
+  (tokenNetworkFilter) => {
+    if (Object.keys(tokenNetworkFilter).length === 1) {
+      return false;
+    }
+    return true;
+  },
 );
 
 export const selectNetworkConfigurationByChainId = createSelector(


### PR DESCRIPTION

## **Description**

When a user adds a new network using a dapp; it should display the correct network filter with the correct tokens display

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/12638

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
