### PR TITLE
test(3615): E2E to test the scenario when the dapp requests to switch the active network, and grant permission on the fly

### DIFF
--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -139,6 +139,13 @@ class TestDApp {
     );
   }
 
+  get switchChainFromTestDappButton() {
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.SWITCH_ETHEREUM_CHAIN,
+    );
+  }
+
   async connect() {
     await this.tapButton(this.DappConnectButton);
   }
@@ -222,6 +229,10 @@ class TestDApp {
       `${TEST_DAPP_LOCAL_URL}?scrollTo=''&contract=${contractAddress}`,
     );
     await TestHelpers.delay(3000); // should have a better assertion that waits until the webpage loads
+  }
+
+  async switchChainFromTestDapp() {
+    await this.tapButton(this.switchChainFromTestDappButton);
   }
 }
 

--- a/e2e/resources/networks.e2e.js
+++ b/e2e/resources/networks.e2e.js
@@ -91,7 +91,17 @@ const CustomNetworks = {
       ticker: 'SepoliaETH',
     },
   },
-
+  ElysiumTestnet: {
+    providerConfig: {
+      type: 'rpc',
+      chainId: '0x53a',
+      rpcUrlInvalid: 'https://rpc.atlantischain.network',
+      rpcUrl: 'https://rpc.atlantischain.network',
+      rpcUrlAlt: 'https://rpc.atlantischain.network',
+      nickname: 'Elysium Testnet',
+      ticker: 'LAVA',
+    },
+  },
   Tenderly: {
     isCustomNetwork: true,
     providerConfig: {

--- a/e2e/selectors/Browser/TestDapp.selectors.js
+++ b/e2e/selectors/Browser/TestDapp.selectors.js
@@ -15,4 +15,5 @@ export const TestDappSelectorsWebIDs = {
   ADD_TOKENS_TO_WALLET_BUTTON: 'watchAssets',
   SEND_FAILING_TRANSACTION_BUTTON_ID: 'sendFailingButton',
   BATCH_TRANSFER_ERC1155_BUTTON_ID: 'batchTransferFromButton',
+  SWITCH_ETHEREUM_CHAIN: 'switchEthereumChain',
 };

--- a/e2e/specs/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
+++ b/e2e/specs/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+import FixtureBuilder from '../../../../fixtures/fixture-builder';
+import { withFixtures } from '../../../../fixtures/fixture-helper';
+import TestHelpers from '../../../../helpers';
+import Browser from '../../../../pages/Browser/BrowserView';
+import ConnectBottomSheet from '../../../../pages/Browser/ConnectBottomSheet';
+import TestDApp from '../../../../pages/Browser/TestDApp';
+import NetworkEducationModal from '../../../../pages/Network/NetworkEducationModal';
+import TabBarComponent from '../../../../pages/wallet/TabBarComponent';
+import WalletView from '../../../../pages/wallet/WalletView';
+import { CustomNetworks } from '../../../../resources/networks.e2e';
+import { SmokeMultiChainPermissions } from '../../../../tags';
+import Assertions from '../../../../utils/Assertions';
+import { loginToApp } from '../../../../viewHelper';
+import ConnectedAccountsModal from '../../../../pages/Browser/ConnectedAccountsModal';
+import NetworkConnectMultiSelector from '../../../../pages/Browser/NetworkConnectMultiSelector';
+
+describe(SmokeMultiChainPermissions('Chain Permission System'), () => {
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+    await TestHelpers.reverseServerPort();
+  });
+
+  describe('When a dApp requests to switch to a new chain', () => {
+    it('should grant permission to the new chain and switch to it when approved', async () => {
+      await withFixtures(
+        {
+          dapp: true,
+          fixture: new FixtureBuilder()
+            .withNetworkController(CustomNetworks.ElysiumTestnet)
+            .withNetworkController(CustomNetworks.EthereumMainCustom)
+            .withPermissionController()
+            .build(),
+          restartDevice: true,
+        },
+        async () => {
+          // Setup: Login and navigate to browser
+          await loginToApp();
+          await TabBarComponent.tapBrowser();
+          await Assertions.checkIfVisible(Browser.browserScreenID);
+
+          // Connect to test dApp
+          await Browser.navigateToTestDApp();
+          await TestDApp.connect();
+          await ConnectBottomSheet.tapConnectButton();
+
+          // Grant permission and switch to new chain
+          await TestDApp.switchChainFromTestDapp();
+          await ConnectBottomSheet.tapConnectButton();
+          await NetworkEducationModal.tapGotItButton();
+
+          // Verify network switch was successful
+          await TabBarComponent.tapWallet();
+          await Assertions.checkIfVisible(WalletView.container);
+          const networkPicker = await WalletView.getNavbarNetworkPicker();
+          await Assertions.checkIfElementHasLabel(
+            networkPicker,
+            CustomNetworks.ElysiumTestnet.providerConfig.nickname,
+          );
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
E2E to test the scenario when the dapp requests to switch the active network, and grant permission on the fl
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Contributes to: https://github.com/MetaMask/MetaMask-planning/issues/3615

## **Manual testing steps**


1. `yarn watch:clean` 
2. `yarn test:e2e:ios:debug:build`
3. `yarn test:e2e:ios:debug:run <path to test file>`



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
