### PR TITLE
MMQA-228: test: Fix Stake Claim smoke test flakiness on Android

### DIFF
--- a/e2e/specs/stake/stake-action-smoke.spec.js
+++ b/e2e/specs/stake/stake-action-smoke.spec.js
@@ -261,6 +261,14 @@ it('should Stake Claim ETH', async () => {
   await TokenOverview.tapClaimButton();
   await StakeConfirmView.tapConfirmButton();
   await TokenOverview.tapBackButton();
+  //Wait for transaction to complete
+  try {
+    await Assertions.checkIfTextIsDisplayed('Transaction #3 Complete!',30000);
+    await TestHelpers.delay(8000);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+       console.log(`Transaction complete didn't pop up: ${e}`);
+    }
   await TabBarComponent.tapActivity();
   await Assertions.checkIfVisible(ActivitiesView.title);
   await Assertions.checkIfVisible(ActivitiesView.stackingClaimLabel);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses the flakiness of the Stake Claim smoke test on Android. The issue occurs when attempting to click on the Activity Tab. Due to a toast message appearing, the automation inadvertently clicks on the toast message, which opens the transaction details view instead of the Activity view. This causes the automation to fail as seen in the video below. This PR provides a workaround for the problem.

https://github.com/user-attachments/assets/42726769-4098-4503-bd43-dc0751891552


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
