### PR TITLE
Expand button for better DApp UX

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -12,8 +12,10 @@ import {
   ImageSourcePropType,
   KeyboardAvoidingView,
   Platform,
+  TouchableWithoutFeedback,
 } from 'react-native';
-import { isEqual } from 'lodash';
+import Icon from 'react-native-vector-icons/FontAwesome';
+import { isEqual, set } from 'lodash';
 import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';
 import BrowserBottomBar from '../../UI/BrowserBottomBar';
 import { connect, useSelector } from 'react-redux';
@@ -146,6 +148,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
   const [blockedUrl, setBlockedUrl] = useState<string>();
   const [ipfsBannerVisible, setIpfsBannerVisible] = useState(false);
   const [isResolvedIpfsUrl, setIsResolvedIpfsUrl] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [isUrlBarFocused, setIsUrlBarFocused] = useState(false);
   const [connectionType, setConnectionType] = useState(ConnectionType.UNKNOWN);
   const webviewRef = useRef<WebView>(null);
@@ -436,6 +439,14 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
       newTab(newTabUrl);
     },
     [dismissTextSelectionIfNeeded, newTab, toggleOptionsIfNeeded],
+  );
+
+  const expandBrowser = useCallback(
+    () => {
+      toggleOptionsIfNeeded();
+      setIsExpanded(true);
+    },
+    [toggleOptionsIfNeeded],
   );
 
   /**
@@ -1007,6 +1018,13 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
   };
 
   /**
+  * Hide the header and the controls 
+  */
+  const onExpand = () => {
+    expandBrowser();
+  };
+
+  /**
    * Show the different tabs
    */
   const triggerShowTabs = () => {
@@ -1170,6 +1188,17 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
       />
     ) : null;
 
+
+    const renderUnExpandButton = () => (
+      <TouchableWithoutFeedback onPress={() => {
+        setIsExpanded(false);
+      }}>
+        <View style={styles.unexpandButton}>
+          <Icon name="compress" size={24} color="colors.primary" />
+        </View>
+      </TouchableWithoutFeedback>
+    );
+
   /**
    * Handle autocomplete selection
    */
@@ -1312,7 +1341,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
           style={styles.wrapper}
           {...(Device.isAndroid() ? { collapsable: false } : {})}
         >
-          <BrowserUrlBar
+          {!isExpanded && <BrowserUrlBar
             ref={urlBarRef}
             connectionType={connectionType}
             onSubmitEditing={onSubmitEditing}
@@ -1324,7 +1353,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
             activeUrl={resolvedUrlRef.current}
             setIsUrlBarFocused={setIsUrlBarFocused}
             isUrlBarFocused={isUrlBarFocused}
-          />
+          />}
           <View style={styles.wrapper}>
             {renderProgressBar()}
             <View style={styles.webview}>
@@ -1399,6 +1428,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
             <Options
               toggleOptions={toggleOptions}
               onNewTabPress={onNewTabPress}
+              onExpand={onExpand}
               toggleOptionsIfNeeded={toggleOptionsIfNeeded}
               activeUrl={resolvedUrlRef.current}
               isHomepage={isHomepage}
@@ -1411,8 +1441,8 @@ export const BrowserTab: React.FC<BrowserTabProps> = ({
               icon={iconRef}
             />
           )}
-
-          {renderBottomBar()}
+          {isExpanded && renderUnExpandButton()}
+          {!isExpanded && renderBottomBar()}
           {isTabActive && renderOnboardingWizard()}
         </View>
       </KeyboardAvoidingView>

--- a/app/components/Views/BrowserTab/components/Options/index.tsx
+++ b/app/components/Views/BrowserTab/components/Options/index.tsx
@@ -16,6 +16,7 @@ import Button from '../../../../UI/Button';
 import { strings } from '../../../../../../locales/i18n';
 import {
   ADD_FAVORITES_OPTION,
+  EXPAND_OPTION,
   MENU_ID,
   NEW_TAB_OPTION,
   OPEN_FAVORITES_OPTION,
@@ -50,6 +51,7 @@ interface OptionsProps {
   sessionENSNames: SessionENSNames;
   favicon: ImageSourcePropType;
   icon: MutableRefObject<ImageSourcePropType | undefined>;
+  onExpand: () => void;
 }
 
 /**
@@ -68,6 +70,7 @@ const Options = ({
   sessionENSNames,
   favicon,
   icon,
+  onExpand
 }: OptionsProps) => {
   // This any can be removed when react navigation is bumped to v6 - issue https://github.com/react-navigation/react-navigation/issues/9037#issuecomment-735698288
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -93,6 +96,7 @@ const Options = ({
       createEventBuilder(MetaMetricsEvents.DAPP_OPEN_IN_BROWSER).build(),
     );
   };
+
   /**
    * Go to favorites page
    */
@@ -287,7 +291,7 @@ const Options = ({
         {renderShareOption()}
         <Button onPress={openInBrowser} style={styles.option}>
           <View style={styles.optionIconWrapper}>
-            <Icon name="expand" size={16} style={styles.optionIcon} />
+            <Icon name="external-link" size={16} style={styles.optionIcon} />
           </View>
           <Text
             style={styles.optionText}
@@ -295,6 +299,18 @@ const Options = ({
             {...generateTestId(Platform, OPEN_IN_BROWSER_OPTION)}
           >
             {strings('browser.open_in_browser')}
+          </Text>
+        </Button>
+        <Button onPress={onExpand} style={styles.option}>
+          <View style={styles.optionIconWrapper}>
+            <Icon name="expand" size={16} style={styles.optionIcon} />
+          </View>
+          <Text
+            style={styles.optionText}
+            numberOfLines={2}
+            {...generateTestId(Platform, EXPAND_OPTION)}
+          >
+            {strings('browser.expand')}
           </Text>
         </Button>
       </React.Fragment>

--- a/app/components/Views/BrowserTab/styles.ts
+++ b/app/components/Views/BrowserTab/styles.ts
@@ -151,6 +151,14 @@ const styleSheet = ({ theme: { colors, shadows } }: { theme: Theme }) => {
       right: 16,
       borderRadius: 4,
     },
+    unexpandButton: {
+      position: 'absolute',
+      top: 10,
+      right: 10,
+      backgroundColor: colors.primary.muted,
+      borderRadius: 20,
+      padding: 5,
+    }
   });
 };
 

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -1020,6 +1020,7 @@ enum DESCRIPTION {
   DAPP_ADD_TO_FAVORITE = 'Add to Favorites',
   DAPP_GO_TO_FAVORITES = 'Go to Favorites',
   DAPP_OPEN_IN_BROWSER = 'Open in Browser',
+  DAPP_EXPAND = 'Expand',
   // Wallet
   WALLET_TOKENS = 'Tokens',
   WALLET_COLLECTIBLES = 'Collectibles',
@@ -1139,6 +1140,11 @@ const legacyMetaMetricsEvents = {
     EVENT_NAME.DAPP_VIEW,
     ACTIONS.DAPP_VIEW,
     DESCRIPTION.DAPP_OPEN_IN_BROWSER,
+  ),
+  DAPP_EXPAND: generateOpt(
+    EVENT_NAME.DAPP_VIEW,
+    ACTIONS.DAPP_VIEW,
+    DESCRIPTION.DAPP_EXPAND,
   ),
   DAPP_GO_TO_FAVORITES: generateOpt(
     EVENT_NAME.DAPP_VIEW,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1604,6 +1604,7 @@
     "home": "Home",
     "close": "Close",
     "open_in_browser": "Open in browser",
+    "expand": "Expand",
     "change_url": "Change url",
     "switch_network": "Switch network",
     "dapp_browser": "DAPP BROWSER",

--- a/wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds.js
+++ b/wdio/screen-objects/testIDs/BrowserScreen/OptionMenu.testIds.js
@@ -12,4 +12,6 @@ export const SHARE_OPTION = 'browser-options-menu-share';
 
 export const OPEN_IN_BROWSER_OPTION = 'browser-options-menu-open-in-browser';
 
+export const EXPAND_OPTION = 'browser-options-menu-expand';
+
 export const SWITCH_NETWORK_OPTION = 'browser-options-switch-browser';


### PR DESCRIPTION
The expand button hides the bottom bar and the header.

## **Description**

I've added a new option to the browser tab menu that expands the browser. Now the app header and the bottom bar need too much space, which degrades the DApp user experience. Users can hide these components with the expand button to see the DApp as a real app.

## **Related issues**

This PR is related to this: https://community.metamask.io/t/pr-for-fullscreen-in-mobile-metamask-browser/29933

## **Manual testing steps**

1. Go to the browser page
2. Open a DApp page
3. In the menu, choose 'Expand'
4. You can change back by the small 'compress' button on the top right

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/aad7848d-66dc-4782-b458-712d5b37f5f4)

![image](https://github.com/user-attachments/assets/c89b55f2-0fc0-43c4-9e56-c62e88e854f3)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

