### PR TITLE
fix: Blockaid banner momentarily visible on benign request opened after malicious one

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
@@ -1,6 +1,7 @@
 import Engine from '../../../../core/Engine';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../util/test/confirm-data-helpers';
+import PPOMUtil from '../../../../lib/ppom/ppom-util';
 import { useConfirmActions } from './useConfirmActions';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -23,6 +24,10 @@ describe('useConfirmAction', () => {
   });
 
   it('call required callbacks when confirm button is clicked', async () => {
+    const clearSecurityAlertResponseSpy = jest.spyOn(
+      PPOMUtil,
+      'clearSignatureSecurityAlertResponse',
+    );
     const { result } = renderHookWithProvider(() => useConfirmActions(), {
       state: personalSignatureConfirmationState,
     });
@@ -30,14 +35,20 @@ describe('useConfirmAction', () => {
     expect(Engine.acceptPendingApproval).toHaveBeenCalledTimes(1);
     await flushPromises();
     expect(mockCaptureSignatureMetrics).toHaveBeenCalledTimes(1);
+    expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
   });
 
   it('call required callbacks when reject button is clicked', async () => {
+    const clearSecurityAlertResponseSpy = jest.spyOn(
+      PPOMUtil,
+      'clearSignatureSecurityAlertResponse',
+    );
     const { result } = renderHookWithProvider(() => useConfirmActions(), {
       state: personalSignatureConfirmationState,
     });
     result?.current?.onReject();
     expect(Engine.rejectPendingApproval).toHaveBeenCalledTimes(1);
     expect(mockCaptureSignatureMetrics).toHaveBeenCalledTimes(1);
+    expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import PPOMUtil from '../../../../lib/ppom/ppom-util';
 import { MetaMetricsEvents } from '../../../hooks/useMetrics';
 import { isSignatureRequest } from '../utils/confirm';
 import useApprovalRequest from './useApprovalRequest';
@@ -24,6 +25,7 @@ export const useConfirmActions = () => {
     });
     if (signatureRequest) {
       captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_APPROVED);
+      PPOMUtil.clearSignatureSecurityAlertResponse();
     }
   }, [captureSignatureMetrics, onRequestConfirm, signatureRequest]);
 
@@ -31,6 +33,7 @@ export const useConfirmActions = () => {
     onRequestReject();
     if (signatureRequest) {
       captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_REJECTED);
+      PPOMUtil.clearSignatureSecurityAlertResponse();
     }
   }, [captureSignatureMetrics, onRequestReject, signatureRequest]);
 

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -480,4 +480,14 @@ describe('PPOM Utils', () => {
       },
     );
   });
+
+  describe('clearSignatureSecurityAlertResponse', () => {
+    it('set call action to set securityAlertResponse for signature in redux state to undefined', async () => {
+      const spy = jest.spyOn(SignatureRequestActions, 'default');
+      PPOMUtil.clearSignatureSecurityAlertResponse();
+      expect(spy).toHaveBeenCalledTimes(1);
+      // function call with no arguments
+      expect(spy).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -251,4 +251,12 @@ function normalizeRequest(request: PPOMRequest): PPOMRequest {
   };
 }
 
-export default { validateRequest, isChainSupported };
+function clearSignatureSecurityAlertResponse() {
+  store.dispatch(setSignatureRequestSecurityAlertResponse());
+}
+
+export default {
+  validateRequest,
+  isChainSupported,
+  clearSignatureSecurityAlertResponse,
+};


### PR DESCRIPTION
## **Description**

Blockaid banner momentarily visible on benign request opened after malicious one

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4024

## **Manual testing steps**

1. Go to test dapp
2. Submit malicious permit and see blockaid banner appearing
3. Submit benign personal request, blockaid banner should not appear

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
