### PR TITLE
cherrypick: blockaid validations are not being flagged in re-designed signature request pages 

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.test.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.test.tsx
@@ -69,29 +69,10 @@ describe('Confirm', () => {
   });
 
   it('should render blockaid banner if confirmation has blockaid error response', async () => {
-    const typedSignApproval =
-      typedSignV1ConfirmationState.engine.backgroundState.ApprovalController
-        .pendingApprovals['7e62bcb1-a4e9-11ef-9b51-ddf21c91a998'];
     const { getByText } = renderWithProvider(<Confirm />, {
       state: {
         ...typedSignV1ConfirmationState,
-        engine: {
-          ...typedSignV1ConfirmationState.engine,
-          backgroundState: {
-            ...typedSignV1ConfirmationState.engine.backgroundState,
-            ApprovalController: {
-              pendingApprovals: {
-                'fb2029e1-b0ab-11ef-9227-05a11087c334': {
-                  ...typedSignApproval,
-                  requestData: {
-                    ...typedSignApproval.requestData,
-                    securityAlertResponse,
-                  },
-                },
-              },
-            },
-          },
-        },
+        signatureRequest: { securityAlertResponse },
       },
     });
     expect(getByText('Signature request')).toBeDefined();

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
@@ -2,19 +2,12 @@ import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme; vars: { hasError: boolean } }) => {
-  const { theme, vars } = params;
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
 
   return StyleSheet.create({
-    confirmButton: {
+    footerButton: {
       flex: 1,
-      backgroundColor: vars.hasError
-        ? theme.colors.error.default
-        : theme.colors.primary.default,
-    },
-    rejectButton: {
-      flex: 1,
-      backgroundColor: theme.colors.background.alternative,
     },
     divider: {
       height: 1,

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -2,38 +2,42 @@ import React from 'react';
 import { View } from 'react-native';
 
 import { strings } from '../../../../../../../locales/i18n';
-import StyledButton from '../../../../../../components/UI/StyledButton';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../../component-library/hooks';
-import useApprovalRequest from '../../../hooks/useApprovalRequest';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
+import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
 import styleSheet from './Footer.styles';
 
 const Footer = () => {
   const { onConfirm, onReject } = useConfirmActions();
-  const { approvalRequest } = useApprovalRequest();
-  const securityAlertResponse =
-    approvalRequest?.requestData?.securityAlertResponse;
-  const { styles } = useStyles(styleSheet, {
-    hasError: securityAlertResponse !== undefined,
-  });
+  const { securityAlertResponse } = useSecurityAlertResponse();
+
+  const { styles } = useStyles(styleSheet, {});
 
   return (
     <View style={styles.buttonsContainer}>
-      <StyledButton
+      <Button
         onPress={onReject}
-        containerStyle={styles.rejectButton}
-        type={'normal'}
-      >
-        {strings('confirm.reject')}
-      </StyledButton>
+        label={strings('confirm.reject')}
+        style={styles.footerButton}
+        size={ButtonSize.Lg}
+        variant={ButtonVariants.Secondary}
+        width={ButtonWidthTypes.Full}
+      />
       <View style={styles.buttonDivider} />
-      <StyledButton
+      <Button
         onPress={onConfirm}
-        containerStyle={styles.confirmButton}
-        type={'confirm'}
-      >
-        {strings('confirm.confirm')}
-      </StyledButton>
+        label={strings('confirm.confirm')}
+        style={styles.footerButton}
+        size={ButtonSize.Lg}
+        variant={ButtonVariants.Primary}
+        width={ButtonWidthTypes.Full}
+        isDanger={securityAlertResponse !== undefined}
+      />
     </View>
   );
 };

--- a/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.test.tsx
@@ -26,27 +26,9 @@ jest.mock('../../../../../../util/confirmation/signatureUtils', () => ({
   getAnalyticsParams: () => ({}),
 }));
 
-const typedSignApproval =
-  typedSignV1ConfirmationState.engine.backgroundState.ApprovalController
-    .pendingApprovals['7e62bcb1-a4e9-11ef-9b51-ddf21c91a998'];
 const typedSignV1ConfirmationStateWithBlockaidResponse = {
-  engine: {
-    ...typedSignV1ConfirmationState.engine,
-    backgroundState: {
-      ...typedSignV1ConfirmationState.engine.backgroundState,
-      ApprovalController: {
-        pendingApprovals: {
-          'fb2029e1-b0ab-11ef-9227-05a11087c334': {
-            ...typedSignApproval,
-            requestData: {
-              ...typedSignApproval.requestData,
-              securityAlertResponse,
-            },
-          },
-        },
-      },
-    },
-  },
+  ...typedSignV1ConfirmationState,
+  signatureRequest: { securityAlertResponse },
 };
 
 describe('Confirm', () => {

--- a/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/Confirm/SignatureBlockaidBanner/SignatureBlockaidBanner.tsx
@@ -5,19 +5,22 @@ import { getAnalyticsParams } from '../../../../../../util/confirmation/signatur
 import { useStyles } from '../../../../../../component-library/hooks';
 import { useMetrics } from '../../../../../hooks/useMetrics';
 import BlockaidBanner from '../../../components/BlockaidBanner/BlockaidBanner';
-import useApprovalRequest from '../../../hooks/useApprovalRequest';
+import { SecurityAlertResponse } from '../../BlockaidBanner/BlockaidBanner.types';
+import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
+import { useSignatureRequest } from '../../../hooks/useSignatureRequest';
 import styleSheet from './SignatureBlockaidBanner.styles';
 
 const SignatureBlockaidBanner = () => {
-  const { approvalRequest } = useApprovalRequest();
+  const signatureRequest = useSignatureRequest();
+  const { securityAlertResponse } = useSecurityAlertResponse();
   const { trackEvent, createEventBuilder } = useMetrics();
   const { styles } = useStyles(styleSheet, {});
 
   const {
     type,
-    requestData: { from: fromAddress },
-  } = approvalRequest ?? {
-    requestData: {},
+    messageParams: { from: fromAddress },
+  } = signatureRequest ?? {
+    messageParams: {},
   };
 
   const onContactUsClicked = useCallback(() => {
@@ -37,16 +40,14 @@ const SignatureBlockaidBanner = () => {
     );
   }, [trackEvent, createEventBuilder, type, fromAddress]);
 
-  if (!approvalRequest?.requestData?.securityAlertResponse) {
+  if (!securityAlertResponse) {
     return null;
   }
 
   return (
     <BlockaidBanner
       onContactUsClicked={onContactUsClicked}
-      securityAlertResponse={
-        approvalRequest?.requestData?.securityAlertResponse
-      }
+      securityAlertResponse={securityAlertResponse as SecurityAlertResponse}
       style={styles.blockaidBanner}
     />
   );

--- a/app/components/Views/confirmations/components/Confirm/Title/Title.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Title/Title.styles.ts
@@ -19,6 +19,7 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     subTitle: {
       color: theme.colors.text.default,
+      ...fontStyles.normal,
       fontSize: 14,
       fontWeight: '400',
       marginTop: 8,

--- a/app/components/Views/confirmations/components/PersonalSign/PersonalSign.tsx
+++ b/app/components/Views/confirmations/components/PersonalSign/PersonalSign.tsx
@@ -27,7 +27,6 @@ import Logger from '../../../../../util/Logger';
 import { getBlockaidMetricsParams } from '../../../../../util/blockaid';
 import createExternalSignModelNav from '../../../../../util/hardwareWallet/signatureUtils';
 import { getDecimalChainId } from '../../../../../util/networks';
-import { SecurityAlertResponse } from '../BlockaidBanner/BlockaidBanner.types';
 import { selectSignatureRequestById } from '../../../../../selectors/signatureController';
 import { selectNetworkTypeByChainId } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
@@ -111,9 +110,7 @@ const PersonalSign = ({
 
     let blockaidParams: Record<string, unknown> = {};
     if (securityAlertResponse) {
-      blockaidParams = getBlockaidMetricsParams(
-        securityAlertResponse as unknown as SecurityAlertResponse,
-      );
+      blockaidParams = getBlockaidMetricsParams(securityAlertResponse);
     }
 
     return {

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.test.ts
@@ -1,0 +1,31 @@
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { securityAlertResponse as mockSecurityAlertResponse } from '../../../../util/test/confirm-data-helpers';
+import { useSecurityAlertResponse } from './useSecurityAlertResponse';
+
+function renderHook(securityAlertResponse?: SecurityAlertResponse) {
+  const { result } = renderHookWithProvider(useSecurityAlertResponse, {
+    state: {
+      signatureRequest: { securityAlertResponse },
+    },
+  });
+
+  return result.current;
+}
+
+describe('useSecurityAlertResponse', () => {
+  it('returns security alert response for signature request is present', () => {
+    const result = renderHook(
+      mockSecurityAlertResponse as SecurityAlertResponse,
+    );
+    expect(result).toStrictEqual({
+      securityAlertResponse: mockSecurityAlertResponse,
+    });
+  });
+
+  it('returns undefined is security alert response is not present for signature request', () => {
+    const result = renderHook();
+    expect(result.securityAlertResponse).toBeUndefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
+++ b/app/components/Views/confirmations/hooks/useSecurityAlertResponse.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+
+import { selectSignatureSecurityAlertResponse } from '../selectors/security-alerts';
+
+// todo: the hook to be extended to include transactions
+export function useSecurityAlertResponse() {
+  const { securityAlertResponse } = useSelector(
+    selectSignatureSecurityAlertResponse,
+  );
+
+  return { securityAlertResponse };
+}

--- a/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
@@ -1,16 +1,16 @@
-import { useCallback, useEffect } from 'react';
 import type { Hex } from '@metamask/utils';
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+import { useCallback, useEffect } from 'react';
 
 import getDecimalChainId from '../../../../util/networks/getDecimalChainId';
 import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
 import { MetaMetrics, MetaMetricsEvents } from '../../../../core/Analytics';
-
 import { getAddressAccountType } from '../../../../util/address';
 import { getBlockaidMetricsParams } from '../../../../util/blockaid';
-import { SecurityAlertResponse } from '../components/BlockaidBanner/BlockaidBanner.types';
 import { getHostFromUrl } from '../utils/generic';
 import { isSignatureRequest } from '../utils/confirm';
 import { useSignatureRequest } from './useSignatureRequest';
+import { useSecurityAlertResponse } from './useSecurityAlertResponse';
 
 interface MessageParamsType {
   meta: Record<string, unknown>;
@@ -21,10 +21,11 @@ interface MessageParamsType {
 
 const getAnalyticsParams = (
   messageParams: MessageParamsType,
+  securityAlertResponse: SecurityAlertResponse,
   type: string,
-  chainId?: Hex,
+  chainId: Hex | undefined,
 ) => {
-  const { meta = {}, from, securityAlertResponse, version } = messageParams;
+  const { meta = {}, from, version } = messageParams;
 
   return {
     account_type: getAddressAccountType(from as string),
@@ -42,6 +43,7 @@ const getAnalyticsParams = (
 
 export const useSignatureMetrics = () => {
   const signatureRequest = useSignatureRequest();
+  const { securityAlertResponse } = useSecurityAlertResponse();
 
   const { chainId, messageParams, type } = signatureRequest ?? {};
 
@@ -58,6 +60,7 @@ export const useSignatureMetrics = () => {
           .addProperties(
             getAnalyticsParams(
               messageParams as unknown as MessageParamsType,
+              securityAlertResponse as SecurityAlertResponse,
               type,
               chainId,
             ),
@@ -65,7 +68,7 @@ export const useSignatureMetrics = () => {
           .build(),
       );
     },
-    [chainId, messageParams, type],
+    [chainId, messageParams, securityAlertResponse, type],
   );
 
   useEffect(() => {

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.test.ts
@@ -1,10 +1,11 @@
+import { ApprovalType } from '@metamask/controller-utils';
 import {
   SignatureRequest,
   SignatureRequestType,
 } from '@metamask/signature-controller';
+
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import { useSignatureRequest } from './useSignatureRequest';
-import { ApprovalType } from '@metamask/controller-utils';
 
 const ID_MOCK = '123-456-789';
 

--- a/app/components/Views/confirmations/hooks/useSignatureRequest.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureRequest.ts
@@ -1,8 +1,10 @@
-import { useSelector } from 'react-redux';
-import useApprovalRequest from './useApprovalRequest';
 import { ApprovalType } from '@metamask/controller-utils';
+import { SignatureRequest } from '@metamask/signature-controller';
+import { useSelector } from 'react-redux';
+
 import { selectSignatureRequestById } from '../../../../selectors/signatureController';
 import { RootState } from '../../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
+import useApprovalRequest from './useApprovalRequest';
 
 const SIGNATURE_APPROVAL_TYPES = [
   ApprovalType.PersonalSign,
@@ -23,5 +25,5 @@ export function useSignatureRequest() {
     return undefined;
   }
 
-  return signatureRequest;
+  return signatureRequest as SignatureRequest;
 }

--- a/app/components/Views/confirmations/hooks/useTypedSignSimulationEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useTypedSignSimulationEnabled.ts
@@ -1,6 +1,10 @@
 import { useSelector } from 'react-redux';
 import { SignTypedDataVersion } from '@metamask/eth-sig-util';
-import { MessageParamsTyped, SignatureRequest, SignatureRequestType } from '@metamask/signature-controller';
+import {
+  MessageParamsTyped,
+  SignatureRequest,
+  SignatureRequestType,
+} from '@metamask/signature-controller';
 import { selectUseTransactionSimulations } from '../../../../selectors/preferencesController';
 import { isRecognizedPermit, parseTypedDataMessage } from '../utils/signature';
 import { useSignatureRequest } from './useSignatureRequest';
@@ -21,7 +25,9 @@ const isNonPermitSupportedByDecodingAPI = (
   signatureRequest: SignatureRequest,
 ) => {
   const data = signatureRequest.messageParams?.data as string;
-  if (!data) { return false; }
+  if (!data) {
+    return false;
+  }
 
   const {
     domain: { name, version },
@@ -47,13 +53,14 @@ export function useTypedSignSimulationEnabled() {
   }
 
   const requestType = signatureRequest.type;
-  const signatureMethod = (signatureRequest.messageParams as MessageParamsTyped)?.version;
+  const signatureMethod = (signatureRequest.messageParams as MessageParamsTyped)
+    ?.version;
 
-  const isTypedSignV3V4 = requestType === SignatureRequestType.TypedSign && (
-    signatureMethod === SignTypedDataVersion.V3 ||
-    signatureMethod === SignTypedDataVersion.V4
-  );
-  const isPermit = isRecognizedPermit(signatureRequest);
+  const isTypedSignV3V4 =
+    requestType === SignatureRequestType.TypedSign &&
+    (signatureMethod === SignTypedDataVersion.V3 ||
+      signatureMethod === SignTypedDataVersion.V4);
+  const isPermit = isTypedSignV3V4 && isRecognizedPermit(signatureRequest);
 
   const nonPermitSupportedByDecodingAPI: boolean =
     isTypedSignV3V4 && isNonPermitSupportedByDecodingAPI(signatureRequest);

--- a/app/components/Views/confirmations/selectors/security-alerts.test.ts
+++ b/app/components/Views/confirmations/selectors/security-alerts.test.ts
@@ -1,0 +1,23 @@
+import { RootState } from '../../../../reducers';
+import { securityAlertResponse } from '../../../../util/test/confirm-data-helpers';
+import { selectSignatureSecurityAlertResponse } from './security-alerts';
+
+describe('Security Alert Selectors', () => {
+  describe('selectSignatureSecurityAlertResponse', () => {
+    it('returns signature security alert response from the state', () => {
+      expect(
+        selectSignatureSecurityAlertResponse({
+          signatureRequest: {
+            securityAlertResponse,
+          },
+        } as RootState),
+      ).toEqual({ securityAlertResponse });
+    });
+
+    it('returns undefined if security alert response not present', () => {
+      expect(
+        selectSignatureSecurityAlertResponse({} as unknown as RootState),
+      ).toEqual(undefined);
+    });
+  });
+});

--- a/app/components/Views/confirmations/selectors/security-alerts.ts
+++ b/app/components/Views/confirmations/selectors/security-alerts.ts
@@ -1,0 +1,7 @@
+import { SecurityAlertResponse } from '@metamask/transaction-controller';
+import { RootState } from '../../../../reducers';
+
+export const selectSignatureSecurityAlertResponse = (
+  rootState: RootState,
+): { securityAlertResponse: SecurityAlertResponse } =>
+  rootState.signatureRequest;

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -1,7 +1,11 @@
 import {
+  SecurityAlertResponse,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+
+import {
   Reason,
   ResultType,
-  SecurityAlertResponse,
   SecurityAlertSource,
 } from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
 // eslint-disable-next-line import/no-namespace
@@ -17,7 +21,6 @@ import {
   isBlockaidFeatureEnabled,
   TransactionType,
 } from '.';
-import { TransactionStatus } from '@metamask/transaction-controller';
 
 jest.mock('../../core/Engine', () => ({
   resetState: jest.fn(),
@@ -139,16 +142,17 @@ describe('Blockaid util', () => {
     });
 
     it('should return additionalParams object when securityAlertResponse is defined', async () => {
-      const securityAlertResponse: SecurityAlertResponse = {
-        result_type: ResultType.Malicious,
-        reason: Reason.notApplicable,
-        source: SecurityAlertSource.API,
-        providerRequestsCount: {
-          eth_call: 5,
-          eth_getCode: 3,
-        },
-        features: [],
-      };
+      const securityAlertResponse: SecurityAlertResponse & { source: string } =
+        {
+          result_type: ResultType.Malicious,
+          reason: Reason.notApplicable,
+          source: SecurityAlertSource.API,
+          providerRequestsCount: {
+            eth_call: 5,
+            eth_getCode: 3,
+          },
+          features: [],
+        };
 
       const result = getBlockaidMetricsParams(securityAlertResponse);
       expect(result).toEqual({

--- a/app/util/blockaid/index.ts
+++ b/app/util/blockaid/index.ts
@@ -1,11 +1,12 @@
-import Engine from '../../core/Engine';
-import {
-  ResultType,
+import type {
   SecurityAlertResponse,
-} from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+
+import Engine from '../../core/Engine';
+import { ResultType } from '../../components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.types';
 import { store } from '../../store';
 import { selectChainId } from '../../selectors/networkController';
-import type { TransactionMeta } from '@metamask/transaction-controller';
 import PPOMUtils from '../../lib/ppom/ppom-util';
 
 interface TransactionSecurityAlertResponseType {
@@ -35,7 +36,7 @@ export const getBlockaidMetricsParams = (
 
   if (securityAlertResponse) {
     const { result_type, reason, providerRequestsCount, source } =
-      securityAlertResponse;
+      securityAlertResponse as SecurityAlertResponse & { source: string };
 
     additionalParams.security_alert_response = result_type;
     additionalParams.security_alert_reason = reason;


### PR DESCRIPTION
## **Description**

fix for blockaid validations are not being flagged in re-designed signature request pages

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13068

## **Manual testing steps**

1. To to test dapp
2. Submit malicious permit
3. Check blockaid banner on the page

## **Screenshots/Recordings**
<img width="401" alt="Screenshot 2025-01-21 at 11 24 39 PM" src="https://github.com/user-attachments/assets/1fc1d0e6-2959-4ec4-bc99-3605089474e6" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
