### PR TITLE
fix: blockaid validations are not being flagged in re-designed signature request pages

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.test.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.test.tsx
@@ -69,29 +69,10 @@ describe('Confirm', () => {
   });
 
   it('should render blockaid banner if confirmation has blockaid error response', async () => {
-    const typedSignApproval =
-      typedSignV1ConfirmationState.engine.backgroundState.ApprovalController
-        .pendingApprovals['7e62bcb1-a4e9-11ef-9b51-ddf21c91a998'];
     const { getByText } = renderWithProvider(<Confirm />, {
       state: {
         ...typedSignV1ConfirmationState,
-        engine: {
-          ...typedSignV1ConfirmationState.engine,
-          backgroundState: {
-            ...typedSignV1ConfirmationState.engine.backgroundState,
-            ApprovalController: {
-              pendingApprovals: {
-                'fb2029e1-b0ab-11ef-9227-05a11087c334': {
-                  ...typedSignApproval,
-                  requestData: {
-                    ...typedSignApproval.requestData,
-                    securityAlertResponse,
-                  },
-                },
-              },
-            },
-          },
-        },
+        signatureRequest: { securityAlertResponse },
       },
     });
     expect(getByText('Signature request')).toBeDefined();

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
@@ -2,19 +2,12 @@ import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme; vars: { hasError: boolean } }) => {
-  const { theme, vars } = params;
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
 
   return StyleSheet.create({
-    confirmButton: {
+    footerButton: {
       flex: 1,
-      backgroundColor: vars.hasError
-        ? theme.colors.error.default
-        : theme.colors.primary.default,
-    },
-    rejectButton: {
-      flex: 1,
-      backgroundColor: theme.colors.background.alternative,
     },
     divider: {
       height: 1,

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { View } from 'react-native';
 
 import { strings } from '../../../../../../../locales/i18n';
-import StyledButton from '../../../../../../components/UI/StyledButton';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
@@ -12,27 +16,28 @@ const Footer = () => {
   const { onConfirm, onReject } = useConfirmActions();
   const { securityAlertResponse } = useSecurityAlertResponse();
 
-  const { styles } = useStyles(styleSheet, {
-    hasError: securityAlertResponse !== undefined,
-  });
+  const { styles } = useStyles(styleSheet, {});
 
   return (
     <View style={styles.buttonsContainer}>
-      <StyledButton
+      <Button
         onPress={onReject}
-        containerStyle={styles.rejectButton}
-        type={'normal'}
-      >
-        {strings('confirm.reject')}
-      </StyledButton>
+        label={strings('confirm.reject')}
+        style={styles.footerButton}
+        size={ButtonSize.Lg}
+        variant={ButtonVariants.Secondary}
+        width={ButtonWidthTypes.Full}
+      />
       <View style={styles.buttonDivider} />
-      <StyledButton
+      <Button
         onPress={onConfirm}
-        containerStyle={styles.confirmButton}
-        type={'confirm'}
-      >
-        {strings('confirm.confirm')}
-      </StyledButton>
+        label={strings('confirm.confirm')}
+        style={styles.footerButton}
+        size={ButtonSize.Lg}
+        variant={ButtonVariants.Primary}
+        width={ButtonWidthTypes.Full}
+        isDanger={securityAlertResponse !== undefined}
+      />
     </View>
   );
 };

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -4,15 +4,14 @@ import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import StyledButton from '../../../../../../components/UI/StyledButton';
 import { useStyles } from '../../../../../../component-library/hooks';
-import useApprovalRequest from '../../../hooks/useApprovalRequest';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
+import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
 import styleSheet from './Footer.styles';
 
 const Footer = () => {
   const { onConfirm, onReject } = useConfirmActions();
-  const { approvalRequest } = useApprovalRequest();
-  const securityAlertResponse =
-    approvalRequest?.requestData?.securityAlertResponse;
+  const { securityAlertResponse } = useSecurityAlertResponse();
+
   const { styles } = useStyles(styleSheet, {
     hasError: securityAlertResponse !== undefined,
   });

--- a/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.test.tsx
@@ -30,27 +30,9 @@ jest.mock('../../../../../../util/confirmation/signatureUtils', () => ({
   getAnalyticsParams: () => ({}),
 }));
 
-const typedSignApproval =
-  typedSignV1ConfirmationState.engine.backgroundState.ApprovalController
-    .pendingApprovals['7e62bcb1-a4e9-11ef-9b51-ddf21c91a998'];
 const typedSignV1ConfirmationStateWithBlockaidResponse = {
-  engine: {
-    ...typedSignV1ConfirmationState.engine,
-    backgroundState: {
-      ...typedSignV1ConfirmationState.engine.backgroundState,
-      ApprovalController: {
-        pendingApprovals: {
-          '7e62bcb1-a4e9-11ef-9b51-ddf21c91a998': {
-            ...typedSignApproval,
-            requestData: {
-              ...typedSignApproval.requestData,
-              securityAlertResponse,
-            },
-          },
-        },
-      },
-    },
-  },
+  ...typedSignV1ConfirmationState,
+  signatureRequest: { securityAlertResponse },
 };
 
 describe('Confirm', () => {

--- a/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
@@ -5,19 +5,20 @@ import { getAnalyticsParams } from '../../../../../../util/confirmation/signatur
 import { useStyles } from '../../../../../../component-library/hooks';
 import { useMetrics } from '../../../../../hooks/useMetrics';
 import BlockaidBanner from '../../../components/BlockaidBanner/BlockaidBanner';
-import useApprovalRequest from '../../../hooks/useApprovalRequest';
+import { SecurityAlertResponse } from '../../BlockaidBanner/BlockaidBanner.types';
 import styleSheet from './SignatureBlockaidBanner.styles';
+import { useSignatureRequest } from '../../../hooks/useSignatureRequest';
 
 const SignatureBlockaidBanner = () => {
-  const { approvalRequest } = useApprovalRequest();
+  const signatureRequest = useSignatureRequest();
   const { trackEvent, createEventBuilder } = useMetrics();
   const { styles } = useStyles(styleSheet, {});
 
   const {
     type,
-    requestData: { from: fromAddress },
-  } = approvalRequest ?? {
-    requestData: {},
+    messageParams: { from: fromAddress },
+  } = signatureRequest ?? {
+    messageParams: {},
   };
 
   const onContactUsClicked = useCallback(() => {
@@ -37,7 +38,7 @@ const SignatureBlockaidBanner = () => {
     );
   }, [trackEvent, createEventBuilder, type, fromAddress]);
 
-  if (!approvalRequest?.requestData?.securityAlertResponse) {
+  if (!signatureRequest?.securityAlertResponse) {
     return null;
   }
 
@@ -45,7 +46,7 @@ const SignatureBlockaidBanner = () => {
     <BlockaidBanner
       onContactUsClicked={onContactUsClicked}
       securityAlertResponse={
-        approvalRequest?.requestData?.securityAlertResponse
+        signatureRequest?.securityAlertResponse as SecurityAlertResponse
       }
       style={styles.blockaidBanner}
     />

--- a/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
@@ -6,11 +6,13 @@ import { useStyles } from '../../../../../../component-library/hooks';
 import { useMetrics } from '../../../../../hooks/useMetrics';
 import BlockaidBanner from '../../../components/BlockaidBanner/BlockaidBanner';
 import { SecurityAlertResponse } from '../../BlockaidBanner/BlockaidBanner.types';
-import styleSheet from './SignatureBlockaidBanner.styles';
+import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
 import { useSignatureRequest } from '../../../hooks/useSignatureRequest';
+import styleSheet from './SignatureBlockaidBanner.styles';
 
 const SignatureBlockaidBanner = () => {
   const signatureRequest = useSignatureRequest();
+  const { securityAlertResponse } = useSecurityAlertResponse();
   const { trackEvent, createEventBuilder } = useMetrics();
   const { styles } = useStyles(styleSheet, {});
 
@@ -38,16 +40,14 @@ const SignatureBlockaidBanner = () => {
     );
   }, [trackEvent, createEventBuilder, type, fromAddress]);
 
-  if (!signatureRequest?.securityAlertResponse) {
+  if (!securityAlertResponse) {
     return null;
   }
 
   return (
     <BlockaidBanner
       onContactUsClicked={onContactUsClicked}
-      securityAlertResponse={
-        signatureRequest?.securityAlertResponse as SecurityAlertResponse
-      }
+      securityAlertResponse={securityAlertResponse as SecurityAlertResponse}
       style={styles.blockaidBanner}
     />
   );

--- a/app/components/Views/confirmations/components/Confirm/Title/Title.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Title/Title.styles.ts
@@ -19,6 +19,7 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     subTitle: {
       color: theme.colors.text.default,
+      ...fontStyles.normal,
       fontSize: 14,
       fontWeight: '400',
       marginTop: 8,

--- a/app/components/Views/confirmations/components/PersonalSign/PersonalSign.tsx
+++ b/app/components/Views/confirmations/components/PersonalSign/PersonalSign.tsx
@@ -27,7 +27,6 @@ import Logger from '../../../../../util/Logger';
 import { getBlockaidMetricsParams } from '../../../../../util/blockaid';
 import createExternalSignModelNav from '../../../../../util/hardwareWallet/signatureUtils';
 import { getDecimalChainId } from '../../../../../util/networks';
-import { SecurityAlertResponse } from '../BlockaidBanner/BlockaidBanner.types';
 import { selectSignatureRequestById } from '../../../../../selectors/signatureController';
 import { selectNetworkTypeByChainId } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
@@ -111,9 +110,7 @@ const PersonalSign = ({
 
     let blockaidParams: Record<string, unknown> = {};
     if (securityAlertResponse) {
-      blockaidParams = getBlockaidMetricsParams(
-        securityAlertResponse as unknown as SecurityAlertResponse,
-      );
+      blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
     }
 
     return {

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
@@ -20,12 +20,12 @@ describe('useSecurityAlertResponse', () => {
       mockSecurityAlertResponse as SecurityAlertResponse,
     );
     expect(result).toStrictEqual({
-      mockSecurityAlertResponse,
+      securityAlertResponse: mockSecurityAlertResponse,
     });
   });
 
   it('returns undefined is security alert response is not present for signature request', () => {
     const result = renderHook();
-    expect(result).toBeUndefined();
+    expect(result.securityAlertResponse).toBeUndefined();
   });
 });

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
@@ -1,0 +1,31 @@
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { securityAlertResponse as mockSecurityAlertResponse } from '../../../../util/test/confirm-data-helpers';
+import { useSecurityAlertResponse } from './useSecurityAlertResponse';
+
+function renderHook(securityAlertResponse?: SecurityAlertResponse) {
+  const { result } = renderHookWithProvider(useSecurityAlertResponse, {
+    state: {
+      signatureRequest: { securityAlertResponse },
+    },
+  });
+
+  return result.current;
+}
+
+describe('useSecurityAlertResponse', () => {
+  it('returns security alert response for signature request is present', () => {
+    const result = renderHook(
+      mockSecurityAlertResponse as SecurityAlertResponse,
+    );
+    expect(result).toStrictEqual({
+      mockSecurityAlertResponse,
+    });
+  });
+
+  it('returns undefined is security alert response is not present for signature request', () => {
+    const result = renderHook();
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+
+import { selectSignatureSecurityAlertResponse } from '../selectors/security-alerts';
+
+export function useSecurityAlertResponse() {
+  const { securityAlertResponse } = useSelector(
+    selectSignatureSecurityAlertResponse,
+  );
+
+  return { securityAlertResponse };
+}

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { selectSignatureSecurityAlertResponse } from '../selectors/security-alerts';
 
+// todo: the hook to be extended to include transactions
 export function useSecurityAlertResponse() {
   const { securityAlertResponse } = useSelector(
     selectSignatureSecurityAlertResponse,

--- a/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
@@ -12,6 +12,7 @@ import { getHostFromUrl } from '../utils/generic';
 import { isSignatureRequest } from '../utils/confirm';
 import { getSignatureDecodingEventProps } from '../utils/signatureMetrics';
 import { useSignatureRequest } from './useSignatureRequest';
+import { useSecurityAlertResponse } from './useSecurityAlertResponse';
 import { useTypedSignSimulationEnabled } from './useTypedSignSimulationEnabled';
 
 interface MessageParamsType {
@@ -54,15 +55,10 @@ const getAnalyticsParams = (
 export const useSignatureMetrics = () => {
   const signatureRequest = useSignatureRequest();
   const isSimulationEnabled = useTypedSignSimulationEnabled();
+  const { securityAlertResponse } = useSecurityAlertResponse();
 
-  const {
-    chainId,
-    decodingData,
-    decodingLoading,
-    messageParams,
-    type,
-    securityAlertResponse,
-  } = signatureRequest ?? {};
+  const { chainId, decodingData, decodingLoading, messageParams, type } =
+    signatureRequest ?? {};
 
   const captureSignatureMetrics = useCallback(
     async (

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
@@ -3,10 +3,8 @@ import {
   SignatureRequest,
   SignatureRequestType,
 } from '@metamask/signature-controller';
-import { SecurityAlertResponse } from '@metamask/transaction-controller';
 
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
-import { securityAlertResponse as mockSecurityAlertResponse } from '../../../../util/test/confirm-data-helpers';
 import { useSignatureRequest } from './useSignatureRequest';
 
 const ID_MOCK = '123-456-789';
@@ -24,11 +22,9 @@ const SIGNATURE_REQUEST_MOCK: Partial<SignatureRequest> = {
 function renderHook({
   approvalType,
   signatureRequest,
-  securityAlertResponse = undefined,
 }: {
   approvalType?: ApprovalType;
   signatureRequest: Partial<SignatureRequest>;
-  securityAlertResponse?: SecurityAlertResponse;
 }) {
   const { result } = renderHookWithProvider(useSignatureRequest, {
     state: {
@@ -49,7 +45,6 @@ function renderHook({
           },
         },
       },
-      signatureRequest: { securityAlertResponse },
     },
   });
 
@@ -59,10 +54,7 @@ function renderHook({
 describe('useSignatureRequest', () => {
   it('returns signature request matching approval request ID', () => {
     const result = renderHook({ signatureRequest: SIGNATURE_REQUEST_MOCK });
-    expect(result).toStrictEqual({
-      ...SIGNATURE_REQUEST_MOCK,
-      securityAlertResponse: undefined,
-    });
+    expect(result).toStrictEqual(SIGNATURE_REQUEST_MOCK);
   });
 
   it('returns undefined if matching signature request not found', () => {
@@ -78,16 +70,5 @@ describe('useSignatureRequest', () => {
       approvalType: ApprovalType.Transaction,
     });
     expect(result).toBeUndefined();
-  });
-
-  it('returns securityAlertResponse from state if present', () => {
-    const result = renderHook({
-      signatureRequest: SIGNATURE_REQUEST_MOCK,
-      securityAlertResponse: mockSecurityAlertResponse,
-    });
-    expect(result).toStrictEqual({
-      ...SIGNATURE_REQUEST_MOCK,
-      securityAlertResponse: mockSecurityAlertResponse,
-    });
   });
 });

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
@@ -1,10 +1,13 @@
+import { ApprovalType } from '@metamask/controller-utils';
 import {
   SignatureRequest,
   SignatureRequestType,
 } from '@metamask/signature-controller';
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { securityAlertResponse as mockSecurityAlertResponse } from '../../../../util/test/confirm-data-helpers';
 import { useSignatureRequest } from './useSignatureRequest';
-import { ApprovalType } from '@metamask/controller-utils';
 
 const ID_MOCK = '123-456-789';
 
@@ -21,9 +24,11 @@ const SIGNATURE_REQUEST_MOCK: Partial<SignatureRequest> = {
 function renderHook({
   approvalType,
   signatureRequest,
+  securityAlertResponse = undefined,
 }: {
   approvalType?: ApprovalType;
   signatureRequest: Partial<SignatureRequest>;
+  securityAlertResponse?: SecurityAlertResponse;
 }) {
   const { result } = renderHookWithProvider(useSignatureRequest, {
     state: {
@@ -44,6 +49,7 @@ function renderHook({
           },
         },
       },
+      signatureRequest: { securityAlertResponse },
     },
   });
 
@@ -53,7 +59,10 @@ function renderHook({
 describe('useSignatureRequest', () => {
   it('returns signature request matching approval request ID', () => {
     const result = renderHook({ signatureRequest: SIGNATURE_REQUEST_MOCK });
-    expect(result).toStrictEqual(SIGNATURE_REQUEST_MOCK);
+    expect(result).toStrictEqual({
+      ...SIGNATURE_REQUEST_MOCK,
+      securityAlertResponse: undefined,
+    });
   });
 
   it('returns undefined if matching signature request not found', () => {
@@ -69,5 +78,16 @@ describe('useSignatureRequest', () => {
       approvalType: ApprovalType.Transaction,
     });
     expect(result).toBeUndefined();
+  });
+
+  it('returns securityAlertResponse from state if present', () => {
+    const result = renderHook({
+      signatureRequest: SIGNATURE_REQUEST_MOCK,
+      securityAlertResponse: mockSecurityAlertResponse,
+    });
+    expect(result).toStrictEqual({
+      ...SIGNATURE_REQUEST_MOCK,
+      securityAlertResponse: mockSecurityAlertResponse,
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.ts
@@ -1,8 +1,12 @@
-import { useSelector } from 'react-redux';
-import useApprovalRequest from './useApprovalRequest';
 import { ApprovalType } from '@metamask/controller-utils';
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+import { SignatureRequest } from '@metamask/signature-controller';
+import { useSelector } from 'react-redux';
+
 import { selectSignatureRequestById } from '../../../../selectors/signatureController';
 import { RootState } from '../../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
+import { selectSignatureSecurityAlertResponse } from '../selectors/security-alerts';
+import useApprovalRequest from './useApprovalRequest';
 
 const SIGNATURE_APPROVAL_TYPES = [
   ApprovalType.PersonalSign,
@@ -11,6 +15,9 @@ const SIGNATURE_APPROVAL_TYPES = [
 
 export function useSignatureRequest() {
   const { approvalRequest } = useApprovalRequest();
+  const { securityAlertResponse } = useSelector(
+    selectSignatureSecurityAlertResponse,
+  );
 
   const signatureRequest = useSelector((state: RootState) =>
     selectSignatureRequestById(state, approvalRequest?.id as string),
@@ -23,5 +30,7 @@ export function useSignatureRequest() {
     return undefined;
   }
 
-  return signatureRequest;
+  return { ...signatureRequest, securityAlertResponse } as SignatureRequest & {
+    securityAlertResponse: SecurityAlertResponse;
+  };
 }

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.ts
@@ -1,11 +1,9 @@
 import { ApprovalType } from '@metamask/controller-utils';
-import { SecurityAlertResponse } from '@metamask/transaction-controller';
 import { SignatureRequest } from '@metamask/signature-controller';
 import { useSelector } from 'react-redux';
 
 import { selectSignatureRequestById } from '../../../../selectors/signatureController';
 import { RootState } from '../../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
-import { selectSignatureSecurityAlertResponse } from '../selectors/security-alerts';
 import useApprovalRequest from './useApprovalRequest';
 
 const SIGNATURE_APPROVAL_TYPES = [
@@ -15,9 +13,6 @@ const SIGNATURE_APPROVAL_TYPES = [
 
 export function useSignatureRequest() {
   const { approvalRequest } = useApprovalRequest();
-  const { securityAlertResponse } = useSelector(
-    selectSignatureSecurityAlertResponse,
-  );
 
   const signatureRequest = useSelector((state: RootState) =>
     selectSignatureRequestById(state, approvalRequest?.id as string),
@@ -30,7 +25,5 @@ export function useSignatureRequest() {
     return undefined;
   }
 
-  return { ...signatureRequest, securityAlertResponse } as SignatureRequest & {
-    securityAlertResponse: SecurityAlertResponse;
-  };
+  return signatureRequest as SignatureRequest;
 }

--- a/app/components/Views/confirmations/hooks/useTypedSignSimulationEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useTypedSignSimulationEnabled.ts
@@ -1,6 +1,10 @@
 import { useSelector } from 'react-redux';
 import { SignTypedDataVersion } from '@metamask/eth-sig-util';
-import { MessageParamsTyped, SignatureRequest, SignatureRequestType } from '@metamask/signature-controller';
+import {
+  MessageParamsTyped,
+  SignatureRequest,
+  SignatureRequestType,
+} from '@metamask/signature-controller';
 import { selectUseTransactionSimulations } from '../../../../selectors/preferencesController';
 import { isRecognizedPermit, parseTypedDataMessage } from '../utils/signature';
 import { useSignatureRequest } from './useSignatureRequest';
@@ -21,7 +25,9 @@ const isNonPermitSupportedByDecodingAPI = (
   signatureRequest: SignatureRequest,
 ) => {
   const data = signatureRequest.messageParams?.data as string;
-  if (!data) { return false; }
+  if (!data) {
+    return false;
+  }
 
   const {
     domain: { name, version },
@@ -47,13 +53,14 @@ export function useTypedSignSimulationEnabled() {
   }
 
   const requestType = signatureRequest.type;
-  const signatureMethod = (signatureRequest.messageParams as MessageParamsTyped)?.version;
+  const signatureMethod = (signatureRequest.messageParams as MessageParamsTyped)
+    ?.version;
 
-  const isTypedSignV3V4 = requestType === SignatureRequestType.TypedSign && (
-    signatureMethod === SignTypedDataVersion.V3 ||
-    signatureMethod === SignTypedDataVersion.V4
-  );
-  const isPermit = isRecognizedPermit(signatureRequest);
+  const isTypedSignV3V4 =
+    requestType === SignatureRequestType.TypedSign &&
+    (signatureMethod === SignTypedDataVersion.V3 ||
+      signatureMethod === SignTypedDataVersion.V4);
+  const isPermit = isTypedSignV3V4 && isRecognizedPermit(signatureRequest);
 
   const nonPermitSupportedByDecodingAPI: boolean =
     isTypedSignV3V4 && isNonPermitSupportedByDecodingAPI(signatureRequest);

--- a/app/components/Views/confirmations/selectors/security-alerts.test.ts
+++ b/app/components/Views/confirmations/selectors/security-alerts.test.ts
@@ -1,0 +1,23 @@
+import { RootState } from '../../../../reducers';
+import { securityAlertResponse } from '../../../../util/test/confirm-data-helpers';
+import { selectSignatureSecurityAlertResponse } from './security-alerts';
+
+describe('Security Alert Selectors', () => {
+  describe('selectSignatureSecurityAlertResponse', () => {
+    it('returns signature security alert response from the state', () => {
+      expect(
+        selectSignatureSecurityAlertResponse({
+          signatureRequest: {
+            securityAlertResponse,
+          },
+        } as RootState),
+      ).toEqual({ securityAlertResponse });
+    });
+
+    it('returns undefined if security alert response not present', () => {
+      expect(
+        selectSignatureSecurityAlertResponse({} as unknown as RootState),
+      ).toEqual(undefined);
+    });
+  });
+});

--- a/app/components/Views/confirmations/selectors/security-alerts.ts
+++ b/app/components/Views/confirmations/selectors/security-alerts.ts
@@ -1,0 +1,7 @@
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+import { RootState } from '../../../../reducers';
+
+export const selectSignatureSecurityAlertResponse = (
+  rootState: RootState,
+): { securityAlertResponse: SecurityAlertResponse } =>
+  rootState.signatureRequest;

--- a/app/components/Views/confirmations/utils/signatureMetrics.test.ts
+++ b/app/components/Views/confirmations/utils/signatureMetrics.test.ts
@@ -1,56 +1,38 @@
-import { Hex } from '@metamask/utils';
 import { getSignatureDecodingEventProps } from './signatureMetrics';
-import { DecodingDataChangeType, SignatureRequest, SignatureRequestStatus, SignatureRequestType } from '@metamask/signature-controller';
-
-const mockSignatureRequest = {
-  id: 'fb2029e1-b0ab-11ef-9227-05a11087c334',
-  chainId: '0x1' as Hex,
-  type: SignatureRequestType.TypedSign,
-  messageParams: {
-    data: '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"MyToken","version":"1","verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC","chainId":1},"message":{"owner":"0x935e73edb9ff52e23bac7f7e043a1ecd06d05477","spender":"0x5B38Da6a701c568545dCfcB03FcB875f56beddC4","value":3000,"nonce":0,"deadline":50000000000}}',
-    from: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
-    version: 'V4',
-    requestId: 14,
-    origin: 'https://metamask.github.io',
-    metamaskId: 'fb2029e0-b0ab-11ef-9227-05a11087c334',
-  },
-  networkClientId: '1',
-  status: SignatureRequestStatus.Unapproved,
-  time: 1733143817088
-} satisfies SignatureRequest;
+import { DecodingDataChangeType } from '@metamask/signature-controller';
 
 describe('signatureMetrics', () => {
   describe('getSignatureDecodingEventProps', () => {
     it('returns empty object when decoding API is disabled', () => {
-      const mockRequest = {
-        ...mockSignatureRequest,
-        decodingData: {
-          stateChanges: [],
-          error: undefined,
-        },
-      } satisfies SignatureRequest;
+      const mockDecodingData = {
+        stateChanges: [],
+        error: undefined,
+      };
 
-      const result = getSignatureDecodingEventProps(mockRequest, false);
+      const result = getSignatureDecodingEventProps(
+        mockDecodingData,
+        false,
+        false,
+      );
       expect(result).toEqual({});
     });
 
     it('returns empty object when no decodingData is present', () => {
-      const mockRequest = {} as SignatureRequest;
-      const result = getSignatureDecodingEventProps(mockRequest, true);
+      const result = getSignatureDecodingEventProps(undefined, false, true);
       expect(result).toEqual({});
     });
 
     it('returns no change response when stateChanges are empty', () => {
-      const mockRequest = {
-        ...mockSignatureRequest,
-        decodingData: {
-          stateChanges: [],
-          error: undefined,
-        },
-        decodingLoading: false,
-      } satisfies SignatureRequest;
+      const mockDecodingData = {
+        stateChanges: [],
+        error: undefined,
+      };
 
-      const result = getSignatureDecodingEventProps(mockRequest, true);
+      const result = getSignatureDecodingEventProps(
+        mockDecodingData,
+        false,
+        true,
+      );
       expect(result).toEqual({
         decoding_change_types: [],
         decoding_description: null,
@@ -59,16 +41,16 @@ describe('signatureMetrics', () => {
     });
 
     it('returns loading response when decodingLoading is true', () => {
-      const mockRequest = {
-        ...mockSignatureRequest,
-        decodingData: {
-          stateChanges: [],
-          error: undefined,
-        },
-        decodingLoading: true,
-      } satisfies SignatureRequest;
+      const mockDecodingData = {
+        stateChanges: [],
+        error: undefined,
+      };
 
-      const result = getSignatureDecodingEventProps(mockRequest, true);
+      const result = getSignatureDecodingEventProps(
+        mockDecodingData,
+        false,
+        true,
+      );
       expect(result).toEqual({
         decoding_change_types: [],
         decoding_description: null,
@@ -77,19 +59,19 @@ describe('signatureMetrics', () => {
     });
 
     it('returns error response when error exists', () => {
-      const mockRequest = {
-        ...mockSignatureRequest,
-        decodingData: {
-          stateChanges: [],
-          error: {
-            type: 'ERROR_TYPE',
-            message: 'Error message',
-          },
+      const mockDecodingData = {
+        stateChanges: [],
+        error: {
+          type: 'ERROR_TYPE',
+          message: 'Error message',
         },
-        decodingLoading: false,
-      } satisfies SignatureRequest;
+      };
 
-      const result = getSignatureDecodingEventProps(mockRequest, true);
+      const result = getSignatureDecodingEventProps(
+        mockDecodingData,
+        false,
+        true,
+      );
       expect(result).toEqual({
         decoding_change_types: [],
         decoding_description: 'Error message',
@@ -98,19 +80,31 @@ describe('signatureMetrics', () => {
     });
 
     it('returns change response when stateChanges exist', () => {
-      const mockRequest = {
-        ...mockSignatureRequest,
-        decodingData: {
-          stateChanges: [
-            { changeType: DecodingDataChangeType.Approve, assetType: 'ERC20', address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477', amount: '12345', contractAddress: '0x6b175474e89094c44da98b954eedeac495271d0f' },
-            { changeType: DecodingDataChangeType.Transfer, assetType: 'ERC20', address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477', amount: '12345', contractAddress: '0x6b175474e89094c44da98b954eedeac495271d0f' },
-          ],
-          error: undefined,
-        },
-        decodingLoading: false,
-      } satisfies SignatureRequest;
+      const mockDecodingData = {
+        stateChanges: [
+          {
+            changeType: DecodingDataChangeType.Approve,
+            assetType: 'ERC20',
+            address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+            amount: '12345',
+            contractAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          },
+          {
+            changeType: DecodingDataChangeType.Transfer,
+            assetType: 'ERC20',
+            address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+            amount: '12345',
+            contractAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          },
+        ],
+        error: undefined,
+      };
 
-      const result = getSignatureDecodingEventProps(mockRequest, true);
+      const result = getSignatureDecodingEventProps(
+        mockDecodingData,
+        false,
+        true,
+      );
       expect(result).toEqual({
         decoding_change_types: ['APPROVE', 'TRANSFER'],
         decoding_description: null,

--- a/app/components/Views/confirmations/utils/signatureMetrics.test.ts
+++ b/app/components/Views/confirmations/utils/signatureMetrics.test.ts
@@ -48,7 +48,7 @@ describe('signatureMetrics', () => {
 
       const result = getSignatureDecodingEventProps(
         mockDecodingData,
-        false,
+        true,
         true,
       );
       expect(result).toEqual({

--- a/app/components/Views/confirmations/utils/signatureMetrics.ts
+++ b/app/components/Views/confirmations/utils/signatureMetrics.ts
@@ -1,4 +1,7 @@
-import { DecodingDataStateChange, SignatureRequest } from '@metamask/signature-controller';
+import {
+  DecodingData,
+  DecodingDataStateChange,
+} from '@metamask/signature-controller';
 
 enum DecodingResponseType {
   Change = 'CHANGE',
@@ -6,9 +9,11 @@ enum DecodingResponseType {
   Loading = 'decoding_in_progress',
 }
 
-export const getSignatureDecodingEventProps = (signatureRequest?: SignatureRequest, isDecodingAPIEnabled: boolean = false) => {
-  const { decodingData, decodingLoading } = signatureRequest || {};
-
+export const getSignatureDecodingEventProps = (
+  decodingData: DecodingData | undefined,
+  decodingLoading: boolean,
+  isDecodingAPIEnabled: boolean = false,
+) => {
   if (!isDecodingAPIEnabled || !decodingData) {
     return {};
   }
@@ -19,7 +24,8 @@ export const getSignatureDecodingEventProps = (signatureRequest?: SignatureReque
     (change: DecodingDataStateChange) => change.changeType,
   );
 
-  const responseType = error?.type ??
+  const responseType =
+    error?.type ??
     (changeTypes.length
       ? DecodingResponseType.Change
       : DecodingResponseType.NoChange);

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -1,7 +1,11 @@
 import {
+  SecurityAlertResponse,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+
+import {
   Reason,
   ResultType,
-  SecurityAlertResponse,
   SecurityAlertSource,
 } from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
 // eslint-disable-next-line import/no-namespace
@@ -17,7 +21,6 @@ import {
   isBlockaidFeatureEnabled,
   TransactionType,
 } from '.';
-import { TransactionStatus } from '@metamask/transaction-controller';
 
 jest.mock('../../core/Engine', () => ({
   resetState: jest.fn(),
@@ -139,16 +142,17 @@ describe('Blockaid util', () => {
     });
 
     it('should return additionalParams object when securityAlertResponse is defined', async () => {
-      const securityAlertResponse: SecurityAlertResponse = {
-        result_type: ResultType.Malicious,
-        reason: Reason.notApplicable,
-        source: SecurityAlertSource.API,
-        providerRequestsCount: {
-          eth_call: 5,
-          eth_getCode: 3,
-        },
-        features: [],
-      };
+      const securityAlertResponse: SecurityAlertResponse & { source: string } =
+        {
+          result_type: ResultType.Malicious,
+          reason: Reason.notApplicable,
+          source: SecurityAlertSource.API,
+          providerRequestsCount: {
+            eth_call: 5,
+            eth_getCode: 3,
+          },
+          features: [],
+        };
 
       const result = getBlockaidMetricsParams(securityAlertResponse);
       expect(result).toEqual({

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -1,11 +1,12 @@
-import Engine from '../../core/Engine';
-import {
-  ResultType,
+import type {
   SecurityAlertResponse,
-} from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+
+import Engine from '../../core/Engine';
+import { ResultType } from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
 import { store } from '../../store';
 import { selectChainId } from '../../selectors/networkController';
-import type { TransactionMeta } from '@metamask/transaction-controller';
 import PPOMUtils from '../../lib/ppom/ppom-util';
 
 interface TransactionSecurityAlertResponseType {
@@ -35,7 +36,7 @@ export const getBlockaidMetricsParams = (
 
   if (securityAlertResponse) {
     const { result_type, reason, providerRequestsCount, source } =
-      securityAlertResponse;
+      securityAlertResponse as SecurityAlertResponse & { source: string };
 
     additionalParams.security_alert_response = result_type;
     additionalParams.security_alert_reason = reason;


### PR DESCRIPTION
## **Description**

fix for blockaid validations are not being flagged in re-designed signature request pages

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13068

## **Manual testing steps**

1. To to test dapp
2. Submit malicious permit
3. Check blockaid banner on the page

## **Screenshots/Recordings**
<img width="401" alt="Screenshot 2025-01-21 at 11 24 39 PM" src="https://github.com/user-attachments/assets/1fc1d0e6-2959-4ec4-bc99-3605089474e6" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
