### PR TITLE
fix(action): revert recent change, due to impossibility to indicate working directory for reusable workflows from github-tools repo

### DIFF
--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -21,9 +21,16 @@ jobs:
         if: steps.extract_version.outputs.version
         uses: actions/checkout@v4
 
-      - name: Setup environment
+      - name: Set up Node.js
         if: steps.extract_version.outputs.version
-        uses: metamask/github-tools/.github/actions/setup-environment@main
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        if: steps.extract_version.outputs.version
+        run: yarn --immutable
+        working-directory: '.github/scripts'
 
       - name: Create bug report issue on planning repo
         if: steps.extract_version.outputs.version


### PR DESCRIPTION
## **Description**

On Mobile repo ci-only devDependencies were moved into a separate project file in this [PR](https://github.com/MetaMask/metamask-mobile/pull/10917) back in September 2024. A consequence of this change is that we now have to keep indicating the working directory in our GitHub actions on the Mobile repo ([example](https://github.com/MetaMask/metamask-mobile/pull/13419/files)).

When I merged this [PR](https://github.com/MetaMask/metamask-mobile/pull/13562) earlier today, I broke the Github action because because I haven't been able to specify the working directory for the "setup-environment" reusable workflow imported from github-tools repo.

The purpose of this PR is to revert the changes that broke the Github action.

## **Related issues**

None

## **Manual testing steps**

None, this PR needs to be merged to retry the Github action.

## **Screenshots/Recordings**

[Here's](https://github.com/MetaMask/metamask-mobile/actions/runs/13433823463/job/37531485933) where the issue occured.
<img width="1390" alt="Screenshot 2025-02-20 at 08 18 23" src="https://github.com/user-attachments/assets/4bde8476-211a-4cec-92ea-a73efb36ac28" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
