### PR TITLE
fix: error thrown from DisplayURL component

### DIFF
--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 
 import Icon, {
@@ -16,16 +16,18 @@ interface DisplayURLProps {
 }
 
 const DisplayURL = ({ url }: DisplayURLProps) => {
-  let urlObject;
+  const [isHTTP, setIsHTTP] = useState(false);
 
-  try {
-    urlObject = new URL(url);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
-  }
-
-  const isHTTP = urlObject?.protocol === 'http:';
+  useEffect(() => {
+    let urlObject;
+    try {
+      urlObject = new URL(url);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
+    }
+    setIsHTTP(urlObject?.protocol === 'http:');
+  }, [url]);
 
   const urlWithoutProtocol = url?.replace(/https?:\/\//u, '');
 


### PR DESCRIPTION
## **Description**

PR fixes error thrown from DisplayURL component. I found that error throw during rendering phase get propagated despite try/catch block. The PR wraps code in `useEffect` hook.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13580

## **Manual testing steps**

1. Go to dapp not using `https://` only using `http://`
2. Submit signature
3. Check displayed url

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
