### PR TITLE
fix: fiat estimates disabled in send flow

### DIFF
--- a/app/components/Views/confirmations/SendFlow/Amount/index.js
+++ b/app/components/Views/confirmations/SendFlow/Amount/index.js
@@ -100,6 +100,11 @@ import { selectGasFeeEstimates } from '../../../../../selectors/confirmTransacti
 import { selectGasFeeControllerEstimateType } from '../../../../../selectors/gasFeeController';
 import { createBuyNavigationDetails } from '../../../../UI/Ramp/routes/utils';
 import {
+  // Pending updated multichain UX to specify the send chain.
+  /* eslint-disable no-restricted-syntax */
+  selectChainId,
+  selectNetworkClientId,
+  /* eslint-enable no-restricted-syntax */
   selectNativeCurrencyByChainId,
   selectProviderTypeByChainId,
 } from '../../../../../selectors/networkController';
@@ -481,7 +486,7 @@ class Amount extends PureComponent {
     /**
      * String that indicates the current chain id
      */
-    chainId: PropTypes.string,
+    globalChainId: PropTypes.string,
     /**
      * Metrics injected by withMetricsAwareness HOC
      */
@@ -501,7 +506,7 @@ class Amount extends PureComponent {
     /**
      * Network client id
      */
-    networkClientId: PropTypes.string,
+    globalNetworkClientId: PropTypes.string,
   };
 
   state = {
@@ -890,14 +895,14 @@ class Amount extends PureComponent {
       transaction: { from },
       transactionTo,
     } = this.props.transactionState;
-    const { networkClientId } = this.props;
+    const { globalNetworkClientId } = this.props;
     const { gas } = await getGasLimit(
       {
         from,
         to: transactionTo,
       },
       false,
-      networkClientId,
+      globalNetworkClientId,
     );
 
     return gas;
@@ -1279,7 +1284,7 @@ class Amount extends PureComponent {
       navigation,
       isNetworkBuyNativeTokenSupported,
       swapsIsLive,
-      chainId,
+      globalChainId,
       ticker,
     } = this.props;
     const colors = this.context.colors || mockTheme.colors;
@@ -1300,7 +1305,7 @@ class Amount extends PureComponent {
       !isNativeToken(selectedAsset) &&
       AppConstants.SWAPS.ACTIVE &&
       swapsIsLive &&
-      isSwapsAllowed(chainId) &&
+      isSwapsAllowed(globalChainId) &&
       amountError === strings('transaction.insufficient');
 
     const navigateToBuyOrSwaps = () => {
@@ -1583,34 +1588,34 @@ Amount.contextType = ThemeContext;
 
 const mapStateToProps = (state, ownProps) => {
   const transaction = ownProps.transaction || state.transaction;
-  const chainId = transaction?.chainId;
-  const networkClientId = transaction?.networkClientId;
+  const globalChainId = selectChainId(state);
+  const globalNetworkClientId = selectNetworkClientId(state);
 
   return {
     accounts: selectAccounts(state),
-    contractExchangeRates: selectContractExchangeRatesByChainId(state, chainId),
+    contractExchangeRates: selectContractExchangeRatesByChainId(state, globalChainId),
     contractBalances: selectContractBalances(state),
     collectibles: collectiblesSelector(state),
     collectibleContracts: collectibleContractsSelector(state),
-    conversionRate: selectConversionRateByChainId(state, chainId),
+    conversionRate: selectConversionRateByChainId(state, globalChainId),
     currentCurrency: selectCurrentCurrency(state),
     gasEstimateType: selectGasFeeControllerEstimateType(state),
     gasFeeEstimates: selectGasFeeEstimates(state),
-    providerType: selectProviderTypeByChainId(state, chainId),
+    providerType: selectProviderTypeByChainId(state, globalChainId),
     primaryCurrency: state.settings.primaryCurrency,
     selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
-    ticker: selectNativeCurrencyByChainId(state, chainId),
+    ticker: selectNativeCurrencyByChainId(state, globalChainId),
     tokens: selectTokens(state),
     transactionState: transaction,
     selectedAsset: state.transaction.selectedAsset,
     isPaymentRequest: state.transaction.paymentRequest,
     isNetworkBuyNativeTokenSupported: isNetworkRampNativeTokenSupported(
-      chainId,
+      globalChainId,
       getRampNetworks(state),
     ),
     swapsIsLive: swapsLivenessSelector(state),
-    chainId,
-    networkClientId,
+    globalChainId,
+    globalNetworkClientId,
   };
 };
 

--- a/app/components/Views/confirmations/SendFlow/Amount/index.test.tsx
+++ b/app/components/Views/confirmations/SendFlow/Amount/index.test.tsx
@@ -112,7 +112,7 @@ const initialState = {
     backgroundState: {
       ...backgroundState,
       NetworkController: {
-        selectedNetworkClientId: 'mainnet',
+        selectedNetworkClientId: 'sepolia',
         networksMetadata: {
           mainnet: {
             status: 'available',
@@ -274,7 +274,6 @@ describe('Amount', () => {
           name: 'Ether',
           symbol: 'ETH',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -348,7 +347,6 @@ describe('Amount', () => {
           name: 'Ether',
           symbol: 'ETH',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -461,7 +459,6 @@ describe('Amount', () => {
           name: 'Avalanche',
           symbol: 'AVAX',
         },
-        chainId: '0xa86a',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -544,7 +541,6 @@ describe('Amount', () => {
           name: 'Ether',
           symbol: 'ETH',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -628,7 +624,6 @@ describe('Amount', () => {
           name: 'Ether',
           symbol: 'ETH',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -707,7 +702,6 @@ describe('Amount', () => {
           isERC721: false,
           symbol: 'LINK',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -779,7 +773,6 @@ describe('Amount', () => {
           name: 'Ether',
           symbol: 'ETH',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -858,7 +851,6 @@ describe('Amount', () => {
           isERC721: false,
           symbol: 'LINK',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -933,7 +925,6 @@ describe('Amount', () => {
           isERC721: false,
           symbol: 'LINK',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -1008,7 +999,6 @@ describe('Amount', () => {
           isERC721: false,
           symbol: 'LINK',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },
@@ -1074,7 +1064,6 @@ describe('Amount', () => {
           standard: 'ERC721',
           tokenId: '1850',
         },
-        chainId: '0xaa36a7',
         transaction: {
           from: CURRENT_ACCOUNT,
         },


### PR DESCRIPTION
## **Description**

Use global chain in send amount page as no transaction state available.

## **Related issues**

Fixes: #13287 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
