### PR TITLE
fix: update toLocaleString locale to undefined

### DIFF
--- a/app/components/UI/Stake/components/StakingEarnings/StakingEarningsHistory/StakingEarningsHistory.utils.ts
+++ b/app/components/UI/Stake/components/StakingEarnings/StakingEarningsHistory/StakingEarningsHistory.utils.ts
@@ -36,16 +36,16 @@ export const getEntryTimePeriodGroupInfo = (
     listGroupLabel: '',
     listGroupHeader: '',
   };
-  const dayLabel = date.toLocaleString('fullwide', {
+  const dayLabel = date.toLocaleString(undefined, {
     month: 'long',
     day: 'numeric',
     timeZone: 'UTC',
   });
-  const monthLabel = date.toLocaleString('fullwide', {
+  const monthLabel = date.toLocaleString(undefined, {
     month: 'long',
     timeZone: 'UTC',
   });
-  const yearLabel = date.toLocaleString('fullwide', {
+  const yearLabel = date.toLocaleString(undefined, {
     year: 'numeric',
     timeZone: 'UTC',
   });


### PR DESCRIPTION
## **Description**

This PR removes 'fullwide' as an arg to Date.toLocaleString as it is not supported. Instead use undefined so that the locale will be set automatically.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/STAKE-947

## **Manual testing steps**

1. Go to iphone settings > General > Language and Region and switch to France with English US as a primary and French as a secondary language
2. Go to the user rewards history graph on the ETH asset detail page, the dates should be human-readable text
3. Go to iphone settings > General > Language and Region and switch to France with English US as a primary and French as a secondary language
4. Go to the user rewards history graph on the ETH asset detail page, the dates should be human-readable text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

n/a

### **After**

https://github.com/user-attachments/assets/7f8e061e-8418-42b5-82a0-fe057fc1a1ad

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
