### PR TITLE
fix(action): the next semver version can not be a patch version

### DIFF
--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -21,7 +21,7 @@ VERSION_PACKAGE=$(node -p "require('../../package.json').version")
 # Compare versions and keep the highest one
 HIGHEST_VERSION=$(printf "%s\n%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" "$VERSION_PACKAGE" | sort --version-sort | tail -n 1)
 
-# Increment the minor version of the highest version found
-NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; print}')
+# Increment the minor version of the highest version found and reset the patch version to 0
+NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')
 
 echo "NEXT_SEMVER_VERSION=${NEXT_VERSION}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## **Description**

There was a bug in our script that determines the next semver version. It was taking the highest release version and incrementing the minor version number to deduce the next semver version number to apply on PRs when they get merged, which works in most cases, but not when the highest version number is a patch version. By incrementing the minor version number of a patch version, we end up with a new patch version number, which doesn't even exist by the way. This is not expected as the next semver version shall never be a patch version.

For example: all these PRs have been incorrectly labeled (release 12.11.1 doesn't even exist): https://github.com/MetaMask/metamask-extension/issues?q=label%3Arelease-12.11.1+is%3Aclosed

[Same PR for Extension repo](https://github.com/MetaMask/metamask-extension/pull/29951)

## **Related issues**

- None

## **Manual testing steps**

1. Go to this page...
I tested it on this [test repo](https://github.com/gauthierpetetin-test/repo_test/branches/all?query=release%2F), where the current highest version number is 12.12.166
 - I merged this [PR](https://github.com/gauthierpetetin-test/repo_test/pull/217) before fixing the bug, and it got labeled with `release-12.13.166`
 - I merged this [PR](https://github.com/gauthierpetetin-test/repo_test/pull/218) after fixing the bug, and it got labeled with `release-12.13.0`

## **Screenshots/Recordings**

- None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
