### PR TITLE
fix: prev network eth swap send main branch

### DIFF
--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -77,7 +77,7 @@ import {
   selectCurrentCurrency,
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
-import { selectAccounts } from '../../../selectors/accountTrackerController';
+import { selectAccountsByChainId } from '../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../selectors/tokenBalancesController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import AccountSelector from '../Ramp/components/AccountSelector';
@@ -182,7 +182,7 @@ const MAX_TOP_ASSETS = 20;
 function SwapsAmountView({
   swapsTokens,
   swapsControllerTokens,
-  accounts,
+  accountsByChainId,
   selectedAddress,
   chainId,
   selectedNetworkClientId,
@@ -196,6 +196,7 @@ function SwapsAmountView({
   currentCurrency,
   setLiveness,
 }) {
+  const accounts = accountsByChainId[chainId];
   const navigation = useNavigation();
   const route = useRoute();
   const { colors } = useTheme();
@@ -963,9 +964,9 @@ SwapsAmountView.propTypes = {
   tokensWithBalance: PropTypes.arrayOf(PropTypes.object),
   tokensTopAssets: PropTypes.arrayOf(PropTypes.object),
   /**
-   * Map of accounts to information objects including balances
+   * Map of chainId to accounts to information objects including balances
    */
-  accounts: PropTypes.object,
+  accountsByChainId: PropTypes.object,
   /**
    * A string that represents the selected address
    */
@@ -1011,7 +1012,7 @@ SwapsAmountView.propTypes = {
 const mapStateToProps = (state) => ({
   swapsTokens: swapsTokensSelector(state),
   swapsControllerTokens: swapsControllerTokens(state),
-  accounts: selectAccounts(state),
+  accountsByChainId: selectAccountsByChainId(state),
   balances: selectContractBalances(state),
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
   conversionRate: selectConversionRate(state),

--- a/app/components/Views/confirmations/SendFlow/AddressFrom/AddressFrom.test.tsx
+++ b/app/components/Views/confirmations/SendFlow/AddressFrom/AddressFrom.test.tsx
@@ -51,6 +51,13 @@ const mockInitialState = {
             balance: '0x0',
           },
         },
+        accountsByChainId: {
+          '0x1': {
+            '0xd018538C87232FF95acbCe4870629b75640a78E7': {
+              balance: '0x0',
+            },
+          },
+        },
       },
       AccountsController: {
         internalAccounts: {

--- a/app/components/Views/confirmations/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/confirmations/SendFlow/AddressFrom/AddressFrom.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
 import { useNavigation } from '@react-navigation/native';
-
 import {
   newAssetTransaction,
   setSelectedAsset,
 } from '../../../../../actions/transaction';
 import Routes from '../../../../../constants/navigation/Routes';
-import { selectAccounts } from '../../../../../selectors/accountTrackerController';
+import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
 import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
 import { doENSReverseLookup } from '../../../../../util/ENSUtils';
 import { renderFromWei, hexToBN } from '../../../../../util/number';
@@ -27,11 +25,11 @@ const SendFlowAddressFrom = ({
 }: SFAddressFromProps) => {
   const navigation = useNavigation();
 
-  const accounts = useSelector(selectAccounts);
-
   const ticker = useSelector((state: RootState) =>
     selectNativeCurrencyByChainId(state, chainId as Hex),
   );
+  const accountsByChainId = useSelector(selectAccountsByChainId);
+  const accounts = accountsByChainId[chainId];
 
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const checksummedSelectedAddress = selectedInternalAccount


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where if you switched networks and went to Swap/Send, the gas token balance would be for the previous network.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13194

## **Manual testing steps**

1. Switch networks
2. Go to swap/send
3. See balance is correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
