### PR TITLE
fix(12758): As requested, replace logging with swallowed error.

### DIFF
--- a/app/components/Views/AccountPermissions/AccountPermissions.tsx
+++ b/app/components/Views/AccountPermissions/AccountPermissions.tsx
@@ -155,7 +155,7 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
         );
       }
     } catch (e) {
-      Logger.error(e as Error, 'Error getting permitted chains caveat');
+      // no-op
     }
 
     const networks = Object.entries(networkConfigurations).map(
@@ -812,7 +812,7 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
             );
           }
         } catch (e) {
-          Logger.error(e as Error, 'Error getting permitted chains caveat');
+          // no-op
         }
 
         // Add current chainId if no chains are permitted yet


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
It seems this error is 'expected', and was creating unnecessary traffic on sentry which is intended for errors. This PR brings back the logic to what it was initially, which swallowed the error.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/12758

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
