### PR TITLE
feat(action): Improve bug report creation

### DIFF
--- a/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
+++ b/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
@@ -6,6 +6,7 @@ import { retrieveLinkedIssues } from './shared/issue';
 import { Label } from './shared/label';
 import { Labelable, addLabelToLabelable } from './shared/labelable';
 import { retrievePullRequest } from './shared/pull-request';
+import { isValidVersionFormat } from './shared/utils';
 
 main().catch((error: Error): void => {
   console.error(error);
@@ -89,10 +90,4 @@ async function main(): Promise<void> {
   for (const linkedIssue of linkedIssues) {
     await addLabelToLabelable(octokit, linkedIssue, releaseLabel);
   }
-}
-
-// This helper function checks if version has the correct format: "x.y.z" where "x", "y" and "z" are numbers.
-function isValidVersionFormat(str: string): boolean {
-  const regex = /^\d+\.\d+\.\d+$/;
-  return regex.test(str);
 }

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -12,20 +12,14 @@ import {
 } from './shared/labelable';
 import {
   Label,
+  RegressionStage,
+  craftRegressionLabel,
   externalContributorLabel,
   invalidIssueTemplateLabel,
   invalidPullRequestTemplateLabel,
 } from './shared/label';
 import { TemplateType, templates } from './shared/template';
 import { retrievePullRequest } from './shared/pull-request';
-
-enum RegressionStage {
-  DevelopmentFeature,
-  DevelopmentMain,
-  Testing,
-  Beta,
-  Production
-}
 
 const knownBots = ["metamaskbot", "dependabot", "github-actions", "sentry-io", "devin-ai-integration"];
 
@@ -315,51 +309,4 @@ async function userBelongsToMetaMaskOrg(
   } = await octokit.graphql(userBelongsToMetaMaskOrgQuery, { login: username });
 
   return Boolean(userBelongsToMetaMaskOrgResult?.user?.organization?.id);
-}
-
-// This function crafts appropriate label, corresponding to regression stage and release version.
-function craftRegressionLabel(regressionStage: RegressionStage | undefined, releaseVersion: string | undefined): Label {
-  switch (regressionStage) {
-    case RegressionStage.DevelopmentFeature:
-      return {
-        name: `feature-branch-bug`,
-        color: '5319E7', // violet
-        description: `bug that was found on a feature branch, but not yet merged in main branch`,
-      };
-
-    case RegressionStage.DevelopmentMain:
-      return {
-        name: `regression-develop`,
-        color: '5319E7', // violet
-        description: `Regression bug that was found on main branch, but not yet present in production`,
-      };
-
-    case RegressionStage.Testing:
-      return {
-        name: `regression-RC-${releaseVersion || '*'}`,
-        color: '744C11', // orange
-        description: releaseVersion ? `Regression bug that was found in release candidate (RC) for release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-RC-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
-      };
-
-    case RegressionStage.Beta:
-      return {
-        name: `regression-beta-${releaseVersion || '*'}`,
-        color: 'D94A83', // pink
-        description: releaseVersion ? `Regression bug that was found in beta in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-beta-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
-      };
-
-    case RegressionStage.Production:
-      return {
-        name: `regression-prod-${releaseVersion || '*'}`,
-        color: '5319E7', // violet
-        description: releaseVersion ? `Regression bug that was found in production in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
-      };
-
-    default:
-      return {
-        name: `regression-*`,
-        color: 'EDEDED', // grey
-        description: `TODO: Unknown regression stage. Please replace with correct regression label: 'regression-develop', 'regression-RC-x.y.z', or 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
-      };
-  }
 }

--- a/.github/scripts/create-bug-report-issue.ts
+++ b/.github/scripts/create-bug-report-issue.ts
@@ -1,0 +1,129 @@
+import * as core from '@actions/core';
+import { context, getOctokit } from '@actions/github';
+import { GitHub } from '@actions/github/lib/utils';
+
+import { createIssue, retrieveIssueByTitle } from './shared/issue';
+import {
+  Label,
+  RegressionStage,
+  craftRegressionLabel,
+  craftTeamLabel,
+  createOrRetrieveLabel,
+  typeBugLabel,
+} from './shared/label';
+import { codeRepoToPlanningRepo, codeRepoToPlatform, getCurrentDateFormatted, isValidVersionFormat } from './shared/utils';
+import { addIssueToGithubProject, GithubProject, GithubProjectField, retrieveGithubProject, updateGithubProjectDateFieldValue } from './shared/project';
+
+main().catch((error: Error): void => {
+  console.error(error);
+  process.exit(1);
+});
+
+async function main(): Promise<void> {
+  // "GITHUB_TOKEN" is an automatically generated, repository-specific access token provided by GitHub Actions.
+  // We can't use "GITHUB_TOKEN" here, as its permissions don't allow neither to create new labels
+  // nor to retrieve the content of organisations Github Projects.
+  // In our case, we may want to create "regression-RC-x.y.z" label when it doesn't already exist.
+  // We may also want to retrieve the content of organisation's Github Projects.
+  // As a consequence, we need to create our own "BUG_REPORT_TOKEN" with "repo" and "read:org" permissions.
+  // Such a token allows both to create new labels and fetch the content of organisation's Github Projects.
+  const personalAccessToken = process.env.BUG_REPORT_TOKEN;
+  if (!personalAccessToken) {
+    core.setFailed('BUG_REPORT_TOKEN not found');
+    process.exit(1);
+  }
+
+  const projectNumber = Number(process.env.RELEASES_GITHUB_PROJECT_BOARD_NUMBER);
+  if (!projectNumber) {
+    core.setFailed('RELEASES_GITHUB_PROJECT_BOARD_NUMBER not found');
+    process.exit(1);
+  }
+
+  const projectViewNumber = Number(process.env.RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER);
+  if (!projectViewNumber) {
+    core.setFailed('RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER not found');
+    process.exit(1);
+  }
+
+  const releaseVersion = process.env.RELEASE_VERSION;
+  if (!releaseVersion) {
+    core.setFailed('RELEASE_VERSION not found');
+    process.exit(1);
+  }
+  if (!isValidVersionFormat(releaseVersion)) {
+    core.setFailed(`Invalid format for RELEASE_VERSION: ${releaseVersion}. Expected format: x.y.z`);
+    process.exit(1);
+  }
+
+  const repoOwner = context.repo.owner;
+  if (!repoOwner) {
+    core.setFailed('repo owner not found');
+    process.exit(1);
+  }
+  const codeRepoName = context.repo.repo;
+  if (!codeRepoName) {
+    core.setFailed('code repo name not found');
+    process.exit(1);
+  }
+  const planningRepoName = codeRepoToPlanningRepo[codeRepoName];
+  if (!planningRepoName) {
+    core.setFailed('planning repo name not found');
+    process.exit(1);
+  }
+
+  // Retrieve platform name
+  const platformName = codeRepoToPlatform[codeRepoName];
+  if (!platformName) {
+    core.setFailed('platform name not found');
+    process.exit(1);
+  }
+
+  // Initialise octokit, required to call Github GraphQL API
+  const octokit: InstanceType<typeof GitHub> = getOctokit(personalAccessToken, {
+    previews: ['bane'], // The "bane" preview is required for adding, updating, creating and deleting labels.
+  });
+
+  // Craft regression labels to add
+  const regressionLabelTesting: Label = craftRegressionLabel(RegressionStage.Testing, releaseVersion);
+  const regressionLabelProduction: Label = craftRegressionLabel(RegressionStage.Production, releaseVersion);
+  const teamLabel: Label = craftTeamLabel(`${platformName}-platform`);
+
+  // Create of retrieve the different labels
+  await createOrRetrieveLabel(octokit, repoOwner, codeRepoName, regressionLabelProduction);
+  await createOrRetrieveLabel(octokit, repoOwner, codeRepoName, regressionLabelTesting);
+  await createOrRetrieveLabel(octokit, repoOwner, planningRepoName, regressionLabelProduction);
+  const regressionLabelTestingId = await createOrRetrieveLabel(octokit, repoOwner, planningRepoName, regressionLabelTesting);
+  const typeBugLabelId = await createOrRetrieveLabel(octokit, repoOwner, planningRepoName, typeBugLabel);
+  const teamLabelId = await createOrRetrieveLabel(octokit, repoOwner, planningRepoName, teamLabel);
+
+  const issueTitle = `v${releaseVersion} Bug Report`;
+  const issueWithSameTitle = await retrieveIssueByTitle(octokit, repoOwner, planningRepoName, issueTitle);
+  if (issueWithSameTitle) {
+    core.setFailed(`Bug report already exists: https://github.com/${repoOwner}/${planningRepoName}/issues/${issueWithSameTitle.number}. This is not desired, but can happen in cases where a release gets re-cut.`);
+    process.exit(1);
+  }
+
+  const issueBody = `**What is this bug report issue for?**\n\n1. This issue is used to track release dates on this [Github Project board](https://github.com/orgs/MetaMask/projects/${projectNumber}/views/${projectViewNumber}), which content then gets pulled into our metrics system.\n\n2. This issue is also used by our Zapier automations, to determine if automated notifications shall be sent on Slack for release \`${releaseVersion}\`. Notifications will only be sent as long as this issue is open.\n\n**Who created and/or closed this issue?**\n\n- This issue was automatically created by a GitHub action upon the creation of the release branch \`release/${releaseVersion}\`, indicating the release was cut.\n\n- This issue gets automatically closed by another GitHub action, once the \`release/${releaseVersion}\` branch merges into \`main\`, indicating the release is prepared for store submission.`;
+  const issueId = await createIssue(octokit, repoOwner, planningRepoName, issueTitle, issueBody, [regressionLabelTestingId, typeBugLabelId, teamLabelId]);
+
+  // Retrieve project, in order to obtain its ID
+  const project: GithubProject = await retrieveGithubProject(octokit, projectNumber);
+
+  const projectFieldName: string = "RC Cut";
+
+  const projectField: GithubProjectField | undefined = project.fields.find(field => field.name === projectFieldName);
+
+  if (!projectField) {
+    throw new Error(`Project field with name ${projectFieldName} was not found on Github Project with ID ${project.id}.`);
+  }
+
+  if (!projectField.id) {
+    throw new Error(`Project field with name ${projectFieldName} was found on Github Project with ID ${project.id}, but it has no 'id' property.`);
+  }
+
+  // Add bug report issue to 'Releases' Github Project Board
+  await addIssueToGithubProject(octokit, project.id, issueId);
+
+  // Update bug report issue's date property on 'Releases' Github Project Board
+  await updateGithubProjectDateFieldValue(octokit, project.id, projectField.id, issueId, getCurrentDateFormatted());
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -7,6 +7,7 @@
     "check-pr-has-required-labels": "ts-node ./check-pr-has-required-labels.ts",
     "close-release-bug-report-issue": "ts-node ./close-release-bug-report-issue.ts",
     "check-template-and-add-labels": "ts-node ./check-template-and-add-labels.ts",
+    "create-bug-report-issue": "ts-node ./create-bug-report-issue.ts",
     "run-bitrise-e2e-check": "ts-node ./bitrise/run-bitrise-e2e-check.ts"
   },
   "dependencies": {

--- a/.github/scripts/shared/label.ts
+++ b/.github/scripts/shared/label.ts
@@ -2,11 +2,25 @@ import { GitHub } from '@actions/github/lib/utils';
 
 import { retrieveRepo } from './repo';
 
+export enum RegressionStage {
+  DevelopmentFeature,
+  DevelopmentMain,
+  Testing,
+  Beta,
+  Production
+}
+
 export interface Label {
   name: string;
   color: string;
   description: string;
 }
+
+export const typeBugLabel: Label = {
+  name: 'type-bug',
+  color: 'D73A4A',
+  description: `Something isn't working`,
+};
 
 export const externalContributorLabel: Label = {
   name: 'external-contributor',
@@ -25,6 +39,79 @@ export const invalidPullRequestTemplateLabel: Label = {
   color: 'EDEDED',
   description: "PR's body doesn't match template",
 };
+
+// This function crafts appropriate label, corresponding to regression stage and release version.
+export function craftRegressionLabel(regressionStage: RegressionStage | undefined, releaseVersion: string | undefined): Label {
+  switch (regressionStage) {
+    case RegressionStage.DevelopmentFeature:
+      return {
+        name: `feature-branch-bug`,
+        color: '5319E7', // violet
+        description: `bug that was found on a feature branch, but not yet merged in main branch`,
+      };
+
+    case RegressionStage.DevelopmentMain:
+      return {
+        name: `regression-develop`,
+        color: '5319E7', // violet
+        description: `Regression bug that was found on main branch, but not yet present in production`,
+      };
+
+    case RegressionStage.Testing:
+      return {
+        name: `regression-RC-${releaseVersion || '*'}`,
+        color: '744C11', // orange
+        description: releaseVersion ? `Regression bug that was found in release candidate (RC) for release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-RC-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+      };
+
+    case RegressionStage.Beta:
+      return {
+        name: `regression-beta-${releaseVersion || '*'}`,
+        color: 'D94A83', // pink
+        description: releaseVersion ? `Regression bug that was found in beta in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-beta-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+      };
+
+    case RegressionStage.Production:
+      return {
+        name: `regression-prod-${releaseVersion || '*'}`,
+        color: '5319E7', // violet
+        description: releaseVersion ? `Regression bug that was found in production in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+      };
+
+    default:
+      return {
+        name: `regression-*`,
+        color: 'EDEDED', // grey
+        description: `TODO: Unknown regression stage. Please replace with correct regression label: 'regression-develop', 'regression-RC-x.y.z', or 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+      };
+  }
+}
+
+// This function crafts appropriate label, corresponding to team name.
+export function craftTeamLabel(teamName: string): Label {
+  switch (teamName) {
+    case 'extension-platform':
+      return {
+        name: `team-${teamName}`,
+        color: '#BFD4F2', // light blue
+        description: `Extension Platform team`,
+      };
+
+    case 'mobile-platform':
+      return {
+        name: `team-${teamName}`,
+        color: '#76E9D0', // light green
+        description: `Mobile Platform team`,
+      };
+
+    default:
+      return {
+        name: `team-*`,
+        color: 'EDEDED', // grey
+        description: `TODO: Unknown team. Please replace with correct team label.`,
+      };
+  }
+}
 
 // This function creates or retrieves the label on a specific repo
 export async function createOrRetrieveLabel(

--- a/.github/scripts/shared/project.ts
+++ b/.github/scripts/shared/project.ts
@@ -1,0 +1,268 @@
+import { GitHub } from '@actions/github/lib/utils';
+import { isValidDateFormat } from './utils';
+
+const MAX_NB_FETCHES = 10; // For protection against infinite loops.
+
+export interface GithubProject {
+  id: string;
+  fields: GithubProjectField[];
+}
+
+export interface GithubProjectField {
+  id: string;
+  name: string;
+}
+
+export interface GithubProjectIssueFieldValues {
+  id: string; // ID of the issue (unrelated to the Github Project board)
+  itemId: string; // ID of the issue, as an item of the Github Project board
+  cutDate: string; // "RC cut date" field value of the issue, as an item of the Github Project board
+}
+
+interface RawGithubProjectIssueFieldValues {
+  id: string;
+  content: {
+    id: string;
+  };
+  cutDate: {
+    date: string;
+  };
+}
+
+interface RawGithubProjectIssuesFieldValues {
+  pageInfo: {
+    endCursor: string;
+  };
+  nodes: RawGithubProjectIssueFieldValues[];
+}
+
+// This function retrieves a Github Project
+export async function retrieveGithubProject(
+  octokit: InstanceType<typeof GitHub>,
+  projectNumber: number,
+): Promise<GithubProject> {
+  const retrieveProjectQuery = `
+      query ($projectNumber: Int!) {
+        organization(login: "MetaMask") {
+            projectV2(number: $projectNumber) {
+                id
+                fields(first: 20) {
+                    nodes {
+                        ... on ProjectV2Field {
+                            id
+                            name
+                        }
+                    }
+                }
+            }
+        }
+      }
+    `;
+
+  const retrieveProjectResult: {
+    organization: {
+      projectV2: {
+        id: string;
+        fields: {
+          nodes: {
+            id: string;
+            name: string;
+          }[];
+        };
+      };
+    };
+  } = await octokit.graphql(retrieveProjectQuery, {
+    projectNumber,
+  });
+
+  const project: GithubProject = {
+    id: retrieveProjectResult?.organization?.projectV2?.id,
+    fields: retrieveProjectResult?.organization.projectV2?.fields?.nodes,
+  };
+
+  if (!project) {
+    throw new Error(`Project with number ${projectNumber} was not found.`);
+  }
+
+  if (!project.id) {
+    throw new Error(`Project with number ${projectNumber} was found, but it has no 'id' property.`);
+  }
+
+  if (!project.fields) {
+    throw new Error(`Project with number ${projectNumber} was found, but it has no 'fields' property.`);
+  }
+
+  return project;
+}
+
+// This function retrieves a Github Project's issues' field values
+export async function retrieveGithubProjectIssuesFieldValues(
+  octokit: InstanceType<typeof GitHub>,
+  projectId: string,
+  cursor: string | undefined,
+): Promise<RawGithubProjectIssuesFieldValues> {
+  const after = cursor ? `after: "${cursor}"` : '';
+
+  const retrieveProjectIssuesFieldValuesQuery = `
+      query ($projectId: ID!) {
+          node(id: $projectId) {
+              ... on ProjectV2 {
+                  items(
+                      first: 100
+                      ${after}
+                  ) {
+                      pageInfo {
+                          endCursor
+                      }
+                      nodes {
+                          id
+                          content {
+                              ... on Issue {
+                                  id
+                              }
+                          }
+                          cutDate: fieldValueByName(name: "RC Cut") {
+                              ... on ProjectV2ItemFieldDateValue {
+                                  date
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+    `;
+
+  const retrieveProjectIssuesFieldValuesResult: {
+    node: {
+      items: {
+        totalCount: number;
+        pageInfo: {
+          endCursor: string;
+        };
+        nodes: {
+          id: string;
+          content: {
+            id: string;
+          };
+          cutDate: {
+            date: string;
+          };
+        }[];
+      };
+    };
+  } = await octokit.graphql(retrieveProjectIssuesFieldValuesQuery, {
+    projectId,
+  });
+
+  const projectIssuesFieldValues: RawGithubProjectIssuesFieldValues = retrieveProjectIssuesFieldValuesResult.node.items;
+
+  return projectIssuesFieldValues;
+}
+
+// This function retrieves a Github Project's issue field values recursively
+export async function retrieveGithubProjectIssueFieldValuesRecursively(
+  nbFetches: number,
+  octokit: InstanceType<typeof GitHub>,
+  projectId: string,
+  issueId: string,
+  cursor: string | undefined,
+): Promise<GithubProjectIssueFieldValues | undefined> {
+  if (nbFetches >= MAX_NB_FETCHES) {
+    throw new Error(`Forbidden: Trying to do more than ${MAX_NB_FETCHES} fetches (${nbFetches}).`);
+  }
+
+  const projectIssuesFieldValuesResponse: RawGithubProjectIssuesFieldValues = await retrieveGithubProjectIssuesFieldValues(
+    octokit,
+    projectId,
+    cursor,
+  );
+
+  const projectIssueFieldValuesResponseWithSameId: RawGithubProjectIssueFieldValues | undefined =
+    projectIssuesFieldValuesResponse.nodes.find((issue) => issue.content.id === issueId);
+
+  if (projectIssueFieldValuesResponseWithSameId) {
+    const projectIssueFieldValues: GithubProjectIssueFieldValues = {
+      id: projectIssueFieldValuesResponseWithSameId.content?.id,
+      itemId: projectIssueFieldValuesResponseWithSameId.id,
+      cutDate: projectIssueFieldValuesResponseWithSameId.cutDate?.date,
+    };
+    return projectIssueFieldValues;
+  }
+
+  const newCursor = projectIssuesFieldValuesResponse.pageInfo.endCursor;
+  if (newCursor) {
+    return await retrieveGithubProjectIssueFieldValuesRecursively(nbFetches + 1, octokit, projectId, issueId, newCursor);
+  } else {
+    return undefined;
+  }
+}
+
+// This function adds an issue to a Github Project
+export async function addIssueToGithubProject(
+  octokit: InstanceType<typeof GitHub>,
+  projectId: string,
+  issueId: string,
+): Promise<void> {
+  const addIssueToProjectMutation = `
+      mutation ($projectId: ID!, $contentId: ID!) {
+        addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+          clientMutationId
+        }
+      }
+    `;
+
+  await octokit.graphql(addIssueToProjectMutation, {
+    projectId: projectId,
+    contentId: issueId,
+  });
+}
+
+// This function updates Github Project issue's date field value
+export async function updateGithubProjectDateFieldValue(
+  octokit: InstanceType<typeof GitHub>,
+  projectId: string,
+  projectFieldId: string,
+  issueId: string,
+  newDatePropertyValue: string,
+): Promise<void> {
+  if (!isValidDateFormat(newDatePropertyValue)) {
+    throw new Error(`Invalid input: date ${newDatePropertyValue} doesn't match "YYYY-MM-DD" format.`);
+  }
+
+  const issue: GithubProjectIssueFieldValues | undefined = await retrieveGithubProjectIssueFieldValuesRecursively(
+    0,
+    octokit,
+    projectId,
+    issueId,
+    undefined,
+  );
+
+  if (!issue) {
+    throw new Error(`Issue with ID ${issueId} was not found on Github Project with ID ${projectId}.`);
+  }
+
+  const updateGithubProjectDatePropertyMutation = `
+      mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+        updateProjectV2ItemFieldValue(
+            input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { date: $date }
+            }
+        ) {
+            projectV2Item {
+                id
+            }
+        }
+      }
+    `;
+
+  await octokit.graphql(updateGithubProjectDatePropertyMutation, {
+    projectId: projectId,
+    itemId: issue.itemId,
+    fieldId: projectFieldId,
+    date: newDatePropertyValue,
+  });
+}

--- a/.github/scripts/shared/repo.ts
+++ b/.github/scripts/shared/repo.ts
@@ -25,5 +25,9 @@ export async function retrieveRepo(
 
   const repoId = retrieveRepoResult?.repository?.id;
 
+  if (!repoId) {
+    throw new Error(`Repo with owner ${repoOwner} and name ${repoName} was not found.`);
+  }
+
   return repoId;
 }

--- a/.github/scripts/shared/utils.ts
+++ b/.github/scripts/shared/utils.ts
@@ -1,0 +1,50 @@
+// This helper function checks if version has the correct format: "x.y.z" where "x", "y" and "z" are numbers.
+export function isValidVersionFormat(str: string): boolean {
+  const regex = /^\d+\.\d+\.\d+$/;
+  return regex.test(str);
+}
+
+// This helper function checks if a string has the date format "YYYY-MM-DD".
+export function isValidDateFormat(dateString: string): boolean {
+  // Regular expression to match the date format "YYYY-MM-DD"
+  const dateFormatRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+  // Check if the dateString matches the regex
+  if (!dateFormatRegex.test(dateString)) {
+    return false;
+  }
+
+  // Parse the date components
+  const [year, month, day] = dateString.split('-').map(Number);
+
+  // Check if the date components form a valid date
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
+// This helper function generates the current date in that format: "YYYY-MM-DD"
+export function getCurrentDateFormatted(): string {
+  const date = new Date();
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are zero-based, so add 1
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+// This mapping is used to know what planning repo is used for each code repo
+export const codeRepoToPlanningRepo: { [key: string]: string } = {
+  "metamask-extension": "MetaMask-planning",
+  "metamask-mobile": "mobile-planning"
+}
+
+// This mapping is used to know what platform each code repo is used for
+export const codeRepoToPlatform: { [key: string]: string } = {
+  "metamask-extension": "extension",
+  "metamask-mobile": "mobile",
+}

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -12,24 +12,31 @@ jobs:
           if [[ "$GITHUB_REF" =~ ^refs/heads/release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             version="${GITHUB_REF#refs/heads/release/}"
             echo "New release branch($version), continue next steps"
-            echo "version=$version" >> "$GITHUB_ENV"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
           else
             echo "Not a release branch, skip next steps"
+            exit 1
           fi
 
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1 # This retrieves only the latest commit.
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --immutable
+
       - name: Create bug report issue on planning repo
-        if: env.version
-        run: |
-          payload=$(cat <<EOF
-          {
-            "title": "v${{ env.version }} Bug Report",
-            "body": "**What is this bug report issue for?**\n\n1. This issue is used to track release dates on this [Github Project board](https://github.com/orgs/MetaMask/projects/86/views/3), which content then gets pulled into our metrics system.\n\n2. This issue is also used by our Zapier automations, to determine if automated notifications shall be sent on Slack for release \`${{ env.version }}\`. Notifications will only be sent as long as this issue is open.\n\n**Who created and/or closed this issue?**\n\n- This issue was automatically created by a GitHub action upon the creation of the release branch \`release/${{ env.version }}\`, indicating the release was cut.\n\n- This issue gets automatically closed by another GitHub action, once the \`release/${{ env.version }}\` branch merges into \`main\`, indicating the release is prepared for store submission.",
-            "labels": ["type-bug", "team-mobile-platform", "regression-RC-${{ env.version }}"]
-          }
-          EOF
-          )
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.BUG_REPORT_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/MetaMask/mobile-planning/issues \
-            -d "$payload"
+        id: create-bug-report-issue
+        env:
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          RELEASES_GITHUB_PROJECT_BOARD_NUMBER: ${{ vars.RELEASES_GITHUB_PROJECT_BOARD_NUMBER }}
+          RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER: ${{ vars.RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER }}
+          RELEASE_VERSION: ${{ steps.extract_version.outputs.version }}
+        run: npm run create-bug-report-issue


### PR DESCRIPTION
## **Description**

The purpose of this improvement is to automate several steps that I currently do manually when a new release x.y.z is created:

1. Create regression labels on public code repo (metamask-extension) and private planning repo (MetaMask-planning)
  a. `regression-RC-x.y.z`
  b. `regression-prod-x.y.z`
2. Create bug report issue on planning repo
3. Add the bug report issue to the Releases Github Project board 
4. Set the RC cut date on the Releases Github Project board.

These steps are important because the data pipelines of our metrics system consume the data that's present on the [Releases Github Project board](https://github.com/orgs/MetaMask/projects/86/views/1).

Finally this improvement includes a check to no longer re-create the bug report issue when it already exists, which used to happen sometimes when the release was re-cut, and which was disturbing other automations (e.g. wrong metrics, duplicated Slack notifications).

The following prerequisites are already met:

- [x] Add `BUG_REPORT_TOKEN` to repo secrets (fine grained access token with `Issues:Write` and `Metadata:Read` permissions for metamask-mobile and mobile-planning repos, as well as `Projects: Write` permissions for MetaMask organization)
- [x] Add `RELEASES_GITHUB_PROJECT_BOARD_NUMBER` to repo variables
- [x] Add `RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER` to repo variables

[Same PR for Extension](https://github.com/MetaMask/metamask-extension/pull/30176)

## **Related issues**

None

## **Manual testing steps**

1. Go to this [public code repo](https://github.com/gauthierpetetin-test/repo_test) (equivalent of metamask-extension repo)
2. Create a [new branch](https://github.com/gauthierpetetin-test/repo_test/branches) with the following format: `release/x.y.z` (where x, y, z, are numbers)
3. Wait for 30s, until the Github action execution is finalised
4. Check that `regression-RC-x.y.z` and r`egression-prod-x.y.z` labels have been created on the [public code repo](https://github.com/gauthierpetetin-test/repo_test/labels)
5. Go to this [private planning repo](https://github.com/gauthierpetetin-test/repo_test_2) (equivalent of MetaMask-planning repo)
6. Check that `regression-RC-x.y.z` and r`egression-prod-x.y.z` labels have been created on the [private planning repo](https://github.com/gauthierpetetin-test/repo_test_2/labels)
7. Check that the bug report issue has been created on the [private planning repo](https://github.com/gauthierpetetin-test/repo_test_2/issues) and has the following title: "vx.y.z Bug Report"
8. Go to this [Github Project board](https://github.com/users/gauthierpetetin-test/projects/2/views/1)
9. Check that the bug report issue is present on the board and its "RC Cut" date is set to the current date.

In case, you don't have sufficient permissions on these test repos, here's a video where the manual testing steps are demoed.

## **Screenshots/Recordings**

### **Before**

None

### **After**

<div>
    <a href="https://www.loom.com/share/0f794c36cb6843809afed9472e396830">
      <p>Github action to automate bug report creation - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/0f794c36cb6843809afed9472e396830">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/0f794c36cb6843809afed9472e396830-6d9405bba082fb85-full-play.gif">
    </a>
  </div>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
