### PR TITLE
fix: Disabling sentry capturing temporarily till we address issue with url missing protocol

### DIFF
--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
@@ -7,7 +7,7 @@ import Icon, {
   IconSize,
 } from '../../../../../../../../component-library/components/Icons/Icon';
 import Text from '../../../../../../../../component-library/components/Texts/Text';
-import Logger from '../../../../../../../../util/Logger';
+// import Logger from '../../../../../../../../util/Logger';
 import { useStyles } from '../../../../../../../../component-library/hooks';
 import styleSheet from './DisplayURL.styles';
 
@@ -23,8 +23,9 @@ const DisplayURL = ({ url }: DisplayURLProps) => {
     try {
       urlObject = new URL(url);
     } catch (e) {
-      // eslint-disable-next-line no-console
-      Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
+      // Commenting out the line below till issue of missing protocol in origin is addressed
+      // https://github.com/MetaMask/metamask-mobile/issues/13580#issuecomment-2671458216
+      // Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
     }
     setIsHTTP(urlObject?.protocol === 'http:');
   }, [url]);


### PR DESCRIPTION
## **Description**
The underlying issue causing the sentry logs [here](https://github.com/MetaMask/metamask-mobile/issues/13580#issuecomment-2671458216) is that `approvalRequest.origin` is missing protocol. This PR temporarily disables sentry logging till we fix underlying issue.

## **Related issues**

Ref: https://github.com/MetaMask/metamask-mobile/issues/13580#issuecomment-2671458216

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
