### PR TITLE
test: decommission potential flakey assertion in test 

### DIFF
--- a/e2e/specs/wallet/edit-recipient-address.spec.js
+++ b/e2e/specs/wallet/edit-recipient-address.spec.js
@@ -78,18 +78,18 @@ describe(
             correctAddress[0],
             CORRECT_SEND_ADDRESS,
           );
-
+          //TODO, renable once transactions activities list is more stable for detox 
           //Assert transactions send screen on IOS only due to android limitations
-          if (device.getPlatform() === 'ios') {
-            // Tap Send
-            await TransactionConfirmationView.tapConfirmButton();
+          // if (device.getPlatform() === 'ios') {
+          //   // Tap Send
+          //   await TransactionConfirmationView.tapConfirmButton();
 
-            // Transactions view to assert address remains consistent
-            await TabBarComponent.tapActivity();
-            await TestHelpers.delay(3000);
-            await ActivitiesView.tapConfirmedTransaction();
-            await Assertions.checkIfTextIsDisplayed(`${SHORTHAND_ADDRESS}`);
-          }
+          //   // Transactions view to assert address remains consistent
+          //   await TabBarComponent.tapActivity();
+          //   await TestHelpers.delay(3000);
+          //   await ActivitiesView.tapConfirmedTransaction();
+          //   await Assertions.checkIfTextIsDisplayed(`${SHORTHAND_ADDRESS}`);
+          // }
         },
       );
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR disables a flaky assertion in e2e/specs/wallet/edit-recipient-address.spec.js related to the Transaction Activity List. The assertion occasionally fails in CI, causing instability. Disabling it temporarily while investigating and addressing the root cause.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

spec file e2e/specs/wallet/edit-recipient-address.spec.js

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
