### PR TITLE
fix(action): handle edge case of issue that can't be accessed by access token

### DIFF
--- a/.github/scripts/shared/project.ts
+++ b/.github/scripts/shared/project.ts
@@ -179,7 +179,9 @@ export async function retrieveGithubProjectIssueFieldValuesRecursively(
   );
 
   const projectIssueFieldValuesResponseWithSameId: RawGithubProjectIssueFieldValues | undefined =
-    projectIssuesFieldValuesResponse.nodes.find((issue) => issue.content.id === issueId);
+    projectIssuesFieldValuesResponse.nodes.find(
+      (issue) => issue.content?.id === issueId
+    ); // 'issue.content' can be equal to null in edge case where the Github Project board includes private repo issues that can't be accessed by the access token we're using
 
   if (projectIssueFieldValuesResponseWithSameId) {
     const projectIssueFieldValues: GithubProjectIssueFieldValues = {


### PR DESCRIPTION
## **Description**

In some cases, the Github Project board includes private issues that can't be accessed by the access token we're using.
For example the access token used on Mobile repo can't access Extension planning issues and vice-versa.

This PR allows to handle that edge case.

## **Related issues**

NA

## **Manual testing steps**

None, this PR needs to be merged to retry the Github action.
(I also tested the fix on this [test repo](https://github.com/gauthierpetetin-test/repo_test/actions/runs/13271381855/job/37051361614) and it works well)

## **Screenshots/Recordings**

[Here's](https://github.com/MetaMask/metamask-mobile/actions/runs/13270507365/job/37048574560) where the issue occurred.

<img width="1369" alt="Screenshot 2025-02-11 at 16 44 05" src="https://github.com/user-attachments/assets/981c423e-da17-4474-bc27-7ed2434ec51b" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
