### PR TITLE
fix: fix old signature e2e by mocking launch darkly api

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -16,7 +16,6 @@ const useConfirmationRedesignEnabled = () => {
   const isRedesignedEnabled = useMemo(
     () =>
       (confirmation_redesign as Record<string, string>)?.signatures &&
-      process.env.REDESIGNED_SIGNATURE_REQUEST === 'true' &&
       approvalRequestType &&
       [ApprovalTypes.PERSONAL_SIGN, ApprovalTypes.ETH_SIGN_TYPED_DATA].includes(
         approvalRequestType as ApprovalTypes,

--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -62,12 +62,30 @@ export const mockEvents = {
       response: [
         {
           mobileMinimumVersions: {
-            androidMinimumAPIVersion: 21,
             appMinimumBuild: 1243,
             appleMinimumOS: 6,
+            androidMinimumAPIVersion: 21,
           },
         },
-        { testFlagForThreshold: [[Object], [Object], [Object]] },
+        {
+          testFlagForThreshold: [
+            {
+              scope: { type: 'threshold', value: 0.3 },
+              value: 'valueA',
+              name: 'groupA',
+            },
+            {
+              scope: { value: 0.5, type: 'threshold' },
+              value: 'valueB',
+              name: 'groupB',
+            },
+            {
+              name: 'groupC',
+              scope: { value: 1, type: 'threshold' },
+              value: 'valueC',
+            },
+          ],
+        },
         { confirmation_redesign: { signatures: false } },
       ],
       responseCode: 200,

--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -67,25 +67,6 @@ export const mockEvents = {
             androidMinimumAPIVersion: 21,
           },
         },
-        {
-          testFlagForThreshold: [
-            {
-              scope: { type: 'threshold', value: 0.3 },
-              value: 'valueA',
-              name: 'groupA',
-            },
-            {
-              scope: { value: 0.5, type: 'threshold' },
-              value: 'valueB',
-              name: 'groupB',
-            },
-            {
-              name: 'groupC',
-              scope: { value: 1, type: 'threshold' },
-              value: 'valueC',
-            },
-          ],
-        },
         { confirmation_redesign: { signatures: false } },
       ],
       responseCode: 200,

--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -59,7 +59,17 @@ export const mockEvents = {
     remoteFeatureFlags: {
       urlEndpoint:
         'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
-      response: [{ confirmation_redesign: { signatures: false } }],
+      response: [
+        {
+          mobileMinimumVersions: {
+            androidMinimumAPIVersion: 21,
+            appMinimumBuild: 1243,
+            appleMinimumOS: 6,
+          },
+        },
+        { testFlagForThreshold: [[Object], [Object], [Object]] },
+        { confirmation_redesign: { signatures: false } },
+      ],
       responseCode: 200,
     },
   },

--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -38,21 +38,28 @@ export const mockEvents = {
     securityAlertApiSupportedChains: {
       urlEndpoint: 'https://security-alerts.api.cx.metamask.io/supportedChains',
       response: [
-          '0xa4b1',
-          '0xa86a',
-          '0x2105',
-          '0x138d5',
-          '0x38',
-          '0xe708',
-          '0x1',
-          '0x1b6e6',
-          '0xcc',
-          '0xa',
-          '0x89',
-          '0x82750',
-          '0xaa36a7',
-          '0x144'
-        ],
+        '0xa4b1',
+        '0xa86a',
+        '0x2105',
+        '0x138d5',
+        '0x38',
+        '0xe708',
+        '0x1',
+        '0x1b6e6',
+        '0xcc',
+        '0xa',
+        '0x89',
+        '0x82750',
+        '0xaa36a7',
+        '0x144',
+      ],
+      responseCode: 200,
+    },
+
+    remoteFeatureFlags: {
+      urlEndpoint:
+        'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
+      response: [{ confirmation_redesign: { signatures: false } }],
       responseCode: 200,
     },
   },
@@ -77,7 +84,8 @@ export const mockEvents = {
     },
 
     securityAlertApiValidate: {
-      urlEndpoint: 'https://security-alerts.api.cx.metamask.io/validate/0xaa36a7',
+      urlEndpoint:
+        'https://security-alerts.api.cx.metamask.io/validate/0xaa36a7',
       response: {
         block: 20733513,
         result_type: 'Benign',
@@ -93,9 +101,9 @@ export const mockEvents = {
           {
             from: '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
             to: '0x50587e46c5b96a3f6f9792922ec647f13e6efae4',
-            value: '0x0'
-          }
-        ]
+            value: '0x0',
+          },
+        ],
       },
       responseCode: 201,
     },

--- a/e2e/api-specs/json-rpc-coverage.js
+++ b/e2e/api-specs/json-rpc-coverage.js
@@ -22,6 +22,7 @@ import ConfirmationsRejectRule from './ConfirmationsRejectionRule';
 import { createDriverTransport } from './helpers';
 import { BrowserViewSelectorsIDs } from '../selectors/Browser/BrowserView.selectors';
 import { getGanachePort } from '../fixtures/utils';
+import { mockEvents } from '../api-mocking/mock-config/mock-events';
 
 const port = getGanachePort(8545, process.pid);
 const chainId = 1337;
@@ -156,6 +157,10 @@ const main = async () => {
   const server = mockServer(port, openrpcDocument);
   server.start();
 
+  const testSpecificMock = {
+    GET: [mockEvents.GET.remoteFeatureFlags],
+  };
+
   await withFixtures(
     {
       dapp: true,
@@ -163,6 +168,7 @@ const main = async () => {
       ganacheOptions: defaultGanacheOptions,
       disableGanache: true,
       restartDevice: true,
+      testSpecificMock,
     },
     async () => {
       await loginToApp();

--- a/e2e/specs/confirmations/signatures/ethereum-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/ethereum-sign.spec.js
@@ -12,6 +12,7 @@ import {
 import { SmokeConfirmations } from '../../../tags';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Ethereum Sign'), () => {
   beforeAll(async () => {
@@ -20,6 +21,10 @@ describe(SmokeConfirmations('Ethereum Sign'), () => {
   });
 
   it('Sign in with Ethereum', async () => {
+    const testSpecificMock = {
+      GET: [mockEvents.GET.remoteFeatureFlags],
+    };
+
     await withFixtures(
       {
         dapp: true,
@@ -29,6 +34,7 @@ describe(SmokeConfirmations('Ethereum Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -12,18 +12,13 @@ import {
 import { SmokeConfirmations } from '../../../tags';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Personal Sign'), () => {
   const testSpecificMock = {
-    GET: [
-      {
-        urlEndpoint:
-          'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
-        response: [{ confirmation_redesign: { signatures: false } }],
-        responseCode: 200,
-      },
-    ],
+    GET: [mockEvents.GET.remoteFeatureFlags],
   };
+
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -39,7 +34,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        testSpecificMock,
+        // testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -19,7 +19,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
       {
         urlEndpoint:
           'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
-        response: [{ confirmation_redesign: { signatures: 'false' } }],
+        response: [{ confirmation_redesign: { signatures: false } }],
         responseCode: 200,
       },
     ],
@@ -38,8 +38,8 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .withPermissionControllerConnectedToTestDapp()
           .build(),
         restartDevice: true,
-        testSpecificMock,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -34,7 +34,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        testSpecificMock,
+        // testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -14,6 +14,26 @@ import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
 
 describe(SmokeConfirmations('Personal Sign'), () => {
+  const mockRemoteFeatureApi = {
+    GET: [
+      {
+        urlEndpoint:
+          'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
+        response: [
+          {
+            mobileMinimumVersions: {
+              androidMinimumAPIVersion: 21,
+              appMinimumBuild: 1243,
+              appleMinimumOS: 6,
+            },
+          },
+          { testFlagForThreshold: [[Object], [Object], [Object]] },
+          { confirmation_redesign: { signatures: false } },
+        ],
+        responseCode: 200,
+      },
+    ],
+  };
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -29,6 +49,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        mockRemoteFeatureApi,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -19,7 +19,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
       {
         urlEndpoint:
           'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
-        response: [{ confirmation_redesign: { signatures: false } }],
+        response: [{ confirmation_redesign: { signatures: 'false' } }],
         responseCode: 200,
       },
     ],
@@ -38,8 +38,8 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .withPermissionControllerConnectedToTestDapp()
           .build(),
         restartDevice: true,
+        testSpecificMock: mockRemoteFeatureApi,
         ganacheOptions: defaultGanacheOptions,
-        mockRemoteFeatureApi,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -19,17 +19,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
       {
         urlEndpoint:
           'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=dev',
-        response: [
-          {
-            mobileMinimumVersions: {
-              androidMinimumAPIVersion: 21,
-              appMinimumBuild: 1243,
-              appleMinimumOS: 6,
-            },
-          },
-          { testFlagForThreshold: [[Object], [Object], [Object]] },
-          { confirmation_redesign: { signatures: false } },
-        ],
+        response: [{ confirmation_redesign: { signatures: false } }],
         responseCode: 200,
       },
     ],

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -14,7 +14,7 @@ import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
 
 describe(SmokeConfirmations('Personal Sign'), () => {
-  const mockRemoteFeatureApi = {
+  const testSpecificMock = {
     GET: [
       {
         urlEndpoint:
@@ -38,7 +38,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .withPermissionControllerConnectedToTestDapp()
           .build(),
         restartDevice: true,
-        testSpecificMock: mockRemoteFeatureApi,
+        testSpecificMock,
         ganacheOptions: defaultGanacheOptions,
       },
       async () => {

--- a/e2e/specs/confirmations/signatures/personal-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/personal-sign.spec.js
@@ -34,7 +34,7 @@ describe(SmokeConfirmations('Personal Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        // testSpecificMock,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/security-alert-signatures.mock.spec.js
+++ b/e2e/specs/confirmations/signatures/security-alert-signatures.mock.spec.js
@@ -60,7 +60,10 @@ describe(SmokeConfirmations('Security Alert API - Signature'), () => {
 
   it('should sign typed message', async () => {
     const testSpecificMock = {
-      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      GET: [
+        mockEvents.GET.securityAlertApiSupportedChains,
+        mockEvents.GET.remoteFeatureFlags,
+      ],
       POST: [
         {
           ...mockEvents.POST.securityAlertApiValidate,
@@ -83,7 +86,10 @@ describe(SmokeConfirmations('Security Alert API - Signature'), () => {
 
   it('should show security alert for malicious request', async () => {
     const testSpecificMock = {
-      GET: [mockEvents.GET.securityAlertApiSupportedChains],
+      GET: [
+        mockEvents.GET.securityAlertApiSupportedChains,
+        mockEvents.GET.remoteFeatureFlags,
+      ],
       POST: [
         {
           ...mockEvents.POST.securityAlertApiValidate,
@@ -108,6 +114,7 @@ describe(SmokeConfirmations('Security Alert API - Signature'), () => {
     const testSpecificMock = {
       GET: [
         mockEvents.GET.securityAlertApiSupportedChains,
+        mockEvents.GET.remoteFeatureFlags,
         {
           urlEndpoint:
             'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json',

--- a/e2e/specs/confirmations/signatures/typed-sign-v3.spec.js
+++ b/e2e/specs/confirmations/signatures/typed-sign-v3.spec.js
@@ -12,8 +12,13 @@ import {
 import { SmokeConfirmations } from '../../../tags';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Typed Sign V3'), () => {
+  const testSpecificMock = {
+    GET: [mockEvents.GET.remoteFeatureFlags],
+  };
+
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -29,6 +34,7 @@ describe(SmokeConfirmations('Typed Sign V3'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/typed-sign-v4.spec.js
+++ b/e2e/specs/confirmations/signatures/typed-sign-v4.spec.js
@@ -12,8 +12,13 @@ import {
 import { SmokeConfirmations } from '../../../tags';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Typed Sign V4'), () => {
+  const testSpecificMock = {
+    GET: [mockEvents.GET.remoteFeatureFlags],
+  };
+
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -29,6 +34,7 @@ describe(SmokeConfirmations('Typed Sign V4'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations/signatures/typed-sign.spec.js
+++ b/e2e/specs/confirmations/signatures/typed-sign.spec.js
@@ -12,8 +12,13 @@ import {
 import { SmokeConfirmations } from '../../../tags';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../utils/Assertions';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events';
 
 describe(SmokeConfirmations('Typed Sign'), () => {
+  const testSpecificMock = {
+    GET: [mockEvents.GET.remoteFeatureFlags],
+  };
+
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -29,6 +34,7 @@ describe(SmokeConfirmations('Typed Sign'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,8 +9,6 @@ process.env.MM_SECURITY_ALERTS_API_ENABLED = 'true';
 process.env.PORTFOLIO_VIEW = 'true';
 process.env.SECURITY_ALERTS_API_URL = 'https://example.com';
 
-process.env.REDESIGNED_SIGNATURE_REQUEST = 'true';
-
 process.env.LAUNCH_DARKLY_URL =
   'https://client-config.dev-api.cx.metamask.io/v1';
 


### PR DESCRIPTION
## **Description**

Fix old signature pages e2e. by mocking launch darkly api.
## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3916

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
