### PR TITLE
fix: toast msg on deleted network

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -270,15 +270,25 @@ const Main = (props) => {
       const newNetwork = currentNetworkValues.find(
         (network) => !previousNetworkValues.includes(network),
       );
+      const deletedNetwork = previousNetworkValues.find(
+        (network) => !currentNetworkValues.includes(network),
+      );
 
       toastRef?.current?.showToast({
         variant: ToastVariants.Plain,
         labelOptions: [
           {
-            label: `${newNetwork?.name ?? strings('asset_details.network')} `,
+            label: `${
+              (newNetwork?.name || deletedNetwork?.name) ??
+              strings('asset_details.network')
+            } `,
             isBold: true,
           },
-          { label: strings('toast.network_added') },
+          {
+            label: deletedNetwork
+              ? strings('toast.network_removed')
+              : strings('toast.network_added'),
+          },
         ],
         networkImageSource: networkImage,
       });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -746,6 +746,7 @@
     "connected_and_active": "connected and active.",
     "now_active": "now active.",
     "network_added": "was successfully added",
+    "network_removed": "was successfully removed",
     "network_deleted": "was successfully deleted",
     "network_permissions_updated": "Network permissions updated",
     "revoked": "revoked.",


### PR DESCRIPTION

## **Description**

PR to fix toast msg when a network is deleted

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click on network selector
2. Delete any network
3. toast msg should day '... successfully deleted' instead of 'successfully added'


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
