### PR TITLE
fix: Confirm button should not be disabled for user to scroll to the bottom of confirmation page

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -18,15 +18,11 @@ import styleSheet from './Confirm.styles';
 const ConfirmWrapped = () => (
   <QRHardwareContextProvider>
     <Title />
-    <ScrollContextProvider
-      scrollableSection={
-        <>
-          <SignatureBlockaidBanner />
-          <Info />
-        </>
-      }
-      staticFooter={<Footer />}
-    ></ScrollContextProvider>
+    <ScrollContextProvider>
+      <SignatureBlockaidBanner />
+      <Info />
+    </ScrollContextProvider>
+    <Footer />
   </QRHardwareContextProvider>
 );
 

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.test.tsx
@@ -6,8 +6,6 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
 // eslint-disable-next-line import/no-namespace
 import * as QRHardwareHook from '../../../context/QRHardwareContext/QRHardwareContext';
-// eslint-disable-next-line import/no-namespace
-import * as ScrollContextHook from '../../../context/ScrollContext/ScrollContext';
 import Footer from './index';
 
 const mockConfirmSpy = jest.fn();
@@ -59,18 +57,6 @@ describe('Footer', () => {
     jest.spyOn(QRHardwareHook, 'useQRHardwareContext').mockReturnValue({
       needsCameraPermission: true,
     } as unknown as QRHardwareHook.QRHardwareContextType);
-    const { getByTestId } = renderWithProvider(<Footer />, {
-      state: personalSignatureConfirmationState,
-    });
-    expect(
-      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
-    ).toBe(true);
-  });
-
-  it('confirm button is disabled if `isScrollToBottomNeeded` is true', () => {
-    jest.spyOn(ScrollContextHook, 'useScrollContext').mockReturnValue({
-      isScrollToBottomNeeded: true,
-    } as unknown as ScrollContextHook.ScrollContextType);
     const { getByTestId } = renderWithProvider(<Footer />, {
       state: personalSignatureConfirmationState,
     });

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -8,11 +8,12 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
-import Text, { TextVariant } from '../../../../../../component-library/components/Texts/Text';
+import Text, {
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import AppConstants from '../../../../../../core/AppConstants';
 import { useQRHardwareContext } from '../../../context/QRHardwareContext/QRHardwareContext';
-import { useScrollContext } from '../../../context/ScrollContext';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
 import { useTransactionMetadataRequest } from '../../../hooks/useTransactionMetadataRequest';
@@ -24,15 +25,17 @@ const Footer = () => {
   const { isQRSigningInProgress, needsCameraPermission } =
     useQRHardwareContext();
   const { securityAlertResponse } = useSecurityAlertResponse();
-  const { isScrollToBottomNeeded } = useScrollContext();
-  const confirmDisabled = needsCameraPermission || isScrollToBottomNeeded;
+  const confirmDisabled = needsCameraPermission;
   const transactionMetadata = useTransactionMetadataRequest();
   const isStakingConfirmation = [
     TransactionType.stakingDeposit,
     TransactionType.stakingUnstake,
     TransactionType.stakingClaim,
   ].includes(transactionMetadata?.type as TransactionType);
-  const { styles } = useStyles(styleSheet, { confirmDisabled, isStakingConfirmation });
+  const { styles } = useStyles(styleSheet, {
+    confirmDisabled,
+    isStakingConfirmation,
+  });
 
   return (
     <View>
@@ -65,9 +68,7 @@ const Footer = () => {
       </View>
       {isStakingConfirmation && (
         <View style={styles.textContainer}>
-          <Text
-            variant={TextVariant.BodySM}
-          >
+          <Text variant={TextVariant.BodySM}>
             {strings('confirm.staking_footer.part1')}
           </Text>
           <Text
@@ -77,21 +78,19 @@ const Footer = () => {
           >
             {strings('confirm.staking_footer.terms_of_use')}
           </Text>
-          <Text
-            variant={TextVariant.BodySM}
-          >
+          <Text variant={TextVariant.BodySM}>
             {strings('confirm.staking_footer.part2')}
           </Text>
           <Text
             variant={TextVariant.BodySM}
             style={styles.linkText}
-            onPress={() => Linking.openURL(AppConstants.URLS.STAKING_RISK_DISCLOSURE)}
+            onPress={() =>
+              Linking.openURL(AppConstants.URLS.STAKING_RISK_DISCLOSURE)
+            }
           >
             {strings('confirm.staking_footer.risk_disclosure')}
           </Text>
-          <Text
-            variant={TextVariant.BodySM}
-          >
+          <Text variant={TextVariant.BodySM}>
             {strings('confirm.staking_footer.part3')}
           </Text>
         </View>

--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import { ConfirmationFooterSelectorIDs } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../../util/test/confirm-data-helpers';
-import Footer from '../../components/Confirm/Footer';
 import Info from '../../components/Confirm/Info';
 import { ScrollContextProvider, useScrollContext } from './ScrollContext';
 
@@ -30,27 +28,11 @@ jest.mock('../../../../../core/Engine', () => ({
 }));
 
 describe('ScrollContext', () => {
-  it('does not disable confirm button if there is no scroll', () => {
-    const { getByTestId } = renderWithProvider(
-      <ScrollContextProvider
-        scrollableSection={<Info />}
-        staticFooter={<Footer />}
-      />,
-      {
-        state: personalSignatureConfirmationState,
-      },
-    );
-    expect(
-      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
-    ).toBe(false);
-  });
-
   it('scroll button is not rendered if there is no scroll', () => {
     const { queryByTestId } = renderWithProvider(
-      <ScrollContextProvider
-        scrollableSection={<Info />}
-        staticFooter={<Footer />}
-      />,
+      <ScrollContextProvider>
+        <Info />
+      </ScrollContextProvider>,
       {
         state: personalSignatureConfirmationState,
       },

--- a/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
+++ b/app/components/Views/confirmations/context/ScrollContext/ScrollContext.tsx
@@ -18,7 +18,10 @@ import {
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
-import { IconColor, IconName } from '../../../../../component-library/components/Icons/Icon';
+import {
+  IconColor,
+  IconName,
+} from '../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './ScrollContext.styles';
 
@@ -31,13 +34,11 @@ export const ScrollContext = createContext<ScrollContextType>({
 });
 
 export interface ScrollContextProviderProps {
-  scrollableSection: ReactElement | ReactElement[];
-  staticFooter: ReactElement;
+  children: ReactElement | ReactElement[];
 }
 
 export const ScrollContextProvider: React.FC<ScrollContextProviderProps> = ({
-  scrollableSection,
-  staticFooter,
+  children,
 }) => {
   const [hasScrolledToBottom, setScrolledToBottom] = useState(false);
   const [isScrollable, setIsScrollable] = useState(false);
@@ -99,11 +100,10 @@ export const ScrollContextProvider: React.FC<ScrollContextProviderProps> = ({
       >
         <TouchableWithoutFeedback>
           <View ref={scrolledSectionRef} style={styles.scrollableSection}>
-            {scrollableSection}
+            {children}
           </View>
         </TouchableWithoutFeedback>
       </ScrollView>
-      {staticFooter}
     </ScrollContext.Provider>
   );
 };


### PR DESCRIPTION
## **Description**

Confirm button should not be disabled for user to scroll to the bottom of confirmation page.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4259

## **Manual testing steps**

1. Go to test DAPP
2. Check permit with scroll
3. Confirm button should not be disabled

## **Screenshots/Recordings**
<img width="386" alt="Screenshot 2025-02-20 at 4 37 02 PM" src="https://github.com/user-attachments/assets/5141ada4-d2ba-4e86-b643-79b11cad6f5b" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
