### PR TITLE
fix: removes runAfterInteractions call from OptinMetrics

### DIFF
--- a/app/components/UI/OptinMetrics/index.js
+++ b/app/components/UI/OptinMetrics/index.js
@@ -368,36 +368,35 @@ class OptinMetrics extends PureComponent {
       setDataCollectionForMarketing(false);
     }
 
-    InteractionManager.runAfterInteractions(async () => {
-      // consolidate device and user settings traits
-      const consolidatedTraits = {
-        ...dataCollectionForMarketingTraits,
-        is_metrics_opted_in: true,
-        ...generateDeviceAnalyticsMetaData(),
-        ...generateUserSettingsAnalyticsMetaData(),
-      };
-      await metrics.addTraitsToUser(consolidatedTraits);
+    // consolidate device and user settings traits
+    const consolidatedTraits = {
+      ...dataCollectionForMarketingTraits,
+      is_metrics_opted_in: true,
+      ...generateDeviceAnalyticsMetaData(),
+      ...generateUserSettingsAnalyticsMetaData(),
+    };
+    await metrics.addTraitsToUser(consolidatedTraits);
 
-      // track onboarding events that were stored before user opted in
-      // only if the user eventually opts in.
-      if (events && events.length) {
-        let delay = 0; // Initialize delay
-        const eventTrackingDelay = 200; // ms delay between each event
-        events.forEach((eventArgs) => {
-          // delay each event to prevent them from
-          // being tracked with the same timestamp
-          // which would cause them to be grouped together
-          // by sentAt time in the Segment dashboard
-          // as precision is only to the milisecond
-          // and loop seems to runs faster than that
-          setTimeout(() => {
-            metrics.trackEvent(...eventArgs);
-          }, delay);
-          delay += eventTrackingDelay;
-        });
-      }
-      this.props.clearOnboardingEvents();
-    });
+    // track onboarding events that were stored before user opted in
+    // only if the user eventually opts in.
+    if (events && events.length) {
+      let delay = 0; // Initialize delay
+      const eventTrackingDelay = 200; // ms delay between each event
+      events.forEach((eventArgs) => {
+        // delay each event to prevent them from
+        // being tracked with the same timestamp
+        // which would cause them to be grouped together
+        // by sentAt time in the Segment dashboard
+        // as precision is only to the milisecond
+        // and loop seems to runs faster than that
+        setTimeout(() => {
+          metrics.trackEvent(...eventArgs);
+        }, delay);
+        delay += eventTrackingDelay;
+      });
+    }
+    this.props.clearOnboardingEvents();
+
     this.continue();
   };
 


### PR DESCRIPTION
fixes: https://github.com/MetaMask/MetaMask-planning/issues/4037

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes runAfterInteractions block from the confirmation function when onboarding, to fix the issue where somtimes the tracking was not being sent through to metametrics.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
