### PR TITLE
feat: allow override remote feature flags

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -113,3 +113,8 @@ export MM_PERMISSIONS_SETTINGS_V1_ENABLED=""
 
 # Feature flag for Stablecoin Lending UI
 export MM_STABLECOIN_LENDING_UI_ENABLED="true"
+
+# Activates remote feature flag override mode.
+# Remote feature flag values won't be updated,
+# and selectors should return their fallback values
+export OVERRIDE_REMOTE_FEATURE_FLAGS="false"

--- a/app/core/Engine/controllers/RemoteFeatureFlagController/utils.ts
+++ b/app/core/Engine/controllers/RemoteFeatureFlagController/utils.ts
@@ -29,6 +29,8 @@ const getFeatureFlagAppDistribution = () => {
   }
 };
 
+export const isRemoteFeatureFlagOverrideActivated = process.env.OVERRIDE_REMOTE_FEATURE_FLAGS;
+
 export const createRemoteFeatureFlagController = ({
   state,
   messenger,
@@ -52,6 +54,8 @@ export const createRemoteFeatureFlagController = ({
 
   if (disabled) {
     Logger.log('Feature flag controller disabled');
+  } else if (isRemoteFeatureFlagOverrideActivated) {
+    Logger.log('Remote feature flags override activated');
   } else {
     remoteFeatureFlagController.updateRemoteFeatureFlags().then(() => {
       Logger.log('Feature flags updated');

--- a/app/selectors/featureFlagController/index.ts
+++ b/app/selectors/featureFlagController/index.ts
@@ -1,11 +1,15 @@
 import { createSelector } from 'reselect';
 import { StateWithPartialEngine } from './types';
+import { isRemoteFeatureFlagOverrideActivated } from '../../core/Engine/controllers/RemoteFeatureFlagController/utils';
 
 export const selectRemoteFeatureFlagControllerState = (state: StateWithPartialEngine) =>
   state.engine.backgroundState.RemoteFeatureFlagController;
 
 export const selectRemoteFeatureFlags = createSelector(
   selectRemoteFeatureFlagControllerState,
-  (remoteFeatureFlagControllerState) =>
-    remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {}
-);
+  (remoteFeatureFlagControllerState) => {
+    if (isRemoteFeatureFlagOverrideActivated) {
+      return {};
+    }
+    return remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {};
+  });


### PR DESCRIPTION
## **Description**
This PR introduces the new environment variable `OVERRIDE_REMOTE_FEATURE_FLAGS`.

When set to `true`, remote feature flag selectors are forced to use their fallback values.

Allows easy feature flag value manipulation for testing purposes.

Update your `.js.env` with the new entry provided at the example file

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2118

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
