### PR TITLE
fix: Add fallback for undefined case when destructuring `isUpdatedAfterSecurityCheck`

### DIFF
--- a/app/components/Views/confirmations/Approval/index.js
+++ b/app/components/Views/confirmations/Approval/index.js
@@ -502,7 +502,7 @@ class Approval extends PureComponent {
       transactions,
       chainId,
       shouldUseSmartTransaction,
-      simulationData: { isUpdatedAfterSecurityCheck },
+      simulationData: { isUpdatedAfterSecurityCheck } = {},
       navigation,
     } = this.props;
     let { transaction } = this.props;

--- a/app/components/Views/confirmations/ApproveView/Approve/index.js
+++ b/app/components/Views/confirmations/ApproveView/Approve/index.js
@@ -511,7 +511,7 @@ class Approve extends PureComponent {
       metrics,
       chainId,
       shouldUseSmartTransaction,
-      simulationData: { isUpdatedAfterSecurityCheck },
+      simulationData: { isUpdatedAfterSecurityCheck } = {},
       navigation,
     } = this.props;
     const {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Resolves Sentry error with 131k occurrence count: https://metamask.sentry.io/issues/6032066305/?project=2299799&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=30d&stream_index=15

## **Related issues**

- See https://github.com/MetaMask/MetaMask-planning/issues/3861#:~:text=131K%20errors%20Cannot%20read%20property%20%27isUpdatedAfterSecurityCheck%27%20of%20undefined%20%2D%20Appears%20to%20require%20simple%20fix%20along%20these%20lines%20in%20two%20files%3A

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
