### PR TITLE
refactor(navigation): unify dapp redirect logic to prevent premature navigation

### DIFF
--- a/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.test.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.test.ts
@@ -1,15 +1,14 @@
+import { Platform } from 'react-native';
 import { ACTIONS, PREFIXES } from '../../../constants/deeplinks';
+import Routes from '../../../constants/navigation/Routes';
+import Device from '../../../util/device';
 import AppConstants from '../../AppConstants';
-import { Minimizer } from '../../NativeModules';
+import handleDeeplink from '../../SDKConnect/handlers/handleDeeplink';
 import SDKConnect from '../../SDKConnect/SDKConnect';
 import WC2Manager from '../../WalletConnect/WalletConnectV2';
 import DeeplinkManager from '../DeeplinkManager';
 import extractURLParams from './extractURLParams';
 import handleMetaMaskDeeplink from './handleMetaMaskDeeplink';
-import handleDeeplink from '../../SDKConnect/handlers/handleDeeplink';
-import Device from '../../../util/device';
-import { Platform } from 'react-native';
-import Routes from '../../../constants/navigation/Routes';
 
 jest.mock('../../../core/AppConstants');
 jest.mock('../../../core/SDKConnect/handlers/handleDeeplink');
@@ -269,49 +268,7 @@ describe('handleMetaMaskProtocol', () => {
       url = `${PREFIXES.METAMASK}${ACTIONS.CONNECT}`;
     });
 
-    it('should call Minimizer.goBack if params.redirect is truthy on android', () => {
-      params.redirect = 'true';
-      // Mock Device.isIos() to return true
-      jest.spyOn(Device, 'isIos').mockReturnValue(false);
-
-      // Set Platform.Version to '16' to ensure it's less than 17
-      Object.defineProperty(Platform, 'Version', { get: () => '16' });
-
-      handleMetaMaskDeeplink({
-        instance,
-        handled,
-        params,
-        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
-        wcURL,
-        url,
-      });
-
-      expect(handled).toHaveBeenCalled();
-      expect(Minimizer.goBack).toHaveBeenCalled();
-    });
-
-    it('should call Minimizer.goBack if params.redirect is truthy on ios <17', () => {
-      params.redirect = 'true';
-      // Mock Device.isIos() to return true
-      jest.spyOn(Device, 'isIos').mockReturnValue(true);
-
-      // Set Platform.Version to '16' to ensure it's less than 17
-      Object.defineProperty(Platform, 'Version', { get: () => '16' });
-
-      handleMetaMaskDeeplink({
-        instance,
-        handled,
-        params,
-        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
-        wcURL,
-        url,
-      });
-
-      expect(handled).toHaveBeenCalled();
-      expect(Minimizer.goBack).toHaveBeenCalled();
-    });
-
-    it('should displays RETURN_TO_DAPP_MODAL if params.redirect is truthy on ios >17', () => {
+    it('should displays RETURN_TO_DAPP_MODAL', () => {
       params.redirect = 'true';
       // Mock Device.isIos() to return true
       jest.spyOn(Device, 'isIos').mockReturnValue(true);
@@ -332,7 +289,6 @@ describe('handleMetaMaskProtocol', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
       });
-      expect(Minimizer.goBack).not.toHaveBeenCalled();
     });
 
 

--- a/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
@@ -43,13 +43,9 @@ export function handleMetaMaskDeeplink({
 
   if (url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.CONNECT}`)) {
     if (params.redirect && origin === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK) {
-      if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-        SDKConnect.getInstance().state.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-          screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-        });
-      }  else {
-        Minimizer.goBack();
-      }
+      SDKConnect.getInstance().state.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+      });
     } else if (params.channelId) {
       // differentiate between  deeplink callback and socket connection
       if (params.comm === 'deeplinking') {

--- a/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
@@ -1,18 +1,15 @@
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { ACTIONS, PREFIXES } from '../../../constants/deeplinks';
+import Routes from '../../../constants/navigation/Routes';
 import Logger from '../../../util/Logger';
-import { Minimizer } from '../../NativeModules';
+import AppConstants from '../../AppConstants';
 import SDKConnect from '../../SDKConnect/SDKConnect';
 import handleDeeplink from '../../SDKConnect/handlers/handleDeeplink';
 import DevLogger from '../../SDKConnect/utils/DevLogger';
 import WC2Manager from '../../WalletConnect/WalletConnectV2';
 import DeeplinkManager from '../DeeplinkManager';
-import extractURLParams from './extractURLParams';
 import parseOriginatorInfo from '../parseOriginatorInfo';
-import { Platform } from 'react-native';
-import Device from '../../../util/device';
-import Routes from '../../../constants/navigation/Routes';
-import AppConstants from '../../AppConstants';
+import extractURLParams from './extractURLParams';
 export function handleMetaMaskDeeplink({
   instance,
   handled,

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
@@ -2,7 +2,6 @@ import { Platform } from 'react-native';
 import { ACTIONS } from '../../../constants/deeplinks';
 import Device from '../../../util/device';
 import AppConstants from '../../AppConstants';
-import { Minimizer } from '../../NativeModules';
 import SDKConnect from '../../SDKConnect/SDKConnect';
 import handleDeeplink from '../../SDKConnect/handlers/handleDeeplink';
 import DevLogger from '../../SDKConnect/utils/DevLogger';
@@ -122,63 +121,7 @@ describe('handleUniversalLinks', () => {
   });
 
   describe('ACTIONS.CONNECT', () => {
-    it('should call Minimizer.goBack if params.redirect is truthy on android', () => {
-      params.redirect = 'true';
-      // Mock Device.isIos() to return true
-      jest.spyOn(Device, 'isIos').mockReturnValue(false);
-
-      // Set Platform.Version to '16' to ensure it's less than 17
-      Object.defineProperty(Platform, 'Version', { get: () => '16' });
-
-      urlObj = {
-        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
-        pathname: `/${ACTIONS.CONNECT}/additional/path`,
-      } as ReturnType<typeof extractURLParams>['urlObj'];
-
-      handleUniversalLink({
-        instance,
-        handled,
-        urlObj,
-        params,
-        browserCallBack: mockBrowserCallBack,
-        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
-        wcURL,
-        url,
-      });
-
-      expect(handled).toHaveBeenCalled();
-      expect(Minimizer.goBack).toHaveBeenCalled();
-    });
-
-    it('should call Minimizer.goBack if params.redirect is truthy on ios <17', () => {
-      params.redirect = 'true';
-      // Mock Device.isIos() to return true
-      jest.spyOn(Device, 'isIos').mockReturnValue(false);
-
-      // Set Platform.Version to '16' to ensure it's less than 17
-      Object.defineProperty(Platform, 'Version', { get: () => '16' });
-
-      urlObj = {
-        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
-        pathname: `/${ACTIONS.CONNECT}/additional/path`,
-      } as ReturnType<typeof extractURLParams>['urlObj'];
-
-      handleUniversalLink({
-        instance,
-        handled,
-        urlObj,
-        params,
-        browserCallBack: mockBrowserCallBack,
-        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
-        wcURL,
-        url,
-      });
-
-      expect(handled).toHaveBeenCalled();
-      expect(Minimizer.goBack).toHaveBeenCalled();
-    });
-
-    it('should displays RETURN_TO_DAPP_MODAL if params.redirect is truthy on ios >17', () => {
+    it('should displays RETURN_TO_DAPP_MODAL', () => {
       params.redirect = 'true';
       // Mock Device.isIos() to return true
       jest.spyOn(Device, 'isIos').mockReturnValue(true);
@@ -215,30 +158,6 @@ describe('handleUniversalLinks', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
       });
-      expect(Minimizer.goBack).not.toHaveBeenCalled();
-    });
-
-    it('should NOT call Minimizer.goBack if params.redirect is falsy', () => {
-      params.redirect = '';
-
-      urlObj = {
-        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
-        pathname: `/${ACTIONS.CONNECT}/additional/path`,
-      } as ReturnType<typeof extractURLParams>['urlObj'];
-
-      handleUniversalLink({
-        instance,
-        handled,
-        urlObj,
-        params,
-        browserCallBack: mockBrowserCallBack,
-        origin,
-        wcURL,
-        url,
-      });
-
-      expect(handled).toHaveBeenCalled();
-      expect(Minimizer.goBack).not.toHaveBeenCalled();
     });
   });
 

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
@@ -1,18 +1,15 @@
+import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { ACTIONS, PREFIXES, PROTOCOLS } from '../../../constants/deeplinks';
+import Routes from '../../../constants/navigation/Routes';
+import Logger from '../../../util/Logger';
 import AppConstants from '../../AppConstants';
-import { Minimizer } from '../../NativeModules';
 import SDKConnect from '../../SDKConnect/SDKConnect';
 import handleDeeplink from '../../SDKConnect/handlers/handleDeeplink';
 import DevLogger from '../../SDKConnect/utils/DevLogger';
 import WC2Manager from '../../WalletConnect/WalletConnectV2';
-import Logger from '../../../util/Logger';
 import DeeplinkManager from '../DeeplinkManager';
-import extractURLParams from './extractURLParams';
-import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import parseOriginatorInfo from '../parseOriginatorInfo';
-import Device from '../../../util/device';
-import { Platform } from 'react-native';
-import Routes from '../../../constants/navigation/Routes';
+import extractURLParams from './extractURLParams';
 
 function handleUniversalLink({
   instance,
@@ -57,13 +54,9 @@ function handleUniversalLink({
 
     if (action === ACTIONS.CONNECT) {
       if (params.redirect && origin === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK) {
-        if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-          SDKConnect.getInstance().state.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-            screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-          });
-        }  else {
-          Minimizer.goBack();
-        }
+        SDKConnect.getInstance().state.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+          screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+        });
       } else if (params.channelId) {
         const protocolVersion = parseInt(params.v ?? '1', 10);
 

--- a/app/core/SDKConnect/AndroidSDK/AndroidService.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService.ts
@@ -2,7 +2,6 @@ import { NetworkController } from '@metamask/network-controller';
 import { EventEmitter2 } from 'eventemitter2';
 import { NativeModules } from 'react-native';
 import Engine from '../../Engine';
-import { Minimizer } from '../../NativeModules';
 import { RPCQueueManager } from '../RPCQueueManager';
 
 import {
@@ -36,6 +35,7 @@ import { DappClient, DappConnections } from './dapp-sdk-types';
 import getDefaultBridgeParams from './getDefaultBridgeParams';
 import { AccountsController } from '@metamask/accounts-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+import Routes from '../../../constants/navigation/Routes';
 
 export default class AndroidService extends EventEmitter2 {
   public communicationClient = NativeModules.CommunicationClient;
@@ -233,7 +233,9 @@ export default class AndroidService extends EventEmitter2 {
               `AndroidService::clients_connected error failed sending jsonrpc error to client`,
             );
           });
-          Minimizer.goBack();
+          SDKConnect.getInstance().state.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+            screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+          });
           return;
         }
 

--- a/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.ts
+++ b/app/core/SDKConnect/AndroidSDK/AndroidService/sendMessage.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Engine from '../../../Engine';
-import { Minimizer } from '../../../NativeModules';
+import { AccountsController } from '@metamask/accounts-controller';
 import Logger from '../../../../util/Logger';
-import { wait } from '../../utils/wait.util';
-import AndroidService from '../AndroidService';
+import Engine from '../../../Engine';
 import { METHODS_TO_DELAY, RPC_METHODS } from '../../SDKConnectConstants';
 import handleBatchRpcResponse from '../../handlers/handleBatchRpcResponse';
 import DevLogger from '../../utils/DevLogger';
-import { AccountsController } from '@metamask/accounts-controller';
+import { wait } from '../../utils/wait.util';
+import AndroidService from '../AndroidService';
 
 async function sendMessage(
   instance: AndroidService,
@@ -120,7 +119,6 @@ async function sendMessage(
     }
 
     DevLogger.log(`AndroidService::sendMessage empty --- goBack()`);
-    Minimizer.goBack();
   } catch (error) {
     Logger.log(error, `AndroidService:: error waiting for empty rpc queue`);
   }

--- a/app/core/SDKConnect/Connection/EventListenersHandlers/handleClientsReady.ts
+++ b/app/core/SDKConnect/Connection/EventListenersHandlers/handleClientsReady.ts
@@ -1,14 +1,12 @@
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
-import { Platform } from 'react-native';
 import Routes from '../../../../constants/navigation/Routes';
+import AppConstants from '../../../../core/AppConstants';
 import Logger from '../../../../util/Logger';
-import Device from '../../../../util/device';
 import Engine from '../../../Engine';
 import SDKConnect, { approveHostProps } from '../../SDKConnect';
 import handleConnectionReady from '../../handlers/handleConnectionReady';
 import DevLogger from '../../utils/DevLogger';
 import { Connection } from '../Connection';
-import AppConstants from '../../../../core/AppConstants';
 
 function handleClientsReady({
   instance,
@@ -48,12 +46,9 @@ function handleClientsReady({
             instance.trigger === 'deeplink' &&
             instance.origin !== AppConstants.DEEPLINKS.ORIGIN_QR_CODE
           ) {
-            // Check for iOS 17 and above to use a custom modal, as Minimizer.goBack() is incompatible with these versions
-            if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-              instance.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-                screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-              });
-            }
+            instance.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+              screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+            });
           }
         },
         disapprove,

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
@@ -1,21 +1,18 @@
 import { MessageType, SendAnalytics, TrackingEvents } from '@metamask/sdk-communication-layer';
-import { Platform } from 'react-native';
 import { resetConnections } from '../../../../app/actions/sdk';
 import { store } from '../../../../app/store';
 import Routes from '../../../constants/navigation/Routes';
 import { selectChainId } from '../../../selectors/networkController';
-import Device from '../../../util/device';
+import Logger from '../../../util/Logger';
+import AppConstants from '../../AppConstants';
 import Engine from '../../Engine';
-import { Minimizer } from '../../NativeModules';
 import { getPermittedAccounts } from '../../Permissions';
 import { Connection, ConnectionProps } from '../Connection';
 import checkPermissions from '../handlers/checkPermissions';
 import { DEFAULT_SESSION_TIMEOUT_MS } from '../SDKConnectConstants';
 import DevLogger from '../utils/DevLogger';
-import { SDKConnect } from './../SDKConnect';
 import { wait, waitForCondition } from '../utils/wait.util';
-import Logger from '../../../util/Logger';
-import AppConstants from '../../AppConstants';
+import { SDKConnect } from './../SDKConnect';
 
 import packageJSON from '../../../../package.json';
 const { version: walletVersion } = packageJSON;
@@ -233,14 +230,10 @@ async function connectToChannel({
         connected.trigger === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK &&
         connected.origin === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK
       ) {
-        if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-          DevLogger.log(`[handleSendMessage] display RETURN_TO_DAPP_MODAL`);
-          connected.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-            screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-          });
-        } else {
-          await Minimizer.goBack();
-        }
+        DevLogger.log(`[handleSendMessage] display RETURN_TO_DAPP_MODAL`);
+        connected.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+          screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+        });
       }
     }
   } catch (error) {

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
@@ -166,15 +166,9 @@ async function connectToChannel({
         // cleanup connection
         await wait(100); // Add delay for connect modal to be fully closed
         await instance.updateSDKLoadingState({ channelId: id, loading: false });
-        // Check for iOS 17 and above to use a custom modal, as Minimizer.goBack() is incompatible with these versions
-        if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-          connected.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-            screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-          });
-        } else {
-          DevLogger.log(`[handleSendMessage] goBack()`);
-          await Minimizer.goBack();
-        }
+        connected.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+          screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+        });
         return;
       }
     }

--- a/app/core/SDKConnect/handlers/handleSendMessage.test.ts
+++ b/app/core/SDKConnect/handlers/handleSendMessage.test.ts
@@ -254,39 +254,6 @@ describe('handleSendMessage', () => {
         });
       });
     });
-
-    describe('When redirection is not allowed', () => {
-      beforeEach(() => {
-        mockRpcQueueManagerGetId.mockReturnValue('1');
-        mockCanRedirect.mockReturnValue(false);
-      });
-      it('should skip goBack if canRedirect is false', async () => {
-        await handleSendMessage({
-          msg: {
-            data: {
-              id: 1,
-            },
-          },
-          connection: mockConnection,
-        });
-
-        expect(mockMinimizer.goBack).not.toHaveBeenCalled();
-      });
-      it('should skip goBack if trigger is not deeplink', async () => {
-        mockConnection.trigger = 'resume';
-
-        await handleSendMessage({
-          msg: {
-            data: {
-              id: 1,
-            },
-          },
-          connection: mockConnection,
-        });
-
-        expect(mockMinimizer.goBack).not.toHaveBeenCalled();
-      });
-    });
   });
 
   describe('Final state update', () => {

--- a/app/core/SDKConnect/handlers/handleSendMessage.test.ts
+++ b/app/core/SDKConnect/handlers/handleSendMessage.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import Device from '../../../util/device';
-import { Minimizer } from '../../NativeModules';
 import { Connection } from '../Connection';
 import { RPC_METHODS } from '../SDKConnectConstants';
 import DevLogger from '../utils/DevLogger';
@@ -27,7 +26,6 @@ describe('handleSendMessage', () => {
   const mockDevLogger = DevLogger.log as jest.MockedFunction<
     typeof DevLogger.log
   >;
-  const mockMinimizer = Minimizer as jest.MockedFunction<typeof Minimizer>;
 
   const mockSendMessage = jest.fn();
   const mockSetLoading = jest.fn();
@@ -202,20 +200,6 @@ describe('handleSendMessage', () => {
         mockRpcQueueManagerGetId.mockReturnValue('1');
         mockCanRedirect.mockReturnValue(true);
         mockConnection.trigger = 'deeplink';
-      });
-      it('should handle deeplink trigger', async () => {
-        mockConnection.trigger = 'deeplink';
-
-        await handleSendMessage({
-          msg: {
-            data: {
-              id: 1,
-            },
-          },
-          connection: mockConnection,
-        });
-
-        expect(mockMinimizer.goBack).toHaveBeenCalled();
       });
       it('should wait for specific methods', async () => {
         mockRpcQueueManagerGetId.mockReturnValue(RPC_METHODS.METAMASK_BATCH);

--- a/app/core/SDKConnect/handlers/handleSendMessage.ts
+++ b/app/core/SDKConnect/handlers/handleSendMessage.ts
@@ -1,9 +1,6 @@
-import { Platform } from 'react-native';
 import Routes from '../../../../app/constants/navigation/Routes';
 import AppConstants from '../../../../app/core/AppConstants';
 import Logger from '../../../util/Logger';
-import Device from '../../../util/device';
-import { Minimizer } from '../../NativeModules';
 import { Connection } from '../Connection';
 import { METHODS_TO_DELAY, RPC_METHODS } from '../SDKConnectConstants';
 import DevLogger from '../utils/DevLogger';
@@ -140,16 +137,9 @@ export const handleSendMessage = async ({
 
     // Trigger should be removed after redirect so we don't redirect the dapp next time and go back to nothing.
     connection.trigger = 'resume';
-
-    // Check for iOS 17 and above to use a custom modal, as Minimizer.goBack() is incompatible with these versions
-    if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-      connection.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
-      });
-    } else {
-      DevLogger.log(`[handleSendMessage] goBack()`);
-      await Minimizer.goBack();
-    }
+    connection.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.RETURN_TO_DAPP_MODAL,
+    });
   } catch (err) {
     Logger.log(
       err,


### PR DESCRIPTION
## **Description**

This PR addresses a critical timing issue in our dapp redirection logic where the wallet would prematurely redirect users back to dapps before completing important operations like chain addition. 

1. **Reason for change**: 
- Multiple code paths were handling redirects inconsistently
- `Minimizer.goBack()` was being called too early in some flows
- Platform-specific navigation logic created edge cases in timing

2. **Solution**:
- Unified all navigation to use `RETURN_TO_DAPP_MODAL` instead of `Minimizer.goBack()`
- Standardized navigation timing across all platforms
- Removed platform-specific checks to simplify logic
- Ensured operations complete before navigation occurs

## **Related issues**

Fixes: #13096

## **Manual testing steps**

1. Connect to an SDK dapp while on mainnet
2. Switch to Polygon network
3. Switch back to mainnet
4. Attempt to add a new chain (e.g., Celo Mainnet)
5. Verify that:
   - Chain addition confirmation is shown
   - Wallet does not redirect before confirmation
   - Navigation occurs only after operation completes

Additional test cases:
- Test deeplink connections
- Test QR code connections
- Test direct dapp connections
- Verify proper navigation timing in each case

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/6c50f083-5963-4504-bbfe-6f4eb03b347d



### **Before**
[Reference Screen.Recording.2025-01-21.at.12.14.23.PM.mov from issue #13096]

### **After**
[To be added during testing]

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm this PR addresses all acceptance criteria and includes necessary testing evidence