### PR TITLE
fix: Adjust browser display when multiple tabs are present

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1307,10 +1307,10 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
     <ErrorBoundary navigation={navigation} view="BrowserTab">
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.wrapper}
+        style={[styles.wrapper, !isTabActive && styles.hide]}
       >
         <View
-          style={[styles.wrapper, !isTabActive && styles.hide]}
+          style={styles.wrapper}
           {...(Device.isAndroid() ? { collapsable: false } : {})}
         >
           <BrowserUrlBar


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes the browser view when multiple tabs are open

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the browser
2. Open multiple tabs
3. Observe that the view doesn't get pushed down

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="390" alt="image" src="https://github.com/user-attachments/assets/7c86659c-71ae-46ec-8258-8607f195fc35" />
(notice that there are two tabs open)

### **After**

<img width="395" alt="image" src="https://github.com/user-attachments/assets/6e5a04c7-5ef1-4ed1-b204-2c6db00a3d82" />
(notice that there are two tabs open)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
