### PR TITLE
fix: hide simulation button pill value if no value loaded

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.test.tsx
@@ -101,6 +101,24 @@ describe('SimulationValueDisplay', () => {
     expect(await findByTestId('simulation-value-display-loader')).toBeDefined();
   });
 
+  it('renders no value display if no value was loaded', () => {
+    (useGetTokenStandardAndDetails as jest.MockedFn<typeof useGetTokenStandardAndDetails>).mockReturnValue({
+      details: { decimalsNumber: undefined },
+      isPending: false,
+    });
+
+    const { queryByTestId } = renderWithProvider(
+      <SimulationValueDisplay
+        modalHeaderText={'Spending Cap'}
+        tokenContract={'0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'}
+        value={''}
+        chainId={'0x1'}
+      />,
+      { state: mockInitialState },
+    );
+    expect(queryByTestId('simulation-value-display-loader')).not.toBeTruthy();
+  });
+
   it('renders "Unlimited" for large values when canDisplayValueAsUnlimited is true', async () => {
     (useGetTokenStandardAndDetails as jest.MockedFn<typeof useGetTokenStandardAndDetails>).mockReturnValue({
       details: {

--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.tsx
@@ -153,6 +153,11 @@ const SimulationValueDisplay: React.FC<SimulationValueDisplayParams> = ({
     return null;
   }
 
+  // Avoid empty button pill container
+  const showValueButtonPill = Boolean(isPendingTokenDetails
+    || shouldShowUnlimitedValue
+    || (tokenValue !== null || tokenId));
+
   function handlePressTokenValue() {
     setHasValueModalOpen(true);
   }
@@ -161,7 +166,7 @@ const SimulationValueDisplay: React.FC<SimulationValueDisplayParams> = ({
       <View style={styles.wrapper}>
         <View style={styles.flexRowTokenValueAndAddress}>
           <View style={styles.valueAndAddress}>
-            {
+            {showValueButtonPill &&
               <AnimatedPulse isPulsing={isPendingTokenDetails} testID="simulation-value-display-loader">
                 <ButtonPill
                   isDisabled={isNFT}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In case no value was loaded in a permit simulation, then we should not display an empty value ButtonPill component.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13662

## **Manual testing steps**

e.g.

1. Go to https://develop.d3bkcslj57l47p.amplifyapp.com/
2. Trigger DAI
We are also fixing this particular issue here: https://github.com/MetaMask/metamask-mobile/issues/13336. Adding this PR to be more robust and prevent other outlying cases

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
