### PR TITLE
feat: Adding remote feature flag for signature redesign

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
 import { ApprovalTypes } from '../../../../core/RPCMethods/RPCMethodMiddleware';
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
 import useApprovalRequest from './useApprovalRequest';
 
 const useConfirmationRedesignEnabled = () => {
   const { approvalRequest } = useApprovalRequest();
+  const { confirmation_redesign } = useSelector(selectRemoteFeatureFlags);
 
   const { type: approvalRequestType } = approvalRequest ?? {
     requestData: {},
@@ -12,12 +15,12 @@ const useConfirmationRedesignEnabled = () => {
 
   const isRedesignedEnabled = useMemo(
     () =>
+      (confirmation_redesign as Record<string, string>)?.signatures &&
       approvalRequestType &&
-      process.env.REDESIGNED_SIGNATURE_REQUEST === 'true' &&
       [ApprovalTypes.PERSONAL_SIGN, ApprovalTypes.ETH_SIGN_TYPED_DATA].includes(
         approvalRequestType as ApprovalTypes,
       ),
-    [approvalRequestType],
+    [approvalRequestType, confirmation_redesign],
   );
 
   return { isRedesignedEnabled };

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -16,6 +16,7 @@ const useConfirmationRedesignEnabled = () => {
   const isRedesignedEnabled = useMemo(
     () =>
       (confirmation_redesign as Record<string, string>)?.signatures &&
+      process.env.REDESIGNED_SIGNATURE_REQUEST === 'true' &&
       approvalRequestType &&
       [ApprovalTypes.PERSONAL_SIGN, ApprovalTypes.ETH_SIGN_TYPED_DATA].includes(
         approvalRequestType as ApprovalTypes,

--- a/app/util/test/confirm-data-helpers.ts
+++ b/app/util/test/confirm-data-helpers.ts
@@ -32,6 +32,13 @@ export const personalSignatureConfirmationState = {
         pendingApprovalCount: 1,
         approvalFlows: [],
       },
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          confirmation_redesign: {
+            signatures: true,
+          },
+        },
+      },
     },
   },
 };
@@ -92,6 +99,13 @@ export const typedSignV1ConfirmationState = {
               metamaskId: '7e62bcb0-a4e9-11ef-9b51-ddf21c91a998',
               version: 'V1',
             } as MessageParamsTyped,
+          },
+        },
+      },
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          confirmation_redesign: {
+            signatures: true,
           },
         },
       },
@@ -181,6 +195,13 @@ export const typedSignV3ConfirmationState = {
               metamaskId: 'fb2029e1-b0ab-11ef-9227-05a11087c334',
               version: 'V3',
             } as MessageParamsTyped,
+          },
+        },
+      },
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          confirmation_redesign: {
+            signatures: true,
           },
         },
       },


### PR DESCRIPTION
## **Description**

Adding remote feature flag for signature re-designs.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3875

## **Manual testing steps**

1. Run the app locally
2. Submit signature request and it should open in new designs

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
