### PR TITLE
fix: origin url displayed for signatures

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/PersonalSign/Message.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/PersonalSign/Message.tsx
@@ -12,7 +12,6 @@ import { sanitizeString } from '../../../../../../../util/string';
 import { getSIWEDetails, SIWEMessage } from '../../../../utils/signature';
 import { useSignatureRequest } from '../../../../hooks/useSignatureRequest';
 import Address from '../../../UI/InfoRow/InfoValue/Address';
-import DisplayURL from '../../../UI/InfoRow/InfoValue/DisplayURL';
 import InfoDate from '../../../UI/InfoRow/InfoValue/InfoDate';
 import InfoRow from '../../../UI/InfoRow';
 import Network from '../../../UI/InfoRow/InfoValue/Network';
@@ -59,9 +58,7 @@ const DetailedSIWEMessage = ({
   return (
     <View>
       <Text style={styles.siweTos}>{parsedMessage?.statement}</Text>
-      <InfoRow label={strings('confirm.siwe_message.url')}>
-        <DisplayURL url={uri} />
-      </InfoRow>
+      <InfoRow label={strings('confirm.siwe_message.url')}>{uri}</InfoRow>
       <InfoRow label={strings('confirm.siwe_message.network')}>
         <Network chainId={numberToHex(parseInt(chainId))} />
       </InfoRow>

--- a/app/components/Views/confirmations/components/Confirm/Info/PersonalSign/PersonalSign.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/PersonalSign/PersonalSign.test.tsx
@@ -52,7 +52,8 @@ describe('PersonalSign', () => {
       ),
     ).toHaveLength(2);
     expect(getByText('URL')).toBeDefined();
-    expect(getAllByText('metamask.github.io')).toHaveLength(2);
+    expect(getAllByText('metamask.github.io')).toBeDefined();
+    expect(getAllByText('https://metamask.github.io')).toBeDefined();
     expect(getByText('Network')).toBeDefined();
     expect(getAllByText('Ethereum Mainnet')).toHaveLength(2);
     expect(getByText('Account')).toBeDefined();

--- a/app/components/Views/confirmations/components/Confirm/Info/Shared/InfoRowOrigin/InfoRowOrigin.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/Shared/InfoRowOrigin/InfoRowOrigin.tsx
@@ -30,7 +30,8 @@ const InfoRowOrigin = () => {
         label={strings('confirm.label.request_from')}
         tooltip={strings('confirm.personal_sign_tooltip')}
       >
-        <DisplayURL url={approvalRequest.origin} />
+        {/* TODO: request from url below will only work for signatures */}
+        <DisplayURL url={approvalRequest?.requestData?.meta?.url} />
       </InfoRow>
       {isSIWEMessage && (
         <InfoRow

--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.test.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.test.tsx
@@ -13,4 +13,11 @@ describe('DisplayURL', () => {
     const { getByText } = render(<DisplayURL url="http://google.com" />);
     expect(getByText('HTTP')).toBeTruthy();
   });
+
+  it('displays only the host part of the URL', () => {
+    const { getByText } = render(
+      <DisplayURL url="https://metamask.github.io/test-dapp/" />,
+    );
+    expect(getByText('metamask.github.io')).toBeTruthy();
+  });
 });

--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
@@ -15,6 +15,12 @@ interface DisplayURLProps {
   url: string;
 }
 
+function extractHostname(url: string) {
+  // eslint-disable-next-line no-useless-escape
+  const match = url.match(/^(?:https?:\/\/)?([^\/:]+)/);
+  return match ? match[1] : null;
+}
+
 const DisplayURL = ({ url }: DisplayURLProps) => {
   const [isHTTP, setIsHTTP] = useState(false);
 
@@ -28,7 +34,7 @@ const DisplayURL = ({ url }: DisplayURLProps) => {
     setIsHTTP(urlObject?.protocol === 'http:');
   }, [url]);
 
-  const urlWithoutProtocol = url?.replace(/https?:\/\//u, '');
+  const hostName = extractHostname(url);
 
   const { styles } = useStyles(styleSheet, {});
 
@@ -44,7 +50,7 @@ const DisplayURL = ({ url }: DisplayURLProps) => {
           <Text style={styles.warningText}>HTTP</Text>
         </View>
       )}
-      <Text style={styles.value}>{urlWithoutProtocol}</Text>
+      <Text style={styles.value}>{hostName}</Text>
     </View>
   );
 };

--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
@@ -7,7 +7,7 @@ import Icon, {
   IconSize,
 } from '../../../../../../../../component-library/components/Icons/Icon';
 import Text from '../../../../../../../../component-library/components/Texts/Text';
-// import Logger from '../../../../../../../../util/Logger';
+import Logger from '../../../../../../../../util/Logger';
 import { useStyles } from '../../../../../../../../component-library/hooks';
 import styleSheet from './DisplayURL.styles';
 
@@ -23,9 +23,7 @@ const DisplayURL = ({ url }: DisplayURLProps) => {
     try {
       urlObject = new URL(url);
     } catch (e) {
-      // Commenting out the line below till issue of missing protocol in origin is addressed
-      // https://github.com/MetaMask/metamask-mobile/issues/13580#issuecomment-2671458216
-      // Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
+      Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
     }
     setIsHTTP(urlObject?.protocol === 'http:');
   }, [url]);


### PR DESCRIPTION
## **Description**

Fix request from url displayed for signatures. Wrong url is spamming sentry.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13580

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
