### PR TITLE
fix(13492): background shapes animation stories and centering fix

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -128,6 +128,7 @@ const getStories = () => {
     "./app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories.tsx": require("../app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories.tsx"),
     "./app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx": require("../app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx"),
     "./app/component-library/components/Texts/SensitiveText/SensitiveText.stories.tsx": require("../app/component-library/components/Texts/SensitiveText/SensitiveText.stories.tsx"),
+    "./app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx": require("../app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx"),
   };
 };
 

--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1178,13 +1178,15 @@ exports[`Quotes renders animation on first fetching 1`] = `
                                       collapsable={false}
                                       style={
                                         {
-                                          "height": "70%",
+                                          "alignItems": "center",
+                                          "height": "100%",
+                                          "justifyContent": "center",
                                           "transform": [
                                             {
                                               "rotate": "0deg",
                                             },
                                           ],
-                                          "width": "70%",
+                                          "width": "100%",
                                         }
                                       }
                                       testID="shapes-background-animation"

--- a/app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx
+++ b/app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable react-native/no-inline-styles */
+/* eslint-disable react/display-name */
+// Third party dependencies.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Device from '../../../../../util/device';
+
+// Internal dependencies.
+import { default as ShapesBackgroundAnimationComponent } from './ShapesBackgroundAnimation';
+import { mockTheme } from '../../../../../util/theme';
+
+const IS_NARROW = Device.getDeviceWidth() <= 320;
+const STAGE_SIZE = IS_NARROW ? 240 : 260;
+
+const styles = StyleSheet.create({
+  storyContainer: {
+    flex: 1,
+    backgroundColor: mockTheme.colors.background.default,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  animationContainer: {
+    width: STAGE_SIZE,
+    height: STAGE_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const ShapesBackgroundAnimationMeta = {
+  title: 'Components Animations / Loading Animation',
+  component: ShapesBackgroundAnimationComponent,
+  argTypes: {
+    width: {
+      control: { type: 'number' },
+      defaultValue: STAGE_SIZE,
+    },
+    height: {
+      control: { type: 'number' },
+      defaultValue: STAGE_SIZE,
+    },
+  },
+};
+
+export default ShapesBackgroundAnimationMeta;
+
+export const ShapesBackgroundAnimation = {
+  render: ({ width, height }: { width: number; height: number }) => (
+    <View style={styles.storyContainer}>
+      <View style={styles.animationContainer}>
+        <ShapesBackgroundAnimationComponent width={width} height={height} />
+      </View>
+    </View>
+  ),
+};

--- a/app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.tsx
+++ b/app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.tsx
@@ -4,8 +4,10 @@ import Svg, { Path, LinearGradient, Stop, Defs } from 'react-native-svg';
 
 const styles = StyleSheet.create({
   container: {
-    width: '70%',
-    height: '70%',
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -39,7 +41,12 @@ const ShapesBackgroundAnimation = ({
   return (
     <Animated.View
       testID="shapes-background-animation"
-      style={[styles.container, { transform: [{ rotate: spin }] }]}
+      style={[
+        styles.container,
+        {
+          transform: [{ rotate: spin }],
+        },
+      ]}
     >
       <Svg width={width} height={height} viewBox="0 0 401 376" fill="none">
         <Path

--- a/app/components/UI/Swaps/components/LoadingAnimation/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Swaps/components/LoadingAnimation/__snapshots__/index.test.tsx.snap
@@ -149,14 +149,6 @@ exports[`LoadingAnimation renders 1`] = `
             "position": "absolute",
             "right": 0,
             "top": 0,
-            "transform": [
-              {
-                "translateX": -20,
-              },
-              {
-                "translateY": -10,
-              },
-            ],
             "zIndex": 1,
           }
         }
@@ -165,13 +157,15 @@ exports[`LoadingAnimation renders 1`] = `
           collapsable={false}
           style={
             {
-              "height": "70%",
+              "alignItems": "center",
+              "height": "100%",
+              "justifyContent": "center",
               "transform": [
                 {
                   "rotate": "0deg",
                 },
               ],
-              "width": "70%",
+              "width": "100%",
             }
           }
           testID="shapes-background-animation"

--- a/app/components/UI/Swaps/components/LoadingAnimation/index.js
+++ b/app/components/UI/Swaps/components/LoadingAnimation/index.js
@@ -105,7 +105,6 @@ const createStyles = (colors, shadows) =>
       zIndex: 1,
       justifyContent: 'center',
       alignItems: 'center',
-      transform: [{ translateX: -20 }, { translateY: -10 }],
     },
   });
 


### PR DESCRIPTION
## **Description**

Added stories for the `app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.tsx` component. Also, fixed a centering issue when animating

## **Related issues**

Fixes: [#13492](https://github.com/MetaMask/metamask-mobile/issues/13492)

## **Manual testing steps**

1. Goto swaps page
2. When getting a quote you should see the animation with the fox
3. Open Storybook to view component under "Component Animations"

## **Screenshots/Recordings**

### Stories


https://github.com/user-attachments/assets/b63e64d4-0e5a-4966-9683-c20b732e27b5


### **Before**

NOTE: The animation slowly moves off center

https://github.com/user-attachments/assets/f491b7b2-5d03-470c-b8c4-110a942b9d92


### **After**

https://github.com/user-attachments/assets/aa4763ec-aafa-42ef-83b6-ddbeffd8afa8



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
