### PR TITLE
fix: Prevent extra dismissModal call after network selection

### DIFF
--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -251,11 +251,10 @@ const NetworkSelector = () => {
         } catch (error) {
           Logger.error(new Error(`Error in setActiveNetwork: ${error}`));
         }
-        sheetRef.current?.dismissModal();
       }
 
       setTokenNetworkFilter(chainId);
-      sheetRef.current?.dismissModal();
+      if (!(domainIsConnectedDapp && isMultichainV1Enabled())) sheetRef.current?.dismissModal();
       endTrace({ name: TraceName.SwitchCustomNetwork });
       endTrace({ name: TraceName.NetworkSwitch });
       trackEvent(


### PR DESCRIPTION
## **Description**

When switching networks on Android, the app often re-navigates to a different screen.  In cases where `domainIsConnectedDapp` and `isMultichainV1Enabled()` are both false the `onSetRpcTarget` method is calling `sheetRef.current?.dismissModal()` twice. My suspicion is that the first call will dismiss the modal and the second call is likely bubbling up to the action page / screen homepage where it is dismissing the actual page (which is often implemented by the navigation library as a modal). As a result, the page / route before the main one becomes the top or "current" page.

Preventing the second `dismissModal()` call fixed the issue, as expected.

## **Related issues**

Fixes: #13193 

## **Manual testing steps**

1. Add BNB Chain to list of networks
2. Select Ethereum Mainnet as current network
3. Click on the "Settings" or In-App Browser button on the bottom 4 tabs.
4. Click back to the main homepage
5. Select BNB Chain from the network selection popup
6. After network changes, tab should slide out to the bottom and main page should be visible with BNB chain listed as the current network. The app should NOT navigate back to the "Settings" or In-App Browser page.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/c743b6bd-c236-4862-aa5a-34d0e95e7ce4

https://github.com/user-attachments/assets/63d20f4c-a465-4e63-9b1c-7e960c7b7013

### **After**

https://github.com/user-attachments/assets/723a8fe6-a6fe-4d52-958b-233b4645cabf

https://github.com/user-attachments/assets/a8cb73cf-d201-4b64-818f-eb184706c1ef


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
