### PR TITLE
feat: Use a dynamic interval value for smart transaction status polling

### DIFF
--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -11,7 +11,10 @@ import {
   WalletDevice,
 } from '@metamask/transaction-controller';
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
-import { type SmartTransaction, ClientId } from '@metamask/smart-transactions-controller/dist/types';
+import {
+  type SmartTransaction,
+  ClientId,
+} from '@metamask/smart-transactions-controller/dist/types';
 
 import {
   AllowedActions,
@@ -113,11 +116,15 @@ type WithRequestOptions = {
 type WithRequestCallback<ReturnValue> = ({
   request,
   controllerMessenger,
+  getFeesSpy,
+  submitSignedTransactionsSpy,
+  smartTransactionsController,
 }: {
   request: SubmitSmartTransactionRequestMocked;
   controllerMessenger: SubmitSmartTransactionRequestMocked['controllerMessenger'];
   getFeesSpy: jest.SpyInstance;
   submitSignedTransactionsSpy: jest.SpyInstance;
+  smartTransactionsController: SmartTransactionsController;
 }) => ReturnValue;
 
 type WithRequestArgs<ReturnValue> =
@@ -209,6 +216,7 @@ function withRequest<ReturnValue>(
     request,
     getFeesSpy,
     submitSignedTransactionsSpy,
+    smartTransactionsController,
   });
 }
 
@@ -393,7 +401,7 @@ describe('submitSmartTransactionHook', () => {
         const result = await submitSmartTransactionHook(request);
 
         expect(result).toEqual({ transactionHash });
-        const { txParams, chainId } = request.transactionMeta;        
+        const { txParams, chainId } = request.transactionMeta;
 
         expect(
           request.transactionController.approveTransactionsWithSameNonce,
@@ -656,6 +664,35 @@ describe('submitSmartTransactionHook', () => {
           });
         },
       );
+    });
+  });
+  it('sets the status refresh interval if provided in feature flags', async () => {
+    withRequest(async ({ request, smartTransactionsController }) => {
+      const setStatusRefreshIntervalSpy = jest.spyOn(
+        smartTransactionsController,
+        'setStatusRefreshInterval',
+      );
+
+      request.featureFlags.smartTransactions.batchStatusPollingInterval = 2000;
+
+      await submitSmartTransactionHook(request);
+
+      expect(setStatusRefreshIntervalSpy).toHaveBeenCalledWith(2000);
+    });
+  });
+
+  it('does not set the status refresh interval if not provided in feature flags', async () => {
+    withRequest(async ({ request, smartTransactionsController }) => {
+      const setStatusRefreshIntervalSpy = jest.spyOn(
+        smartTransactionsController,
+        'setStatusRefreshInterval',
+      );
+
+      request.featureFlags.smartTransactions.batchStatusPollingInterval = 0;
+
+      await submitSmartTransactionHook(request);
+
+      expect(setStatusRefreshIntervalSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -194,6 +194,7 @@ function withRequest<ReturnValue>(
         expectedDeadline: 45,
         maxDeadline: 150,
         mobileReturnTxHashAsap: false,
+        batchStatusPollingInterval: 1000,
       },
       mobile_active: true,
       extension_active: true,

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -53,6 +53,7 @@ export interface SubmitSmartTransactionRequest {
           expectedDeadline: number;
           maxDeadline: number;
           mobileReturnTxHashAsap: boolean;
+          batchStatusPollingInterval: number;
         }
       | Record<string, never>;
   };
@@ -75,6 +76,7 @@ class SmartTransactionHook {
       expectedDeadline?: number;
       maxDeadline?: number;
       mobileReturnTxHashAsap?: boolean;
+      batchStatusPollingInterval?: number;
     };
   };
   #shouldUseSmartTransaction: boolean;
@@ -184,6 +186,11 @@ class SmartTransactionHook {
       // In the event that STX health check passes, but for some reason /getFees fails, we fallback to a regular transaction
       if (!getFeesResponse) {
         return useRegularTransactionSubmit;
+      }
+
+      const batchStatusPollingInterval = this.#featureFlags?.smartTransactions?.batchStatusPollingInterval;
+      if (batchStatusPollingInterval) {
+        this.#smartTransactionsController.setStatusRefreshInterval(batchStatusPollingInterval);
       }
 
       const submitTransactionResponse = await this.#signAndSubmitTransactions({


### PR DESCRIPTION
## **Description**
We want to use a dynamic interval value for smart transaction status polling, which is returned by backend. That way we can easily change it if needed and use the most optimal value.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Make sure smart transactions are enabled in Advanced Settings
2. Be on Ethereum Mainnet
3. Submit a smart transaction
4. Check that a network request for checking smart transaction status happens every second

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
