### PR TITLE
test: Modify Stake smoke test not to use default test account for funding

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -33,6 +33,7 @@ export IS_TEST=""
 # but have to be defined here for local tests
 export MM_TEST_ACCOUNT_SRP=""
 export MM_TEST_ACCOUNT_PRIVATE_KEY=""
+export MM_STAKE_TEST_ACCOUNT_PRIVATE_KEY=""
 export TENDERLY_NETWORK_ID=""
 
 # address is the address of the first account generated from the previous SRP

--- a/.js.env.example
+++ b/.js.env.example
@@ -34,7 +34,6 @@ export IS_TEST=""
 export MM_TEST_ACCOUNT_SRP=""
 export MM_TEST_ACCOUNT_PRIVATE_KEY=""
 export MM_STAKE_TEST_ACCOUNT_PRIVATE_KEY=""
-export TENDERLY_NETWORK_ID=""
 
 # address is the address of the first account generated from the previous SRP
 export MM_TEST_ACCOUNT_ADDRESS=""

--- a/e2e/specs/stake/stake-action-smoke.spec.js
+++ b/e2e/specs/stake/stake-action-smoke.spec.js
@@ -37,7 +37,7 @@ const fixtureServer = new FixtureServer();
 
 describe(SmokeStake('Stake from Actions'), () => {
   const FIRST_ROW = 0;
-  const AMOUNT_TO_SEND = '.01';
+  const AMOUNT_TO_SEND = '.005';
   let mockServer;
   const wallet = ethers.Wallet.createRandom();
 
@@ -68,6 +68,20 @@ describe(SmokeStake('Stake from Actions'), () => {
     jest.setTimeout(150000);
   });
 
+  it('should be able to import stake test account with funds', async () => {
+    await Assertions.checkIfVisible(WalletView.container);
+    await WalletView.tapIdenticon();
+    await Assertions.checkIfVisible(AccountListBottomSheet.accountList);
+    await AccountListBottomSheet.tapAddAccountButton();
+    await AddAccountBottomSheet.tapImportAccount();
+    await Assertions.checkIfVisible(ImportAccountView.container);
+    await ImportAccountView.enterPrivateKey(process.env.MM_STAKE_TEST_ACCOUNT_PRIVATE_KEY);
+    await Assertions.checkIfVisible(SuccessImportAccountView.container);
+    await SuccessImportAccountView.tapCloseButton();
+    await AccountListBottomSheet.swipeToDismissAccountsModal();
+    await Assertions.checkIfVisible(WalletView.container);
+  });
+
   it('should send ETH to new account', async () => {
     await TabBarComponent.tapActions();
     await WalletActionsBottomSheet.tapSendButton();
@@ -87,7 +101,7 @@ describe(SmokeStake('Stake from Actions'), () => {
     await Assertions.checkIfTextIsNotDisplayed('$0',60000);
   });
 
-  it('should be able to import the funded account', async () => {
+  it('should be able to import the new funded account', async () => {
     await Assertions.checkIfVisible(WalletView.container);
     await WalletView.tapIdenticon();
     await Assertions.checkIfVisible(AccountListBottomSheet.accountList);
@@ -105,7 +119,7 @@ describe(SmokeStake('Stake from Actions'), () => {
     await Assertions.checkIfVisible(TabBarComponent.tabBarWalletButton);
     await WalletView.tapOnEarnButton();
     await Assertions.checkIfVisible(StakeView.stakeContainer);
-    await StakeView.enterAmount('.004');
+    await StakeView.enterAmount('.002');
     await StakeView.tapReview();
     await StakeView.tapContinue();
     await StakeConfirmView.tapConfirmButton();
@@ -128,7 +142,7 @@ describe(SmokeStake('Stake from Actions'), () => {
     await TestHelpers.delay(3000);
     await TokenOverview.tapStakeMoreButton();
     await Assertions.checkIfVisible(StakeView.stakeContainer);
-    await StakeView.enterAmount('.003');
+    await StakeView.enterAmount('.001');
     await StakeView.tapReview();
     await StakeView.tapContinue();
     await StakeConfirmView.tapConfirmButton();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is a solution for preventing somebody from draining holesky ETH from our test account as the SRP is currently exposed. Basically the stake account containing the Holesky ETH is now imported from the ENV variable  `MM_STAKE_TEST_ACCOUNT_PRIVATE_KEY` containing the PK of the account. To run the tests locally engineers will need to set the value found 1Password and add it to `.js.env`

I also reduced the amount of ETH used for staking as requested by the stake team

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/13433

## **Manual testing steps**

1. yarn test:e2e:android:debug:run e2e/specs/stake/stake-action-smoke.spec.js

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
