### PR TITLE
refactor: remove global network usage from transaction simulation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,7 @@ module.exports = {
     {
       files: [
         'app/components/UI/Name/**/*.{js,ts,tsx}',
+        'app/components/UI/SimulationDetails/**/*.{js,ts,tsx}',
         'app/components/hooks/DisplayName/**/*.{js,ts,tsx}'
       ],
       rules: {

--- a/app/components/UI/SimulationDetails/AmountPill/AmountPill.test.tsx
+++ b/app/components/UI/SimulationDetails/AmountPill/AmountPill.test.tsx
@@ -5,25 +5,33 @@ import AmountPill from './AmountPill';
 import {
   AssetIdentifier,
   AssetType,
-  NATIVE_ASSET_IDENTIFIER,
+  NativeAssetIdentifier,
   TokenAssetIdentifier,
 } from '../types';
 
 const TOKEN_ID_MOCK = '0xabc';
+const CHAIN_ID_MOCK = '0x123';
 
 const ERC20_ASSET_MOCK: TokenAssetIdentifier = {
   type: AssetType.ERC20,
   address: '0x456',
+  chainId: CHAIN_ID_MOCK,
 };
 const ERC721_ASSET_MOCK: TokenAssetIdentifier = {
   type: AssetType.ERC721,
   address: '0x123',
   tokenId: TOKEN_ID_MOCK,
+  chainId: CHAIN_ID_MOCK,
 };
 const ERC1155_ASSET_MOCK: TokenAssetIdentifier = {
   type: AssetType.ERC1155,
   address: '0x789',
   tokenId: TOKEN_ID_MOCK,
+  chainId: CHAIN_ID_MOCK,
+};
+const NATIVE_ASSET_MOCK: NativeAssetIdentifier = {
+  type: AssetType.Native,
+  chainId: CHAIN_ID_MOCK,
 };
 
 const renderAndExpect = (
@@ -83,7 +91,7 @@ describe('AmountPill', () => {
     it.each(nativeAndErc20Cases)(
       'renders the correct sign and amount for $amount',
       ({ amount, expected }) => {
-        renderAndExpect(NATIVE_ASSET_IDENTIFIER, amount, expected);
+        renderAndExpect(NATIVE_ASSET_MOCK, amount, expected);
       },
     );
   });

--- a/app/components/UI/SimulationDetails/AssetPill/AssetPill.test.tsx
+++ b/app/components/UI/SimulationDetails/AssetPill/AssetPill.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
 
 import AssetPill from './AssetPill';
 import { AssetType, AssetIdentifier } from '../types';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { mockNetworkState } from '../../../../util/test/network';
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn().mockImplementation((selector) => selector()),
-}));
-jest.mock('../../../../selectors/networkController');
 jest.mock(
   '../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork',
   () => 'AvatarNetwork',
@@ -18,10 +14,33 @@ jest.mock('../../../hooks/useStyles', () => ({
   useStyles: () => ({ styles: {} }),
 }));
 
+const CHAIN_ID_MOCK = '0x123';
+
+const STATE_MOCK = {
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        ...mockNetworkState({
+          chainId: CHAIN_ID_MOCK,
+        }),
+      },
+    },
+  },
+};
+
 describe('AssetPill', () => {
   it('renders correctly for native assets', () => {
-    const asset = { type: AssetType.Native } as AssetIdentifier;
-    const { getByText, getByTestId } = render(<AssetPill asset={asset} />);
+    const asset = {
+      type: AssetType.Native,
+      chainId: CHAIN_ID_MOCK,
+    } as AssetIdentifier;
+
+    const { getByText, getByTestId } = renderWithProvider(
+      <AssetPill asset={asset} />,
+      {
+        state: STATE_MOCK,
+      },
+    );
 
     expect(
       getByTestId('simulation-details-asset-pill-avatar-network'),
@@ -33,10 +52,12 @@ describe('AssetPill', () => {
     const asset = {
       type: AssetType.ERC20,
       address: '0xabc123',
-      chainId: '0x1',
+      chainId: CHAIN_ID_MOCK,
     } as AssetIdentifier;
 
-    const { getByTestId } = render(<AssetPill asset={asset} />);
+    const { getByTestId } = renderWithProvider(<AssetPill asset={asset} />, {
+      state: STATE_MOCK,
+    });
 
     expect(getByTestId('simulation-details-asset-pill-name')).toBeTruthy();
   });

--- a/app/components/UI/SimulationDetails/AssetPill/AssetPill.test.tsx
+++ b/app/components/UI/SimulationDetails/AssetPill/AssetPill.test.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 
 import AssetPill from './AssetPill';
-import {
-  selectChainId,
-  selectTicker,
-} from '../../../../selectors/networkController';
 import { AssetType, AssetIdentifier } from '../types';
 
 jest.mock('react-redux', () => ({
@@ -23,14 +19,6 @@ jest.mock('../../../hooks/useStyles', () => ({
 }));
 
 describe('AssetPill', () => {
-  const selectChainIdMock = jest.mocked(selectChainId);
-  const selectTickerMock = jest.mocked(selectTicker);
-
-  beforeAll(() => {
-    selectChainIdMock.mockReturnValue('0x1');
-    selectTickerMock.mockReturnValue('ETH');
-  });
-
   it('renders correctly for native assets', () => {
     const asset = { type: AssetType.Native } as AssetIdentifier;
     const { getByText, getByTestId } = render(<AssetPill asset={asset} />);
@@ -45,7 +33,9 @@ describe('AssetPill', () => {
     const asset = {
       type: AssetType.ERC20,
       address: '0xabc123',
+      chainId: '0x1',
     } as AssetIdentifier;
+
     const { getByTestId } = render(<AssetPill asset={asset} />);
 
     expect(getByTestId('simulation-details-asset-pill-name')).toBeTruthy();

--- a/app/components/UI/SimulationDetails/AssetPill/AssetPill.tsx
+++ b/app/components/UI/SimulationDetails/AssetPill/AssetPill.tsx
@@ -9,16 +9,13 @@ import Text, {
 } from '../../../../component-library/components/Texts/Text';
 import AvatarNetwork from '../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 import { AvatarSize } from '../../../../component-library/components/Avatars/Avatar/Avatar.types';
-import {
-  selectChainId,
-  selectTicker,
-} from '../../../../selectors/networkController';
 import { NetworkList } from '../../../../util/networks';
 import { useStyles } from '../../../hooks/useStyles';
 import Name from '../../Name/Name';
 import { NameType } from '../../Name/Name.types';
 import { AssetIdentifier, AssetType } from '../types';
 import styleSheet from './AssetPill.styles';
+import { selectNetworkConfigurations } from '../../../../selectors/networkController';
 
 interface AssetPillProperties extends ViewProps {
   asset: AssetIdentifier;
@@ -35,21 +32,26 @@ const getNetworkImage = (chainId: Hex) => {
   return network?.imageSource || null;
 };
 
-const NativeAssetPill: React.FC = () => {
+const NativeAssetPill: React.FC<AssetPillProperties> = ({ asset }) => {
   const { styles } = useStyles(styleSheet, {});
-  const ticker = useSelector(selectTicker);
-  const chainId = useSelector(selectChainId);
-  const imageSource = getNetworkImage(chainId);
+  const imageSource = getNetworkImage(asset.chainId);
+
+  const networkConfigurationsByChainId = useSelector(
+    selectNetworkConfigurations,
+  );
+
+  const { nativeCurrency } =
+    networkConfigurationsByChainId[asset.chainId] || {};
 
   return (
     <View style={styles.nativeAssetPill}>
       <AvatarNetwork
         testID="simulation-details-asset-pill-avatar-network"
         size={AvatarSize.Xs}
-        name={ticker}
+        name={nativeCurrency}
         imageSource={imageSource}
       />
-      <Text variant={TextVariant.BodyMD}>{ticker}</Text>
+      <Text variant={TextVariant.BodyMD}>{nativeCurrency}</Text>
     </View>
   );
 };
@@ -57,20 +59,17 @@ const NativeAssetPill: React.FC = () => {
 const AssetPill: React.FC<AssetPillProperties> = ({ asset }) => {
   const { styles } = useStyles(styleSheet, {});
 
-  // TODO: Remove global network selector usage once simulations refactored.
-  const chainId = useSelector(selectChainId);
-
   return (
     <View style={styles.assetPill}>
       {asset.type === AssetType.Native ? (
-        <NativeAssetPill />
+        <NativeAssetPill asset={asset} />
       ) : (
         <Name
           preferContractSymbol
           testID="simulation-details-asset-pill-name"
           type={NameType.EthereumAddress}
           value={asset.address}
-          variation={chainId}
+          variation={asset.chainId}
         />
       )}
     </View>

--- a/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.test.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeList/BalanceChangeList.test.tsx
@@ -14,11 +14,14 @@ jest.mock('../FiatDisplay/FiatDisplay', () => ({
   TotalFiatDisplay: 'TotalFiatDisplay',
 }));
 
+const CHAIN_ID_MOCK = '0x123';
+
 const balanceChangesMock = [
   {
     asset: {
       type: 'ERC20',
       address: '0xabc123',
+      chainId: CHAIN_ID_MOCK,
     },
     amount: new BigNumber(100),
     fiatAmount: 100,
@@ -68,6 +71,7 @@ describe('BalanceChangeList', () => {
         asset: {
           type: 'ERC20',
           address: '0xabc123',
+          chainId: CHAIN_ID_MOCK,
         },
         amount: new BigNumber(100),
         fiatAmount: 100,

--- a/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.test.tsx
+++ b/app/components/UI/SimulationDetails/BalanceChangeRow/BalanceChangeRow.test.tsx
@@ -5,21 +5,23 @@ import { BigNumber } from 'bignumber.js';
 import BalanceChangeRow from './BalanceChangeRow';
 import { AssetType, BalanceChange } from '../types';
 
+jest.mock('../AmountPill/AmountPill', () => 'AmountPill');
+jest.mock('../AssetPill/AssetPill', () => 'AssetPill');
 jest.mock('../FiatDisplay/FiatDisplay', () => ({
   IndividualFiatDisplay: 'IndividualFiatDisplay',
 }));
+
+const CHAIN_ID_MOCK = '0x123';
 
 const balanceChangeMock: BalanceChange = {
   asset: {
     type: AssetType.ERC20,
     address: '0xabc123',
+    chainId: CHAIN_ID_MOCK,
   },
   amount: new BigNumber(100),
   fiatAmount: 0,
 } as BalanceChange;
-
-jest.mock('../AmountPill/AmountPill', () => 'AmountPill');
-jest.mock('../AssetPill/AssetPill', () => 'AssetPill');
 
 describe('BalanceChangeList', () => {
   it('renders a balance change row', () => {

--- a/app/components/UI/SimulationDetails/SimulationDetails.stories.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.stories.tsx
@@ -9,6 +9,8 @@ import {
   SimulationErrorCode,
   SimulationTokenStandard,
   CHAIN_IDS,
+  TransactionMeta,
+  SimulationData,
 } from '@metamask/transaction-controller';
 
 import {
@@ -145,8 +147,20 @@ const meta: Meta<typeof SimulationDetails> = {
 };
 export default meta;
 
+function buildArgs({
+  simulationData,
+}: {
+  simulationData?: SimulationData;
+}): Partial<SimulationDetailsProps> {
+  return {
+    transaction: {
+      simulationData,
+    } as TransactionMeta,
+  };
+}
+
 export const MultipleTokens: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
@@ -193,11 +207,11 @@ export const MultipleTokens: Story = {
         },
       ],
     },
-  },
+  }),
 };
 
 export const SendSmallAmount: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
@@ -206,11 +220,11 @@ export const SendSmallAmount: Story = {
       },
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };
 
 export const LongValuesAndNames: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
@@ -234,11 +248,11 @@ export const LongValuesAndNames: Story = {
         },
       ],
     },
-  },
+  }),
 };
 
 export const PolygonNativeAsset: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
@@ -247,14 +261,14 @@ export const PolygonNativeAsset: Story = {
       },
       tokenBalanceChanges: [],
     },
-  },
+  }),
   decorators: [
     (story) => <Provider store={storeMockPolygon}>{story()}</Provider>,
   ],
 };
 
 export const ArbitrumNativeAsset: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         ...DUMMY_BALANCE_CHANGE,
@@ -263,14 +277,14 @@ export const ArbitrumNativeAsset: Story = {
       },
       tokenBalanceChanges: [],
     },
-  },
+  }),
   decorators: [
     (story) => <Provider store={storeMockArbitrum}>{story()}</Provider>,
   ],
 };
 
 export const ReceiveOnly: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         previousBalance: '0x2',
@@ -280,11 +294,11 @@ export const ReceiveOnly: Story = {
       },
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };
 
 export const SendOnly: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: {
         previousBalance: '0x1',
@@ -294,40 +308,40 @@ export const SendOnly: Story = {
       },
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };
 
 export const NoBalanceChanges: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       nativeBalanceChange: undefined,
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };
 
 export const Loading: Story = {
-  args: {
+  args: buildArgs({
     simulationData: undefined,
-  },
+  }),
 };
 
 export const TransactionReverted: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       error: { code: SimulationErrorCode.Reverted },
       nativeBalanceChange: undefined,
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };
 
 export const GenericError: Story = {
-  args: {
+  args: buildArgs({
     simulationData: {
       error: {},
       nativeBalanceChange: undefined,
       tokenBalanceChanges: [],
     },
-  },
+  }),
 };

--- a/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
@@ -6,6 +6,7 @@ import {
   SimulationData,
   SimulationErrorCode,
   SimulationTokenStandard,
+  TransactionMeta,
 } from '@metamask/transaction-controller';
 
 import AnimatedSpinner from '../AnimatedSpinner';
@@ -21,6 +22,7 @@ const DUMMY_BALANCE_CHANGE = {
   previousBalance: '0xIGNORED' as Hex,
   newBalance: '0xIGNORED' as Hex,
 };
+const CHAIN_ID_MOCK = '0x123';
 const mockTransactionId = '0x1234567890';
 const simulationDataMock = {
   nativeBalanceChange: {
@@ -81,8 +83,12 @@ describe('SimulationDetails', () => {
 
     render(
       <SimulationDetails
-        simulationData={simulationDataMock}
-        transactionId={mockTransactionId}
+        transaction={
+          {
+            id: mockTransactionId,
+            simulationData: simulationDataMock,
+          } as TransactionMeta
+        }
         enableMetrics={false}
       />,
     );
@@ -95,11 +101,15 @@ describe('SimulationDetails', () => {
       expect(
         render(
           <SimulationDetails
-            simulationData={{
-              ...simulationDataMock,
-              error: { code: SimulationErrorCode.ChainNotSupported },
-            }}
-            transactionId={mockTransactionId}
+            transaction={
+              {
+                id: mockTransactionId,
+                simulationData: {
+                  ...simulationDataMock,
+                  error: { code: SimulationErrorCode.ChainNotSupported },
+                },
+              } as TransactionMeta
+            }
             enableMetrics={false}
           />,
         ).toJSON(),
@@ -110,11 +120,15 @@ describe('SimulationDetails', () => {
       expect(
         render(
           <SimulationDetails
-            simulationData={{
-              ...simulationDataMock,
-              error: { code: SimulationErrorCode.Disabled },
-            }}
-            transactionId={mockTransactionId}
+            transaction={
+              {
+                id: mockTransactionId,
+                simulationData: {
+                  ...simulationDataMock,
+                  error: { code: SimulationErrorCode.Disabled },
+                },
+              } as TransactionMeta
+            }
             enableMetrics={false}
           />,
         ).toJSON(),
@@ -126,11 +140,15 @@ describe('SimulationDetails', () => {
     it('if transaction will be reverted', () => {
       const { getByText } = render(
         <SimulationDetails
-          simulationData={{
-            ...simulationDataMock,
-            error: { code: SimulationErrorCode.Reverted },
-          }}
-          transactionId={mockTransactionId}
+          transaction={
+            {
+              id: mockTransactionId,
+              simulationData: {
+                ...simulationDataMock,
+                error: { code: SimulationErrorCode.Reverted },
+              },
+            } as TransactionMeta
+          }
           enableMetrics={false}
         />,
       );
@@ -141,11 +159,15 @@ describe('SimulationDetails', () => {
     it('if simulation is failed', () => {
       const { getByText } = render(
         <SimulationDetails
-          simulationData={{
-            ...simulationDataMock,
-            error: { code: SimulationErrorCode.InvalidResponse },
-          }}
-          transactionId={mockTransactionId}
+          transaction={
+            {
+              id: mockTransactionId,
+              simulationData: {
+                ...simulationDataMock,
+                error: { code: SimulationErrorCode.InvalidResponse },
+              },
+            } as TransactionMeta
+          }
           enableMetrics={false}
         />,
       );
@@ -159,8 +181,12 @@ describe('SimulationDetails', () => {
   it('renders if no balance change', () => {
     const { getByText } = render(
       <SimulationDetails
-        simulationData={simulationDataMock}
-        transactionId={mockTransactionId}
+        transaction={
+          {
+            id: mockTransactionId,
+            simulationData: simulationDataMock,
+          } as TransactionMeta
+        }
         enableMetrics={false}
       />,
     );
@@ -175,7 +201,7 @@ describe('SimulationDetails', () => {
         {
           amount: new BigNumber('0x1', 16).times(-1),
           fiatAmount: 10,
-          asset: { type: AssetType.Native },
+          asset: { type: AssetType.Native, chainId: CHAIN_ID_MOCK },
         },
         {
           amount: new BigNumber('0x123456', 16).times(1),
@@ -184,6 +210,7 @@ describe('SimulationDetails', () => {
             address: FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK,
             tokenId: undefined,
             type: AssetType.ERC20,
+            chainId: CHAIN_ID_MOCK,
           },
         },
         {
@@ -193,6 +220,7 @@ describe('SimulationDetails', () => {
             address: FIRST_PARTY_CONTRACT_ADDRESS_2_MOCK,
             tokenId: undefined,
             type: AssetType.ERC20,
+            chainId: CHAIN_ID_MOCK,
           },
         },
       ],
@@ -200,8 +228,12 @@ describe('SimulationDetails', () => {
 
     const { getByTestId } = render(
       <SimulationDetails
-        simulationData={simulationDataMock}
-        transactionId={mockTransactionId}
+        transaction={
+          {
+            id: mockTransactionId,
+            simulationData: simulationDataMock,
+          } as TransactionMeta
+        }
         enableMetrics={false}
       />,
     );

--- a/app/components/UI/SimulationDetails/SimulationDetails.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.tsx
@@ -2,9 +2,9 @@
 import React, { useState } from 'react';
 import { View, Pressable } from 'react-native';
 import {
-  SimulationData,
   SimulationErrorCode,
   SimulationError,
+  TransactionMeta,
 } from '@metamask/transaction-controller';
 
 import { strings } from '../../../../locales/i18n';
@@ -25,8 +25,7 @@ import styleSheet from './SimulationDetails.styles';
 import { useSimulationMetrics } from './useSimulationMetrics';
 
 export interface SimulationDetailsProps {
-  simulationData?: SimulationData;
-  transactionId: string;
+  transaction: TransactionMeta;
   enableMetrics: boolean;
 }
 
@@ -140,12 +139,12 @@ const SimulationDetailsLayout: React.FC<{
  * @returns The simulation details.
  */
 export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
-  simulationData,
+  transaction,
   enableMetrics = false,
-  transactionId,
 }: SimulationDetailsProps) => {
   const { styles } = useStyles(styleSheet, {});
-  const balanceChangesResult = useBalanceChanges(simulationData);
+  const { chainId, id: transactionId, simulationData } = transaction;
+  const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const loading = !simulationData || balanceChangesResult.pending;
 
   useSimulationMetrics({

--- a/app/components/UI/SimulationDetails/types.ts
+++ b/app/components/UI/SimulationDetails/types.ts
@@ -8,10 +8,6 @@ export enum AssetType {
   ERC1155 = 'ERC1155',
 }
 
-export const NATIVE_ASSET_IDENTIFIER: NativeAssetIdentifier = {
-  type: AssetType.Native,
-};
-
 /**
  * Describes an amount of fiat.
  */
@@ -23,18 +19,20 @@ export type FiatAmount = FiatAmountAvailable | typeof FIAT_UNAVAILABLE;
  * Identifies the native asset of a chain.
  */
 export interface NativeAssetIdentifier {
-  type: AssetType.Native;
   address?: undefined;
+  chainId: Hex;
   tokenId?: undefined;
+  type: AssetType.Native;
 }
 
 /**
  * Uniquely identifies a token asset on a chain.
  */
 export interface TokenAssetIdentifier {
-  type: Exclude<AssetType, AssetType.Native>;
   address: Hex;
+  chainId: Hex;
   tokenId?: Hex;
+  type: Exclude<AssetType, AssetType.Native>;
 }
 
 export type AssetIdentifier = Readonly<

--- a/app/components/UI/SimulationDetails/useBalanceChanges.test.ts
+++ b/app/components/UI/SimulationDetails/useBalanceChanges.test.ts
@@ -61,6 +61,8 @@ const DIFFERENCE_1_MOCK: Hex = '0x11';
 const DIFFERENCE_2_MOCK: Hex = '0x2';
 const DIFFERENCE_ETH_MOCK: Hex = '0x1234567890123456789';
 
+const CHAIN_ID_MOCK = '0x123';
+
 const dummyBalanceChange = {
   previousBalance: '0xIGNORE' as Hex,
   newBalance: '0xIGNORE' as Hex,
@@ -98,7 +100,10 @@ describe('useBalanceChanges', () => {
   describe('pending states', () => {
     it('returns pending=true if no simulation data', async () => {
       const { result, waitForNextUpdate } = renderHook(() =>
-        useBalanceChanges(undefined),
+        useBalanceChanges({
+          chainId: CHAIN_ID_MOCK,
+          simulationData: undefined,
+        }),
       );
       expect(result.current).toEqual({ pending: true, value: [] });
       await waitForNextUpdate();
@@ -119,7 +124,10 @@ describe('useBalanceChanges', () => {
         ],
       };
       const { result, unmount, waitForNextUpdate } = renderHook(() =>
-        useBalanceChanges(simulationData),
+        useBalanceChanges({
+          chainId: CHAIN_ID_MOCK,
+          simulationData,
+        }),
       );
 
       await waitForNextUpdate();
@@ -143,7 +151,10 @@ describe('useBalanceChanges', () => {
         ],
       };
       const { result, unmount } = renderHook(() =>
-        useBalanceChanges(simulationData),
+        useBalanceChanges({
+          chainId: CHAIN_ID_MOCK,
+          simulationData,
+        }),
       );
 
       expect(result.current).toEqual({ pending: true, value: [] });
@@ -159,7 +170,12 @@ describe('useBalanceChanges', () => {
         nativeBalanceChange: undefined,
         tokenBalanceChanges,
       };
-      return renderHook(() => useBalanceChanges(simulationData));
+      return renderHook(() =>
+        useBalanceChanges({
+          chainId: CHAIN_ID_MOCK,
+          simulationData,
+        }),
+      );
     };
 
     it('maps token balance changes correctly', async () => {
@@ -182,6 +198,7 @@ describe('useBalanceChanges', () => {
             address: ERC20_TOKEN_ADDRESS_1_MOCK,
             type: AssetType.ERC20,
             tokenId: undefined,
+            chainId: CHAIN_ID_MOCK,
           },
           amount: new BigNumber('-0.017'),
           fiatAmount: -0.0255,
@@ -238,6 +255,7 @@ describe('useBalanceChanges', () => {
             address: NFT_TOKEN_ADDRESS_MOCK,
             type: AssetType.ERC721,
             tokenId: TOKEN_ID_1_MOCK,
+            chainId: CHAIN_ID_MOCK,
           },
           amount: new BigNumber('-1'),
           fiatAmount: FIAT_UNAVAILABLE,
@@ -305,7 +323,12 @@ describe('useBalanceChanges', () => {
         nativeBalanceChange,
         tokenBalanceChanges: [],
       };
-      return renderHook(() => useBalanceChanges(simulationData));
+      return renderHook(() =>
+        useBalanceChanges({
+          chainId: CHAIN_ID_MOCK,
+          simulationData,
+        }),
+      );
     };
 
     it('maps native balance change correctly', async () => {
@@ -322,6 +345,7 @@ describe('useBalanceChanges', () => {
         {
           asset: {
             type: AssetType.Native,
+            chainId: CHAIN_ID_MOCK,
           },
           amount: new BigNumber('-5373.003641998677469065'),
           fiatAmount: Number('-16119.010925996032'),
@@ -367,7 +391,10 @@ describe('useBalanceChanges', () => {
       ],
     };
     const { result, waitForNextUpdate } = renderHook(() =>
-      useBalanceChanges(simulationData),
+      useBalanceChanges({
+        chainId: CHAIN_ID_MOCK,
+        simulationData,
+      }),
     );
 
     await waitForNextUpdate();
@@ -376,6 +403,7 @@ describe('useBalanceChanges', () => {
     expect(changes).toHaveLength(2);
     expect(changes[0].asset).toEqual({
       type: AssetType.Native,
+      chainId: CHAIN_ID_MOCK,
     });
     expect(changes[0].amount).toEqual(
       new BigNumber('-5373.003641998677469065'),
@@ -384,6 +412,7 @@ describe('useBalanceChanges', () => {
     expect(changes[1].asset).toEqual({
       address: ERC20_TOKEN_ADDRESS_1_MOCK,
       type: AssetType.ERC20,
+      chainId: CHAIN_ID_MOCK,
     });
     expect(changes[1].amount).toEqual(new BigNumber('0.002'));
   });

--- a/app/components/UI/SimulationDetails/useBalanceChanges.ts
+++ b/app/components/UI/SimulationDetails/useBalanceChanges.ts
@@ -15,17 +15,16 @@ import {
 
 import {
   BalanceChange,
-  NATIVE_ASSET_IDENTIFIER,
   TokenAssetIdentifier,
   AssetType,
   FIAT_UNAVAILABLE,
+  NativeAssetIdentifier,
 } from './types';
 import { getTokenDetails } from '../../../util/address';
 import {
   selectConversionRate,
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
-import { selectChainId } from '../../../selectors/networkController';
 import { useAsyncResultOrThrow } from '../../hooks/useAsyncResult';
 
 const NATIVE_DECIMALS = 18;
@@ -132,14 +131,20 @@ async function fetchTokenFiatRates(
 function getNativeBalanceChange(
   nativeBalanceChange: SimulationBalanceChange | undefined,
   nativeFiatRate: number,
+  chainId: Hex,
 ): BalanceChange | undefined {
   if (!nativeBalanceChange) {
     return undefined;
   }
-  const asset = NATIVE_ASSET_IDENTIFIER;
-  const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
 
+  const asset: NativeAssetIdentifier = {
+    type: AssetType.Native,
+    chainId,
+  };
+
+  const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
   const fiatAmount = amount.times(nativeFiatRate).toNumber();
+
   return { asset, amount, fiatAmount };
 }
 
@@ -148,12 +153,14 @@ function getTokenBalanceChanges(
   tokenBalanceChanges: SimulationTokenBalanceChange[],
   erc20Decimals: Record<Hex, number>,
   erc20FiatRates: Partial<Record<Hex, number>>,
+  chainId: Hex,
 ): BalanceChange[] {
   return tokenBalanceChanges.map((tokenBc) => {
     const asset: TokenAssetIdentifier = {
       type: convertStandard(tokenBc.standard),
       address: tokenBc.address.toLowerCase() as Hex,
       tokenId: tokenBc.id,
+      chainId,
     };
 
     const decimals =
@@ -172,12 +179,15 @@ function getTokenBalanceChanges(
 }
 
 // Compiles a list of balance changes from simulation data
-export default function useBalanceChanges(
-  simulationData: SimulationData | undefined,
-): { pending: boolean; value: BalanceChange[] } {
+export default function useBalanceChanges({
+  chainId,
+  simulationData,
+}: {
+  chainId: Hex;
+  simulationData?: SimulationData;
+}): { pending: boolean; value: BalanceChange[] } {
   const nativeFiatRate = useSelector(selectConversionRate) as number;
   const fiatCurrency = useSelector(selectCurrentCurrency);
-  const chainId = useSelector(selectChainId);
 
   const { nativeBalanceChange, tokenBalanceChanges = [] } =
     simulationData ?? {};
@@ -200,18 +210,21 @@ export default function useBalanceChanges(
     [JSON.stringify(erc20TokenAddresses), chainId, fiatCurrency],
   );
 
-  if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData ) {
+  if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData) {
     return { pending: true, value: [] };
   }
 
   const nativeChange = getNativeBalanceChange(
     nativeBalanceChange,
     nativeFiatRate,
+    chainId,
   );
+
   const tokenChanges = getTokenBalanceChanges(
     tokenBalanceChanges,
     erc20Decimals.value,
     erc20FiatRates.value,
+    chainId,
   );
 
   const balanceChanges: BalanceChange[] = [

--- a/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  CHAIN_IDS,
   SimulationData,
   SimulationErrorCode,
 } from '@metamask/transaction-controller';
@@ -23,7 +22,6 @@ import {
   useSimulationMetrics,
 } from './useSimulationMetrics';
 import useLoadingTime from './useLoadingTime';
-import { selectChainId } from '../../../selectors/networkController';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 
 jest.mock('react-redux', () => ({
@@ -89,7 +87,6 @@ describe('useSimulationMetrics', () => {
   const useDisplayNamesMock = jest.mocked(useDisplayNames);
   const useLoadingTimeMock = jest.mocked(useLoadingTime);
   const setLoadingCompleteMock = jest.fn();
-  const selectChainIdMock = jest.mocked(selectChainId);
 
   function expectUpdateTransactionMetricsCalled(
     {
@@ -141,7 +138,6 @@ describe('useSimulationMetrics', () => {
       loadingTime: LOADING_TIME_MOCK,
       setLoadingComplete: setLoadingCompleteMock,
     });
-    selectChainIdMock.mockReturnValue(CHAIN_IDS.MAINNET);
   });
 
   describe('updates transaction simulation metrics', () => {

--- a/app/components/UI/SimulationDetails/useSimulationMetrics.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import {
   SimulationData,
   SimulationErrorCode,
@@ -17,7 +17,6 @@ import { NameType } from '../../UI/Name/Name.types';
 import useLoadingTime from './useLoadingTime';
 import { calculateTotalFiat } from './FiatDisplay/FiatDisplay';
 import { BalanceChange } from './types';
-import { selectChainId } from '../../../selectors/networkController';
 
 export interface UseSimulationMetricsProps {
   balanceChanges: BalanceChange[];
@@ -50,9 +49,6 @@ export function useSimulationMetrics({
   const { loadingTime, setLoadingComplete } = useLoadingTime();
   const dispatch = useDispatch();
 
-  // TODO: Remove global network selector usage once simulations refactored.
-  const chainId = useSelector(selectChainId);
-
   if (!loading) {
     setLoadingComplete();
   }
@@ -62,7 +58,7 @@ export function useSimulationMetrics({
       value: asset.address ?? '',
       type: NameType.EthereumAddress,
       preferContractSymbol: true,
-      variation: chainId,
+      variation: asset.chainId,
     }),
   );
 

--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -264,16 +264,14 @@ class Confirm extends PureComponent {
      * Boolean that indicates if smart transaction should be used
      */
     shouldUseSmartTransaction: PropTypes.bool,
-
     /**
      * Object containing transaction metrics by id
      */
     transactionMetricsById: PropTypes.object,
-
     /**
-     * Object containing the transaction simulation data
+     * Transaction metadata from the transaction controller
      */
-    transactionSimulationData: PropTypes.object,
+    transactionMetadata: PropTypes.object,
     /**
      * Update transaction metrics
      */
@@ -915,8 +913,11 @@ class Confirm extends PureComponent {
       resetTransaction,
       gasEstimateType,
       shouldUseSmartTransaction,
-      transactionSimulationData: { isUpdatedAfterSecurityCheck } = {},
+      transactionMetadata,
     } = this.props;
+
+    const transactionSimulationData = transactionMetadata?.simulationData;
+    const { isUpdatedAfterSecurityCheck } = transactionSimulationData ?? {};
 
     const {
       legacyGasTransaction,
@@ -1326,7 +1327,7 @@ class Confirm extends PureComponent {
       gasEstimateType,
       isNativeTokenBuySupported,
       shouldUseSmartTransaction,
-      transactionSimulationData,
+      transactionMetadata,
       transactionState,
       useTransactionSimulations,
     } = this.props;
@@ -1359,6 +1360,7 @@ class Confirm extends PureComponent {
     const isLedgerAccount = isHardwareAccount(fromSelectedAddress, [
       ExtendedKeyringTypes.ledger,
     ]);
+    const transactionSimulationData = transactionMetadata?.simulationData;
 
     const isTestNetwork = isTestNet(chainId);
 
@@ -1430,9 +1432,8 @@ class Confirm extends PureComponent {
           {useTransactionSimulations && transactionState?.id && (
             <View style={styles.simulationWrapper}>
               <SimulationDetails
+                transaction={transactionMetadata}
                 enableMetrics
-                simulationData={transactionSimulationData}
-                transactionId={transactionState.id}
               />
             </View>
           )}
@@ -1575,8 +1576,8 @@ const mapStateToProps = (state) => ({
   ),
   shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
   transactionMetricsById: selectTransactionMetrics(state),
-  transactionSimulationData:
-    selectCurrentTransactionMetadata(state)?.simulationData,
+  transactionMetadata:
+    selectCurrentTransactionMetadata(state),
   useTransactionSimulations: selectUseTransactionSimulations(state),
   securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
 });

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -262,10 +262,6 @@ class TransactionReview extends PureComponent {
      */
     shouldUseSmartTransaction: PropTypes.bool,
     /**
-     * Transaction simulation data
-     */
-    transactionSimulationData: PropTypes.object,
-    /**
      * Boolean that indicates if transaction simulations should be enabled
      */
     useTransactionSimulations: PropTypes.bool,
@@ -523,9 +519,11 @@ class TransactionReview extends PureComponent {
       transaction,
       transaction: { to, origin, from, ensRecipient, id: transactionId },
       error,
-      transactionSimulationData,
+      transactionMetadata,
       useTransactionSimulations,
     } = this.props;
+
+    const transactionSimulationData = transactionMetadata?.simulationData;
 
     const {
       actionKey,
@@ -619,9 +617,8 @@ class TransactionReview extends PureComponent {
                     {useTransactionSimulations && transactionSimulationData && (
                       <View style={styles.transactionSimulations}>
                         <SimulationDetails
-                          simulationData={transactionSimulationData}
+                          transaction={transactionMetadata}
                           enableMetrics
-                          transactionId={transactionId}
                         />
                       </View>
                     )}
@@ -720,8 +717,6 @@ const mapStateToProps = (state) => ({
   primaryCurrency: state.settings.primaryCurrency,
   tokenList: selectTokenList(state),
   shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
-  transactionSimulationData:
-    selectCurrentTransactionMetadata(state)?.simulationData,
   useTransactionSimulations: selectUseTransactionSimulations(state),
   securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
   transactionMetadata: selectCurrentTransactionMetadata(state),


### PR DESCRIPTION
## **Description**

Remove any usage of the global network from transaction simulation.

This requires using the `chainId` from the `TransactionMeta`, and so the `SimulationDetails` properties have been simplified to accept `TransactionMeta` directly to minimise the number of tightly coupled properties.

## **Related issues**

Fixes: [#2011](https://github.com/MetaMask/mobile-planning/issues/2011)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
