### PR TITLE
fix: Precision of BigNumber values of calcTokenAmount and Configure BigNumber to support 36 decimals

### DIFF
--- a/app/components/UI/SimulationDetails/formatAmount.ts
+++ b/app/components/UI/SimulationDetails/formatAmount.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from 'bignumber.js';
 
 const MIN_AMOUNT = new BigNumber('0.000001');
-const PRECISION = 6;
+
+// The default precision for displaying currency values.
+// It set to the number of decimal places in the minimum amount.
+export const DEFAULT_PRECISION = new BigNumber(MIN_AMOUNT).decimalPlaces();
 
 // The number of significant decimals places to show for amounts less than 1.
 const MAX_SIGNIFICANT_DECIMAL_PLACES = 3;
@@ -12,10 +15,20 @@ export function formatAmountMaxPrecision(
   locale: string,
   num: number | BigNumber,
 ): string {
-  return new Intl.NumberFormat(locale, {
-    minimumSignificantDigits: 1,
-  }).format(new BigNumber(num.toString()).toNumber());
+  const bigNumberValue = new BigNumber(num);
+  const numberOfDecimals = bigNumberValue.decimalPlaces();
+  const formattedValue = bigNumberValue.toFixed(numberOfDecimals ?? 0);
+
+  const [integerPart, fractionalPart] = formattedValue.split('.');
+  const formattedIntegerPart = new Intl.NumberFormat(locale).format(
+    integerPart as unknown as number,
+  );
+
+  return fractionalPart
+    ? `${formattedIntegerPart}.${fractionalPart}`
+    : formattedIntegerPart;
 }
+
 
 /**
  * Formats the a token amount with variable precision and significant
@@ -65,7 +78,7 @@ export function formatAmount(locale: string, amount: BigNumber): string {
     return new Intl.NumberFormat(locale, {
       maximumSignificantDigits: MAX_SIGNIFICANT_DECIMAL_PLACES,
     } as Intl.NumberFormatOptions).format(
-      amount.decimalPlaces(PRECISION).toNumber(),
+      amount.dp(DEFAULT_PRECISION ?? 0).toNumber(),
     );
   }
 
@@ -73,7 +86,7 @@ export function formatAmount(locale: string, amount: BigNumber): string {
   // Cap the digits right of the decimal point: The more digits present
   // on the left side of the decimal point, the less decimal places
   // we show on the right side.
-  const digitsLeftOfDecimal = amount.abs().toFixed(0).length;
+  const digitsLeftOfDecimal = amount.abs().dp(0).toString().length;
   const maximumFractionDigits = Math.max(
     0,
     MAX_SIGNIFICANT_DECIMAL_PLACES - digitsLeftOfDecimal + 1,
@@ -81,5 +94,10 @@ export function formatAmount(locale: string, amount: BigNumber): string {
 
   return new Intl.NumberFormat(locale, {
     maximumFractionDigits,
-  } as Intl.NumberFormatOptions).format(amount.toNumber());
+  } as Intl.NumberFormatOptions).format(
+    // string is valid parameter for format function
+    // for some reason it gives TS issue
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#number
+    amount.toFixed(maximumFractionDigits) as unknown as number,
+  );
 }

--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.tsx
@@ -108,7 +108,7 @@ const SimulationValueDisplay: React.FC<
       tokenDetails as TokenDetailsERC20,
     );
 
-    const tokenAmount = isNumberValue(value) && !tokenId ? calcTokenAmount(value, tokenDecimals) : null;
+    const tokenAmount = isNumberValue(value) && !tokenId ? calcTokenAmount(value as number | string, tokenDecimals) : null;
     const isValidTokenAmount = tokenAmount !== null && tokenAmount !== undefined && tokenAmount instanceof BigNumber;
 
     const fiatValue = isValidTokenAmount && exchangeRate && !tokenId

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -16,6 +16,9 @@ import { isZero } from '../lodash';
 import { regex } from '../regex';
 export { BNToHex };
 
+const MAX_DECIMALS_FOR_TOKENS = 36;
+BigNumber.config({ DECIMAL_PLACES: MAX_DECIMALS_FOR_TOKENS });
+
 // Big Number Constants
 const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000');
 const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000');

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -1428,9 +1428,14 @@ export function validateTransactionActionBalance(transaction, rate, accounts) {
   }
 }
 
+/**
+ * @param {number|string|BigNumber} value
+ * @param {number=} decimals
+ * @returns {BigNumber}
+ */
 export function calcTokenAmount(value, decimals) {
-  const multiplier = Math.pow(10, Number(decimals || 0));
-  return new BigNumber(String(value)).div(multiplier);
+  const divisor = new BigNumber(10).pow(decimals ?? 0);
+  return new BigNumber(String(value)).div(divisor);
 }
 
 export function calcTokenValue(value, decimals) {


### PR DESCRIPTION
## **Description**

Fix precision across mobile transaction values. JavaScript Number coerces values into scientific notation which looses precision when rendering full values

Update BigNumber.config to support 36 decimals similarly to https://github.com/MetaMask/metamask-extension/pull/21147

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/12991
Relates to: https://github.com/MetaMask/metamask-mobile/pull/12994

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" src="https://github.com/user-attachments/assets/52177add-cb0c-4835-be5e-8ea4098e29fd">


### **After**

<img width="320" src="https://github.com/user-attachments/assets/88e59987-a820-45d4-85a3-55f51997101e">

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
