### PR TITLE
fix: tooltip display for text should have label

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/DataTree/DataField.tsx
+++ b/app/components/Views/confirmations/components/Confirm/DataTree/DataField.tsx
@@ -108,7 +108,13 @@ const DataField = memo(
           <InfoDate unixTimestamp={parseInt(value, 10)} />
         );
     } else if (isTokenValueField(label, primaryType)) {
-      fieldDisplay = <TokenValue value={value} decimals={tokenDecimals} />;
+      fieldDisplay = (
+        <TokenValue
+          label={startCase(label)}
+          value={value}
+          decimals={tokenDecimals}
+        />
+      );
     } else if (typeof value === 'object' && value !== null) {
       fieldDisplay = (
         <DataTree

--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/TokenValue/TokenValue.test.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/TokenValue/TokenValue.test.tsx
@@ -7,42 +7,58 @@ import TokenValue from './TokenValue';
 describe('TokenValue', () => {
   it('should render value correctly', () => {
     const { getByText } = render(
-      <TokenValue value={1000000000000000000} decimals={18} />,
+      <TokenValue label={'Value'} value={1000000000000000000} decimals={18} />,
     );
     expect(getByText('1')).toBeDefined();
   });
 
   it('should render BigNumber value correctly', () => {
     const { getByText } = render(
-      <TokenValue value={new BigNumber('1000000000000000000')} decimals={18} />,
+      <TokenValue
+        label={'Value'}
+        value={new BigNumber('1000000000000000000')}
+        decimals={18}
+      />,
     );
     expect(getByText('1')).toBeDefined();
   });
 
   it('should handle small decimal values', () => {
-    const { getByText } = render(<TokenValue value="1000" decimals={6} />);
+    const { getByText } = render(
+      <TokenValue label={'Value'} value="1000" decimals={6} />,
+    );
     expect(getByText('0.001')).toBeDefined();
   });
 
   it('should handle large numbers', () => {
     const { getByText } = render(
-      <TokenValue value="123456789000000000000000000" decimals={18} />,
+      <TokenValue
+        label={'Value'}
+        value="123456789000000000000000000"
+        decimals={18}
+      />,
     );
     expect(getByText('123,456,789')).toBeDefined();
   });
 
   it('should handle zero value', () => {
-    const { getByText } = render(<TokenValue value="0" decimals={18} />);
+    const { getByText } = render(
+      <TokenValue label={'Value'} value="0" decimals={18} />,
+    );
     expect(getByText('0')).toBeDefined();
   });
 
   it('should handle very long value with undefined decimals', () => {
-    const { getByText } = render(<TokenValue value="1000000000000000000" />);
+    const { getByText } = render(
+      <TokenValue label={'Value'} value="1000000000000000000" />,
+    );
     expect(getByText('1,000,000,000,0...')).toBeDefined();
   });
 
   it('should handle very small numbers', () => {
-    const { getByText } = render(<TokenValue value="100" decimals={18} />);
+    const { getByText } = render(
+      <TokenValue label={'Value'} value="100" decimals={18} />,
+    );
     expect(getByText('< 0.000001')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/TokenValue/TokenValue.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/TokenValue/TokenValue.tsx
@@ -10,11 +10,12 @@ import { shortenString } from '../../../../../../../../util/notifications';
 import TextWithTooltip from '../../../TextWithTooltip';
 
 interface TokenValueProps {
-  value: number | string | BigNumber;
+  label: string;
   decimals?: number;
+  value: number | string | BigNumber;
 }
 
-const TokenValue = ({ value, decimals }: TokenValueProps) => {
+const TokenValue = ({ label, decimals, value }: TokenValueProps) => {
   const tokenValue = calcTokenAmount(value, decimals);
 
   const tokenText = formatAmount('en-US', tokenValue);
@@ -22,6 +23,7 @@ const TokenValue = ({ value, decimals }: TokenValueProps) => {
 
   return (
     <TextWithTooltip
+      label={label}
       text={shortenString(tokenText, {
         truncatedCharLimit: 15,
         truncatedStartChars: 15,

--- a/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx
+++ b/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx
@@ -17,6 +17,7 @@ storiesOf('Confirmations / TextWithTooltip', module)
         Simple Text With Tooltip
       </Text>
       <TextWithTooltip
+        label={'some_dummy_label'}
         text={'some_dummy_value'}
         tooltip={'some_dummy_tooltip'}
       />

--- a/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.styles.ts
+++ b/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.styles.ts
@@ -7,16 +7,23 @@ const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
 
   return StyleSheet.create({
+    backIcon: {
+      left: 10,
+      top: 10,
+      position: 'absolute',
+    },
     container: {
       backgroundColor: theme.colors.background.default,
       paddingHorizontal: 8,
       paddingVertical: 8,
     },
-    tooltipText: {
+    text: {
       fontSize: 16,
       ...fontStyles.normal,
     },
     tooltipHeader: {
+      flexDirection: 'row',
+      justifyContent: 'center',
       paddingHorizontal: 8,
       paddingVertical: 8,
     },

--- a/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.test.tsx
+++ b/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.test.tsx
@@ -7,6 +7,7 @@ describe('TextWithTooltip', () => {
   it('renders correctly', async () => {
     const { getByText } = render(
       <TextWithTooltip
+        label={'some_dummy_label'}
         text={'some_dummy_value'}
         tooltip={'some_dummy_tooltip'}
       />,
@@ -17,12 +18,14 @@ describe('TextWithTooltip', () => {
   it('should open modal when value pressed', async () => {
     const { getByTestId, getByText } = render(
       <TextWithTooltip
+        label={'some_dummy_label'}
         text={'some_dummy_value'}
         tooltip={'some_dummy_tooltip'}
       />,
     );
     expect(getByText('some_dummy_value')).toBeDefined();
     fireEvent.press(getByText('some_dummy_value'));
+    expect(getByText('some_dummy_label')).toBeDefined();
     expect(getByText('some_dummy_tooltip')).toBeDefined();
     fireEvent.press(getByTestId('tooltipTestId'));
     expect(getByText('some_dummy_value')).toBeDefined();

--- a/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.tsx
+++ b/app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.tsx
@@ -12,12 +12,14 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import BottomModal from '../BottomModal';
 import styleSheet from './TextWithTooltip.styles';
 interface TextWithTooltipProps {
+  label: string;
   text: string;
   tooltip: string;
   tooltipTestId?: string;
 }
 
 const TextWithTooltip = ({
+  label,
   text,
   tooltip,
   tooltipTestId,
@@ -35,15 +37,17 @@ const TextWithTooltip = ({
           <View style={styles.container}>
             <View style={styles.tooltipHeader}>
               <ButtonIcon
+                style={styles.backIcon}
                 iconColor={IconColor.Default}
                 size={ButtonIconSizes.Sm}
                 onPress={() => setTooltipVisible(false)}
                 iconName={IconName.ArrowLeft}
                 testID={tooltipTestId ?? 'tooltipTestId'}
               />
+              <Text style={styles.text}>{label}</Text>
             </View>
             <View style={styles.tooltipContext}>
-              <Text style={styles.tooltipText}>{tooltip}</Text>
+              <Text style={styles.text}>{tooltip}</Text>
             </View>
           </View>
         </BottomModal>


### PR DESCRIPTION
## **Description**

tooltip display for text should have label, this change is suggestion of design team

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4230

## **Manual testing steps**

1. Go to test dapp
2. Open permit and detailed message
3. Click token value to see tooltip and ensure it has label

## **Screenshots/Recordings**
<img width="398" alt="Screenshot 2025-02-18 at 3 49 39 PM" src="https://github.com/user-attachments/assets/7c586eed-2d51-48ea-b0a8-6bfc2b68c1ef" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
