### PR TITLE
chore: Scope PortfolioView feature flag to iOS devices only

### DIFF
--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -14,6 +14,7 @@ import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
 import { toLowerCaseEquals } from '../general';
 import { fastSplit } from '../number';
 import { regex } from '../../../app/util/regex';
+import Device from '../../util/device';
 
 /* eslint-disable */
 const ethLogo = require('../../images/eth-logo-new.png');
@@ -498,4 +499,4 @@ export const isPermissionsSettingsV1Enabled =
   process.env.MM_PERMISSIONS_SETTINGS_V1_ENABLED === 'true';
 
 export const isPortfolioViewEnabled = () =>
-  process.env.PORTFOLIO_VIEW === 'true';
+  Device.isIos() && process.env.PORTFOLIO_VIEW === 'true';


### PR DESCRIPTION
## **Description**

Scopes the PortfolioView feature flag to only be true for iOS devices, while we do more troubleshooting on the performance bottleneck on Android devices.

## **Related issues**

Performance related bug ticket: https://github.com/MetaMask/metamask-mobile/issues/12679

## **Manual testing steps**

1. Run app with feature flag: `PORTFOLIO_VIEW='true' yarn watch:clean`
2. On iOS device, PortfolioView should be enabled
3. On Android device, PortfolioView should not be enabled

## **Screenshots/Recordings**

<img width="474" alt="Screenshot 2025-01-16 at 11 31 49 AM" src="https://github.com/user-attachments/assets/645d7f95-db1c-4b40-a3a5-aa6f8bf5fcbb" />

<img width="484" alt="Screenshot 2025-01-16 at 11 35 57 AM" src="https://github.com/user-attachments/assets/8bf5d3cf-aed7-419a-9e4d-72829c37e7cf" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
