### PR TITLE
chore: Adding e2e for confirmation page scroll button

### DIFF
--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
   ConfirmationFooterSelectorIDs,
-  ConfirmationPageScrollButton,
+  ConfirmationPageSectionsSelectorIDs,
 } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../../util/test/confirm-data-helpers';
@@ -58,7 +58,9 @@ describe('ScrollContext', () => {
         state: personalSignatureConfirmationState,
       },
     );
-    expect(queryByTestId(ConfirmationPageScrollButton)).toBeNull();
+    expect(
+      queryByTestId(ConfirmationPageSectionsSelectorIDs.SCROLL_BUTTON),
+    ).toBeNull();
   });
 });
 

--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { ConfirmationFooterSelectorIDs } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
+import {
+  ConfirmationFooterSelectorIDs,
+  ConfirmationPageScrollButton,
+} from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../../util/test/confirm-data-helpers';
 import Footer from '../../components/Confirm/Footer';
@@ -55,7 +58,7 @@ describe('ScrollContext', () => {
         state: personalSignatureConfirmationState,
       },
     );
-    expect(queryByTestId('scroll-to-bottom-button')).toBeNull();
+    expect(queryByTestId(ConfirmationPageScrollButton)).toBeNull();
   });
 });
 

--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
@@ -15,7 +15,7 @@ import {
   View,
 } from 'react-native';
 
-import { ConfirmationPageScrollButton } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
+import { ConfirmationPageSectionsSelectorIDs } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -82,7 +82,7 @@ export const ScrollContextProvider: React.FC<{
           style={styles.scrollButton}
           iconName={IconName.Arrow2Down}
           onPress={scrollToBottom}
-          testID={ConfirmationPageScrollButton}
+          testID={ConfirmationPageSectionsSelectorIDs.SCROLL_BUTTON}
         />
       )}
       <ScrollView

--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
@@ -15,6 +15,7 @@ import {
   View,
 } from 'react-native';
 
+import { ConfirmationPageScrollButton } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -81,7 +82,7 @@ export const ScrollContextProvider: React.FC<{
           style={styles.scrollButton}
           iconName={IconName.Arrow2Down}
           onPress={scrollToBottom}
-          testID="scroll-to-bottom-button"
+          testID={ConfirmationPageScrollButton}
         />
       )}
       <ScrollView

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -9,6 +9,6 @@ export const testConfig = {};
  * TODO: Update this condition once we change E2E builds to use release instead of debug
  */
 export const isTest = process.env.METAMASK_ENVIRONMENT !== 'production';
-export const isE2E = true; //process.env.IS_TEST === 'true';
+export const isE2E = process.env.IS_TEST === 'true';
 export const getFixturesServerPortInApp = () =>
   testConfig.fixtureServerPort ?? FIXTURE_SERVER_PORT;

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -9,6 +9,6 @@ export const testConfig = {};
  * TODO: Update this condition once we change E2E builds to use release instead of debug
  */
 export const isTest = process.env.METAMASK_ENVIRONMENT !== 'production';
-export const isE2E = process.env.IS_TEST === 'true';
+export const isE2E = true; //process.env.IS_TEST === 'true';
 export const getFixturesServerPortInApp = () =>
   testConfig.fixtureServerPort ?? FIXTURE_SERVER_PORT;

--- a/e2e/pages/Browser/Confirmations/PageSections.js
+++ b/e2e/pages/Browser/Confirmations/PageSections.js
@@ -1,4 +1,7 @@
-import { ConfirmationPageSectionsSelectorIDs } from '../../../selectors/Confirmation/ConfirmationView.selectors';
+import {
+  ConfirmationPageScrollButton,
+  ConfirmationPageSectionsSelectorIDs,
+} from '../../../selectors/Confirmation/ConfirmationView.selectors';
 import Matchers from '../../../utils/Matchers';
 
 class PageSections {
@@ -24,6 +27,10 @@ class PageSections {
     return Matchers.getElementByID(
       ConfirmationPageSectionsSelectorIDs.MESSAGE_SECTION,
     );
+  }
+
+  get ScrollButton() {
+    return Matchers.getElementByID(ConfirmationPageScrollButton);
   }
 }
 

--- a/e2e/pages/Browser/Confirmations/PageSections.js
+++ b/e2e/pages/Browser/Confirmations/PageSections.js
@@ -1,7 +1,4 @@
-import {
-  ConfirmationPageScrollButton,
-  ConfirmationPageSectionsSelectorIDs,
-} from '../../../selectors/Confirmation/ConfirmationView.selectors';
+import { ConfirmationPageSectionsSelectorIDs } from '../../../selectors/Confirmation/ConfirmationView.selectors';
 import Matchers from '../../../utils/Matchers';
 
 class PageSections {
@@ -30,7 +27,9 @@ class PageSections {
   }
 
   get ScrollButton() {
-    return Matchers.getElementByID(ConfirmationPageScrollButton);
+    return Matchers.getElementByID(
+      ConfirmationPageSectionsSelectorIDs.SCROLL_BUTTON,
+    );
   }
 }
 

--- a/e2e/pages/Browser/Confirmations/PageSections.js
+++ b/e2e/pages/Browser/Confirmations/PageSections.js
@@ -1,4 +1,5 @@
 import { ConfirmationPageSectionsSelectorIDs } from '../../../selectors/Confirmation/ConfirmationView.selectors';
+import Gestures from '../../../utils/Gestures';
 import Matchers from '../../../utils/Matchers';
 
 class PageSections {
@@ -30,6 +31,10 @@ class PageSections {
     return Matchers.getElementByID(
       ConfirmationPageSectionsSelectorIDs.SCROLL_BUTTON,
     );
+  }
+
+  async tapScrollButton() {
+    await Gestures.waitAndTap(this.ScrollButton);
   }
 }
 

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -96,10 +96,10 @@ class TestDApp {
       TestDappSelectorsWebIDs.ETHEREUM_SIGN,
     );
   }
-  get seaportBulkSignButton() {
+  get permitSignButton() {
     return Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestDappSelectorsWebIDs.SEAPORT_BULK_ORDER,
+      TestDappSelectorsWebIDs.PERMIT_SIGN,
     );
   }
   // This taps on the transfer tokens button under the "SEND TOKENS section"
@@ -205,8 +205,8 @@ class TestDApp {
     await this.tapButton(this.ethereumSignButton);
   }
 
-  async tapSeaportBulkSignButton() {
-    await this.tapButton(this.seaportBulkSignButton);
+  async tapPermitSignButton() {
+    await this.tapButton(this.permitSignButton);
   }
 
   async tapERC20TransferButton() {

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -96,6 +96,12 @@ class TestDApp {
       TestDappSelectorsWebIDs.ETHEREUM_SIGN,
     );
   }
+  get seaportBulkSignButton() {
+    return Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestDappSelectorsWebIDs.SEAPORT_BULK_ORDER,
+    );
+  }
   // This taps on the transfer tokens button under the "SEND TOKENS section"
   get nftTransferFromTokensButton() {
     return Matchers.getElementByWebID(
@@ -197,6 +203,10 @@ class TestDApp {
 
   async tapEthereumSignButton() {
     await this.tapButton(this.ethereumSignButton);
+  }
+
+  async tapSeaportBulkSignButton() {
+    await this.tapButton(this.seaportBulkSignButton);
   }
 
   async tapERC20TransferButton() {

--- a/e2e/selectors/Browser/TestDapp.selectors.js
+++ b/e2e/selectors/Browser/TestDapp.selectors.js
@@ -8,7 +8,7 @@ export const TestDappSelectorsWebIDs = {
   INCREASE_ALLOWANCE_BUTTON_ID: 'increaseTokenAllowance',
   NFT_TRANSFER_FROM_BUTTON_ID: 'transferFromButton',
   PERSONAL_SIGN: 'personalSign',
-  SEAPORT_BULK_ORDER: 'signSeaportBulkOrder',
+  PERMIT_SIGN: 'signPermit',
   SET_APPROVAL_FOR_ALL_NFT_BUTTON_ID: 'setApprovalForAllButton',
   SET_APPROVAL_FOR_ALL_ERC1155_BUTTON_ID: 'setApprovalForAllERC1155Button',
   SIGN_TYPE_DATA: 'signTypedData',

--- a/e2e/selectors/Browser/TestDapp.selectors.js
+++ b/e2e/selectors/Browser/TestDapp.selectors.js
@@ -8,6 +8,7 @@ export const TestDappSelectorsWebIDs = {
   INCREASE_ALLOWANCE_BUTTON_ID: 'increaseTokenAllowance',
   NFT_TRANSFER_FROM_BUTTON_ID: 'transferFromButton',
   PERSONAL_SIGN: 'personalSign',
+  SEAPORT_BULK_ORDER: 'signSeaportBulkOrder',
   SET_APPROVAL_FOR_ALL_NFT_BUTTON_ID: 'setApprovalForAllButton',
   SET_APPROVAL_FOR_ALL_ERC1155_BUTTON_ID: 'setApprovalForAllERC1155Button',
   SIGN_TYPE_DATA: 'signTypedData',

--- a/e2e/selectors/Confirmation/ConfirmationView.selectors.js
+++ b/e2e/selectors/Confirmation/ConfirmationView.selectors.js
@@ -22,7 +22,5 @@ export const ConfirmationPageSectionsSelectorIDs = {
   SIWE_SIGNING_ACCOUNT_INFO_SECTION: 'siwe-signing-account-info-section',
   MESSAGE_SECTION: 'message-section',
   STAKING_DETAILS_SECTION: 'staking-details-section',
+  SCROLL_BUTTON: 'scroll-to-bottom-button',
 };
-
-export const ConfirmationPageScrollButton =
-  'confirmation-scroll-to-bottom-button';

--- a/e2e/selectors/Confirmation/ConfirmationView.selectors.js
+++ b/e2e/selectors/Confirmation/ConfirmationView.selectors.js
@@ -23,3 +23,6 @@ export const ConfirmationPageSectionsSelectorIDs = {
   MESSAGE_SECTION: 'message-section',
   STAKING_DETAILS_SECTION: 'staking-details-section',
 };
+
+export const ConfirmationPageScrollButton =
+  'confirmation-scroll-to-bottom-button';

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -2,6 +2,7 @@
 import Assertions from '../../../utils/Assertions.js';
 import Browser from '../../../pages/Browser/BrowserView.js';
 import FixtureBuilder from '../../../fixtures/fixture-builder.js';
+import FooterActions from '../../../pages/Browser/Confirmations/FooterActions.js';
 import PageSections from '../../../pages/Browser/Confirmations/PageSections.js';
 import TabBarComponent from '../../../pages/wallet/TabBarComponent.js';
 import TestDApp from '../../../pages/Browser/TestDApp.js';
@@ -29,33 +30,7 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
     await TestHelpers.reverseServerPort();
   });
 
-  it('should not display scroll button if the page has no scroll', async () => {
-    await withFixtures(
-      {
-        dapp: true,
-        fixture: new FixtureBuilder()
-          .withGanacheNetwork()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        restartDevice: true,
-        ganacheOptions: defaultGanacheOptions,
-        testSpecificMock: {
-          GET: [mockEvents.GET.remoteFeatureFlagsReDesignedConfirmations],
-        },
-      },
-      async () => {
-        await loginToApp();
-
-        await TabBarComponent.tapBrowser();
-        await Browser.navigateToTestDApp();
-
-        await TestDApp.tapPersonalSignButton();
-        await Assertions.checkIfNotVisible(PageSections.ScrollButton);
-      },
-    );
-  });
-
-  it('should display scroll button if the page has scroll', async () => {
+  it('should display scroll button only if the page has scroll', async () => {
     await withFixtures(
       {
         dapp: true,
@@ -88,8 +63,13 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
         await TabBarComponent.tapBrowser();
         await Browser.navigateToTestDApp();
 
+        await TestDApp.tapPersonalSignButton();
+        await Assertions.checkIfNotVisible(PageSections.ScrollButton);
+        await FooterActions.tapCancelButton();
+
         await TestDApp.tapPermitSignButton();
         await Assertions.checkIfVisible(PageSections.ScrollButton);
+        await FooterActions.tapCancelButton();
       },
     );
   });

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -1,0 +1,75 @@
+'use strict';
+import Assertions from '../../../utils/Assertions.js';
+import Browser from '../../../pages/Browser/BrowserView.js';
+import FixtureBuilder from '../../../fixtures/fixture-builder.js';
+import PageSections from '../../../pages/Browser/Confirmations/PageSections.js';
+import RequestTypes from '../../../pages/Browser/Confirmations/RequestTypes.js';
+import TabBarComponent from '../../../pages/wallet/TabBarComponent.js';
+import TestDApp from '../../../pages/Browser/TestDApp.js';
+import TestHelpers from '../../../helpers.js';
+import { loginToApp } from '../../../viewHelper.js';
+import {
+  withFixtures,
+  defaultGanacheOptions,
+} from '../../../fixtures/fixture-helper.js';
+import { SmokeConfirmationsRedesigned } from '../../../tags.js';
+import { mockEvents } from '../../../api-mocking/mock-config/mock-events.js';
+
+describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
+  const testSpecificMock = {
+    GET: [mockEvents.GET.remoteFeatureFlagsReDesignedConfirmations],
+  };
+
+  beforeAll(async () => {
+    jest.setTimeout(2500000);
+    await TestHelpers.reverseServerPort();
+  });
+
+  it('should not display scroll button if the page has no scroll', async () => {
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestDApp.tapPersonalSignButton.bind(TestDApp);
+        await Assertions.checkIfNotVisible(PageSections.ScrollButton);
+      },
+    );
+  });
+
+  it('should display scroll button if the page has scroll', async () => {
+    await withFixtures(
+      {
+        dapp: true,
+        fixture: new FixtureBuilder()
+          .withGanacheNetwork()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        restartDevice: true,
+        ganacheOptions: defaultGanacheOptions,
+        testSpecificMock,
+      },
+      async () => {
+        await loginToApp();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToTestDApp();
+
+        await TestDApp.tapSeaportBulkSignButton.bind(TestDApp);
+        await Assertions.checkIfVisible(PageSections.ScrollButton);
+      },
+    );
+  });
+});

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -3,7 +3,6 @@ import Assertions from '../../../utils/Assertions.js';
 import Browser from '../../../pages/Browser/BrowserView.js';
 import FixtureBuilder from '../../../fixtures/fixture-builder.js';
 import PageSections from '../../../pages/Browser/Confirmations/PageSections.js';
-import RequestTypes from '../../../pages/Browser/Confirmations/RequestTypes.js';
 import TabBarComponent from '../../../pages/wallet/TabBarComponent.js';
 import TestDApp from '../../../pages/Browser/TestDApp.js';
 import TestHelpers from '../../../helpers.js';
@@ -67,7 +66,7 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
         await TabBarComponent.tapBrowser();
         await Browser.navigateToTestDApp();
 
-        await TestDApp.tapSeaportBulkSignButton.bind(TestDApp);
+        await TestDApp.tapPermitSignButton.bind(TestDApp);
         await Assertions.checkIfVisible(PageSections.ScrollButton);
       },
     );

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -49,7 +49,7 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
         await TabBarComponent.tapBrowser();
         await Browser.navigateToTestDApp();
 
-        await TestDApp.tapPersonalSignButton.bind(TestDApp);
+        await TestDApp.tapPersonalSignButton();
         await Assertions.checkIfNotVisible(PageSections.ScrollButton);
       },
     );
@@ -88,7 +88,7 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
         await TabBarComponent.tapBrowser();
         await Browser.navigateToTestDApp();
 
-        await TestDApp.tapPermitSignButton.bind(TestDApp);
+        await TestDApp.tapPermitSignButton();
         await Assertions.checkIfVisible(PageSections.ScrollButton);
       },
     );

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -14,11 +14,16 @@ import {
 import { SmokeConfirmationsRedesigned } from '../../../tags.js';
 import { mockEvents } from '../../../api-mocking/mock-config/mock-events.js';
 
-describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
-  const testSpecificMock = {
-    GET: [mockEvents.GET.remoteFeatureFlagsReDesignedConfirmations],
-  };
+const permitSignRequestBody = {
+  method: 'eth_signTypedData_v4',
+  params: [
+    '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
+    '{"primaryType":"Permit","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"domain":{"chainId":1,"name":"MyToken","verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC","version":"1"},"message":{"owner":"0x8eeee1781fd885ff5ddef7789486676961873d12","spender":"0x5B38Da6a701c568545dCfcB03FcB875f56beddC4","value":3000,"nonce":0,"deadline":50000000000}}',
+  ],
+  origin: 'localhost',
+};
 
+describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
   beforeAll(async () => {
     jest.setTimeout(2500000);
     await TestHelpers.reverseServerPort();
@@ -34,7 +39,9 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        testSpecificMock,
+        testSpecificMock: {
+          GET: [mockEvents.GET.remoteFeatureFlagsReDesignedConfirmations],
+        },
       },
       async () => {
         await loginToApp();
@@ -58,7 +65,22 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
           .build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        testSpecificMock,
+        testSpecificMock: {
+          GET: [mockEvents.GET.remoteFeatureFlagsReDesignedConfirmations],
+          POST: [
+            {
+              ...mockEvents.POST.securityAlertApiValidate,
+              requestBody: permitSignRequestBody,
+              response: {
+                block: 20733277,
+                result_type: 'Malicious',
+                reason: 'malicious_domain',
+                description: `You're interacting with a malicious domain. If you approve this request, you might lose your assets.`,
+                features: [],
+              },
+            },
+          ],
+        },
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
+++ b/e2e/specs/confirmations-redesigned/signatures/confirm-scroll.spec.js
@@ -69,6 +69,8 @@ describe(SmokeConfirmationsRedesigned('Confirmations Page Scroll'), () => {
 
         await TestDApp.tapPermitSignButton();
         await Assertions.checkIfVisible(PageSections.ScrollButton);
+        await PageSections.tapScrollButton();
+        await Assertions.checkIfNotVisible(PageSections.ScrollButton);
         await FooterActions.tapCancelButton();
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adding e2e for confirmation page scroll button

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4218

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
