### PR TITLE
feat: adding navigation to confirmation pages

### DIFF
--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -144,7 +144,7 @@ import {
   TraceOperation,
 } from '../../../util/trace';
 import getUIStartupSpan from '../../../core/Performance/UIStartup';
-import Confirm from '../../Views/confirmations/Confirm/Confirm';
+import { Confirm } from '../../Views/confirmations/Confirm';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -583,7 +583,7 @@ const ConnectHardwareWalletFlow = () => (
 
 const ConfirmRequest = () => (
   <Stack.Navigator mode={'modal'}>
-    <Stack.Screen name={Routes.CONFIRM_REQUEST} component={Confirm} />
+    <Stack.Screen name={Routes.CONFIRM_FLAT_PAGE} component={Confirm} />
   </Stack.Navigator>
 );
 
@@ -595,7 +595,7 @@ const ConfirmDappRequest = () => (
     }}
     mode={'modal'}
   >
-    <Stack.Screen name={Routes.CONFIRM_DAPP_REQUEST} component={Confirm} />
+    <Stack.Screen name={Routes.CONFIRM_MODAL} component={Confirm} />
   </Stack.Navigator>
 );
 
@@ -1037,12 +1037,12 @@ const App = (props) => {
             options={{ gestureEnabled: false }}
           />
           <Stack.Screen
-            name={Routes.CONFIRM_REQUEST}
+            name={Routes.CONFIRM_FLAT_PAGE}
             component={ConfirmRequest}
             options={{ animationEnabled: true }}
           />
           <Stack.Screen
-            name={Routes.CONFIRM_DAPP_REQUEST}
+            name={Routes.CONFIRM_MODAL}
             component={ConfirmDappRequest}
             options={{ animationEnabled: true }}
           />

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -144,7 +144,7 @@ import {
   TraceOperation,
 } from '../../../util/trace';
 import getUIStartupSpan from '../../../core/Performance/UIStartup';
-import { Confirm } from '../../Views/confirmations/Confirm';
+import Confirm from '../../Views/confirmations/Confirm/Confirm';
 
 const clearStackNavigatorOptions = {
   headerShown: false,

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -583,7 +583,7 @@ const ConnectHardwareWalletFlow = () => (
 
 const ConfirmRequest = () => (
   <Stack.Navigator mode={'modal'}>
-    <Stack.Screen name={Routes.CONFIRM_FLAT_PAGE} component={Confirm} />
+    <Stack.Screen name={Routes.CONFIRM_REQUEST} component={Confirm} />
   </Stack.Navigator>
 );
 
@@ -595,7 +595,7 @@ const ConfirmDappRequest = () => (
     }}
     mode={'modal'}
   >
-    <Stack.Screen name={Routes.CONFIRM_MODAL} component={Confirm} />
+    <Stack.Screen name={Routes.CONFIRM_DAPP_REQUEST} component={Confirm} />
   </Stack.Navigator>
 );
 
@@ -1037,13 +1037,14 @@ const App = (props) => {
             options={{ gestureEnabled: false }}
           />
           <Stack.Screen
-            name={Routes.CONFIRM_FLAT_PAGE}
+            name={Routes.CONFIRM_REQUEST}
             component={ConfirmRequest}
             options={{ animationEnabled: true }}
           />
           <Stack.Screen
-            name={Routes.CONFIRM_MODAL}
+            name={Routes.CONFIRM_DAPP_REQUEST}
             component={ConfirmDappRequest}
+            options={{ animationEnabled: true }}
           />
         </Stack.Navigator>
       </NavigationContainer>

--- a/app/components/Nav/App/index.js
+++ b/app/components/Nav/App/index.js
@@ -144,6 +144,7 @@ import {
   TraceOperation,
 } from '../../../util/trace';
 import getUIStartupSpan from '../../../core/Performance/UIStartup';
+import { Confirm } from '../../Views/confirmations/Confirm';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -577,6 +578,24 @@ const ConnectHardwareWalletFlow = () => (
       component={SelectHardwareWallet}
       options={SelectHardwareWallet.navigationOptions}
     />
+  </Stack.Navigator>
+);
+
+const ConfirmRequest = () => (
+  <Stack.Navigator mode={'modal'}>
+    <Stack.Screen name={Routes.CONFIRM_FLAT_PAGE} component={Confirm} />
+  </Stack.Navigator>
+);
+
+const ConfirmDappRequest = () => (
+  <Stack.Navigator
+    screenOptions={{
+      headerShown: false,
+      cardStyle: { backgroundColor: importedColors.transparent },
+    }}
+    mode={'modal'}
+  >
+    <Stack.Screen name={Routes.CONFIRM_MODAL} component={Confirm} />
   </Stack.Navigator>
 );
 
@@ -1016,6 +1035,15 @@ const App = (props) => {
             name={Routes.LOCK_SCREEN}
             component={LockScreen}
             options={{ gestureEnabled: false }}
+          />
+          <Stack.Screen
+            name={Routes.CONFIRM_FLAT_PAGE}
+            component={ConfirmRequest}
+            options={{ animationEnabled: true }}
+          />
+          <Stack.Screen
+            name={Routes.CONFIRM_MODAL}
+            component={ConfirmDappRequest}
           />
         </Stack.Navigator>
       </NavigationContainer>

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -62,7 +62,7 @@ import { getDeviceId } from '../../../core/Ledger/Ledger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { createLedgerTransactionModalNavDetails } from '../../UI/LedgerModals/LedgerTransactionModal';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
-import Confirm from '../../../components/Views/confirmations/Confirm';
+import { ConfirmRoot } from '../../../components/Views/confirmations/Confirm';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransactionsController';
 import { STX_NO_HASH_ERROR } from '../../../util/smart-transactions/smart-publish-hook';
@@ -335,7 +335,7 @@ const RootRPCMethodsUI = (props) => {
               transactionId: transactionMeta.id,
               deviceId,
               // eslint-disable-next-line no-empty-function
-              onConfirmationComplete: () => { },
+              onConfirmationComplete: () => {},
               type: 'signTransaction',
             }),
           );
@@ -405,7 +405,8 @@ const RootRPCMethodsUI = (props) => {
           data &&
           data !== '0x' &&
           to &&
-          (await getMethodData(data, networkClientId)).name === TOKEN_METHOD_TRANSFER
+          (await getMethodData(data, networkClientId)).name ===
+            TOKEN_METHOD_TRANSFER
         ) {
           let asset = props.tokens.find(({ address }) =>
             toLowerCaseEquals(address, to),
@@ -515,7 +516,7 @@ const RootRPCMethodsUI = (props) => {
 
   return (
     <React.Fragment>
-      <Confirm />
+      <ConfirmRoot />
       <SignatureApproval />
       <WalletConnectApproval />
       <TransactionApproval

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -62,7 +62,7 @@ import { getDeviceId } from '../../../core/Ledger/Ledger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { createLedgerTransactionModalNavDetails } from '../../UI/LedgerModals/LedgerTransactionModal';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
-import ConfirmRoot from '../../../components/Views/confirmations/Confirm/ConfirmRoot';
+import { ConfirmRoot } from '../../../components/Views/confirmations/Confirm';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransactionsController';
 import { STX_NO_HASH_ERROR } from '../../../util/smart-transactions/smart-publish-hook';

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -62,7 +62,7 @@ import { getDeviceId } from '../../../core/Ledger/Ledger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { createLedgerTransactionModalNavDetails } from '../../UI/LedgerModals/LedgerTransactionModal';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
-import { ConfirmRoot } from '../../../components/Views/confirmations/Confirm';
+import ConfirmRoot from '../../../components/Views/confirmations/Confirm/ConfirmRoot';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransactionsController';
 import { STX_NO_HASH_ERROR } from '../../../util/smart-transactions/smart-publish-hook';

--- a/app/components/Views/confirmations/Confirm/Confirm.test.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.test.tsx
@@ -10,7 +10,7 @@ import {
 // eslint-disable-next-line import/no-namespace
 import * as ConfirmationRedesignEnabled from '../hooks/useConfirmationRedesignEnabled';
 
-import Confirm from './index';
+import Confirm from './Confirm';
 
 jest.mock('../../../../core/Engine', () => ({
   getTotalFiatAccountBalance: () => ({ tokenFiat: 10 }),

--- a/app/components/Views/confirmations/Confirm/Confirm.test.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.test.tsx
@@ -10,7 +10,7 @@ import {
 // eslint-disable-next-line import/no-namespace
 import * as ConfirmationRedesignEnabled from '../hooks/useConfirmationRedesignEnabled';
 
-import Confirm from './Confirm';
+import { Confirm } from './Confirm';
 
 jest.mock('../../../../core/Engine', () => ({
   getTotalFiatAccountBalance: () => ({ tokenFiat: 10 }),

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { TransactionType } from '@metamask/transaction-controller';
 
 import { useStyles } from '../../../../component-library/hooks';
 import BottomModal from '../components/UI/BottomModal';
@@ -11,13 +10,8 @@ import SignatureBlockaidBanner from '../components/Confirm/SignatureBlockaidBann
 import Title from '../components/Confirm/Title';
 import useApprovalRequest from '../hooks/useApprovalRequest';
 import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
-import { useTransactionMetadataRequest } from '../hooks/useTransactionMetadataRequest';
+import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
 import styleSheet from './Confirm.styles';
-
-// todo: if possible derive way to dynamically check if confirmation should be rendered flat
-const FLAT_TRANSACTION_CONFIRMATIONS: TransactionType[] = [
-  TransactionType.stakingDeposit,
-];
 
 const ConfirmWrapped = ({
   styles,
@@ -41,12 +35,8 @@ const ConfirmWrapped = ({
 
 const Confirm = () => {
   const { approvalRequest } = useApprovalRequest();
-  const transactionMetadata = useTransactionMetadataRequest();
+  const { isFlatConfirmation } = useFlatConfirmation();
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
-
-  const isFlatConfirmation = FLAT_TRANSACTION_CONFIRMATIONS.includes(
-    transactionMetadata?.type as TransactionType,
-  );
 
   const { styles } = useStyles(styleSheet, { isFlatConfirmation });
 
@@ -56,10 +46,7 @@ const Confirm = () => {
 
   if (isFlatConfirmation) {
     return (
-      <View
-        style={styles.flatContainer}
-        testID="flat-confirmation-container"
-      >
+      <View style={styles.flatContainer} testID="flat-confirmation-container">
         <ConfirmWrapped styles={styles} />
       </View>
     );

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -33,7 +33,7 @@ const ConfirmWrapped = ({
   </QRHardwareContextProvider>
 );
 
-const Confirm = () => {
+export const Confirm = () => {
   const { approvalRequest } = useApprovalRequest();
   const { isFlatConfirmation } = useFlatConfirmation();
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
@@ -63,5 +63,3 @@ const Confirm = () => {
     </BottomModal>
   );
 };
-
-export default Confirm;

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -33,7 +33,7 @@ const ConfirmWrapped = ({
   </QRHardwareContextProvider>
 );
 
-export const Confirm = () => {
+const Confirm = () => {
   const { approvalRequest } = useApprovalRequest();
   const { isFlatConfirmation } = useFlatConfirmation();
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
@@ -63,3 +63,5 @@ export const Confirm = () => {
     </BottomModal>
   );
 };
+
+export default Confirm;

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import renderWithProvider from '../../../../util/test/renderWithProvider';
-import { stakingDepositConfirmationState } from '../../../../util/test/confirm-data-helpers';
+import {
+  personalSignatureConfirmationState,
+  stakingDepositConfirmationState,
+} from '../../../../util/test/confirm-data-helpers';
 import Routes from '../../../../constants/navigation/Routes';
 
 import ConfirmRoot from './ConfirmRoot';
@@ -17,6 +20,10 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('Confirm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders flat confirmation', async () => {
     renderWithProvider(<ConfirmRoot />, {
       state: stakingDepositConfirmationState,
@@ -27,9 +34,9 @@ describe('Confirm', () => {
 
   it('renders modal confirmation', async () => {
     renderWithProvider(<ConfirmRoot />, {
-      state: stakingDepositConfirmationState,
+      state: personalSignatureConfirmationState,
     });
-    expect(mockNavigate).toHaveBeenCalledTimes(2);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.CONFIRM_MODAL);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenLastCalledWith(Routes.CONFIRM_MODAL);
   });
 });

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../util/test/confirm-data-helpers';
 import Routes from '../../../../constants/navigation/Routes';
 
-import ConfirmRoot from './ConfirmRoot';
+import { ConfirmRoot } from './ConfirmRoot';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { stakingDepositConfirmationState } from '../../../../util/test/confirm-data-helpers';
+import Routes from '../../../../constants/navigation/Routes';
+
+import ConfirmRoot from './ConfirmRoot';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    addListener: jest.fn(),
+    dispatch: jest.fn(),
+  }),
+}));
+
+describe('Confirm', () => {
+  it('renders flat confirmation', async () => {
+    renderWithProvider(<ConfirmRoot />, {
+      state: stakingDepositConfirmationState,
+    });
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CONFIRM_FLAT_PAGE);
+  });
+
+  it('renders modal confirmation', async () => {
+    renderWithProvider(<ConfirmRoot />, {
+      state: stakingDepositConfirmationState,
+    });
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CONFIRM_MODAL);
+  });
+});

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
@@ -5,7 +5,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
 import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
 
-export const ConfirmRoot = () => {
+const ConfirmRoot = () => {
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
   const { isFlatConfirmation } = useFlatConfirmation();
   const navigation = useNavigation();
@@ -20,3 +20,5 @@ export const ConfirmRoot = () => {
 
   return null;
 };
+
+export default ConfirmRoot;

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigation } from '@react-navigation/native';
+
+import Routes from '../../../../constants/navigation/Routes';
+import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
+import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
+
+const ConfirmRoot = () => {
+  const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
+  const { isFlatConfirmation } = useFlatConfirmation();
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    if (isRedesignedEnabled) {
+      navigation.navigate(
+        isFlatConfirmation ? Routes.CONFIRM_FLAT_PAGE : Routes.CONFIRM_MODAL,
+      );
+    }
+  }, [isFlatConfirmation, isRedesignedEnabled, navigation]);
+
+  return null;
+};
+
+export default ConfirmRoot;

--- a/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
+++ b/app/components/Views/confirmations/Confirm/ConfirmRoot.tsx
@@ -5,7 +5,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
 import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
 
-const ConfirmRoot = () => {
+export const ConfirmRoot = () => {
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
   const { isFlatConfirmation } = useFlatConfirmation();
   const navigation = useNavigation();
@@ -20,5 +20,3 @@ const ConfirmRoot = () => {
 
   return null;
 };
-
-export default ConfirmRoot;

--- a/app/components/Views/confirmations/Confirm/index.ts
+++ b/app/components/Views/confirmations/Confirm/index.ts
@@ -1,1 +1,2 @@
-export { default } from './Confirm';
+export { Confirm } from './Confirm';
+export { ConfirmRoot } from './ConfirmRoot';

--- a/app/components/Views/confirmations/Confirm/index.ts
+++ b/app/components/Views/confirmations/Confirm/index.ts
@@ -1,2 +1,1 @@
-export { Confirm } from './Confirm';
-export { ConfirmRoot } from './ConfirmRoot';
+export { default } from './Confirm';

--- a/app/components/Views/confirmations/Confirm/index.ts
+++ b/app/components/Views/confirmations/Confirm/index.ts
@@ -1,2 +1,2 @@
-export { default as Confirm } from './Confirm';
-export { default as ConfirmRoot } from './ConfirmRoot';
+export { Confirm } from './Confirm';
+export { ConfirmRoot } from './ConfirmRoot';

--- a/app/components/Views/confirmations/Confirm/index.ts
+++ b/app/components/Views/confirmations/Confirm/index.ts
@@ -1,2 +1,2 @@
-export * from './Confirm';
-export * from './ConfirmRoot';
+export { default as Confirm } from './Confirm';
+export { default as ConfirmRoot } from './ConfirmRoot';

--- a/app/components/Views/confirmations/Confirm/index.ts
+++ b/app/components/Views/confirmations/Confirm/index.ts
@@ -1,1 +1,2 @@
-export { default } from './Confirm';
+export * from './Confirm';
+export * from './ConfirmRoot';

--- a/app/components/Views/confirmations/components/Confirm/Info/Info.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/Info.test.tsx
@@ -10,6 +10,13 @@ import * as QRHardwareHook from '../../../context/QRHardwareContext/QRHardwareCo
 import Info from './Info';
 import { Text } from 'react-native';
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: jest.fn(),
+  }),
+}));
+
 const MockText = Text;
 jest.mock('./QRInfo', () => () => <MockText>QR Scanning Component</MockText>);
 

--- a/app/components/Views/confirmations/context/QRHardwareContext/QRHardwareContext.test.tsx
+++ b/app/components/Views/confirmations/context/QRHardwareContext/QRHardwareContext.test.tsx
@@ -17,6 +17,13 @@ import {
   useQRHardwareContext,
 } from './QRHardwareContext';
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: jest.fn(),
+  }),
+}));
+
 jest.mock('../../../../../core/Engine', () => ({
   context: {
     KeyringController: {

--- a/app/components/Views/confirmations/context/QRHardwareContext/QRHardwareContext.test.tsx
+++ b/app/components/Views/confirmations/context/QRHardwareContext/QRHardwareContext.test.tsx
@@ -17,13 +17,6 @@ import {
   useQRHardwareContext,
 } from './QRHardwareContext';
 
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    goBack: jest.fn(),
-  }),
-}));
-
 jest.mock('../../../../../core/Engine', () => ({
   context: {
     KeyringController: {
@@ -45,6 +38,7 @@ jest.mock('@react-navigation/native', () => ({
     addListener: jest.fn(),
     removeListener: jest.fn(),
     dispatch: jest.fn(),
+    goBack: jest.fn(),
   }),
 }));
 

--- a/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
@@ -6,6 +6,13 @@ import PPOMUtil from '../../../../lib/ppom/ppom-util';
 import * as QRHardwareHook from '../context/QRHardwareContext/QRHardwareContext';
 import { useConfirmActions } from './useConfirmActions';
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: jest.fn(),
+  }),
+}));
+
 jest.mock('../../../../core/Engine', () => ({
   acceptPendingApproval: jest.fn(),
   rejectPendingApproval: jest.fn(),
@@ -31,12 +38,10 @@ describe('useConfirmAction', () => {
       'clearSignatureSecurityAlertResponse',
     );
     const mockSetScannerVisible = jest.fn().mockResolvedValue(undefined);
-    jest
-      .spyOn(QRHardwareHook, 'useQRHardwareContext')
-      .mockReturnValue({
-        isQRSigningInProgress: true,
-        setScannerVisible: mockSetScannerVisible,
-      } as unknown as QRHardwareHook.QRHardwareContextType);
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      isQRSigningInProgress: true,
+      setScannerVisible: mockSetScannerVisible,
+    } as unknown as QRHardwareHook.QRHardwareContextType);
     const { result } = renderHookWithProvider(() => useConfirmActions(), {
       state: personalSignatureConfirmationState,
     });
@@ -72,11 +77,9 @@ describe('useConfirmAction', () => {
     const mockCancelQRScanRequestIfPresent = jest
       .fn()
       .mockResolvedValue(undefined);
-    jest
-      .spyOn(QRHardwareHook, 'useQRHardwareContext')
-      .mockReturnValue({
-        cancelQRScanRequestIfPresent: mockCancelQRScanRequestIfPresent,
-      } as unknown as QRHardwareHook.QRHardwareContextType);
+    jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
+      cancelQRScanRequestIfPresent: mockCancelQRScanRequestIfPresent,
+    } as unknown as QRHardwareHook.QRHardwareContextType);
     const { result } = renderHookWithProvider(() => useConfirmActions(), {
       state: personalSignatureConfirmationState,
     });

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -7,7 +7,7 @@ import { isSignatureRequest } from '../utils/confirm';
 import { useQRHardwareContext } from '../context/QRHardwareContext/QRHardwareContext';
 import useApprovalRequest from './useApprovalRequest';
 import { useSignatureMetrics } from './useSignatureMetrics';
-  
+
 export const useConfirmActions = () => {
   const {
     onConfirm: onRequestConfirm,

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
 
 import PPOMUtil from '../../../../lib/ppom/ppom-util';
 import { MetaMetricsEvents } from '../../../hooks/useMetrics';
@@ -6,7 +7,7 @@ import { isSignatureRequest } from '../utils/confirm';
 import { useQRHardwareContext } from '../context/QRHardwareContext/QRHardwareContext';
 import useApprovalRequest from './useApprovalRequest';
 import { useSignatureMetrics } from './useSignatureMetrics';
-
+  
 export const useConfirmActions = () => {
   const {
     onConfirm: onRequestConfirm,
@@ -19,6 +20,7 @@ export const useConfirmActions = () => {
     isQRSigningInProgress,
     setScannerVisible,
   } = useQRHardwareContext();
+  const navigation = useNavigation();
 
   const signatureRequest =
     approvalRequest?.type && isSignatureRequest(approvalRequest?.type);
@@ -33,6 +35,7 @@ export const useConfirmActions = () => {
       deleteAfterResult: true,
       handleErrors: false,
     });
+    navigation.goBack();
     if (signatureRequest) {
       captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_APPROVED);
       PPOMUtil.clearSignatureSecurityAlertResponse();
@@ -40,6 +43,7 @@ export const useConfirmActions = () => {
   }, [
     captureSignatureMetrics,
     isQRSigningInProgress,
+    navigation,
     onRequestConfirm,
     setScannerVisible,
     signatureRequest,
@@ -48,6 +52,7 @@ export const useConfirmActions = () => {
   const onReject = useCallback(async () => {
     await cancelQRScanRequestIfPresent();
     onRequestReject();
+    navigation.goBack();
     if (signatureRequest) {
       captureSignatureMetrics(MetaMetricsEvents.SIGNATURE_REJECTED);
       PPOMUtil.clearSignatureSecurityAlertResponse();
@@ -55,6 +60,7 @@ export const useConfirmActions = () => {
   }, [
     cancelQRScanRequestIfPresent,
     captureSignatureMetrics,
+    navigation,
     onRequestReject,
     signatureRequest,
   ]);

--- a/app/components/Views/confirmations/hooks/useFlatConfirmation.test.ts
+++ b/app/components/Views/confirmations/hooks/useFlatConfirmation.test.ts
@@ -1,0 +1,24 @@
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import {
+  personalSignatureConfirmationState,
+  stakingDepositConfirmationState,
+} from '../../../../util/test/confirm-data-helpers';
+import { useFlatConfirmation } from './useFlatConfirmation';
+
+describe('useFlatConfirmation', () => {
+  it('returns true for staking confirmation', async () => {
+    const { result } = renderHookWithProvider(useFlatConfirmation, {
+      state: stakingDepositConfirmationState,
+    });
+
+    expect(result.current.isFlatConfirmation).toBe(true);
+  });
+
+  it('returns false for personal sign request', async () => {
+    const { result } = renderHookWithProvider(useFlatConfirmation, {
+      state: personalSignatureConfirmationState,
+    });
+
+    expect(result.current.isFlatConfirmation).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/hooks/useFlatConfirmation.ts
+++ b/app/components/Views/confirmations/hooks/useFlatConfirmation.ts
@@ -1,0 +1,18 @@
+import { TransactionType } from '@metamask/transaction-controller';
+
+import { useTransactionMetadataRequest } from '../hooks/useTransactionMetadataRequest';
+
+// todo: if possible derive way to dynamically check if confirmation should be rendered flat
+const FLAT_TRANSACTION_CONFIRMATIONS: TransactionType[] = [
+  TransactionType.stakingDeposit,
+];
+
+export const useFlatConfirmation = () => {
+  const transactionMetadata = useTransactionMetadataRequest();
+
+  const isFlatConfirmation = FLAT_TRANSACTION_CONFIRMATIONS.includes(
+    transactionMetadata?.type as TransactionType,
+  );
+
+  return { isFlatConfirmation };
+};

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -138,6 +138,8 @@ const Routes = {
   EDIT_NETWORK: 'EditNetwork',
   SWAPS: 'Swaps',
   LOCK_SCREEN: 'LockScreen',
+  CONFIRM_FLAT_PAGE: 'Confirmation',
+  CONFIRM_MODAL: 'Confirmation',
   NOTIFICATIONS: {
     VIEW: 'NotificationsView',
     OPT_IN: 'OptIn',

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -138,8 +138,8 @@ const Routes = {
   EDIT_NETWORK: 'EditNetwork',
   SWAPS: 'Swaps',
   LOCK_SCREEN: 'LockScreen',
-  CONFIRM_FLAT_PAGE: 'Confirmation',
-  CONFIRM_MODAL: 'Confirmation',
+  CONFIRM_FLAT_PAGE: 'Confirmation Flat Page',
+  CONFIRM_MODAL: 'Confirmation Modal',
   NOTIFICATIONS: {
     VIEW: 'NotificationsView',
     OPT_IN: 'OptIn',


### PR DESCRIPTION
## **Description**

Add navigation for opening confirmation pages.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4143

## **Manual testing steps**

1. Go to test dapp
2. Open signature pages and check navigation

## **Screenshots/Recordings**

Dapp Requests:

https://github.com/user-attachments/assets/a82e7170-d9d5-4574-9772-418b253a7f48

Staking:

https://github.com/user-attachments/assets/bfe0d65c-fc00-4561-8b61-1e55bad104a4

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
