### PR TITLE
fix(walletconnect): improve chain switching error message with standard code 4902

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -452,12 +452,12 @@ class WalletConnect2Session {
       );
       if (!existingEntry && !existingNetworkDefault) {
         DevLogger.log(
-          `SKIP rpcMiddleWare -- auto rejection is detected (_chainId=${_chainId})`,
+          `wallet_switchEthereumChain: chain not found, throwing 4902 (_chainId=${_chainId})`,
         );
         await this.web3Wallet.rejectRequest({
           id: requestEvent.id,
           topic: requestEvent.topic,
-          error: { code: 32603, message: ERROR_MESSAGES.INVALID_CHAIN },
+          error: { code: 4902, message: `Unrecognized chain ID "${_chainId}". Try adding the chain using wallet_addEthereumChain first.` },
         });
 
         showWCLoadingState({ navigation: this.navigation });


### PR DESCRIPTION
## **Description**
This change improves WalletConnect chain switching error handling by implementing standard error codes and more descriptive messages when users attempt to switch to unregistered chains.

1. **Reason for change:**
   - Currently, attempting to switch to an unregistered chain returns a generic error code (32603)
   - Error message lacks clarity about how to resolve the issue

2. **Improvement/solution:**
   - Implements standard Ethereum error code 4902 for unrecognized chain scenarios
   - Provides clear error message suggesting the user to add the chain first
   - Updates logging for better debugging

## **Related issues**
Fixes: #13406

## **Manual testing steps**
1. Connect to the WalletConnect dApp example (using provided test dApp)
2. Attempt to switch to Arbitrum network that hasn't been added yet
3. Verify error code 4902 is returned with descriptive message
4. Confirm loading state behaves as expected

## **Screenshots/Recordings**
### **Before**
Error with code 32603:
```javascript
error: { code: 32603, message: ERROR_MESSAGES.INVALID_CHAIN }
```

### **After**
Improved error with code 4902:
```javascript
error: { 
  code: 4902, 
  message: `Unrecognized chain ID "${_chainId}". Try adding the chain using wallet_addEthereumChain first.`
}
```

## **Pre-merge author checklist**
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots