### PR TITLE
build: add SENTRY_DEBUG_DEV ENV to turn off Sentry Logger

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -18,7 +18,11 @@ export MM_FOX_CODE="EXAMPLE_FOX_CODE"
 
 export MM_INFURA_PROJECT_ID="null"
 export IGNORE_BOXLOGS_DEVELOPMENT="false"
+
+# Sentry.init dsn value
 export MM_SENTRY_DSN=""
+# Sentry.init debug option is set to true in dev environments by default. Set this to "false" to turn it off
+export SENTRY_DEBUG_DEV="false"
 # Determines if Sentry will auto upload source maps and debug files. Disabled by default
 export SENTRY_DISABLE_AUTO_UPLOAD="true"
 

--- a/app/util/sentry/utils.js
+++ b/app/util/sentry/utils.js
@@ -546,7 +546,7 @@ export function setupSentry() {
 
     Sentry.init({
       dsn,
-      debug: isDev,
+      debug: isDev && process.env.SENTRY_DEBUG_DEV !== 'false',
       environment,
       integrations,
       // Set tracesSampleRate to 1.0, as that ensures that every transaction will be sent to Sentry for development builds.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds SENTRY_DEBUG_DEV ENV variable to turn off Sentry Logger debug

## **Related issues**

Fixes:

## **Manual testing steps**

1. Add `SENTRY_DEBUG_DEV` to js.env
2. Run simulation and run Flipper `yarn start:flipper`
3. Observe console

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Example Before**

![CleanShot 2025-02-07 at 21 01 13](https://github.com/user-attachments/assets/aa3c0b95-a94b-43a2-b6f2-3efc880b78ee)


### **Example After**

![CleanShot 2025-02-07 at 20 48 42](https://github.com/user-attachments/assets/47cdb751-b604-455e-a178-db90e5bc1ead)



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
