### PR TITLE
feat(snaps): Add Snap UI Banner component

### DIFF
--- a/app/components/Snaps/SnapUIBanner/SnapUIBanner.tsx
+++ b/app/components/Snaps/SnapUIBanner/SnapUIBanner.tsx
@@ -1,0 +1,20 @@
+import React, { FunctionComponent } from 'react';
+import Banner, {
+  BannerAlertSeverity,
+  BannerVariant,
+} from '../../../component-library/components/Banners/Banner';
+
+export interface SnapUIBannerProps {
+  severity: BannerAlertSeverity | undefined;
+  title: string;
+}
+
+export const SnapUIBanner: FunctionComponent<SnapUIBannerProps> = ({
+  children,
+  severity,
+  title,
+}) => (
+    <Banner severity={severity} title={title} variant={BannerVariant.Alert}>
+      {children}
+    </Banner>
+  );

--- a/app/components/Snaps/SnapUIBanner/SnapUIBanner.tsx
+++ b/app/components/Snaps/SnapUIBanner/SnapUIBanner.tsx
@@ -14,7 +14,7 @@ export const SnapUIBanner: FunctionComponent<SnapUIBannerProps> = ({
   severity,
   title,
 }) => (
-    <Banner severity={severity} title={title} variant={BannerVariant.Alert}>
-      {children}
-    </Banner>
-  );
+  <Banner severity={severity} title={title} variant={BannerVariant.Alert}>
+    {children}
+  </Banner>
+);

--- a/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
@@ -1,0 +1,105 @@
+import { banner } from './banner';
+import { BannerElement } from '@metamask/snaps-sdk/jsx';
+import { mockTheme } from '../../../../util/theme';
+
+describe('banner component', () => {
+  const defaultParams = {
+    map: {},
+    t: jest.fn(),
+    theme: mockTheme,
+  };
+
+  const createTextElement = (
+    textContent: string,
+  ): BannerElement['props']['children'] => ({
+    type: 'Text' as const,
+    key: 'mock-key',
+    props: { children: textContent },
+  });
+
+  it('should render banner with some props', () => {
+    const el: BannerElement = {
+      type: 'Banner',
+      props: {
+        title: 'Test Title',
+        severity: 'info',
+        children: createTextElement('Test content'),
+      },
+      key: null,
+    };
+
+    const result = banner({ element: el, ...defaultParams });
+
+    expect(result).toEqual({
+      element: 'SnapUIBanner',
+      children: [
+        {
+          element: 'Text',
+          key: 'mock-key',
+          children: [
+            {
+              element: 'RNText',
+              props: {
+                color: 'inherit',
+              },
+              children: 'Test content',
+            },
+          ],
+          props: {
+            color: 'inherit',
+            fontWeight: 'normal',
+            textAlign: 'left',
+            variant: 'sBodyMD',
+          },
+        },
+      ],
+      props: {
+        severity: 'Info',
+        title: 'Test Title',
+      },
+    });
+  });
+
+  it('should properly map danger to error severity prop', () => {
+    const el: BannerElement = {
+      type: 'Banner',
+      props: {
+        title: 'Test Title',
+        severity: 'danger',
+        children: createTextElement('Test content'),
+      },
+      key: null,
+    };
+
+    const result = banner({ element: el, ...defaultParams });
+
+    expect(result).toEqual({
+      element: 'SnapUIBanner',
+      children: [
+        {
+          element: 'Text',
+          key: 'mock-key',
+          children: [
+            {
+              element: 'RNText',
+              props: {
+                color: 'inherit',
+              },
+              children: 'Test content',
+            },
+          ],
+          props: {
+            color: 'inherit',
+            fontWeight: 'normal',
+            textAlign: 'left',
+            variant: 'sBodyMD',
+          },
+        },
+      ],
+      props: {
+        severity: 'Error',
+        title: 'Test Title',
+      },
+    });
+  });
+});

--- a/app/components/Snaps/SnapUIRenderer/components/banner.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.ts
@@ -3,6 +3,14 @@ import { getJsxChildren } from '@metamask/snaps-utils';
 import { mapToTemplate } from '../utils';
 import { UIComponentFactory } from './types';
 
+function transformSeverity(severity: BannerElement['props']['severity']): string {
+  if (severity === 'danger') {
+    return 'Error';
+  }
+
+  return severity?.charAt(0).toUpperCase() + severity?.slice(1);
+}
+
 export const banner: UIComponentFactory<BannerElement> = ({
   element: e,
   ...params
@@ -13,7 +21,6 @@ export const banner: UIComponentFactory<BannerElement> = ({
   ),
   props: {
     title: e.props.title,
-    severity:
-      e.props.severity?.charAt(0).toUpperCase() + e.props.severity?.slice(1),
+    severity: transformSeverity(e.props.severity),
   },
 });

--- a/app/components/Snaps/SnapUIRenderer/components/banner.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.ts
@@ -7,12 +7,13 @@ export const banner: UIComponentFactory<BannerElement> = ({
   element: e,
   ...params
 }) => ({
-    element: 'SnapUIBanner',
-    children: getJsxChildren(e).map((children) =>
-      mapToTemplate({ element: children as JSXElement, ...params }),
-    ),
-    props: {
-      title: e.props.title,
-      severity: e.props.severity,
-    },
-  });
+  element: 'SnapUIBanner',
+  children: getJsxChildren(e).map((children) =>
+    mapToTemplate({ element: children as JSXElement, ...params }),
+  ),
+  props: {
+    title: e.props.title,
+    severity:
+      e.props.severity?.charAt(0).toUpperCase() + e.props.severity?.slice(1),
+  },
+});

--- a/app/components/Snaps/SnapUIRenderer/components/banner.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.ts
@@ -1,0 +1,18 @@
+import { BannerElement, JSXElement } from '@metamask/snaps-sdk/jsx';
+import { getJsxChildren } from '@metamask/snaps-utils';
+import { mapToTemplate } from '../utils';
+import { UIComponentFactory } from './types';
+
+export const banner: UIComponentFactory<BannerElement> = ({
+  element: e,
+  ...params
+}) => ({
+    element: 'SnapUIBanner',
+    children: getJsxChildren(e).map((children) =>
+      mapToTemplate({ element: children as JSXElement, ...params }),
+    ),
+    props: {
+      title: e.props.title,
+      severity: e.props.severity,
+    },
+  });

--- a/app/components/Snaps/SnapUIRenderer/components/index.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/index.ts
@@ -2,6 +2,7 @@ import { box } from './box';
 import { text } from './text';
 import { row } from './row';
 import { button } from './button';
+import { banner } from './banner';
 import { input } from './input';
 import { bold } from './bold';
 import { value } from './value';
@@ -23,6 +24,7 @@ export const COMPONENT_MAPPING = {
   Text: text,
   Row: row,
   Button: button,
+  Banner: banner,
   Input: input,
   Bold: bold,
   Value: value,

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -18,6 +18,7 @@ import { SnapUIFooterButton } from '../../Snaps/SnapUIFooterButton/SnapUIFooterB
 import { ConfirmInfoRowValueDouble } from '../../../component-library/components-temp/Snaps/ConfirmInfoRowValueDouble/ConfirmInfoRowValueDouble';
 import { SnapUIIcon } from '../../Snaps/SnapUIIcon/SnapUIIcon';
 import { SnapUIButton } from '../../Snaps/SnapUIButton/SnapUIButton';
+import { SnapUIBanner } from '../../Snaps/SnapUIBanner/SnapUIBanner';
 import { SnapUICheckbox } from '../../Snaps/SnapUICheckbox/SnapUICheckbox';
 import { SnapUIAddress } from '../../UI/Snaps/SnapUIAddress/SnapUIAddress';
 import { SnapUIAvatar } from '../../UI/Snaps/SnapUIAvatar/SnapUIAvatar';
@@ -47,6 +48,7 @@ export const safeComponentList = {
   SnapUICheckbox,
   SnapUIAvatar,
   SnapUIAddress,
+  SnapUIBanner,
   InfoRow,
   RNText,
 };


### PR DESCRIPTION
## **Description**
Add possibility to use Snap UI Banner component.

## **Related issues**
Fixes: https://github.com/MetaMask/snaps/issues/3151

## **Manual testing steps**
1. Install a test Snap with provided code and test banner rendering result.

```typescript
export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          type: 'confirmation',
          content: (
            <Container>
              <Box>
                <Box>
                  <Banner title="Snap Banner" severity="info">
                    <Text>Hello, this is Snap UI banner - info!</Text>
                  </Banner>
                </Box>
                <Box>
                  <Banner title="Snap Banner" severity="danger">
                    <Text>Hello, this is Snap UI banner - danger!</Text>
                  </Banner>
                </Box>
                <Box>
                  <Banner title="Snap Banner" severity="success">
                    <Text>Hello, this is Snap UI banner - success!</Text>
                  </Banner>
                </Box>
                <Box>
                  <Banner title="Snap Banner" severity="warning">
                    <Text>Hello, this is Snap UI banner - warning!</Text>
                  </Banner>
                </Box>
              </Box>
            </Container>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};
```

## **Screenshots/Recordings**
### **Before**
Banner was not available before this PR. Nothing to show.

### **After**
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-26 at 16 56 05](https://github.com/user-attachments/assets/22bae8f1-87a3-4832-86dd-50e2d1a1688b)

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
