### PR TITLE
chore: Rename ControllerMessenger to Messenger

### DIFF
--- a/app/core/Engine/controllers/RatesController/subscriptions.ts
+++ b/app/core/Engine/controllers/RatesController/subscriptions.ts
@@ -5,10 +5,10 @@ import {
   CurrencyRateControllerEvents,
 } from '@metamask/assets-controllers';
 import Logger from '../../../../util/Logger';
-import { RestrictedControllerMessenger } from '@metamask/base-controller';
+import { RestrictedMessenger } from '@metamask/base-controller';
 
 // FIXME: This messenger type is not exported on `@metamask/assets-controllers`, so declare it here for now:
-type CurrencyRateControllerMessenger = RestrictedControllerMessenger<
+type CurrencyRateControllerMessenger = RestrictedMessenger<
   CurrencyRateController['name'],
   never,
   CurrencyRateControllerEvents,

--- a/app/core/Engine/controllers/RemoteFeatureFlagController/utils.test.ts
+++ b/app/core/Engine/controllers/RemoteFeatureFlagController/utils.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   RemoteFeatureFlagController,
   RemoteFeatureFlagControllerMessenger,
@@ -24,7 +24,7 @@ describe('RemoteFeatureFlagController utils', () => {
 
   beforeEach(() => {
     messenger =
-      new ControllerMessenger() as unknown as RemoteFeatureFlagControllerMessenger;
+      new Messenger() as unknown as RemoteFeatureFlagControllerMessenger;
     jest.clearAllMocks();
   });
 

--- a/app/core/ExtendedControllerMessenger.ts
+++ b/app/core/ExtendedControllerMessenger.ts
@@ -1,6 +1,6 @@
 import {
   ActionConstraint,
-  ControllerMessenger,
+  Messenger,
   EventConstraint,
   ExtractEventHandler,
 } from '@metamask/base-controller';
@@ -8,7 +8,7 @@ import {
 export class ExtendedControllerMessenger<
   Action extends ActionConstraint,
   Event extends EventConstraint,
-> extends ControllerMessenger<Action, Event> {
+> extends Messenger<Action, Event> {
   subscribeOnceIf<EventType extends Event['type']>(
     eventType: EventType,
     handler: ExtractEventHandler<Event, EventType>,

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -7,7 +7,11 @@ import type {
   JsonRpcResponse,
   JsonRpcSuccess,
 } from '@metamask/utils';
-import { type JsonRpcError, providerErrors, rpcErrors } from '@metamask/rpc-errors';
+import {
+  type JsonRpcError,
+  providerErrors,
+  rpcErrors,
+} from '@metamask/rpc-errors';
 import type { TransactionParams } from '@metamask/transaction-controller';
 import Engine from '../Engine';
 import { store } from '../../store';
@@ -22,7 +26,7 @@ import { backgroundState } from '../../util/test/initial-root-state';
 import { Store } from 'redux';
 import { RootState } from 'app/reducers';
 import { addTransaction } from '../../util/transaction-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   getCaveatSpecifications,
   getPermissionSpecifications,
@@ -364,7 +368,7 @@ describe('getRpcMethodMiddleware', () => {
 
   describe('with permission middleware before', () => {
     const engine = new JsonRpcEngine();
-    const controllerMessenger = new ControllerMessenger();
+    const messenger = new Messenger();
     const baseEoaAccount = {
       type: EthAccountType.Eoa,
       options: {},
@@ -391,7 +395,7 @@ describe('getRpcMethodMiddleware', () => {
       },
     ]);
     const permissionController = new PermissionController({
-      messenger: controllerMessenger.getRestricted({
+      messenger: messenger.getRestricted({
         name: 'PermissionController',
         allowedActions: [],
         allowedEvents: [],

--- a/app/core/SnapKeyring/SnapKeyring.test.ts
+++ b/app/core/SnapKeyring/SnapKeyring.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { EthAccountType, EthScopes, KeyringEvent } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { snapKeyringBuilder } from './SnapKeyring';
@@ -55,7 +55,7 @@ const createControllerMessenger = ({
 }: {
   account?: InternalAccount;
 } = {}): SnapKeyringBuilderMessenger => {
-  const messenger = new ControllerMessenger<
+  const messenger = new Messenger<
     SnapKeyringBuilderAllowActions,
     never
   >().getRestricted({

--- a/app/core/SnapKeyring/types.ts
+++ b/app/core/SnapKeyring/types.ts
@@ -1,4 +1,4 @@
-import { RestrictedControllerMessenger } from '@metamask/base-controller';
+import { RestrictedMessenger } from '@metamask/base-controller';
 import { MaybeUpdateState, TestOrigin } from '@metamask/phishing-controller';
 import type { KeyringControllerGetAccountsAction } from '@metamask/keyring-controller';
 import { GetSubjectMetadata } from '@metamask/permission-controller';
@@ -33,7 +33,7 @@ export type SnapKeyringBuilderAllowActions =
   | AccountsControllerGetAccountByAddressAction
   | AccountsControllerSetAccountNameAction;
 
-export type SnapKeyringBuilderMessenger = RestrictedControllerMessenger<
+export type SnapKeyringBuilderMessenger = RestrictedMessenger<
   'SnapKeyringBuilder',
   SnapKeyringBuilderAllowActions,
   never,

--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -24,7 +24,7 @@ import {
 } from './smart-publish-hook';
 import { ChainId } from '@metamask/controller-utils';
 import { ApprovalController } from '@metamask/approval-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerStateChangeEvent,
@@ -140,13 +140,13 @@ function withRequest<ReturnValue>(
     pendingApprovals = [],
     ...options
   } = rest;
-  const controllerMessenger = new ControllerMessenger<
+  const messenger = new Messenger<
     NetworkControllerGetNetworkClientByIdAction | AllowedActions,
     NetworkControllerStateChangeEvent | AllowedEvents
   >();
 
   const smartTransactionsController = new SmartTransactionsController({
-    messenger: controllerMessenger.getRestricted({
+    messenger: messenger.getRestricted({
       name: 'SmartTransactionsController',
       allowedActions: ['NetworkController:getNetworkClientById'],
       allowedEvents: ['NetworkController:stateChange'],
@@ -185,7 +185,7 @@ function withRequest<ReturnValue>(
       ...defaultTransactionMeta,
     },
     smartTransactionsController,
-    controllerMessenger,
+    controllerMessenger: messenger,
     transactionController: createTransactionControllerMock(),
     shouldUseSmartTransaction: true,
     approvalController: createApprovalControllerMock({
@@ -212,7 +212,7 @@ function withRequest<ReturnValue>(
   };
 
   return fn({
-    controllerMessenger,
+    controllerMessenger: messenger,
     request,
     getFeesSpy,
     submitSignedTransactionsSpy,

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -23,7 +23,7 @@ import { v1 as random } from 'uuid';
 import { decimalToHex } from '../conversions';
 import { ApprovalTypes } from '../../core/RPCMethods/RPCMethodMiddleware';
 import { RAMPS_SEND } from '../../components/UI/Ramp/constants';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { addSwapsTransaction } from '../swaps/swaps-transactions';
 
 export declare type Hex = `0x${string}`;
@@ -36,7 +36,7 @@ export interface SubmitSmartTransactionRequest {
   transactionMeta: TransactionMeta;
   smartTransactionsController: SmartTransactionsController;
   transactionController: TransactionController;
-  controllerMessenger: ControllerMessenger<AllowedActions, AllowedEvents>;
+  controllerMessenger: Messenger<AllowedActions, AllowedEvents>;
   shouldUseSmartTransaction: boolean;
   approvalController: ApprovalController;
   featureFlags: {


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger`.

## References

Relates to [#4538](https://github.com/MetaMask/core/issues/4538)

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
