### PR TITLE
fix: Add `transactionMeta` condition to render `SimulationDetails`

### DIFF
--- a/app/components/Views/confirmations/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/SendFlow/Confirm/index.js
@@ -1457,14 +1457,16 @@ class Confirm extends PureComponent {
               </View>
             </View>
           )}
-          {useTransactionSimulations && transactionState?.id && (
-            <View style={styles.simulationWrapper}>
-              <SimulationDetails
-                transaction={transactionMetadata}
-                enableMetrics
-              />
-            </View>
-          )}
+          {useTransactionSimulations &&
+            transactionState?.id &&
+            transactionMetadata && (
+              <View style={styles.simulationWrapper}>
+                <SimulationDetails
+                  transaction={transactionMetadata}
+                  enableMetrics
+                />
+              </View>
+            )}
           <TransactionReview
             gasSelected={this.state.gasSelected}
             primaryCurrency={primaryCurrency}

--- a/app/components/Views/confirmations/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/components/TransactionReview/index.js
@@ -614,14 +614,16 @@ class TransactionReview extends PureComponent {
                       primaryCurrency={primaryCurrency}
                       chainId={chainId}
                     />
-                    {useTransactionSimulations && transactionSimulationData && (
-                      <View style={styles.transactionSimulations}>
-                        <SimulationDetails
-                          transaction={transactionMetadata}
-                          enableMetrics
-                        />
-                      </View>
-                    )}
+                    {useTransactionSimulations &&
+                      transactionSimulationData &&
+                      transactionMetadata && (
+                        <View style={styles.transactionSimulations}>
+                          <SimulationDetails
+                            transaction={transactionMetadata}
+                            enableMetrics
+                          />
+                        </View>
+                      )}
                     <View style={styles.accountInfoCardWrapper}>
                       <TransactionReviewInformation
                         navigation={navigation}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove render case for `SimulationDetails` when `transactionMeta` is not ready.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/12914

## **Manual testing steps**

1. Open the app and initiate a transaction.
2. Enter a destination wallet address in the send view.
3. Navigate to the confirmation screen.
4. Return to the send view and edit the destination wallet address.
5. Navigate back to the confirmation screen.


## **Screenshots/Recordings**


https://github.com/user-attachments/assets/8590fbfb-a1cc-492f-ac61-659a82312719


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
