### PR TITLE
fix: move migration validation out of onPersistComplete

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -14,7 +14,6 @@ import persistConfig from './persistConfig';
 import getUIStartupSpan from '../core/Performance/UIStartup';
 import ReduxService from '../core/redux';
 import { onPersistedDataLoaded } from '../actions/user';
-import { validatePostMigrationState } from './validateMigration/validateMigration';
 
 // TODO: Improve type safety by using real Action types instead of `any`
 // TODO: Replace "any" with type

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -70,10 +70,6 @@ const createStoreAndPersistor = async () => {
     endTrace({ name: TraceName.StoreInit });
     // Signal that persisted data has been loaded
     store.dispatch(onPersistedDataLoaded());
-
-    // validate the state after migration
-    const currentState = store.getState();
-    validatePostMigrationState(currentState);
   };
 
   persistor = persistStore(store, null, onPersistComplete);

--- a/app/store/migrations/index.test.ts
+++ b/app/store/migrations/index.test.ts
@@ -71,6 +71,37 @@ describe('asyncifyMigrations', () => {
 
     expect(isPromiseMigrations).toEqual(true);
   });
+
+  it('should only call validation callback after all migrations complete', async () => {
+    const mockValidation = jest.fn();
+    const testMigrationList = {
+      0: synchronousMigration,
+      1: asyncMigration,
+      2: synchronousMigration,
+    };
+
+    // Convert all migrations to async with validation callback
+    const asyncMigrations = asyncifyMigrations(
+      testMigrationList,
+      mockValidation,
+    );
+
+    // Run migrations in sequence and verify validation is only called after the highest migration
+    let state: PersistedState = initialState;
+
+    for (const migrationKey in asyncMigrations) {
+      state = (await asyncMigrations[migrationKey](state)) as PersistedState;
+
+      if (Number(migrationKey) === 2) {
+        // Should be called exactly once after the last migration
+        expect(mockValidation).toHaveBeenCalledTimes(1);
+        expect(mockValidation).toHaveBeenCalledWith(state);
+      } else {
+        // Should not be called for any other migration
+        expect(mockValidation).not.toHaveBeenCalled();
+      }
+    }
+  });
 });
 
 describe('migrations', () => {

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -67,6 +67,8 @@ import migration63 from './063';
 import migration64 from './064';
 import migration65 from './065';
 import migration66 from './066';
+import { validatePostMigrationState } from '../validateMigration/validateMigration';
+import { RootState } from '../../reducers';
 
 type MigrationFunction = (state: unknown) => unknown;
 type AsyncMigrationFunction = (state: unknown) => Promise<unknown>;
@@ -149,7 +151,10 @@ export const migrationList: MigrationsList = {
 };
 
 // Enable both synchronous and asynchronous migrations
-export const asyncifyMigrations = (inputMigrations: MigrationsList) =>
+export const asyncifyMigrations = (
+  inputMigrations: MigrationsList,
+  onMigrationsComplete?: (state: unknown) => void,
+) =>
   Object.entries(inputMigrations).reduce(
     (newMigrations, [migrationNumber, migrationFunction]) => {
       // Handle migrations as async
@@ -157,7 +162,17 @@ export const asyncifyMigrations = (inputMigrations: MigrationsList) =>
         incomingState: Promise<unknown> | unknown,
       ) => {
         const state = await incomingState;
-        return migrationFunction(state);
+        const migratedState = await migrationFunction(state);
+
+        // If this is the last migration and we have a callback, run it
+        if (
+          onMigrationsComplete &&
+          Number(migrationNumber) === Object.keys(inputMigrations).length - 1
+        ) {
+          onMigrationsComplete(migratedState);
+        }
+
+        return migratedState;
       };
       newMigrations[migrationNumber] = asyncMigration;
       return newMigrations;
@@ -166,9 +181,9 @@ export const asyncifyMigrations = (inputMigrations: MigrationsList) =>
   );
 
 // Convert all migrations to async
-export const migrations = asyncifyMigrations(
-  migrationList,
-) as unknown as MigrationManifest;
+export const migrations = asyncifyMigrations(migrationList, (state) => {
+  validatePostMigrationState(state as RootState);
+}) as unknown as MigrationManifest;
 
 // The latest (i.e. highest) version number.
 export const version = Object.keys(migrations).length - 1;

--- a/app/store/persistConfig.ts
+++ b/app/store/persistConfig.ts
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import FilesystemStorage from 'redux-persist-filesystem-storage';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import { RootState } from '../reducers';
-import { migrations, version } from './migrations';
+import { version, migrations } from './migrations';
 import Logger from '../util/Logger';
 import Device from '../util/device';
 import { UserState } from '../reducers/user';

--- a/app/store/validateMigration/validateMigration.test.ts
+++ b/app/store/validateMigration/validateMigration.test.ts
@@ -7,6 +7,7 @@ import { validateEngineInitialized } from './engineBackgroundState';
 
 jest.mock('../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 jest.mock('./accountsController');
@@ -21,6 +22,14 @@ describe('validatePostMigrationState', () => {
     (validateEngineInitialized as jest.Mock).mockReturnValue([]);
     (validateAccountsController as jest.Mock).mockReturnValue([]);
     (validateKeyringController as jest.Mock).mockReturnValue([]);
+  });
+
+  it('logs when validation starts', () => {
+    const mockState = {} as RootState;
+    validatePostMigrationState(mockState);
+
+    expect(Logger.log).toHaveBeenCalledWith('Migration validation started');
+    expect(Logger.log).toHaveBeenCalledTimes(1);
   });
 
   it('runs all validation checks', () => {

--- a/app/store/validateMigration/validateMigration.ts
+++ b/app/store/validateMigration/validateMigration.ts
@@ -18,6 +18,7 @@ const checks: ValidationCheck[] = [
  * This makes sure your app keeps running even if some data is unexpected.
  */
 export function validatePostMigrationState(state: RootState): void {
+  Logger.log('Migration validation started');
   const allErrors = checks.flatMap((check) => check(state));
 
   // If there are any errors, log them

--- a/app/util/sentry/__snapshots__/utils.test.ts.snap
+++ b/app/util/sentry/__snapshots__/utils.test.ts.snap
@@ -52,6 +52,9 @@ exports[`captureSentryFeedback maskObject masks initial root state fixture 1`] =
                 "eth_signTypedData_v4",
               ],
               "options": {},
+              "scopes": [
+                "eip155",
+              ],
               "type": "eip155:eoa",
             },
             "2be55f5b-eba9-41a7-a9ed-a6a8274aca28": {
@@ -70,6 +73,9 @@ exports[`captureSentryFeedback maskObject masks initial root state fixture 1`] =
                 "eth_signTransaction",
               ],
               "options": {},
+              "scopes": [
+                "eip155",
+              ],
               "type": "eip155:eoa",
             },
           },

--- a/app/util/sentry/utils.js
+++ b/app/util/sentry/utils.js
@@ -39,6 +39,7 @@ export const sentryStateMask = {
               type: true,
               options: true,
               methods: true,
+              scopes: true,
               metadata: {
                 name: true,
                 importTime: true,

--- a/app/util/sentry/utils.test.ts
+++ b/app/util/sentry/utils.test.ts
@@ -11,6 +11,7 @@ import {
 import { DeepPartial } from '../test/renderWithProvider';
 import { RootState } from '../../reducers';
 import { NetworkStatus } from '@metamask/network-controller';
+import { EthScopes } from '@metamask/keyring-api';
 
 jest.mock('@sentry/react-native', () => ({
   ...jest.requireActual('@sentry/react-native'),
@@ -177,6 +178,7 @@ describe('captureSentryFeedback', () => {
                     'eth_signTypedData_v3',
                     'eth_signTypedData_v4',
                   ],
+                  scopes: [EthScopes.Namespace],
                   options: {},
                   type: 'eip155:eoa',
                 },
@@ -191,6 +193,7 @@ describe('captureSentryFeedback', () => {
                     lastSelected: 1720023898237,
                     name: 'Account 2',
                   },
+                  scopes: [EthScopes.Namespace],
                   methods: ['personal_sign', 'eth_signTransaction'],
                   options: {},
                   type: 'eip155:eoa',
@@ -630,6 +633,7 @@ describe('captureSentryFeedback', () => {
         'eth_signTypedData_v3',
         'eth_signTypedData_v4',
       ]);
+      expect(maskedAccount1.scopes).toEqual([EthScopes.Namespace]);
       expect(maskedAccount1.metadata).toEqual({
         importTime: 1720023898234,
         keyring: { type: 'HD Key Tree' },
@@ -645,6 +649,7 @@ describe('captureSentryFeedback', () => {
         'personal_sign',
         'eth_signTransaction',
       ]);
+      expect(maskedAccount2.scopes).toEqual([EthScopes.Namespace]);
       expect(maskedAccount2.metadata).toEqual({
         importTime: 1720023898235,
         keyring: { type: 'HD Key Tree' },


### PR DESCRIPTION
## **Description**

- The issue now seems to be that onPersistComplete is not only called after migrations run, they are called even for new users so we are seeing errors logged to sentry that do not pertain to existing users. 

- In this PR I hope to only run the migration validation after after we have completed all the migrations. This should only happen when a user updates the app. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13144

## **Manual testing steps**

1. Download an old version of the app
2. create accounts (ideally ones that have tokens)
3. Update to this version of the app
4. there should be no crashes
5.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
