### PR TITLE
fix: Reject transaction as user closes modal by swiping out

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -10,6 +10,7 @@ import SignatureBlockaidBanner from '../components/Confirm/SignatureBlockaidBann
 import Title from '../components/Confirm/Title';
 import { QRHardwareContextProvider } from '../context/QRHardwareContext/QRHardwareContext';
 import useApprovalRequest from '../hooks/useApprovalRequest';
+import { useConfirmActions } from '../hooks/useConfirmActions';
 import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
 import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
 import styleSheet from './Confirm.styles';
@@ -33,6 +34,7 @@ export const Confirm = () => {
   const { approvalRequest } = useApprovalRequest();
   const { isFlatConfirmation } = useFlatConfirmation();
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
+  const { onReject } = useConfirmActions();
 
   const { styles } = useStyles(styleSheet, {});
 
@@ -49,10 +51,7 @@ export const Confirm = () => {
   }
 
   return (
-    <BottomModal
-      canCloseOnBackdropClick={false}
-      testID="modal-confirmation-container"
-    >
+    <BottomModal onClose={onReject} testID="modal-confirmation-container">
       <View style={styles.modalContainer} testID={approvalRequest?.type}>
         <ConfirmWrapped />
       </View>

--- a/app/components/Views/confirmations/components/UI/BottomModal/BottomModal.tsx
+++ b/app/components/Views/confirmations/components/UI/BottomModal/BottomModal.tsx
@@ -8,7 +8,6 @@ import styleSheet from './BottomModal.styles';
 
 const OPAQUE_GRAY = '#414141';
 interface BottomModalProps {
-  canCloseOnBackdropClick?: boolean;
   children: ReactChild;
   onClose?: () => void;
   hideBackground?: boolean;
@@ -20,7 +19,6 @@ interface BottomModalProps {
  * {@see {@link https://github.com/MetaMask/metamask-mobile/issues/12656}}
  */
 const BottomModal = ({
-  canCloseOnBackdropClick = true,
   children,
   hideBackground,
   onClose,
@@ -40,7 +38,7 @@ const BottomModal = ({
       animationInTiming={600}
       animationOutTiming={600}
       onBackButtonPress={onClose}
-      onBackdropPress={canCloseOnBackdropClick ? onClose : undefined}
+      onBackdropPress={onClose}
       onSwipeComplete={onClose}
       swipeDirection={'down'}
       propagateSwipe

--- a/app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.tsx
+++ b/app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.tsx
@@ -65,7 +65,7 @@ const ExpandableSection = ({
         </View>
       </TouchableOpacity>
       {expanded && (
-        <BottomModal onClose={() => setExpanded(false)} canCloseOnBackdropClick>
+        <BottomModal onClose={() => setExpanded(false)}>
           <View style={styles.modalContent}>
             <View style={styles.modalHeader}>
               <ButtonIcon


### PR DESCRIPTION
## **Description**

Reject transaction as user closes modal by swiping out.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4231

## **Manual testing steps**

1. Open signature request in test dapp
2. Swiping out modal should reject the transaction

## **Screenshots/Recordings**
https://github.com/user-attachments/assets/0ac41b2b-96d5-4809-b2c5-f109d990585d

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
