### PR TITLE
fix: disable flaky tests on incoming-transactions.spec

### DIFF
--- a/e2e/specs/wallet/incoming-transactions.spec.js
+++ b/e2e/specs/wallet/incoming-transactions.spec.js
@@ -5,7 +5,9 @@ import { loginToApp } from '../../viewHelper';
 import Assertions from '../../utils/Assertions';
 import { startMockServer, stopMockServer } from '../../api-mocking/mock-server';
 import { withFixtures } from '../../fixtures/fixture-helper';
-import FixtureBuilder, { DEFAULT_FIXTURE_ACCOUNT } from '../../fixtures/fixture-builder';
+import FixtureBuilder, {
+  DEFAULT_FIXTURE_ACCOUNT,
+} from '../../fixtures/fixture-builder';
 import ActivitiesView from '../../pages/Transactions/ActivitiesView';
 import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import ToastModal from '../../pages/wallet/ToastModal';
@@ -14,189 +16,202 @@ const TOKEN_SYMBOL_MOCK = 'ABC';
 const TOKEN_ADDRESS_MOCK = '0x123';
 
 const RESPONSE_STANDARD_MOCK = {
-    hash: '0x123456',
-    timestamp: new Date().toISOString(),
-    chainId: 1,
-    blockNumber: 1,
-    blockHash: '0x2',
-    gas: 1,
-    gasUsed: 1,
-    gasPrice: '1',
-    effectiveGasPrice: '1',
-    nonce: 1,
-    cumulativeGasUsed: 1,
-    methodId: null,
-    value: '1230000000000000000',
-    to: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
-    from: '0x2',
-    isError: false,
-    valueTransfers: [],
+  hash: '0x123456',
+  timestamp: new Date().toISOString(),
+  chainId: 1,
+  blockNumber: 1,
+  blockHash: '0x2',
+  gas: 1,
+  gasUsed: 1,
+  gasPrice: '1',
+  effectiveGasPrice: '1',
+  nonce: 1,
+  cumulativeGasUsed: 1,
+  methodId: null,
+  value: '1230000000000000000',
+  to: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
+  from: '0x2',
+  isError: false,
+  valueTransfers: [],
 };
 
 const RESPONSE_STANDARD_2_MOCK = {
-    ...RESPONSE_STANDARD_MOCK,
-    timestamp: new Date().toISOString(),
-    hash: '0x2',
-    value: '2340000000000000000',
+  ...RESPONSE_STANDARD_MOCK,
+  timestamp: new Date().toISOString(),
+  hash: '0x2',
+  value: '2340000000000000000',
 };
 
 const RESPONSE_TOKEN_TRANSFER_MOCK = {
-    ...RESPONSE_STANDARD_MOCK,
-    to: '0x2',
-    valueTransfers: [
-        {
-            contractAddress: TOKEN_ADDRESS_MOCK,
-            decimal: 18,
-            symbol: TOKEN_SYMBOL_MOCK,
-            from: '0x2',
-            to: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
-            amount: '4560000000000000000',
-        },
-    ],
+  ...RESPONSE_STANDARD_MOCK,
+  to: '0x2',
+  valueTransfers: [
+    {
+      contractAddress: TOKEN_ADDRESS_MOCK,
+      decimal: 18,
+      symbol: TOKEN_SYMBOL_MOCK,
+      from: '0x2',
+      to: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
+      amount: '4560000000000000000',
+    },
+  ],
 };
 
 const RESPONSE_OUTGOING_TRANSACTION_MOCK = {
-    ...RESPONSE_STANDARD_MOCK,
-    to: '0x2',
-    from: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
+  ...RESPONSE_STANDARD_MOCK,
+  to: '0x2',
+  from: DEFAULT_FIXTURE_ACCOUNT.toLowerCase(),
 };
 
 function mockAccountsApi(transactions) {
-    return {
-        urlEndpoint: `https://accounts.api.cx.metamask.io/v1/accounts/${DEFAULT_FIXTURE_ACCOUNT}/transactions?networks=0x1&sortDirection=ASC`,
-        response: {
-            data: transactions ?? [RESPONSE_STANDARD_MOCK, RESPONSE_STANDARD_2_MOCK],
-            pageInfo: {
-                count: 2,
-                hasNextPage: false
-            }
-        },
-        responseCode: 200,
-    };
+  return {
+    urlEndpoint: `https://accounts.api.cx.metamask.io/v1/accounts/${DEFAULT_FIXTURE_ACCOUNT}/transactions?networks=0x1&sortDirection=ASC`,
+    response: {
+      data: transactions ?? [RESPONSE_STANDARD_MOCK, RESPONSE_STANDARD_2_MOCK],
+      pageInfo: {
+        count: 2,
+        hasNextPage: false,
+      },
+    },
+    responseCode: 200,
+  };
 }
 
 describe(SmokeCore('Incoming Transactions'), () => {
+  beforeAll(async () => {
+    jest.setTimeout(2500000);
+    await TestHelpers.reverseServerPort();
+  });
 
-    beforeAll(async () => {
-        jest.setTimeout(2500000);
-        await TestHelpers.reverseServerPort();
-    });
+  it('displays standard incoming transaction', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock: {
+          GET: [mockAccountsApi()],
+        },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await Assertions.checkIfTextIsDisplayed('Received ETH');
+        await Assertions.checkIfTextIsDisplayed(/.*1\.23 ETH.*/);
+        await Assertions.checkIfTextIsDisplayed(/.*2\.34 ETH.*/);
+      },
+    );
+  });
 
-    it('displays standard incoming transaction', async () => {
-        await withFixtures(
+  it('displays incoming token transfers', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder()
+          .withTokens([
             {
-                fixture: new FixtureBuilder().build(),
-                restartDevice: true,
-                testSpecificMock: {
-                    GET: [mockAccountsApi()]
-                }
+              address: TOKEN_ADDRESS_MOCK,
+              decimals: 18,
+              symbol: TOKEN_SYMBOL_MOCK,
             },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await Assertions.checkIfTextIsDisplayed('Received ETH');
-                await Assertions.checkIfTextIsDisplayed(/.*1\.23 ETH.*/);
-                await Assertions.checkIfTextIsDisplayed(/.*2\.34 ETH.*/);
-            }
-        );
-    });
+          ])
+          .build(),
+        restartDevice: true,
+        testSpecificMock: {
+          GET: [mockAccountsApi([RESPONSE_TOKEN_TRANSFER_MOCK])],
+        },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await Assertions.checkIfTextIsDisplayed('Received ABC');
+        await Assertions.checkIfTextIsDisplayed(/.*4\.56 ABC.*/);
+      },
+    );
+  });
 
-    it('displays incoming token transfers', async () => {
-        await withFixtures(
-            {
-                fixture: new FixtureBuilder().withTokens([{
-                    address: TOKEN_ADDRESS_MOCK, decimals: 18, symbol: TOKEN_SYMBOL_MOCK
-                }]).build(),
-                restartDevice: true,
-                testSpecificMock: { GET: [mockAccountsApi([RESPONSE_TOKEN_TRANSFER_MOCK])] }
-            },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await Assertions.checkIfTextIsDisplayed('Received ABC');
-                await Assertions.checkIfTextIsDisplayed(/.*4\.56 ABC.*/);
-            }
-        );
-    });
+  xit('displays outgoing transactions', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock: {
+          GET: [mockAccountsApi([RESPONSE_OUTGOING_TRANSACTION_MOCK])],
+        },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await Assertions.checkIfTextIsDisplayed('Sent ETH');
+        await Assertions.checkIfTextIsDisplayed(/.*1\.23 ETH.*/);
+      },
+    );
+  });
 
-    it('displays outgoing transactions', async () => {
-        await withFixtures(
-            {
-                fixture: new FixtureBuilder().build(),
-                restartDevice: true,
-                testSpecificMock: { GET: [mockAccountsApi([RESPONSE_OUTGOING_TRANSACTION_MOCK])] }
-            },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await Assertions.checkIfTextIsDisplayed('Sent ETH');
-                await Assertions.checkIfTextIsDisplayed(/.*1\.23 ETH.*/);
-            }
-        );
-    });
+  it('displays nothing if incoming transactions disabled', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder()
+          .withIncomingTransactionPreferences({
+            '0x1': false,
+          })
+          .build(),
+        restartDevice: true,
+        testSpecificMock: { GET: [mockAccountsApi()] },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await TestHelpers.delay(2000);
+        await Assertions.checkIfTextIsNotDisplayed('Received ETH');
+      },
+    );
+  });
 
-    it('displays nothing if incoming transactions disabled', async () => {
-        await withFixtures(
+  it('displays nothing if incoming transaction is a duplicate', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder()
+          .withTransactions([
             {
-                fixture: new FixtureBuilder()
-                    .withIncomingTransactionPreferences({
-                        '0x1': false
-                    })
-                    .build(),
-                restartDevice: true,
-                testSpecificMock: { GET: [mockAccountsApi()] }
+              hash: RESPONSE_STANDARD_MOCK.hash,
+              txParams: {
+                from: RESPONSE_STANDARD_MOCK.from,
+              },
             },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await TestHelpers.delay(2000);
-                await Assertions.checkIfTextIsNotDisplayed('Received ETH');
-            }
-        );
-    });
+          ])
+          .build(),
+        restartDevice: true,
+        testSpecificMock: { GET: [mockAccountsApi([RESPONSE_STANDARD_MOCK])] },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await TestHelpers.delay(2000);
+        await Assertions.checkIfTextIsNotDisplayed('Received ETH');
+      },
+    );
+  });
 
-    it('displays nothing if incoming transaction is a duplicate', async () => {
-        await withFixtures(
-            {
-                fixture: new FixtureBuilder()
-                    .withTransactions([{
-                        hash: RESPONSE_STANDARD_MOCK.hash,
-                        txParams: {
-                            from: RESPONSE_STANDARD_MOCK.from
-                        }
-                    }])
-                    .build(),
-                restartDevice: true,
-                testSpecificMock: { GET: [mockAccountsApi([RESPONSE_STANDARD_MOCK])] }
-            },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await TestHelpers.delay(2000);
-                await Assertions.checkIfTextIsNotDisplayed('Received ETH');
-            }
+  xit('displays notification', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock: { GET: [mockAccountsApi()] },
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.swipeDown();
+        await Assertions.checkIfElementToHaveText(
+          await ToastModal.notificationTitle,
+          'You received 1.23 ETH',
         );
-    });
-
-    it('displays notification', async () => {
-        await withFixtures(
-            {
-                fixture: new FixtureBuilder()
-                    .build(),
-                restartDevice: true,
-                testSpecificMock: { GET: [mockAccountsApi()] }
-            },
-            async () => {
-                await loginToApp();
-                await TabBarComponent.tapActivity();
-                await ActivitiesView.swipeDown();
-                await Assertions.checkIfElementToHaveText(await ToastModal.notificationTitle, 'You received 1.23 ETH');
-            }
-        );
-    });
+      },
+    );
+  });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Disable flaky tests.

## **Related issues**

Fixes: #12666 



## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
https://consensys.slack.com/archives/C02U025CVU4/p1734015329502949?thread_ts=1733944216.093729&cid=C02U025CVU4

https://app.bitrise.io/build/60766eba-3b3c-4b91-b1ea-7e78fa7cd881?tab=tests

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
