### PR TITLE
fix: Fix disappearing security alert response

### DIFF
--- a/app/reducers/transaction/index.js
+++ b/app/reducers/transaction/index.js
@@ -110,6 +110,8 @@ const transactionReducer = (state = initialState, action) => {
           ...getTxData(action.transaction),
         },
         ...txMeta,
+        // Retain the securityAlertResponses from the old state
+        securityAlertResponses: state.securityAlertResponses,
       };
     }
     case 'SET_TOKENS_TRANSACTION': {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to retain `securityAlertResponses` on `SET_TRANSACTION_OBJECT` action. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3903

## **Manual testing steps**

1. Open up our [[MetaMask E2E test dapp](https://metamask.github.io/test-dapp/)](https://metamask.github.io/test-dapp/) and attempt to prompt a malicious approval for BUSD in our PPOM section.
2. Notice that the malicious warning might popup and stay on screen.

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/60eb5398-c914-4498-8592-4acea5caa163



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
