### PR TITLE
fix: cp-7.41.0 13708 fix the submitQRSignature scope issue

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/QRInfo/QRInfo.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/QRInfo/QRInfo.tsx
@@ -31,9 +31,7 @@ const QRInfo = () => {
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [shouldPause, setShouldPause] = useState(false);
 
-  const submitQRSignature = Engine.context.KeyringController.submitQRSignature.bind(
-    Engine.context.KeyringController,
-  );
+  const KeyringController = Engine.context.KeyringController;
 
   useEffect(() => {
     if (scannerVisible) {
@@ -49,7 +47,7 @@ const QRInfo = () => {
       if (buffer) {
         const requestId = uuidStringify(buffer);
         if (QRState?.sign?.request?.requestId === requestId) {
-          submitQRSignature(
+          KeyringController.submitQRSignature(
             QRState.sign.request?.requestId as string,
             ur.cbor.toString('hex'),
           );
@@ -72,7 +70,7 @@ const QRInfo = () => {
       createEventBuilder,
       setRequestCompleted,
       setScannerVisible,
-      submitQRSignature,
+      KeyringController,
       trackEvent,
     ],
   );

--- a/app/components/Views/confirmations/components/Confirm/Info/QRInfo/QRInfo.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/QRInfo/QRInfo.tsx
@@ -31,7 +31,9 @@ const QRInfo = () => {
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [shouldPause, setShouldPause] = useState(false);
 
-  const submitQRSignature = Engine.context.KeyringController.submitQRSignature;
+  const submitQRSignature = Engine.context.KeyringController.submitQRSignature.bind(
+    Engine.context.KeyringController,
+  );
 
   useEffect(() => {
     if (scannerVisible) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1334,12 +1334,12 @@ SPEC CHECKSUMS:
   lottie-react-native: b6776287d7fd31be4fd865059cd890f744242ffd
   MMKV: f7d1d5945c8765f97f39c3d121f353d46735d801
   MMKVCore: c04b296010fcb1d1638f2c69405096aac12f6390
-  MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
+  MultiplatformBleAdapter: ea8bac405ec200d0ca9de0f89afef6f06fb2abbc
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 8dc08ca5a393b48b1c523ab6220dfdcc0fe000ad
+  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: fb207f74935626041e7308c9e88dcdda680f1073
   RCTSearchApi: 5fc36140c598a74fd831dca924a28ed53bc7aa18
   RCTTypeSafety: 146fd11361680250b7580dd1f7f601995cfad1b1

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1334,12 +1334,12 @@ SPEC CHECKSUMS:
   lottie-react-native: b6776287d7fd31be4fd865059cd890f744242ffd
   MMKV: f7d1d5945c8765f97f39c3d121f353d46735d801
   MMKVCore: c04b296010fcb1d1638f2c69405096aac12f6390
-  MultiplatformBleAdapter: ea8bac405ec200d0ca9de0f89afef6f06fb2abbc
+  MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 8dc08ca5a393b48b1c523ab6220dfdcc0fe000ad
   RCTRequired: fb207f74935626041e7308c9e88dcdda680f1073
   RCTSearchApi: 5fc36140c598a74fd831dca924a28ed53bc7aa18
   RCTTypeSafety: 146fd11361680250b7580dd1f7f601995cfad1b1


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This QR is to fix the bug report #13708 , 
The affect area was Personal sign, Sign Typed data v4, sign permit feature.
The error was caused by `submitQRSignature` didnt provide the bind() function to KeyringController, which make the `this` scope in KeyringController change. which cause `this.getOrAddQRKeyring is not a function` error.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #13708 

## **Manual testing steps**

1.Install MM
2. Recover from SRP
3. Add hardware wallet (QR - Keystone)
4. Import QR accounts from device
5. Visit Test dapp
6. Connect QR account
7. Sign permit / Sign typed data v4

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
