### PR TITLE
test: Disable flakey chain permissions e2e

### DIFF
--- a/e2e/specs/multichain/permissions/chains/permission-system-add-non-permitted.spec.js
+++ b/e2e/specs/multichain/permissions/chains/permission-system-add-non-permitted.spec.js
@@ -102,7 +102,7 @@ describe(
       );
     });
 
-    it('should add network permission when requested', async () => {
+    it.skip('should add network permission when requested', async () => {
       await withFixtures(
         {
           dapp: true,

--- a/e2e/specs/multichain/permissions/chains/permission-system-update-permissions.spec.js
+++ b/e2e/specs/multichain/permissions/chains/permission-system-update-permissions.spec.js
@@ -21,7 +21,7 @@ describe(SmokeMultiChainPermissions('Chain Permission Management'), () => {
     jest.setTimeout(150000);
     await TestHelpers.reverseServerPort();
   });
-  it('allows simultaneous granting and revoking of multiple chain permissions', async () => {
+  it.skip('allows simultaneous granting and revoking of multiple chain permissions', async () => {
     await withFixtures(
       {
         dapp: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The purpose of this PR is to disable a couple of chain permission tests that are flaking as of recently. We aim to renable these tests in https://github.com/MetaMask/metamask-mobile/issues/12872

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
