### PR TITLE
test: send failing contract

### DIFF
--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -119,6 +119,13 @@ class TestDApp {
     );
   }
 
+  get sendFailingTransactionButton() {
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.SEND_FAILING_TRANSACTION_BUTTON_ID,
+    );
+  }
+
   async connect() {
     await this.tapButton(this.DappConnectButton);
   }
@@ -179,6 +186,10 @@ class TestDApp {
 
   async tapApproveButton() {
     await Gestures.tap(this.approveButtonText, 0);
+  }
+
+  async tapSendFailingTransactionButton() {
+    await this.tapButton(this.sendFailingTransactionButton);
   }
 
   async tapButton(elementId) {

--- a/e2e/selectors/Browser/TestDapp.selectors.js
+++ b/e2e/selectors/Browser/TestDapp.selectors.js
@@ -13,4 +13,5 @@ export const TestDappSelectorsWebIDs = {
   SIGN_TYPE_DATA_V4: 'signTypedDataV4',
   ETHEREUM_SIGN: 'siwe',
   ADD_TOKENS_TO_WALLET_BUTTON: 'watchAssets',
+  SEND_FAILING_TRANSACTION_BUTTON_ID: 'sendFailingButton',
 };

--- a/e2e/selectors/Transactions/ActivitiesView.selectors.js
+++ b/e2e/selectors/Transactions/ActivitiesView.selectors.js
@@ -10,6 +10,7 @@ export const ActivitiesViewSelectorsIDs = {
 
 export const ActivitiesViewSelectorsText = {
   CONFIRM_TEXT: enContent.transaction.confirmed,
+  FAILED_TEXT: enContent.transaction.failed,
   SMART_CONTRACT_INTERACTION: enContent.transactions.smart_contract_interaction,
   INCREASE_ALLOWANCE_METHOD: enContent.transactions.increase_allowance,
   SENT_COLLECTIBLE_MESSAGE_TEXT: enContent.transactions.sent_collectible,

--- a/e2e/specs/confirmations/send-failing-contract.spec.js
+++ b/e2e/specs/confirmations/send-failing-contract.spec.js
@@ -1,0 +1,69 @@
+'use strict';
+
+import { SmokeConfirmations } from '../../tags';
+import TestHelpers from '../../helpers';
+import { loginToApp } from '../../viewHelper';
+
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestDApp from '../../pages/Browser/TestDApp';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../fixtures/fixture-helper';
+import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
+import { ActivitiesViewSelectorsText } from '../../selectors/Transactions/ActivitiesView.selectors';
+import Assertions from '../../utils/Assertions';
+
+describe(SmokeConfirmations('Failing contracts'), () => {
+  const FAILING_CONTRACT = SMART_CONTRACTS.FAILING;
+
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+    await TestHelpers.reverseServerPort();
+  });
+
+  it('sends a failing contract transaction', async () => {
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+        smartContract: FAILING_CONTRACT,
+      },
+      async ({ contractRegistry }) => {
+        const failingAddress = await contractRegistry.getContractAddress(
+          FAILING_CONTRACT,
+        );
+        await loginToApp();
+
+        // Navigate to the browser screen
+        await TabBarComponent.tapBrowser();
+        await TestDApp.navigateToTestDappWithContract({
+          contractAddress: failingAddress,
+        });
+
+        // Send a failing transaction
+        await TestDApp.tapSendFailingTransactionButton();
+        await TestHelpers.delay(3000);
+
+        await TestDApp.tapConfirmButton();
+
+        // Navigate to the activity screen
+        await TabBarComponent.tapActivity();
+
+        // Assert the failed transaction is displayed
+        await Assertions.checkIfTextIsDisplayed(
+          ActivitiesViewSelectorsText.SMART_CONTRACT_INTERACTION
+        );
+        await Assertions.checkIfTextIsDisplayed(
+          ActivitiesViewSelectorsText.FAILED_TEXT
+        );
+      },
+    );
+  });
+});

--- a/e2e/specs/confirmations/send-failing-contract.spec.js
+++ b/e2e/specs/confirmations/send-failing-contract.spec.js
@@ -14,6 +14,7 @@ import {
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 import { ActivitiesViewSelectorsText } from '../../selectors/Transactions/ActivitiesView.selectors';
 import Assertions from '../../utils/Assertions';
+import { mockEvents } from '../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Failing contracts'), () => {
   const FAILING_CONTRACT = SMART_CONTRACTS.FAILING;
@@ -24,6 +25,12 @@ describe(SmokeConfirmations('Failing contracts'), () => {
   });
 
   it('sends a failing contract transaction', async () => {
+
+    const testSpecificMock  = {
+        GET: [
+          mockEvents.GET.suggestedGasFeesApiGanache
+        ],
+      };
     await withFixtures(
       {
         dapp: true,
@@ -34,6 +41,7 @@ describe(SmokeConfirmations('Failing contracts'), () => {
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
         smartContract: FAILING_CONTRACT,
+        testSpecificMock,
       },
       async ({ contractRegistry }) => {
         const failingAddress = await contractRegistry.getContractAddress(
@@ -46,6 +54,8 @@ describe(SmokeConfirmations('Failing contracts'), () => {
         await TestDApp.navigateToTestDappWithContract({
           contractAddress: failingAddress,
         });
+
+        await TestHelpers.delay(99999999);
 
         // Send a failing transaction
         await TestDApp.tapSendFailingTransactionButton();

--- a/e2e/specs/confirmations/send-failing-contract.spec.js
+++ b/e2e/specs/confirmations/send-failing-contract.spec.js
@@ -54,9 +54,7 @@ describe(SmokeConfirmations('Failing contracts'), () => {
         await TestDApp.navigateToTestDappWithContract({
           contractAddress: failingAddress,
         });
-
-        await TestHelpers.delay(99999999);
-
+        
         // Send a failing transaction
         await TestDApp.tapSendFailingTransactionButton();
         await TestHelpers.delay(3000);


### PR DESCRIPTION
## **Description**

This PR is within the scope of the Quality Quest.

We're including an e2e test case that send a failing contract in the test dApp.

**Steps:**
Given I am on the test dapp
When I tap on the Send failing transaction button in the Failing Contract section
Then the transaction bottom sheet should appear
_And I should see a warning "this transaction will likely fail"_ <- This message is not present
When I submit the transaction
Then the transaction should appear in the transaction history
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [✓] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [✓] I've completed the PR template to the best of my ability
- [✓] I’ve included tests if applicable
- [✓] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [✓] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
