### PR TITLE
fix: update plist to include CFBundleIconName for app icons

### DIFF
--- a/ios/MetaMask/Info.plist
+++ b/ios/MetaMask/Info.plist
@@ -10,6 +10,8 @@
 	<string>MetaMask</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+    <string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
## **Description**

Added `CFBundleIconName` to `Info.plist` to fix TestFlight validation error. This was required because:

1. Recent app icon changes switched from device-specific format (`iphone`/`ipad`) to universal format (`platform: "ios"`)
2. The new universal icon format requires explicit icon configuration in Info.plist
3. Added:
```
<key>CFBundleIconName</key>
<string>AppIcon</string>
```

This matches our asset catalog name `AppIcon.appiconset` and should resolve the TestFlight upload error.

## **Related issues**

Fixes:

## **Manual testing steps**

1. View `ios/MetaMask/Info.plist` to confirm `CFBundleIconName` is there
2.
3.

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
