### PR TITLE
chore(cherry-pick) fix: enable earn button navigation on unsupported networks (#12988)

### DIFF
--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -25,6 +25,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { RootState } from '../../../../../reducers';
 import useStakingEligibility from '../../hooks/useStakingEligibility';
 import { StakeSDKProvider } from '../../sdk/stakeSdkProvider';
+import useStakingChain from '../../hooks/useStakingChain';
+import Engine from '../../../../../core/Engine';
 
 interface StakeButtonProps {
   asset: TokenI;
@@ -37,12 +39,15 @@ const StakeButtonContent = ({ asset }: StakeButtonProps) => {
 
   const browserTabs = useSelector((state: RootState) => state.browser.tabs);
   const chainId = useSelector(selectChainId);
-
-  const { refreshPooledStakingEligibility } = useStakingEligibility();
+  const { isEligible } = useStakingEligibility();
+  const { isStakingSupportedChain } = useStakingChain();
 
   const onStakeButtonPress = async () => {
-    const { isEligible } = await refreshPooledStakingEligibility();
-    if (isPooledStakingFeatureEnabled() && isEligible) {
+    if (!isStakingSupportedChain) {
+      const { NetworkController } = Engine.context;
+      await NetworkController.setActiveNetwork('mainnet');
+    }
+    if (isEligible) {
       navigation.navigate('StakeScreens', { screen: Routes.STAKING.STAKE });
     } else {
       const existingStakeTab = browserTabs.find((tab: BrowserTab) =>

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -250,10 +250,14 @@ jest.mock('../../UI/Stake/hooks/useStakingEligibility', () => ({
   })),
 }));
 
-jest.mock('../Stake/hooks/useStakingChain', () => ({
-  useStakingChainByChainId: () => ({
+jest.mock('../../UI/Stake/hooks/useStakingChain', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
     isStakingSupportedChain: true,
-  }),
+  })),
+  useStakingChainByChainId: jest.fn(() => ({
+    isStakingSupportedChain: true,
+  })),
 }));
 
 const Stack = createStackNavigator();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->
This PR fixes Earn CTA navigation behavior when clicked on unsupported
networks. Previously, the button was unresponsive or navigated to
Portfolio screen when clicked on networks that don't support staking.
Now, it properly switches to mainnet and navigates to the staking UI.

- Jira ticket:
[STAKE-916](https://consensyssoftware.atlassian.net/browse/STAKE-916)

1. Open the app and navigate to home page and select Portfolio View
2. Change the Network to Linea
3. Click on Earn button next to Ethereum in Portfolio View
4. It should change the network to mainnet and then navigate to staking
UI

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

https://github.com/user-attachments/assets/8421278f-43c1-48c3-9d4b-1c48d2dc9669

https://github.com/user-attachments/assets/a14f2b86-5701-4c91-b566-ddefa563f4ee

- [x] I’ve followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding

Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling

guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.

[STAKE-916]:
https://consensyssoftware.atlassian.net/browse/STAKE-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[STAKE-916]: https://consensyssoftware.atlassian.net/browse/STAKE-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STAKE-916]: https://consensyssoftware.atlassian.net/browse/STAKE-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ