### PR TITLE
cherrypick: Hide simulation section in typed sign v1 pages

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.test.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.test.tsx
@@ -54,12 +54,6 @@ describe('Confirm', () => {
         state: typedSignV1ConfirmationState,
       });
     expect(getByText('Signature request')).toBeDefined();
-    expect(getByText('Estimated changes')).toBeDefined();
-    expect(
-      getByText(
-        "You're signing into a site and there are no predicted changes to your account.",
-      ),
-    ).toBeDefined();
     expect(getByText('Request from')).toBeDefined();
     expect(getByText('metamask.github.io')).toBeDefined();
     expect(getAllByText('Message')).toHaveLength(2);

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -10,6 +10,7 @@ import Button, {
 import { useStyles } from '../../../../../../component-library/hooks';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
+import { ResultType } from '../../BlockaidBanner/BlockaidBanner.types';
 import styleSheet from './Footer.styles';
 
 const Footer = () => {
@@ -36,7 +37,7 @@ const Footer = () => {
         size={ButtonSize.Lg}
         variant={ButtonVariants.Primary}
         width={ButtonWidthTypes.Full}
-        isDanger={securityAlertResponse !== undefined}
+        isDanger={securityAlertResponse?.result_type === ResultType.Malicious}
       />
     </View>
   );

--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV1/TypedSignV1.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV1/TypedSignV1.test.tsx
@@ -9,12 +9,6 @@ describe('TypedSignV1', () => {
     const { getByText, getAllByText } = renderWithProvider(<TypedSignV1 />, {
       state: typedSignV1ConfirmationState,
     });
-    expect(getByText('Estimated changes')).toBeDefined();
-    expect(
-      getByText(
-        "You're signing into a site and there are no predicted changes to your account.",
-      ),
-    ).toBeDefined();
     expect(getByText('Request from')).toBeDefined();
     expect(getByText('metamask.github.io')).toBeDefined();
     expect(getAllByText('Message')).toHaveLength(2);

--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV1/TypedSignV1.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV1/TypedSignV1.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import useApprovalRequest from '../../../../hooks/useApprovalRequest';
-import NoChangeSimulation from '../../NoChangeSimulation';
 import InfoRowOrigin from '../Shared/InfoRowOrigin';
 import Message from './Message';
 
@@ -14,7 +13,6 @@ const TypedSignV1 = () => {
 
   return (
     <>
-      <NoChangeSimulation />
       <InfoRowOrigin />
       <Message />
     </>


### PR DESCRIPTION
## **Description**

Simulation section should not be displayed on typed sign V1 page.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4012

## **Manual testing steps**

1. Go to test dapp
2. Submit type sign request
3. Ensure that simulation section is not present

## **Screenshots/Recordings**
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="398" alt="Screenshot 2025-01-23 at 7 02 52 PM" src="https://github.com/user-attachments/assets/50d93b57-f3aa-44ef-bcc4-05a31e433436" />

<!-- [screenshots/recordings] -->

### **After**
<img width="400" alt="Screenshot 2025-01-23 at 7 08 27 PM" src="https://github.com/user-attachments/assets/1a697fae-4f28-418f-8675-0c063f56eea6" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
