### PR TITLE
fix: Keep latest 50 history instead of first 50

### DIFF
--- a/app/reducers/browser/index.js
+++ b/app/reducers/browser/index.js
@@ -27,7 +27,7 @@ const browserReducer = (state = initialState, action) => {
 
       return {
         ...state,
-        history: [...state.history, { url, name }].slice(0, 50),
+        history: [...state.history, { url, name }].slice(-50),
       };
     }
     case 'ADD_TO_BROWSER_WHITELIST':


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
History is kept in chronological order, but we cut off the latest elements instead of the most recent ones. This PR fixes that.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Manual testing steps**

1. Make sure you have 50 elements in your history
2. Browse to a URL you've never been to before
3. Verify that the new URL is part of your browsing history

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
