### PR TITLE
fix: swaps button missing when no feature flags

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -128,7 +128,12 @@ describe('AssetOverview', () => {
 
   it('should render correctly', async () => {
     const container = renderWithProvider(
-      <AssetOverview asset={asset} displayBuyButton displaySwapsButton />,
+      <AssetOverview
+        asset={asset}
+        displayBuyButton
+        displaySwapsButton
+        swapsIsLive
+      />,
       { state: mockInitialState },
     );
     expect(container).toMatchSnapshot();
@@ -138,7 +143,12 @@ describe('AssetOverview', () => {
     jest.spyOn(networks, 'isPortfolioViewEnabled').mockReturnValue(true);
 
     const container = renderWithProvider(
-      <AssetOverview asset={asset} displayBuyButton displaySwapsButton />,
+      <AssetOverview
+        asset={asset}
+        displayBuyButton
+        displaySwapsButton
+        swapsIsLive
+      />,
       { state: mockInitialState },
     );
     expect(container).toMatchSnapshot();
@@ -146,7 +156,12 @@ describe('AssetOverview', () => {
 
   it('should handle buy button press', async () => {
     const { getByTestId } = renderWithProvider(
-      <AssetOverview asset={asset} displayBuyButton displaySwapsButton />,
+      <AssetOverview
+        asset={asset}
+        displayBuyButton
+        displaySwapsButton
+        swapsIsLive
+      />,
       { state: mockInitialState },
     );
 
@@ -163,7 +178,12 @@ describe('AssetOverview', () => {
 
   it('should handle send button press', async () => {
     const { getByTestId } = renderWithProvider(
-      <AssetOverview asset={asset} displayBuyButton displaySwapsButton />,
+      <AssetOverview
+        asset={asset}
+        displayBuyButton
+        displaySwapsButton
+        swapsIsLive
+      />,
       { state: mockInitialState },
     );
 
@@ -175,7 +195,12 @@ describe('AssetOverview', () => {
 
   it('should handle swap button press', async () => {
     const { getByTestId } = renderWithProvider(
-      <AssetOverview asset={asset} displayBuyButton displaySwapsButton />,
+      <AssetOverview
+        asset={asset}
+        displayBuyButton
+        displaySwapsButton
+        swapsIsLive
+      />,
       { state: mockInitialState },
     );
 
@@ -232,6 +257,7 @@ describe('AssetOverview', () => {
         asset={asset}
         displayBuyButton={false}
         displaySwapsButton
+        swapsIsLive
       />,
       { state: mockInitialState },
     );

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -74,12 +74,14 @@ interface AssetOverviewProps {
   asset: TokenI;
   displayBuyButton?: boolean;
   displaySwapsButton?: boolean;
+  swapsIsLive?: boolean;
 }
 
 const AssetOverview: React.FC<AssetOverviewProps> = ({
   asset,
   displayBuyButton,
   displaySwapsButton,
+  swapsIsLive,
 }: AssetOverviewProps) => {
   const navigation = useNavigation();
   const [timePeriod, setTimePeriod] = React.useState<TimePeriod>('1d');
@@ -434,6 +436,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
           <AssetDetailsActions
             displayBuyButton={displayBuyButton}
             displaySwapsButton={displaySwapsButton}
+            swapsIsLive={swapsIsLive}
             goToBridge={goToBridge}
             goToSwaps={goToSwaps}
             onBuy={onBuy}

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -522,10 +522,7 @@ class Asset extends PureComponent {
       asset.address?.toLowerCase() in this.props.swapsTokens;
 
     const displaySwapsButton =
-      isSwapsFeatureLive &&
-      isNetworkAllowed &&
-      isAssetAllowed &&
-      AppConstants.SWAPS.ACTIVE;
+      isNetworkAllowed && isAssetAllowed && AppConstants.SWAPS.ACTIVE;
 
     const displayBuyButton = asset.isETH
       ? this.props.isNetworkBuyNativeTokenSupported

--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -539,6 +539,7 @@ class Asset extends PureComponent {
                   asset={asset}
                   displayBuyButton={displayBuyButton}
                   displaySwapsButton={displaySwapsButton}
+                  swapsIsLive={isSwapsFeatureLive}
                 />
                 <ActivityHeader asset={asset} />
               </>

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories.tsx
@@ -39,6 +39,7 @@ export const Default = Template.bind(
   {
     displayBuyButton: true,
     displaySwapsButton: true,
+    swapsIsLive: true,
     onBuy: () => null,
     goToSwaps: () => null,
     goToBridge: () => null,
@@ -52,6 +53,7 @@ export const NoBuyButton = Template.bind(
   {
     displayBuyButton: false,
     displaySwapsButton: true,
+    swapsIsLive: true,
     onBuy: () => null,
     goToSwaps: () => null,
     goToBridge: () => null,
@@ -65,6 +67,7 @@ export const NoSwapsButton = Template.bind(
   {
     displayBuyButton: true,
     displaySwapsButton: false,
+    swapsIsLive: false,
     onBuy: () => null,
     goToSwaps: () => null,
     goToBridge: () => null,
@@ -78,6 +81,7 @@ export const NoButtons = Template.bind(
   {
     displayBuyButton: false,
     displaySwapsButton: false,
+    swapsIsLive: false,
     onBuy: () => null,
     goToSwaps: () => null,
     goToBridge: () => null,

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
@@ -21,6 +21,7 @@ describe('AssetDetailsActions', () => {
   const defaultProps = {
     displayBuyButton: true,
     displaySwapsButton: true,
+    swapsIsLive: true,
     onBuy: mockOnBuy,
     goToSwaps: mockGoToSwaps,
     goToBridge: mockGoToBridge,

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
@@ -16,6 +16,7 @@ import { selectCanSignTransactions } from '../../../../selectors/accountsControl
 export interface AssetDetailsActionsProps {
   displayBuyButton: boolean | undefined;
   displaySwapsButton: boolean | undefined;
+  swapsIsLive: boolean | undefined;
   onBuy: () => void;
   goToSwaps: () => void;
   goToBridge: () => void;
@@ -26,6 +27,7 @@ export interface AssetDetailsActionsProps {
 export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
   displayBuyButton,
   displaySwapsButton,
+  swapsIsLive,
   onBuy,
   goToSwaps,
   goToBridge,
@@ -61,7 +63,7 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
             iconStyle={styles.icon}
             containerStyle={styles.containerStyle}
             iconSize={AvatarSize.Lg}
-            disabled={!canSignTransactions}
+            disabled={!canSignTransactions || !swapsIsLive}
             actionID={TokenOverviewSelectorsIDs.SWAP_BUTTON}
           />
           <Text variant={TextVariant.BodyMD}>

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -222,7 +222,6 @@ const WalletActions = () => {
           />
         )}
         {AppConstants.SWAPS.ACTIVE &&
-          swapsIsLive &&
           isSwapsAllowed(chainId) && (
             <WalletAction
               actionType={WalletActionType.Swap}
@@ -231,7 +230,7 @@ const WalletActions = () => {
               actionID={WalletActionsBottomSheetSelectorsIDs.SWAP_BUTTON}
               iconStyle={styles.icon}
               iconSize={AvatarSize.Md}
-              disabled={!canSignTransactions}
+              disabled={!canSignTransactions || !swapsIsLive}
             />
           )}
         {isBridgeAllowed(chainId) && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where the Swaps button would be missing if we failed to fetch feature flags.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13205

## **Manual testing steps**

1. Download latest 7.39.0 (1537)
1. Go to wallet view
1. Turn on Airplane mode
1. See swaps icon is disabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
