### PR TITLE
feat(ci): Auto add needs-triage label on bug open

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -15,6 +15,7 @@ import {
   RegressionStage,
   craftRegressionLabel,
   externalContributorLabel,
+  needsTriageLabel,
   invalidIssueTemplateLabel,
   invalidPullRequestTemplateLabel,
 } from './shared/label';
@@ -109,6 +110,9 @@ async function main(): Promise<void> {
 
       // Add regression label to the bug report issue
       addRegressionLabelToIssue(octokit, labelable);
+
+      // Add needs triage label to the bug report issue
+      addNeedsTriageLabelToIssue(octokit, labelable);
 
     } else {
       const errorMessage =
@@ -230,6 +234,14 @@ function extractReleaseVersionFromBugReportIssueBody(
   }
 
   return version;
+}
+
+// This function adds the "needs-triage" label to the issue if it doesn't have it
+function addNeedsTriageLabelToIssue(
+  octokit: InstanceType<typeof GitHub>,
+  issue: Labelable,
+): Promise<void> {
+  await addLabelToLabelable(octokit, issue, needsTriageLabel);
 }
 
 // This function adds the correct regression label to the issue, and removes other ones

--- a/.github/scripts/shared/label.ts
+++ b/.github/scripts/shared/label.ts
@@ -28,6 +28,12 @@ export const externalContributorLabel: Label = {
   description: 'Issue or PR created by user outside org',
 };
 
+export const needsTriageLabel: Label = {
+  name: 'needs-triage',
+  color: '#68AEE6',
+  description: 'Issue needs to be triaged',
+};
+
 export const invalidIssueTemplateLabel: Label = {
   name: 'INVALID-ISSUE-TEMPLATE',
   color: 'EDEDED',


### PR DESCRIPTION
## **Description**

We use the stale bot in order to make sure we close out issues which have been open and waiting on additional information from reporters for too long. However, sometimes this can be the case for issues that we just haven't had an opportunity to follow back up on. We feel a couple of process improvements can make this better.

## **Related issues**

Partially fixes: https://github.com/MetaMask/MetaMask-planning/issues/4219

Related to:
https://github.com/MetaMask/github-tools/pull/41/files
https://github.com/MetaMask/metamask-extension/pull/30512

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
