### PR TITLE
fix: fixed getStakingNavbar broken back and cancel buttons regression

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1991,7 +1991,7 @@ export function getStakingNavbar(
       withMetaMetrics(navigationPop, {
         event: metricsOptions.backButtonEvent.event,
         properties: metricsOptions.backButtonEvent.properties,
-      });
+      })();
     } else {
       navigationPop();
     }
@@ -2002,7 +2002,7 @@ export function getStakingNavbar(
       withMetaMetrics(navigationPop, {
         event: metricsOptions.cancelButtonEvent.event,
         properties: metricsOptions.cancelButtonEvent.properties,
-      });
+      })();
     } else {
       navigationPop();
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a recently introduced regression that broke the "back" and "cancel" buttons when using `getStakingNavbar()`. This only impacted the staking views.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

- Ticket that introduced regression: [Stake-884: Add more mobile pooled staking events](https://consensyssoftware.atlassian.net/browse/STAKE-884)
- PR that introduced regression: https://github.com/MetaMask/metamask-mobile/pull/12651


## **Manual testing steps**

Stake Input Screen (broken cancel navbar button)
1. Set `MM_POOLED_STAKING_UI_ENABLED` to `true` in `.js.env`
2. Click "Ethereum" from the token list (home screen)
3. Click on the "Stake" or "Stake more" button (the same can be tested for the unstake flow if you have ETH staked)
4. From the Staking Input View, click the "Cancel" button in the top-right corner.
5. You should be redirected to the previous screen (Ethereum details)

Stake Confirmation Screen (broken back navbar button)
1. Set `MM_POOLED_STAKING_UI_ENABLED` to `true` in `.js.env`
2. Click "Ethereum" from the token list (home screen)
3. Click on the "Stake" or "Stake more" button (the same can be tested for the unstake flow if you have ETH staked)
4. Enter a valid amount and press "Review" to view the stake confirmation screen.
5. Click the "back" button in the top-left corner in the navbar
6. You should be redirected to the previous screen (stake input screen)



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6b626874-7bee-4f32-a352-1a48e105eeb1


### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/7e12e943-bcc1-4f35-89c6-531185a83cd1

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


