### PR TITLE
fix: add fallback for token symbol in toast after hiding token

### DIFF
--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -201,7 +201,10 @@ const AssetOptions = (props: Props) => {
                 duration: 5000,
                 title: strings('wallet.token_toast.token_hidden_title'),
                 description: strings('wallet.token_toast.token_hidden_desc', {
-                  tokenSymbol: tokenList[address.toLowerCase()]?.symbol || null,
+                  tokenSymbol:
+                    tokenList[address.toLowerCase()]?.symbol ||
+                    asset.symbol ||
+                    null,
                 }),
               });
               trackEvent(
@@ -212,7 +215,7 @@ const AssetOptions = (props: Props) => {
                     asset_type: 'token',
                     tokens: [
                       `${
-                        tokenList[address.toLowerCase()]?.symbol
+                        asset.symbol || tokenList[address.toLowerCase()]?.symbol
                       } - ${address}`,
                     ],
                     chain_id: getDecimalChainId(chainId),


### PR DESCRIPTION

## **Description**

PR adds a fallback for token symbol to be displayed in toast after hiding a token

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/12924

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
