### PR TITLE
fix: improve error handling in staking eligibility hook

### DIFF
--- a/app/components/UI/Stake/hooks/useStakingEligibility.test.tsx
+++ b/app/components/UI/Stake/hooks/useStakingEligibility.test.tsx
@@ -27,10 +27,13 @@ const mockStakingApiService: Partial<StakingApiService> = {
   getPooledStakingEligibility: jest.fn(),
 };
 
-const mockSdkContext: Stake = {
+const createMockStakeContext = (overrides?: Partial<Stake>) => ({
   setSdkType: jest.fn(),
   stakingApiService: mockStakingApiService as StakingApiService,
-};
+  ...overrides,
+});
+
+let mockSdkContext = createMockStakeContext();
 
 // Mock the context
 jest.mock('./useStakeContext', () => ({
@@ -38,6 +41,10 @@ jest.mock('./useStakeContext', () => ({
 }));
 
 describe('useStakingEligibility', () => {
+  beforeEach(() => {
+    mockSdkContext = createMockStakeContext();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -122,6 +129,24 @@ describe('useStakingEligibility', () => {
         expect(
           mockStakingApiService.getPooledStakingEligibility,
         ).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('when stakingApiService is undefined', () => {
+    it('handles undefined stakingApiService gracefully', async () => {
+      // Override the mock context with undefined stakingApiService
+      mockSdkContext = createMockStakeContext({
+        stakingApiService: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useStakingEligibility(), {
+        state: mockInitialState,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoadingEligibility).toBe(false);
+        expect(result.current.isEligible).toBe(false);
       });
     });
   });

--- a/app/components/UI/Stake/hooks/useStakingEligibility.ts
+++ b/app/components/UI/Stake/hooks/useStakingEligibility.ts
@@ -19,14 +19,12 @@ const useStakingEligibility = () => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchStakingEligibility = useCallback(async () => {
-    if (!stakingApiService) {
-      throw new Error('Staking API service is unavailable');
-    }
-
-    setIsLoading(true);
-    setError(null);
-
     try {
+      if (!stakingApiService) {
+        return { isEligible: false };
+      }
+      setIsLoading(true);
+      setError(null);
       const { eligible } = await stakingApiService.getPooledStakingEligibility([
         selectedAddress,
       ]);


### PR DESCRIPTION
## **Description**

This PR improves loose error handling in the eligibility hook when Staking API service is not available by moving the check to the existing try catch block. 

## **Related issues**

Fixes: 
https://github.com/MetaMask/metamask-mobile/issues/12759
[STAKE-910](https://consensyssoftware.atlassian.net/browse/STAKE-910)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[STAKE-910]: https://consensyssoftware.atlassian.net/browse/STAKE-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ