### PR TITLE
fix: TypedSignDecoded revoke state changes should show "Revoke" not "Spending cap"

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/TypedSignDecoded/TypedSignDecoded.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/TypedSignDecoded/TypedSignDecoded.test.tsx
@@ -26,6 +26,16 @@ const stateChangesApprove = [
   },
 ];
 
+const stateChangesRevoke = [
+  {
+    assetType: 'ERC20',
+    changeType: DecodingDataChangeType.Revoke,
+    address: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+    amount: '12345',
+    contractAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  },
+];
+
 const stateChangesListingERC1155: DecodingDataStateChanges = [
   {
     assetType: 'NATIVE',
@@ -108,6 +118,17 @@ describe('DecodedSimulation', () => {
 
     // Loading renders before the token value renders
     expect(getByTestId('simulation-value-display-loader')).toBeDefined();
+
+    await waitFor(() => expect(getByText('12,345')).toBeDefined());
+  });
+
+  it('renders for ERC20 revoke', async () => {
+    const { getByText } = renderWithProvider(<TypedSignDecoded />, {
+      state: mockState(stateChangesRevoke),
+    });
+
+    expect(await getByText('Estimated changes')).toBeDefined();
+    expect(await getByText('Revoke')).toBeDefined();
 
     await waitFor(() => expect(getByText('12,345')).toBeDefined());
   });

--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/TypedSignDecoded/TypedSignDecoded.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/TypedSignDecoded/TypedSignDecoded.tsx
@@ -84,7 +84,7 @@ const getStateChangeLabelMap = (
         ? strings('confirm.simulation.label_change_type_nft_listing')
         : strings('confirm.simulation.label_change_type_receive'),
     [DecodingDataChangeType.Approve]: strings('confirm.simulation.label_change_type_permit'),
-    [DecodingDataChangeType.Revoke]: strings('confirm.simulation.label_change_type_permit'),
+    [DecodingDataChangeType.Revoke]: strings('confirm.simulation.label_change_type_revoke'),
     [DecodingDataChangeType.Bidding]: strings('confirm.simulation.label_change_type_bidding'),
     [DecodingDataChangeType.Listing]: strings('confirm.simulation.label_change_type_listing'),
   }[changeType]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This issue has been around since https://github.com/MetaMask/metamask-mobile/pull/12994 upon launching the decoding simulation 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13664

## **Manual testing steps**

1. Create a decoded simulation revoke transaction 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
