### PR TITLE
Expand button for better DApp UX

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1618,6 +1618,7 @@
     "home": "Home",
     "close": "Close",
     "open_in_browser": "Open in browser",
+    "expand": "Expand",
     "change_url": "Change url",
     "switch_network": "Switch network",
     "dapp_browser": "DAPP BROWSER",

--- a/wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds.js
+++ b/wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds.js
@@ -13,3 +13,5 @@ export const SHARE_OPTION = 'browser-options-menu-share';
 export const OPEN_IN_BROWSER_OPTION = 'browser-options-menu-open-in-browser';
 
 export const SWITCH_NETWORK_OPTION = 'browser-options-switch-browser';
+
+export const EXPAND_OPTION = 'browser-options-menu-expand';


### PR DESCRIPTION
The expand button hides the bottom bar and the header.

## **Description**

I've added a new option to the browser tab menu that expands the browser. Now the app header and the bottom bar need too much space, which degrades the DApp user experience. Users can hide these components with the expand button to see the DApp as a real app.

## **Related issues**

This PR is related to this: https://community.metamask.io/t/pr-for-fullscreen-in-mobile-metamask-browser/29933

## **Manual testing steps**

1. Go to the browser page
2. Open a DApp page
3. In the menu, choose 'Expand'
4. You can change back by the small 'compress' button on the top right

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/aad7848d-66dc-4782-b458-712d5b37f5f4)

![image](https://github.com/user-attachments/assets/c89b55f2-0fc0-43c4-9e56-c62e88e854f3)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
