### PR TITLE
chore: add package.json script to run unit tests with watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test": "yarn test:unit",
     "test:unit": "jest ./app/ ./locales/",
     "test:unit:update": "time jest -u ./app/",
+    "test:unit:watch": "jest --watch ./app/ ./locales/",
     "test:api-specs": "detox reset-lock-file && detox test -c ios.sim.apiSpecs",
     "test:e2e:ios:build:qa-release": "IS_TEST='true' detox build -c ios.sim.qa",
     "test:e2e:ios:run:qa-release": "IS_TEST='true' detox test -c ios.sim.qa",


### PR DESCRIPTION
- This script allows developers to run Jest in watch mode, providing continuous test execution and immediate feedback on code changes.

- Key bindings in watch mode:

<img width="633" alt="Screenshot 2025-01-15 at 3 54 25 PM" src="https://github.com/user-attachments/assets/0ba55d17-feb5-484d-b5e1-fdda363a7336" />

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
