### PR TITLE
fix(action): indicate working directory

### DIFF
--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -40,3 +40,4 @@ jobs:
           RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER: ${{ vars.RELEASES_GITHUB_PROJECT_BOARD_VIEW_NUMBER }}
           RELEASE_VERSION: ${{ steps.extract_version.outputs.version }}
         run: npm run create-bug-report-issue
+        working-directory: '.github/scripts'


### PR DESCRIPTION
## **Description**

We need to indicate the right working directory to access  create-bug-report-issue command as it is not located in the main package.json file.

This is a fix for this [PR](https://github.com/MetaMask/metamask-mobile/pull/13397) that got merged earlier today.

## **Related issues**

None

## **Manual testing steps**

None, this PR needs to be merged to retry the Github action. But it should work as we've already done similar fixes for other Github actions ([example here](https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/check-template-and-add-labels.yml#L32)).

## **Screenshots/Recordings**

[Here's](https://github.com/MetaMask/metamask-mobile/actions/runs/13261955194/job/37020357932) where the issue occured.

<img width="1370" alt="Screenshot 2025-02-11 at 08 41 41" src="https://github.com/user-attachments/assets/99c82d79-891c-487f-8d4f-dea0d86ef1e1" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
