### PR TITLE
chore: Remove device constraint from isPortfolioViewEnabled feature flag

### DIFF
--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -14,7 +14,6 @@ import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
 import { toLowerCaseEquals } from '../general';
 import { fastSplit } from '../number';
 import { regex } from '../../../app/util/regex';
-import Device from '../../util/device';
 
 /* eslint-disable */
 const ethLogo = require('../../images/eth-logo-new.png');
@@ -499,4 +498,4 @@ export const isPermissionsSettingsV1Enabled =
   process.env.MM_PERMISSIONS_SETTINGS_V1_ENABLED === 'true';
 
 export const isPortfolioViewEnabled = () =>
-  Device.isIos() && process.env.PORTFOLIO_VIEW === 'true';
+  process.env.PORTFOLIO_VIEW === 'true';


### PR DESCRIPTION
## **Description**

Re-enable PV on Android devices.

## **Related issues**

Original PR: https://github.com/MetaMask/metamask-mobile/pull/13039

## **Manual testing steps**

Run app with feature flag: PORTFOLIO_VIEW='true' yarn watch:clean
On iOS device, PortfolioView should be enabled
On Android device, PortfolioView should be enabled

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
