### PR TITLE
fix: SIWE detection on mobile by patching @spruceid+siwe-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "sha256-uint8array": "0.10.3",
     "express": "4.21.2",
     "nanoid": "^3.3.8",
-    "undici": "5.28.5"
+    "undici": "5.28.5",
+    "@spruceid/siwe-parser@npm:2.1.0": "patches/@spruceid+siwe-parser+2.1.0.patch"
   },
   "dependencies": {
     "@config-plugins/detox": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -141,8 +141,7 @@
     "sha256-uint8array": "0.10.3",
     "express": "4.21.2",
     "nanoid": "^3.3.8",
-    "undici": "5.28.5",
-    "@spruceid/siwe-parser@npm:2.1.0": "patches/@spruceid+siwe-parser+2.1.0.patch"
+    "undici": "5.28.5"
   },
   "dependencies": {
     "@config-plugins/detox": "^8.0.0",

--- a/patches/@spruceid+siwe-parser+2.1.0.patch
+++ b/patches/@spruceid+siwe-parser+2.1.0.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/@spruceid/siwe-parser/dist/abnf.js b/node_modules/@spruceid/siwe-parser/dist/abnf.js
+index 15caf98..0eeac1e 100644
+--- a/node_modules/@spruceid/siwe-parser/dist/abnf.js
++++ b/node_modules/@spruceid/siwe-parser/dist/abnf.js
+@@ -290,9 +290,6 @@ class ParsedMessage {
+         if (this.domain.length === 0) {
+             throw new Error("Domain cannot be empty.");
+         }
+-        if (!(0, utils_1.isEIP55Address)(this.address)) {
+-            throw new Error("Address not conformant to EIP-55.");
+-        }
+     }
+ }
+ exports.ParsedMessage = ParsedMessage;
+diff --git a/node_modules/@spruceid/siwe-parser/dist/regex.js b/node_modules/@spruceid/siwe-parser/dist/regex.js
+index 4740a7c..f1d880d 100644
+--- a/node_modules/@spruceid/siwe-parser/dist/regex.js
++++ b/node_modules/@spruceid/siwe-parser/dist/regex.js
+@@ -55,9 +55,6 @@ class ParsedMessage {
+             throw new Error("Domain cannot be empty.");
+         }
+         this.address = (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.address;
+-        if (!(0, utils_1.isEIP55Address)(this.address)) {
+-            throw new Error("Address not conformant to EIP-55.");
+-        }
+         this.statement = (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.statement;
+         this.uri = (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.uri;
+         if (!uri.isUri(this.uri)) {


### PR DESCRIPTION
## **Description**

Fix SIWE detection on mobile by patching @spruceid+siwe-parser
The module is already patched for this issue on extension: https://github.com/MetaMask/metamask-extension/pull/24138

## **Related issues**

Related to: https://github.com/MetaMask/MetaMask-planning/issues/2278
Related to: https://github.com/MetaMask/MetaMask-planning/issues/4076

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
