### PR TITLE
test: Reverse TCP port for edit address test

### DIFF
--- a/e2e/specs/wallet/edit-recipient-address.spec.js
+++ b/e2e/specs/wallet/edit-recipient-address.spec.js
@@ -17,7 +17,10 @@ import {
 import FixtureServer from '../../fixtures/fixture-server';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import Gestures from '../../utils/Gestures';
-import { ActivitiesViewSelectorsText, sentMessageTokenIDs } from '../../selectors/Transactions/ActivitiesView.selectors';
+import {
+  ActivitiesViewSelectorsText,
+  sentMessageTokenIDs,
+} from '../../selectors/Transactions/ActivitiesView.selectors';
 import { contractConfiguration } from '../../../app/util/test/smart-contracts';
 
 const INCORRECT_SEND_ADDRESS = '0xebe6CcB6B55e1d094d9c58980Bc10Fed69932cAb';
@@ -28,8 +31,9 @@ const fixtureServer = new FixtureServer();
 describe(
   SmokeCore('Send ETH to the correct address after editing the recipient'),
   () => {
-    beforeEach(() => {
-      jest.setTimeout(200000);
+    beforeAll(async () => {
+      jest.setTimeout(2500000);
+      await TestHelpers.reverseServerPort();
     });
 
     afterAll(async () => {
@@ -57,7 +61,10 @@ describe(
 
           //Assert Address
           const address = await SendView.splitAddressText();
-          await Assertions.checkIfTextMatches(address[0], INCORRECT_SEND_ADDRESS);
+          await Assertions.checkIfTextMatches(
+            address[0],
+            INCORRECT_SEND_ADDRESS,
+          );
 
           await SendView.tapBackButton();
           await AmountView.tapBackButton();
@@ -70,18 +77,23 @@ describe(
 
           // Assert correct address
           const correctAddress = await SendView.splitAddressText();
-          await Assertions.checkIfTextMatches(correctAddress[0], CORRECT_SEND_ADDRESS);
+          await Assertions.checkIfTextMatches(
+            correctAddress[0],
+            CORRECT_SEND_ADDRESS,
+          );
 
           //Assert transactions send screen on IOS only due to android limitations
           if (device.getPlatform() === 'ios') {
-          // Tap Send
-          await TransactionConfirmationView.tapConfirmButton();
+            // Tap Send
+            await TransactionConfirmationView.tapConfirmButton();
 
-          // Transactions view to assert address remains consistent
-          await TabBarComponent.tapActivity();
-          await TestHelpers.delay(3000);
-          await TestHelpers.tapByText(ActivitiesViewSelectorsText.CONFIRM_TEXT);
-          await Assertions.checkIfTextIsDisplayed(`${SHORTHAND_ADDRESS}`);
+            // Transactions view to assert address remains consistent
+            await TabBarComponent.tapActivity();
+            await TestHelpers.delay(3000);
+            await TestHelpers.tapByText(
+              ActivitiesViewSelectorsText.CONFIRM_TEXT,
+            );
+            await Assertions.checkIfTextIsDisplayed(`${SHORTHAND_ADDRESS}`);
           }
         },
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The edit address test is passing (not even sure how this is possible) and failing (as expected) on CI. In order to utilize fixtures, specifically for android, the emulator needs to be able to communicate with the fixture server. The test in question was missing the line of code to change ports. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
