### PR TITLE
feat: Make Snaps UI footers properly sticky

### DIFF
--- a/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
+++ b/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
@@ -65,8 +65,6 @@ export const SnapUIButton: FunctionComponent<
       {...props}
       id={name}
       onPress={handlePress}
-      // @ts-expect-error This prop is not part of the type but it works.
-      color={color}
       disabled={disabled}
       label={
         loading ? (

--- a/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
+++ b/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
@@ -60,7 +60,6 @@ export const SnapUIButton: FunctionComponent<
 
   const color = COLORS[overriddenVariant as keyof typeof COLORS];
 
-  // TODO: Support sizing the text
   return (
     <ButtonLink
       {...props}

--- a/app/components/Snaps/SnapUICard/SnapUICard.tsx
+++ b/app/components/Snaps/SnapUICard/SnapUICard.tsx
@@ -32,7 +32,6 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
     flexDirection={FlexDirection.Row}
     justifyContent={JustifyContent.spaceBetween}
     alignItems={AlignItems.center}
-    style={{ flex: 1 }}
   >
     <Box
       gap={16}

--- a/app/components/Snaps/SnapUICard/SnapUICard.tsx
+++ b/app/components/Snaps/SnapUICard/SnapUICard.tsx
@@ -32,6 +32,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
     flexDirection={FlexDirection.Row}
     justifyContent={JustifyContent.spaceBetween}
     alignItems={AlignItems.center}
+    style={{ flex: 1 }}
   >
     <Box
       gap={16}

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.test.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.test.tsx
@@ -32,7 +32,7 @@ describe('SnapUIFooterButton', () => {
   const defaultProps = {
     children: 'Test Button',
     type: ButtonType.Submit,
-    snapVariant: ButtonVariants.Primary,
+    snapVariant: 'primary',
     onPress: jest.fn(),
     variant: ButtonVariants.Primary,
     accessibilityLabel: 'Test Button',

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.test.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.test.tsx
@@ -32,7 +32,7 @@ describe('SnapUIFooterButton', () => {
   const defaultProps = {
     children: 'Test Button',
     type: ButtonType.Submit,
-    snapVariant: 'primary',
+    snapVariant: 'primary' as const,
     onPress: jest.fn(),
     variant: ButtonVariants.Primary,
     accessibilityLabel: 'Test Button',

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
@@ -60,7 +60,6 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
   disabled = false,
   loading = false,
   isSnapAction = false,
-  type,
   variant = ButtonVariants.Primary,
   snapVariant,
   ...props
@@ -82,9 +81,6 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const handlePress = isSnapAction ? handleSnapAction : onCancel!;
-
-  const overriddenVariant = disabled ? 'disabled' : variant;
-  const color = COLORS[overriddenVariant as keyof typeof COLORS];
 
   const hideSnapBranding = snapMetadata.hideSnapBranding;
 
@@ -116,7 +112,7 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
       );
     }
     return (
-      <Text variant={DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT} color={color}>
+      <Text variant={DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT}>
         {children}
       </Text>
     );
@@ -132,6 +128,7 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
       label={buttonLabel()}
       size={ButtonSize.Lg}
       style={styles.button}
+      isDanger={snapVariant === 'destructive'}
     />
   );
 };

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
@@ -8,9 +8,7 @@ import {
 } from '../../../component-library/components/Buttons/Button/Button.types';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { SnapIcon } from '../SnapIcon/SnapIcon';
-import Text, {
-  TextColor,
-} from '../../../component-library/components/Texts/Text';
+import Text from '../../../component-library/components/Texts/Text';
 import { useSelector } from 'react-redux';
 import { selectSnaps } from '../../../selectors/snaps/snapController';
 import {
@@ -47,12 +45,6 @@ interface SnapUIFooterButtonProps {
   disabled?: boolean;
   loading?: boolean;
 }
-
-const COLORS = {
-  primary: TextColor.Info,
-  destructive: TextColor.Error,
-  disabled: TextColor.Muted,
-};
 
 export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
   onCancel,

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_BOTTOMSHEETFOOTER_BUTTONSALIGNMENT } from '../../../component-l
 import Button from '../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../component-library/hooks';
 import styleSheet from '../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.styles';
+import { ButtonProps } from '@metamask/snaps-sdk/jsx';
 
 const localStyles = StyleSheet.create({
   snapActionContainer: {
@@ -42,7 +43,7 @@ interface SnapUIFooterButtonProps {
   isSnapAction?: boolean;
   onCancel?: () => void;
   type: ButtonType;
-  snapVariant: ButtonVariants;
+  snapVariant: ButtonProps['variant'];
   disabled?: boolean;
   loading?: boolean;
 }
@@ -112,9 +113,7 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
       );
     }
     return (
-      <Text variant={DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT}>
-        {children}
-      </Text>
+      <Text variant={DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT}>{children}</Text>
     );
   };
 

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -322,6 +322,7 @@ describe('SnapUIRenderer', () => {
     );
 
     const inputsAfterRerender = getAllByTestId('input');
+    expect(inputsAfterRerender).toHaveLength(2);
     expect(inputsAfterRerender[0].props.value).toStrictEqual('bar');
     expect(inputsAfterRerender[1].props.value).toStrictEqual('foo');
 

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -215,9 +215,7 @@ describe('SnapUIRenderer', () => {
   it('adds a footer if required', () => {
     const { toJSON, getByText } = renderInterface(
       Container({
-        children: [
-          Box({ children: Text({ children: 'Hello world!' }) }),
-        ],
+        children: [Box({ children: Text({ children: 'Hello world!' }) })],
       }),
       { useFooter: true },
     );

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -212,6 +212,20 @@ describe('SnapUIRenderer', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it('adds a footer if required', () => {
+    const { toJSON, getByText } = renderInterface(
+      Container({
+        children: [
+          Box({ children: Text({ children: 'Hello world!' }) }),
+        ],
+      }),
+      { useFooter: true },
+    );
+
+    expect(getByText('Close')).toBeDefined();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
   it('supports the onCancel prop', () => {
     const onCancel = jest.fn();
     const { toJSON, getByText } = renderInterface(

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -16,7 +16,7 @@ import {
   Card,
   Image as ImageComponent,
 } from '@metamask/snaps-sdk/jsx';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { SnapUIRenderer } from './SnapUIRenderer';
 import Engine from '../../../core/Engine/Engine';
@@ -161,12 +161,14 @@ function renderInterface(
     newContent: JSXElement,
     newState: FormState | null = null,
   ) => {
-    store.dispatch({
-      type: 'updateInterface',
-      payload: {
-        content: newContent,
-        state: newState,
-      },
+    act(() => {
+      store.dispatch({
+        type: 'updateInterface',
+        payload: {
+          content: newContent,
+          state: newState,
+        },
+      });
     });
   };
 
@@ -215,7 +217,7 @@ describe('SnapUIRenderer', () => {
   it('adds a footer if required', () => {
     const { toJSON, getByText } = renderInterface(
       Container({
-        children: [Box({ children: Text({ children: 'Hello world!' }) })],
+        children: Box({ children: Text({ children: 'Hello world!' }) }),
       }),
       { useFooter: true },
     );

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -12,7 +12,7 @@ import { Container } from '@metamask/snaps-sdk/jsx';
 import { strings } from '../../../../locales/i18n';
 import styles from './SnapUIRenderer.styles';
 import { RootState } from '../../../reducers';
-import { TemplateRendererInput } from '../../UI/TemplateRenderer/types';
+import { TemplateRendererComponent } from '../../UI/TemplateRenderer/types';
 import { useTheme } from '../../../util/theme';
 
 interface SnapUIRendererProps {
@@ -65,7 +65,7 @@ const SnapUIRendererComponent = ({
         onCancel,
         t: strings,
         theme,
-      }) as TemplateRendererInput),
+      }) as TemplateRendererComponent),
     [content, useFooter, onCancel, theme],
   );
 
@@ -73,8 +73,8 @@ const SnapUIRendererComponent = ({
     return <ActivityIndicator size="large" color={Colors.primary} />;
   }
 
-  const contentBox = sections?.children?.[0]
-  const footer = sections?.children?.[1]
+  const contentBox = sections?.children?.[0];
+  const footer = sections?.children?.[1];
 
   const hasFooter = onCancel || content?.props?.children?.[1] !== undefined;
 

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -6,7 +6,7 @@ import { getMemoizedInterface } from '../../../selectors/snaps/interfaceControll
 import { SnapInterfaceContextProvider } from '../SnapInterfaceContext';
 import { mapToTemplate } from './utils';
 import TemplateRenderer from '../../UI/TemplateRenderer';
-import { ActivityIndicator, View, ScrollView } from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import { Container } from '@metamask/snaps-sdk/jsx';
 import { strings } from '../../../../locales/i18n';

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -6,7 +6,7 @@ import { getMemoizedInterface } from '../../../selectors/snaps/interfaceControll
 import { SnapInterfaceContextProvider } from '../SnapInterfaceContext';
 import { mapToTemplate } from './utils';
 import TemplateRenderer from '../../UI/TemplateRenderer';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, View, ScrollView } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import { Container } from '@metamask/snaps-sdk/jsx';
 import { strings } from '../../../../locales/i18n';
@@ -73,18 +73,24 @@ const SnapUIRendererComponent = ({
     return <ActivityIndicator size="large" color={Colors.primary} />;
   }
 
+  const contentBox = sections?.children?.[0]
+  const footer = sections?.children?.[1]
+
   const hasFooter = onCancel || content?.props?.children?.[1] !== undefined;
 
   const { state: initialState, context } = interfaceState;
   return (
-    <Box style={[styles.root, { marginBottom: useFooter && hasFooter ? 80 : 0 }]}>
+    <Box style={styles.root}>
       <SnapInterfaceContextProvider
         snapId={snapId}
         interfaceId={interfaceId}
         initialState={initialState}
         context={context}
       >
-        <TemplateRenderer sections={sections} />
+        <ScrollView style={{ marginBottom: useFooter && hasFooter ? 80 : 0 }}>
+          <TemplateRenderer sections={contentBox} />
+        </ScrollView>
+        {footer && <TemplateRenderer sections={footer} />}
         {PERF_DEBUG && <PerformanceTracker />}
       </SnapInterfaceContextProvider>
     </Box>

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -73,11 +73,6 @@ const SnapUIRendererComponent = ({
     return <ActivityIndicator size="large" color={Colors.primary} />;
   }
 
-  const contentBox = sections?.children?.[0];
-  const footer = sections?.children?.[1];
-
-  const hasFooter = onCancel || content?.props?.children?.[1] !== undefined;
-
   const { state: initialState, context } = interfaceState;
   return (
     <Box style={styles.root}>

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -87,10 +87,7 @@ const SnapUIRendererComponent = ({
         initialState={initialState}
         context={context}
       >
-        <ScrollView style={{ marginBottom: useFooter && hasFooter ? 80 : 0 }}>
-          <TemplateRenderer sections={contentBox} />
-        </ScrollView>
-        {footer && <TemplateRenderer sections={footer} />}
+        <TemplateRenderer sections={sections} />
         {PERF_DEBUG && <PerformanceTracker />}
       </SnapInterfaceContextProvider>
     </Box>

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -73,9 +73,11 @@ const SnapUIRendererComponent = ({
     return <ActivityIndicator size="large" color={Colors.primary} />;
   }
 
+  const hasFooter = onCancel || content?.props?.children?.[1] !== undefined;
+
   const { state: initialState, context } = interfaceState;
   return (
-    <Box style={styles.root}>
+    <Box style={[styles.root, { marginBottom: useFooter && hasFooter ? 80 : 0 }]}>
       <SnapInterfaceContextProvider
         snapId={snapId}
         interfaceId={interfaceId}

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -176,52 +176,61 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value="bar"
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value="bar"
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -279,102 +288,120 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value=""
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value=""
+                />
+              </View>
             </View>
           </View>
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input2"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value=""
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input2"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value=""
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -432,102 +459,120 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value="bar"
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value="bar"
+                />
+              </View>
             </View>
           </View>
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input2"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value="foo"
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input2"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value="foo"
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -1327,129 +1372,138 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
               ]
             }
           >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-              testID="label"
-            >
-              My Input
-            </Text>
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#848c96",
-                  "borderRadius": 8,
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "opacity": 1,
-                  "paddingHorizontal": 16,
-                }
+                [
+                  {},
+                  undefined,
+                ]
               }
-              testID="textfield"
             >
-              <View
+              <Text
+                accessibilityRole="text"
                 style={
                   {
-                    "marginRight": 8,
+                    "color": "#141618",
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
                   }
                 }
-                testID="textfield-startacccessory"
-              />
-              <View
-                style={
-                  {
-                    "flex": 1,
-                  }
-                }
+                testID="label"
               >
-                <TextInput
-                  autoFocus={false}
-                  editable={true}
-                  id="input"
-                  onBlur={[Function]}
-                  onChangeText={[Function]}
-                  onFocus={[Function]}
+                My Input
+              </Text>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#848c96",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                  }
+                }
+                testID="textfield"
+              >
+                <View
                   style={
                     {
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "transparent",
-                      "borderWidth": 1,
-                      "color": "#141618",
-                      "fontFamily": "Euclid Circular B",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "height": 24,
-                      "letterSpacing": 0,
-                      "opacity": 1,
-                      "paddingVertical": 0,
+                      "marginRight": 8,
                     }
                   }
-                  testID="input"
-                  value=""
+                  testID="textfield-startacccessory"
                 />
-              </View>
-              <View
-                style={
-                  {
-                    "marginLeft": 8,
-                  }
-                }
-                testID="textfield-endacccessory"
-              >
-                <Text
-                  accessibilityRole="link"
-                  accessible={true}
-                  disabled={false}
-                  id="submit"
-                  onPress={[Function]}
-                  onPressIn={[Function]}
-                  onPressOut={[Function]}
-                  padding={0}
+                <View
                   style={
                     {
-                      "backgroundColor": "transparent",
-                      "color": "#0376c9",
-                      "fontFamily": "EuclidCircularB-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
+                      "flex": 1,
                     }
                   }
-                  suppressHighlighting={true}
                 >
-                  <Text
-                    accessibilityRole="text"
+                  <TextInput
+                    autoFocus={false}
+                    editable={true}
+                    id="input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
                     style={
                       {
-                        "color": "#0376c9",
-                        "fontFamily": "EuclidCircularB-Medium",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "transparent",
+                        "borderWidth": 1,
+                        "color": "#141618",
+                        "fontFamily": "Euclid Circular B",
                         "fontSize": 14,
-                        "fontWeight": "500",
+                        "fontWeight": "400",
+                        "height": 24,
+                        "letterSpacing": 0,
+                        "opacity": 1,
+                        "paddingVertical": 0,
+                      }
+                    }
+                    testID="input"
+                    value=""
+                  />
+                </View>
+                <View
+                  style={
+                    {
+                      "marginLeft": 8,
+                    }
+                  }
+                  testID="textfield-endacccessory"
+                >
+                  <Text
+                    accessibilityRole="link"
+                    accessible={true}
+                    disabled={false}
+                    id="submit"
+                    onPress={[Function]}
+                    onPressIn={[Function]}
+                    onPressOut={[Function]}
+                    padding={0}
+                    style={
+                      {
+                        "backgroundColor": "transparent",
+                        "color": "#0376c9",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 14,
+                        "fontWeight": "400",
                         "letterSpacing": 0,
                         "lineHeight": 22,
                       }
                     }
+                    suppressHighlighting={true}
                   >
                     <Text
-                      color="inherit"
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#0376c9",
+                          "fontFamily": "EuclidCircularB-Medium",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0,
+                          "lineHeight": 22,
+                        }
+                      }
                     >
-                      Submit
+                      <Text
+                        color="inherit"
+                      >
+                        Submit
+                      </Text>
                     </Text>
                   </Text>
-                </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -1519,70 +1573,79 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
               ]
             }
           >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-              testID="label"
-            >
-              My Input
-            </Text>
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#848c96",
-                  "borderRadius": 8,
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "opacity": 1,
-                  "paddingHorizontal": 16,
-                }
+                [
+                  {},
+                  undefined,
+                ]
               }
-              testID="textfield"
             >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#141618",
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+                testID="label"
+              >
+                My Input
+              </Text>
               <View
                 style={
                   {
-                    "flex": 1,
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#848c96",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
+                testID="textfield"
               >
-                <TextInput
-                  autoFocus={false}
-                  editable={true}
-                  id="input"
-                  onBlur={[Function]}
-                  onChangeText={[Function]}
-                  onFocus={[Function]}
+                <View
                   style={
                     {
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "transparent",
-                      "borderWidth": 1,
-                      "color": "#141618",
-                      "fontFamily": "Euclid Circular B",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "height": 24,
-                      "letterSpacing": 0,
-                      "opacity": 1,
-                      "paddingVertical": 0,
+                      "flex": 1,
                     }
                   }
-                  testID="input"
-                  value="abc"
-                />
+                >
+                  <TextInput
+                    autoFocus={false}
+                    editable={true}
+                    id="input"
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    style={
+                      {
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "transparent",
+                        "borderWidth": 1,
+                        "color": "#141618",
+                        "fontFamily": "Euclid Circular B",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "height": 24,
+                        "letterSpacing": 0,
+                        "opacity": 1,
+                        "paddingVertical": 0,
+                      }
+                    }
+                    testID="input"
+                    value="abc"
+                  />
+                </View>
               </View>
             </View>
             <View
@@ -1776,52 +1839,61 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#848c96",
-                "borderRadius": 8,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-              }
+              [
+                {},
+                undefined,
+              ]
             }
-            testID="textfield"
           >
             <View
               style={
                 {
-                  "flex": 1,
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
-              <TextInput
-                autoFocus={false}
-                editable={true}
-                id="input"
-                onBlur={[Function]}
-                onChangeText={[Function]}
-                onFocus={[Function]}
+              <View
                 style={
                   {
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "transparent",
-                    "borderWidth": 1,
-                    "color": "#141618",
-                    "fontFamily": "Euclid Circular B",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "height": 24,
-                    "letterSpacing": 0,
-                    "opacity": 1,
-                    "paddingVertical": 0,
+                    "flex": 1,
                   }
                 }
-                testID="input"
-                value="a"
-              />
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value="a"
+                />
+              </View>
             </View>
           </View>
         </View>

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -3,121 +3,118 @@
 exports[`SnapUIRenderer adds a footer if required 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 80,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 80,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        fontWeight="normal"
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
         style={
-          {
-            "color": "inherit",
-            "fontFamily": "EuclidCircularB-Regular",
-            "fontSize": 14,
-            "fontWeight": "400",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-        textAlign="left"
-      >
-        <Text
-          color="inherit"
-        >
-          Hello world!
-        </Text>
-      </Text>
-    </View>
-    <View
-      flexDirection="row"
-      gap={16}
-      padding={16}
-      style={
-        {
-          "alignItems": "center",
-          "bottom": 0,
-          "height": 80,
-          "justifyContent": "space-evenly",
-          "marginTop": "auto",
-          "paddingVertical": 20,
-          "position": "fixed",
-          "width": "100%",
-        }
-      }
-    >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "transparent",
-            "borderColor": "#0376c9",
-            "borderRadius": 24,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
+          fontWeight="normal"
           style={
             {
-              "color": "#141618",
-              "fontFamily": "EuclidCircularB-Medium",
+              "color": "inherit",
+              "fontFamily": "EuclidCircularB-Regular",
               "fontSize": 14,
-              "fontWeight": "500",
+              "fontWeight": "400",
               "letterSpacing": 0,
               "lineHeight": 22,
             }
           }
+          textAlign="left"
         >
-          Close
+          <Text
+            color="inherit"
+          >
+            Hello world!
+          </Text>
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
+  </RCTScrollView>
+  <View
+    flexDirection="row"
+    gap={16}
+    padding={16}
+    style={
+      {
+        "alignItems": "center",
+        "bottom": 0,
+        "height": 80,
+        "justifyContent": "space-evenly",
+        "paddingVertical": 16,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#0376c9",
+          "borderRadius": 24,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Close
+      </Text>
+    </TouchableOpacity>
   </View>
   <View
     data-renders={1}
@@ -129,92 +126,90 @@ exports[`SnapUIRenderer adds a footer if required 1`] = `
 exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 0,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
+    <View>
       <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
         style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
         }
-        testID="textfield"
       >
         <View
           style={
             {
-              "flex": 1,
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderColor": "#848c96",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "opacity": 1,
+              "paddingHorizontal": 16,
             }
           }
+          testID="textfield"
         >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
+          <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
+                "flex": 1,
               }
             }
-            testID="input"
-            value="bar"
-          />
+          >
+            <TextInput
+              autoFocus={false}
+              editable={true}
+              id="input"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              style={
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "transparent",
+                  "borderWidth": 1,
+                  "color": "#141618",
+                  "fontFamily": "Euclid Circular B",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "height": 24,
+                  "letterSpacing": 0,
+                  "opacity": 1,
+                  "paddingVertical": 0,
+                }
+              }
+              testID="input"
+              value="bar"
+            />
+          </View>
         </View>
       </View>
     </View>
-  </View>
+  </RCTScrollView>
   <View
     data-renders={1}
     testID="performance"
@@ -225,142 +220,140 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 0,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
+    <View>
       <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
         style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
         }
-        testID="textfield"
       >
         <View
           style={
             {
-              "flex": 1,
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderColor": "#848c96",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "opacity": 1,
+              "paddingHorizontal": 16,
             }
           }
+          testID="textfield"
         >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
+          <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
+                "flex": 1,
               }
             }
-            testID="input"
-            value=""
-          />
+          >
+            <TextInput
+              autoFocus={false}
+              editable={true}
+              id="input"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              style={
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "transparent",
+                  "borderWidth": 1,
+                  "color": "#141618",
+                  "fontFamily": "Euclid Circular B",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "height": 24,
+                  "letterSpacing": 0,
+                  "opacity": 1,
+                  "paddingVertical": 0,
+                }
+              }
+              testID="input"
+              value=""
+            />
+          </View>
         </View>
-      </View>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
-        }
-        testID="textfield"
-      >
         <View
           style={
             {
-              "flex": 1,
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderColor": "#848c96",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "opacity": 1,
+              "paddingHorizontal": 16,
             }
           }
+          testID="textfield"
         >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input2"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
+          <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
+                "flex": 1,
               }
             }
-            testID="input"
-            value=""
-          />
+          >
+            <TextInput
+              autoFocus={false}
+              editable={true}
+              id="input2"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              style={
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "transparent",
+                  "borderWidth": 1,
+                  "color": "#141618",
+                  "fontFamily": "Euclid Circular B",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "height": 24,
+                  "letterSpacing": 0,
+                  "opacity": 1,
+                  "paddingVertical": 0,
+                }
+              }
+              testID="input"
+              value=""
+            />
+          </View>
         </View>
       </View>
     </View>
-  </View>
+  </RCTScrollView>
   <View
     data-renders={2}
     testID="performance"
@@ -517,63 +510,61 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 exports[`SnapUIRenderer renders basic UI 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 0,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        fontWeight="normal"
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
         style={
-          {
-            "color": "inherit",
-            "fontFamily": "EuclidCircularB-Regular",
-            "fontSize": 14,
-            "fontWeight": "400",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
         }
-        textAlign="left"
       >
         <Text
-          color="inherit"
+          accessibilityRole="text"
+          fontWeight="normal"
+          style={
+            {
+              "color": "inherit",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+          textAlign="left"
         >
-          Hello world!
+          <Text
+            color="inherit"
+          >
+            Hello world!
+          </Text>
         </Text>
-      </Text>
+      </View>
     </View>
-  </View>
+  </RCTScrollView>
   <View
     data-renders={1}
     testID="performance"
@@ -584,52 +575,28 @@ exports[`SnapUIRenderer renders basic UI 1`] = `
 exports[`SnapUIRenderer renders complex nested components 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 80,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 80,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
+    <View>
       <View
-        backgroundColor="#f2f4f6"
-        borderRadius={8}
         color="Default"
         flexDirection="column"
         gap={8}
         justifyContent="flex-start"
-        padding={16}
         style={
           [
             {
-              "backgroundColor": "#f2f4f6",
               "color": "Default",
               "flexDirection": "column",
               "gap": 8,
@@ -640,140 +607,208 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
         }
       >
         <View
+          backgroundColor="#f2f4f6"
+          borderRadius={8}
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          padding={16}
           style={
-            {
-              "alignItems": "center",
-              "display": "flex",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "space-between",
-              "paddingBottom": 8,
-              "paddingHorizontal": 8,
-            }
+            [
+              {
+                "backgroundColor": "#f2f4f6",
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
           }
-          testID="info-row"
         >
           <View
             style={
               {
                 "alignItems": "center",
-                "alignSelf": "flex-start",
                 "display": "flex",
                 "flexDirection": "row",
-                "minHeight": 38,
-                "paddingEnd": 4,
+                "flexWrap": "wrap",
+                "justifyContent": "space-between",
+                "paddingBottom": 8,
+                "paddingHorizontal": 8,
               }
             }
+            testID="info-row"
           >
-            <Text
-              accessibilityRole="text"
+            <View
               style={
                 {
                   "alignItems": "center",
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Bold",
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "justifyContent": "center",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "minHeight": 38,
+                  "paddingEnd": 4,
                 }
               }
             >
-              Key
-            </Text>
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "alignItems": "center",
+                    "color": "#141618",
+                    "fontFamily": "EuclidCircularB-Bold",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "justifyContent": "center",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Key
+              </Text>
+            </View>
+            <View
+              style={
+                {
+                  "marginLeft": "auto",
+                }
+              }
+            >
+              <View
+                alignItems="center"
+                flexDirection="row"
+                gap={4}
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 4,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#9fa6ae",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  Extra
+                </Text>
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#141618",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  Value
+                </Text>
+              </View>
+            </View>
           </View>
           <View
+            alignItems="center"
+            flexDirection="row"
+            justifyContent="space-between"
             style={
               {
-                "marginLeft": "auto",
+                "flex": 1,
               }
             }
+            testID="snaps-ui-card"
           >
             <View
               alignItems="center"
               flexDirection="row"
-              gap={4}
+              gap={16}
               style={
                 [
                   {
                     "alignItems": "center",
                     "flexDirection": "row",
-                    "gap": 4,
+                    "gap": 16,
                   },
                   undefined,
                 ]
               }
             >
-              <Text
-                accessibilityRole="text"
+              <View
+                flexDirection="column"
                 style={
-                  {
-                    "color": "#9fa6ae",
-                    "fontFamily": "EuclidCircularB-Regular",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                  }
+                  [
+                    {
+                      "flexDirection": "column",
+                    },
+                    undefined,
+                  ]
                 }
               >
-                Extra
-              </Text>
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#141618",
-                    "fontFamily": "EuclidCircularB-Regular",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
+                <Text
+                  accessibilityRole="text"
+                  ellipsizeMode="tail"
+                  style={
+                    {
+                      "color": "#141618",
+                      "fontFamily": "EuclidCircularB-Medium",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
                   }
-                }
-              >
-                Value
-              </Text>
+                >
+                  CardTitle
+                </Text>
+                <Text
+                  accessibilityRole="text"
+                  ellipsizeMode="tail"
+                  style={
+                    {
+                      "color": "#6a737d",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  CardDescription
+                </Text>
+              </View>
             </View>
-          </View>
-        </View>
-        <View
-          alignItems="center"
-          flexDirection="row"
-          justifyContent="space-between"
-          style={
-            {
-              "flex": 1,
-            }
-          }
-          testID="snaps-ui-card"
-        >
-          <View
-            alignItems="center"
-            flexDirection="row"
-            gap={16}
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 16,
-                },
-                undefined,
-              ]
-            }
-          >
             <View
               flexDirection="column"
               style={
                 [
                   {
                     "flexDirection": "column",
+                    "textAlign": "right",
                   },
                   undefined,
                 ]
               }
+              textAlign="right"
             >
               <Text
                 accessibilityRole="text"
@@ -789,7 +824,7 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
                   }
                 }
               >
-                CardTitle
+                CardValue
               </Text>
               <Text
                 accessibilityRole="text"
@@ -805,105 +840,139 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
                   }
                 }
               >
-                CardDescription
+                CardExtra
               </Text>
             </View>
-          </View>
-          <View
-            flexDirection="column"
-            style={
-              [
-                {
-                  "flexDirection": "column",
-                  "textAlign": "right",
-                },
-                undefined,
-              ]
-            }
-            textAlign="right"
-          >
-            <Text
-              accessibilityRole="text"
-              ellipsizeMode="tail"
-              style={
-                {
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Medium",
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-            >
-              CardValue
-            </Text>
-            <Text
-              accessibilityRole="text"
-              ellipsizeMode="tail"
-              style={
-                {
-                  "color": "#6a737d",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-            >
-              CardExtra
-            </Text>
           </View>
         </View>
       </View>
     </View>
-    <View
-      flexDirection="row"
-      gap={16}
-      padding={16}
+  </RCTScrollView>
+  <View
+    flexDirection="row"
+    gap={16}
+    padding={16}
+    style={
+      {
+        "bottom": 0,
+        "height": 80,
+        "justifyContent": "space-evenly",
+        "paddingVertical": 16,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
       style={
         {
-          "bottom": 0,
-          "height": 80,
-          "justifyContent": "space-evenly",
-          "marginTop": "auto",
-          "paddingVertical": 20,
-          "position": "fixed",
-          "width": "100%",
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#0376c9",
+          "borderRadius": 24,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
         }
       }
     >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
+      <Text
+        accessibilityRole="text"
         style={
           {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "transparent",
-            "borderColor": "#0376c9",
-            "borderRadius": 24,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
           }
         }
       >
+        Cancel
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376c9",
+          "borderRadius": 24,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+      textVariant="sBodyMDMedium"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 4,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 50,
+              "borderWidth": 0,
+              "height": 24,
+              "justifyContent": "center",
+              "overflow": "hidden",
+              "width": 24,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            m
+          </Text>
+        </View>
         <Text
           accessibilityRole="text"
           style={
             {
-              "color": "#141618",
+              "color": "#ffffff",
               "fontFamily": "EuclidCircularB-Medium",
               "fontSize": 14,
               "fontWeight": "500",
@@ -912,95 +981,14 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
             }
           }
         >
-          Cancel
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#0376c9",
-            "borderRadius": 24,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
-        }
-        textVariant="sBodyMDMedium"
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "justifyContent": "center",
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 50,
-                "borderWidth": 0,
-                "height": 24,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "width": 24,
-              }
-            }
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-            >
-              m
-            </Text>
-          </View>
           <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ffffff",
-                "fontFamily": "EuclidCircularB-Medium",
-                "fontSize": 14,
-                "fontWeight": "500",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
+            color="inherit"
           >
-            <Text
-              color="inherit"
-            >
-              Foo
-            </Text>
+            Foo
           </Text>
-        </View>
-      </TouchableOpacity>
-    </View>
+        </Text>
+      </View>
+    </TouchableOpacity>
   </View>
   <View
     data-renders={1}
@@ -1012,108 +1000,186 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
 exports[`SnapUIRenderer renders footers 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 80,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 80,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        fontWeight="normal"
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
         style={
-          {
-            "color": "inherit",
-            "fontFamily": "EuclidCircularB-Regular",
-            "fontSize": 14,
-            "fontWeight": "400",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-        textAlign="left"
-      >
-        <Text
-          color="inherit"
-        >
-          Hello world!
-        </Text>
-      </Text>
-    </View>
-    <View
-      flexDirection="row"
-      gap={16}
-      padding={16}
-      style={
-        {
-          "bottom": 0,
-          "height": 80,
-          "justifyContent": "space-evenly",
-          "marginTop": "auto",
-          "paddingVertical": 20,
-          "position": "fixed",
-          "width": "100%",
-        }
-      }
-    >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "transparent",
-            "borderColor": "#0376c9",
-            "borderRadius": 24,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
+          fontWeight="normal"
           style={
             {
-              "color": "#141618",
+              "color": "inherit",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+          textAlign="left"
+        >
+          <Text
+            color="inherit"
+          >
+            Hello world!
+          </Text>
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    flexDirection="row"
+    gap={16}
+    padding={16}
+    style={
+      {
+        "bottom": 0,
+        "height": 80,
+        "justifyContent": "space-evenly",
+        "paddingVertical": 16,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#0376c9",
+          "borderRadius": 24,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Cancel
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376c9",
+          "borderRadius": 24,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+      textVariant="sBodyMDMedium"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 4,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 50,
+              "borderWidth": 0,
+              "height": 24,
+              "justifyContent": "center",
+              "overflow": "hidden",
+              "width": 24,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            m
+          </Text>
+        </View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
               "fontFamily": "EuclidCircularB-Medium",
               "fontSize": 14,
               "fontWeight": "500",
@@ -1122,95 +1188,14 @@ exports[`SnapUIRenderer renders footers 1`] = `
             }
           }
         >
-          Cancel
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#0376c9",
-            "borderRadius": 24,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
-        }
-        textVariant="sBodyMDMedium"
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "justifyContent": "center",
-            }
-          }
-        >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 50,
-                "borderWidth": 0,
-                "height": 24,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "width": 24,
-              }
-            }
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#141618",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-            >
-              m
-            </Text>
-          </View>
           <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ffffff",
-                "fontFamily": "EuclidCircularB-Medium",
-                "fontSize": 14,
-                "fontWeight": "500",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
+            color="inherit"
           >
-            <Text
-              color="inherit"
-            >
-              Foo
-            </Text>
+            Foo
           </Text>
-        </View>
-      </TouchableOpacity>
-    </View>
+        </Text>
+      </View>
+    </TouchableOpacity>
   </View>
   <View
     data-renders={1}
@@ -1229,310 +1214,45 @@ exports[`SnapUIRenderer renders loading state 1`] = `
 exports[`SnapUIRenderer supports fields with multiple components 1`] = `
 <View
   style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
   }
 >
-  <View
+  <RCTScrollView
     style={
       {
-        "flex": 1,
-        "flexDirection": "column",
+        "marginBottom": 0,
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
+    <View>
       <View
+        color="Default"
         flexDirection="column"
         gap={8}
+        justifyContent="flex-start"
         style={
           [
             {
+              "color": "Default",
               "flexDirection": "column",
               "gap": 8,
+              "justifyContent": "flex-start",
             },
             undefined,
           ]
         }
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#141618",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-          testID="label"
-        >
-          My Input
-        </Text>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="textfield"
-        >
-          <View
-            style={
-              {
-                "marginRight": 8,
-              }
-            }
-            testID="textfield-startacccessory"
-          />
-          <View
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
-                }
-              }
-              testID="input"
-              value=""
-            />
-          </View>
-          <View
-            style={
-              {
-                "marginLeft": 8,
-              }
-            }
-            testID="textfield-endacccessory"
-          >
-            <Text
-              accessibilityRole="link"
-              accessible={true}
-              disabled={false}
-              id="submit"
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              padding={0}
-              style={
-                {
-                  "backgroundColor": "transparent",
-                  "color": "#0376c9",
-                  "fontFamily": "EuclidCircularB-Regular",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 22,
-                }
-              }
-              suppressHighlighting={true}
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#0376c9",
-                    "fontFamily": "EuclidCircularB-Medium",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                  }
-                }
-              >
-                <Text
-                  color="inherit"
-                >
-                  Submit
-                </Text>
-              </Text>
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer supports forms with fields 1`] = `
-<View
-  style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
-  }
->
-  <View
-    style={
-      {
-        "flex": 1,
-        "flexDirection": "column",
-      }
-    }
-  >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        flexDirection="column"
-        gap={8}
-        style={
-          [
-            {
-              "flexDirection": "column",
-              "gap": 8,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#141618",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-          testID="label"
-        >
-          My Input
-        </Text>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="textfield"
-        >
-          <View
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
-                }
-              }
-              testID="input"
-              value="abc"
-            />
-          </View>
-        </View>
         <View
           flexDirection="column"
+          gap={8}
           style={
             [
               {
                 "flexDirection": "column",
+                "gap": 8,
               },
               undefined,
             ]
@@ -1552,62 +1272,86 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
             }
             testID="label"
           >
-            My Checkbox
+            My Input
           </Text>
-          <TouchableOpacity
-            disabled={false}
-            onPress={[Function]}
+          <View
             style={
               {
                 "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
                 "flexDirection": "row",
-                "height": 24,
+                "height": 48,
                 "opacity": 1,
+                "paddingHorizontal": 16,
               }
             }
+            testID="textfield"
           >
             <View
-              accessibilityRole="checkbox"
               style={
                 {
-                  "alignItems": "center",
-                  "backgroundColor": "#0376c9",
-                  "borderColor": "border-muted",
-                  "borderRadius": 4,
-                  "borderWidth": 2,
-                  "height": 20,
-                  "justifyContent": "center",
-                  "width": 20,
+                  "marginRight": 8,
+                }
+              }
+              testID="textfield-startacccessory"
+            />
+            <View
+              style={
+                {
+                  "flex": 1,
                 }
               }
             >
-              <SvgMock
-                color="#ffffff"
-                height={20}
-                name="CheckBold"
-                onPress={[Function]}
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "height": 24,
+                    "letterSpacing": 0,
+                    "opacity": 1,
+                    "paddingVertical": 0,
                   }
                 }
-                testID="checkbox-icon-component"
-                width={20}
+                testID="input"
+                value=""
               />
             </View>
             <View
               style={
                 {
-                  "marginLeft": 12,
+                  "marginLeft": 8,
                 }
               }
+              testID="textfield-endacccessory"
             >
               <Text
-                accessibilityRole="text"
+                accessibilityRole="link"
+                accessible={true}
+                disabled={false}
+                id="submit"
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                padding={0}
                 style={
                   {
-                    "color": "#141618",
+                    "backgroundColor": "transparent",
+                    "color": "#0376c9",
                     "fontFamily": "EuclidCircularB-Regular",
                     "fontSize": 14,
                     "fontWeight": "400",
@@ -1615,321 +1359,163 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                suppressHighlighting={true}
               >
-                This is a checkbox
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#0376c9",
+                      "fontFamily": "EuclidCircularB-Medium",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  <Text
+                    color="inherit"
+                  >
+                    Submit
+                  </Text>
+                </Text>
               </Text>
             </View>
-          </TouchableOpacity>
+          </View>
         </View>
-        <Text
-          accessibilityRole="link"
-          accessible={true}
-          disabled={false}
-          id="submit"
-          onPress={[Function]}
-          onPressIn={[Function]}
-          onPressOut={[Function]}
-          style={
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer supports forms with fields 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      {
+        "marginBottom": 0,
+      }
+    }
+  >
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
+        style={
+          [
             {
-              "backgroundColor": "transparent",
-              "color": "#0376c9",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          flexDirection="column"
+          gap={8}
+          style={
+            [
+              {
+                "flexDirection": "column",
+                "gap": 8,
+              },
+              undefined,
+            ]
           }
-          suppressHighlighting={true}
         >
           <Text
             accessibilityRole="text"
             style={
               {
-                "color": "#0376c9",
-                "fontFamily": "EuclidCircularB-Medium",
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
                 "fontSize": 14,
-                "fontWeight": "500",
+                "fontWeight": "400",
                 "letterSpacing": 0,
                 "lineHeight": 22,
               }
             }
+            testID="label"
           >
-            <Text
-              color="inherit"
-            >
-              Submit
-            </Text>
+            My Input
           </Text>
-        </Text>
-      </View>
-    </View>
-  </View>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer supports interactive inputs 1`] = `
-<View
-  style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
-  }
->
-  <View
-    style={
-      {
-        "flex": 1,
-        "flexDirection": "column",
-      }
-    }
-  >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
-        }
-        testID="textfield"
-      >
-        <View
-          style={
-            {
-              "flex": 1,
-            }
-          }
-        >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            style={
-              {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
-              }
-            }
-            testID="input"
-            value="a"
-          />
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer supports the onCancel prop 1`] = `
-<View
-  style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 80,
-      },
-    ]
-  }
->
-  <View
-    style={
-      {
-        "flex": 1,
-        "flexDirection": "column",
-      }
-    }
-  >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
-      style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        fontWeight="normal"
-        style={
-          {
-            "color": "inherit",
-            "fontFamily": "EuclidCircularB-Regular",
-            "fontSize": 14,
-            "fontWeight": "400",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-        textAlign="left"
-      >
-        <Text
-          color="inherit"
-        >
-          Hello world!
-        </Text>
-      </Text>
-    </View>
-    <View
-      flexDirection="row"
-      gap={16}
-      padding={16}
-      style={
-        {
-          "bottom": 0,
-          "height": 80,
-          "justifyContent": "space-evenly",
-          "marginTop": "auto",
-          "paddingVertical": 20,
-          "position": "fixed",
-          "width": "100%",
-        }
-      }
-    >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[MockFunction]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "transparent",
-            "borderColor": "#0376c9",
-            "borderRadius": 24,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#141618",
-              "fontFamily": "EuclidCircularB-Medium",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-        >
-          Cancel
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        disabled={false}
-        loading={false}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#0376c9",
-            "borderRadius": 24,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "paddingHorizontal": 16,
-          }
-        }
-        textVariant="sBodyMDMedium"
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "justifyContent": "center",
-            }
-          }
-        >
           <View
             style={
               {
                 "alignItems": "center",
                 "backgroundColor": "#ffffff",
-                "borderRadius": 50,
-                "borderWidth": 0,
-                "height": 24,
-                "justifyContent": "center",
-                "overflow": "hidden",
-                "width": 24,
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "opacity": 1,
+                "paddingHorizontal": 16,
               }
+            }
+            testID="textfield"
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "height": 24,
+                    "letterSpacing": 0,
+                    "opacity": 1,
+                    "paddingVertical": 0,
+                  }
+                }
+                testID="input"
+                value="abc"
+              />
+            </View>
+          </View>
+          <View
+            flexDirection="column"
+            style={
+              [
+                {
+                  "flexDirection": "column",
+                },
+                undefined,
+              ]
             }
           >
             <Text
@@ -1944,32 +1530,422 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
                   "lineHeight": 22,
                 }
               }
+              testID="label"
             >
-              m
+              My Checkbox
             </Text>
+            <TouchableOpacity
+              disabled={false}
+              onPress={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "height": 24,
+                  "opacity": 1,
+                }
+              }
+            >
+              <View
+                accessibilityRole="checkbox"
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#0376c9",
+                    "borderColor": "border-muted",
+                    "borderRadius": 4,
+                    "borderWidth": 2,
+                    "height": 20,
+                    "justifyContent": "center",
+                    "width": 20,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#ffffff"
+                  height={20}
+                  name="CheckBold"
+                  onPress={[Function]}
+                  style={
+                    {
+                      "height": 20,
+                      "width": 20,
+                    }
+                  }
+                  testID="checkbox-icon-component"
+                  width={20}
+                />
+              </View>
+              <View
+                style={
+                  {
+                    "marginLeft": 12,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#141618",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  This is a checkbox
+                </Text>
+              </View>
+            </TouchableOpacity>
           </View>
+          <Text
+            accessibilityRole="link"
+            accessible={true}
+            disabled={false}
+            id="submit"
+            onPress={[Function]}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "backgroundColor": "transparent",
+                "color": "#0376c9",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#0376c9",
+                  "fontFamily": "EuclidCircularB-Medium",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              <Text
+                color="inherit"
+              >
+                Submit
+              </Text>
+            </Text>
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer supports interactive inputs 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      {
+        "marginBottom": 0,
+      }
+    }
+  >
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
+        style={
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderColor": "#848c96",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "height": 48,
+              "opacity": 1,
+              "paddingHorizontal": 16,
+            }
+          }
+          testID="textfield"
+        >
+          <View
+            style={
+              {
+                "flex": 1,
+              }
+            }
+          >
+            <TextInput
+              autoFocus={false}
+              editable={true}
+              id="input"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              style={
+                {
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "transparent",
+                  "borderWidth": 1,
+                  "color": "#141618",
+                  "fontFamily": "Euclid Circular B",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "height": 24,
+                  "letterSpacing": 0,
+                  "opacity": 1,
+                  "paddingVertical": 0,
+                }
+              }
+              testID="input"
+              value="a"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer supports the onCancel prop 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <RCTScrollView
+    style={
+      {
+        "marginBottom": 80,
+      }
+    }
+  >
+    <View>
+      <View
+        color="Default"
+        flexDirection="column"
+        gap={8}
+        justifyContent="flex-start"
+        style={
+          [
+            {
+              "color": "Default",
+              "flexDirection": "column",
+              "gap": 8,
+              "justifyContent": "flex-start",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          fontWeight="normal"
+          style={
+            {
+              "color": "inherit",
+              "fontFamily": "EuclidCircularB-Regular",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+          textAlign="left"
+        >
+          <Text
+            color="inherit"
+          >
+            Hello world!
+          </Text>
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+  <View
+    flexDirection="row"
+    gap={16}
+    padding={16}
+    style={
+      {
+        "bottom": 0,
+        "height": 80,
+        "justifyContent": "space-evenly",
+        "paddingVertical": 16,
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[MockFunction]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#0376c9",
+          "borderRadius": 24,
+          "borderWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Cancel
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      loading={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376c9",
+          "borderRadius": 24,
+          "flex": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+      textVariant="sBodyMDMedium"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 4,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 50,
+              "borderWidth": 0,
+              "height": 24,
+              "justifyContent": "center",
+              "overflow": "hidden",
+              "width": 24,
+            }
+          }
+        >
           <Text
             accessibilityRole="text"
             style={
               {
-                "color": "#ffffff",
-                "fontFamily": "EuclidCircularB-Medium",
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
                 "fontSize": 14,
-                "fontWeight": "500",
+                "fontWeight": "400",
                 "letterSpacing": 0,
                 "lineHeight": 22,
               }
             }
           >
-            <Text
-              color="inherit"
-            >
-              Foo
-            </Text>
+            m
           </Text>
         </View>
-      </TouchableOpacity>
-    </View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "EuclidCircularB-Medium",
+              "fontSize": 14,
+              "fontWeight": "500",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          <Text
+            color="inherit"
+          >
+            Foo
+          </Text>
+        </Text>
+      </View>
+    </TouchableOpacity>
   </View>
   <View
     data-renders={1}

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -827,9 +827,14 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
               flexDirection="row"
               justifyContent="space-between"
               style={
-                {
-                  "flex": 1,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  },
+                  undefined,
+                ]
               }
               testID="snaps-ui-card"
             >

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1,12 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SnapUIRenderer adds a footer if required 1`] = `
+<View
+  style={
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 80,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      color="Default"
+      flexDirection="column"
+      justifyContent="flex-start"
+      style={
+        [
+          {
+            "color": "Default",
+            "flexDirection": "column",
+            "justifyContent": "flex-start",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        fontWeight="normal"
+        style={
+          {
+            "color": "inherit",
+            "fontFamily": "EuclidCircularB-Regular",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+        textAlign="left"
+      >
+        <Text
+          color="inherit"
+        >
+          Hello world!
+        </Text>
+      </Text>
+    </View>
+    <View
+      flexDirection="row"
+      gap={16}
+      padding={16}
+      style={
+        {
+          "alignItems": "center",
+          "bottom": 0,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "marginTop": "auto",
+          "paddingVertical": 20,
+          "position": "fixed",
+          "width": "100%",
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376c9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#141618",
+              "fontFamily": "EuclidCircularB-Medium",
+              "fontSize": 14,
+              "fontWeight": "500",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Close
+        </Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
 exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -94,10 +225,15 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -235,10 +371,15 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -376,10 +517,15 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 exports[`SnapUIRenderer renders basic UI 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -438,10 +584,15 @@ exports[`SnapUIRenderer renders basic UI 1`] = `
 exports[`SnapUIRenderer renders complex nested components 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 80,
+      },
+    ]
   }
 >
   <View
@@ -592,14 +743,9 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
           flexDirection="row"
           justifyContent="space-between"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-              },
-              undefined,
-            ]
+            {
+              "flex": 1,
+            }
           }
           testID="snaps-ui-card"
         >
@@ -714,18 +860,19 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
     </View>
     <View
       flexDirection="row"
-      gap={4}
-      padding={4}
+      gap={16}
+      padding={16}
       style={
         {
           "bottom": 0,
+          "height": 80,
           "justifyContent": "space-evenly",
+          "marginTop": "auto",
           "paddingVertical": 20,
-          "position": "absolute",
+          "position": "fixed",
           "width": "100%",
         }
       }
-      width="100%"
     >
       <TouchableOpacity
         accessibilityRole="button"
@@ -865,10 +1012,15 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
 exports[`SnapUIRenderer renders footers 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 80,
+      },
+    ]
   }
 >
   <View
@@ -918,18 +1070,19 @@ exports[`SnapUIRenderer renders footers 1`] = `
     </View>
     <View
       flexDirection="row"
-      gap={4}
-      padding={4}
+      gap={16}
+      padding={16}
       style={
         {
           "bottom": 0,
+          "height": 80,
           "justifyContent": "space-evenly",
+          "marginTop": "auto",
           "paddingVertical": 20,
-          "position": "absolute",
+          "position": "fixed",
           "width": "100%",
         }
       }
-      width="100%"
     >
       <TouchableOpacity
         accessibilityRole="button"
@@ -1076,10 +1229,15 @@ exports[`SnapUIRenderer renders loading state 1`] = `
 exports[`SnapUIRenderer supports fields with multiple components 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -1256,10 +1414,15 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
 exports[`SnapUIRenderer supports forms with fields 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -1512,10 +1675,15 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
 exports[`SnapUIRenderer supports interactive inputs 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 0,
+      },
+    ]
   }
 >
   <View
@@ -1603,10 +1771,15 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
 exports[`SnapUIRenderer supports the onCancel prop 1`] = `
 <View
   style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
+    [
+      {
+        "flexGrow": 1,
+        "minHeight": 667,
+      },
+      {
+        "marginBottom": 80,
+      },
+    ]
   }
 >
   <View
@@ -1656,18 +1829,19 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
     </View>
     <View
       flexDirection="row"
-      gap={4}
-      padding={4}
+      gap={16}
+      padding={16}
       style={
         {
           "bottom": 0,
+          "height": 80,
           "justifyContent": "space-evenly",
+          "marginTop": "auto",
           "paddingVertical": 20,
-          "position": "absolute",
+          "position": "fixed",
           "width": "100%",
         }
       }
-      width="100%"
     >
       <TouchableOpacity
         accessibilityRole="button"

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1473,7 +1473,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                     style={
                       {
                         "backgroundColor": "transparent",
-                        "color": "#0376c9",
+                        "color": "#141618",
                         "fontFamily": "EuclidCircularB-Regular",
                         "fontSize": 14,
                         "fontWeight": "400",
@@ -1753,7 +1753,7 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
               style={
                 {
                   "backgroundColor": "transparent",
-                  "color": "#0376c9",
+                  "color": "#141618",
                   "fontFamily": "EuclidCircularB-Regular",
                   "fontSize": 14,
                   "fontWeight": "400",

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -9,112 +9,121 @@ exports[`SnapUIRenderer adds a footer if required 1`] = `
     }
   }
 >
-  <RCTScrollView
+  <View
     style={
       {
-        "marginBottom": 80,
+        "flex": 1,
+        "flexDirection": "column",
       }
     }
   >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 80,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            fontWeight="normal"
+            style={
+              {
+                "color": "inherit",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+            textAlign="left"
+          >
+            <Text
+              color="inherit"
+            >
+              Hello world!
+            </Text>
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      flexDirection="row"
+      gap={16}
+      padding={16}
+      style={
+        {
+          "alignItems": "center",
+          "bottom": 0,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
         style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376c9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
         }
       >
         <Text
           accessibilityRole="text"
-          fontWeight="normal"
           style={
             {
-              "color": "inherit",
-              "fontFamily": "EuclidCircularB-Regular",
+              "color": "#141618",
+              "fontFamily": "EuclidCircularB-Medium",
               "fontSize": 14,
-              "fontWeight": "400",
+              "fontWeight": "500",
               "letterSpacing": 0,
               "lineHeight": 22,
             }
           }
-          textAlign="left"
         >
-          <Text
-            color="inherit"
-          >
-            Hello world!
-          </Text>
+          Close
         </Text>
-      </View>
+      </TouchableOpacity>
     </View>
-  </RCTScrollView>
-  <View
-    flexDirection="row"
-    gap={16}
-    padding={16}
-    style={
-      {
-        "alignItems": "center",
-        "bottom": 0,
-        "height": 80,
-        "justifyContent": "space-evenly",
-        "paddingVertical": 16,
-        "position": "absolute",
-        "width": "100%",
-      }
-    }
-  >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "transparent",
-          "borderColor": "#0376c9",
-          "borderRadius": 24,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#141618",
-            "fontFamily": "EuclidCircularB-Medium",
-            "fontSize": 14,
-            "fontWeight": "500",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-      >
-        Close
-      </Text>
-    </TouchableOpacity>
   </View>
   <View
     data-renders={1}
@@ -132,249 +141,6 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
     }
   }
 >
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 0,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="textfield"
-        >
-          <View
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
-                }
-              }
-              testID="input"
-              value="bar"
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
-<View
-  style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
-  }
->
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 0,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="textfield"
-        >
-          <View
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
-                }
-              }
-              testID="input"
-              value=""
-            />
-          </View>
-        </View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-          testID="textfield"
-        >
-          <View
-            style={
-              {
-                "flex": 1,
-              }
-            }
-          >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input2"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
-              style={
-                {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
-                }
-              }
-              testID="input"
-              value=""
-            />
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    data-renders={2}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
-<View
-  style={
-    [
-      {
-        "flexGrow": 1,
-        "minHeight": 667,
-      },
-      {
-        "marginBottom": 0,
-      },
-    ]
-  }
->
   <View
     style={
       {
@@ -383,241 +149,22 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
       }
     }
   >
-    <View
-      color="Default"
-      flexDirection="column"
-      justifyContent="flex-start"
+    <RCTScrollView
       style={
-        [
-          {
-            "color": "Default",
-            "flexDirection": "column",
-            "justifyContent": "flex-start",
-          },
-          undefined,
-        ]
+        {
+          "marginBottom": 0,
+        }
       }
     >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
-        }
-        testID="textfield"
-      >
+      <View>
         <View
-          style={
-            {
-              "flex": 1,
-            }
-          }
-        >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            style={
-              {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
-              }
-            }
-            testID="input"
-            value="bar"
-          />
-        </View>
-      </View>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#848c96",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-            "paddingHorizontal": 16,
-          }
-        }
-        testID="textfield"
-      >
-        <View
-          style={
-            {
-              "flex": 1,
-            }
-          }
-        >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            id="input2"
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            style={
-              {
-                "backgroundColor": "#ffffff",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#141618",
-                "fontFamily": "Euclid Circular B",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "height": 24,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingVertical": 0,
-              }
-            }
-            testID="input"
-            value="foo"
-          />
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    data-renders={2}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer renders basic UI 1`] = `
-<View
-  style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
-  }
->
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 0,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          fontWeight="normal"
-          style={
-            {
-              "color": "inherit",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-          textAlign="left"
-        >
-          <Text
-            color="inherit"
-          >
-            Hello world!
-          </Text>
-        </Text>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer renders complex nested components 1`] = `
-<View
-  style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
-  }
->
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 80,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <View
-          backgroundColor="#f2f4f6"
-          borderRadius={8}
           color="Default"
           flexDirection="column"
           gap={8}
           justifyContent="flex-start"
-          padding={16}
           style={
             [
               {
-                "backgroundColor": "#f2f4f6",
                 "color": "Default",
                 "flexDirection": "column",
                 "gap": 8,
@@ -627,653 +174,6 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
             ]
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "display": "flex",
-                "flexDirection": "row",
-                "flexWrap": "wrap",
-                "justifyContent": "space-between",
-                "paddingBottom": 8,
-                "paddingHorizontal": 8,
-              }
-            }
-            testID="info-row"
-          >
-            <View
-              style={
-                {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "minHeight": 38,
-                  "paddingEnd": 4,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "alignItems": "center",
-                    "color": "#141618",
-                    "fontFamily": "EuclidCircularB-Bold",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "justifyContent": "center",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                  }
-                }
-              >
-                Key
-              </Text>
-            </View>
-            <View
-              style={
-                {
-                  "marginLeft": "auto",
-                }
-              }
-            >
-              <View
-                alignItems="center"
-                flexDirection="row"
-                gap={4}
-                style={
-                  [
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 4,
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#9fa6ae",
-                      "fontFamily": "EuclidCircularB-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  Extra
-                </Text>
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#141618",
-                      "fontFamily": "EuclidCircularB-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  Value
-                </Text>
-              </View>
-            </View>
-          </View>
-          <View
-            alignItems="center"
-            flexDirection="row"
-            justifyContent="space-between"
-            style={
-              {
-                "flex": 1,
-              }
-            }
-            testID="snaps-ui-card"
-          >
-            <View
-              alignItems="center"
-              flexDirection="row"
-              gap={16}
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "gap": 16,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <View
-                flexDirection="column"
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                <Text
-                  accessibilityRole="text"
-                  ellipsizeMode="tail"
-                  style={
-                    {
-                      "color": "#141618",
-                      "fontFamily": "EuclidCircularB-Medium",
-                      "fontSize": 14,
-                      "fontWeight": "500",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  CardTitle
-                </Text>
-                <Text
-                  accessibilityRole="text"
-                  ellipsizeMode="tail"
-                  style={
-                    {
-                      "color": "#6a737d",
-                      "fontFamily": "EuclidCircularB-Regular",
-                      "fontSize": 14,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  CardDescription
-                </Text>
-              </View>
-            </View>
-            <View
-              flexDirection="column"
-              style={
-                [
-                  {
-                    "flexDirection": "column",
-                    "textAlign": "right",
-                  },
-                  undefined,
-                ]
-              }
-              textAlign="right"
-            >
-              <Text
-                accessibilityRole="text"
-                ellipsizeMode="tail"
-                style={
-                  {
-                    "color": "#141618",
-                    "fontFamily": "EuclidCircularB-Medium",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                  }
-                }
-              >
-                CardValue
-              </Text>
-              <Text
-                accessibilityRole="text"
-                ellipsizeMode="tail"
-                style={
-                  {
-                    "color": "#6a737d",
-                    "fontFamily": "EuclidCircularB-Regular",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                  }
-                }
-              >
-                CardExtra
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    flexDirection="row"
-    gap={16}
-    padding={16}
-    style={
-      {
-        "bottom": 0,
-        "height": 80,
-        "justifyContent": "space-evenly",
-        "paddingVertical": 16,
-        "position": "absolute",
-        "width": "100%",
-      }
-    }
-  >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "transparent",
-          "borderColor": "#0376c9",
-          "borderRadius": 24,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#141618",
-            "fontFamily": "EuclidCircularB-Medium",
-            "fontSize": 14,
-            "fontWeight": "500",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-      >
-        Cancel
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#0376c9",
-          "borderRadius": 24,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-      textVariant="sBodyMDMedium"
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "gap": 4,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 50,
-              "borderWidth": 0,
-              "height": 24,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 24,
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#141618",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-          >
-            m
-          </Text>
-        </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "EuclidCircularB-Medium",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-        >
-          <Text
-            color="inherit"
-          >
-            Foo
-          </Text>
-        </Text>
-      </View>
-    </TouchableOpacity>
-  </View>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer renders footers 1`] = `
-<View
-  style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
-  }
->
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 80,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          fontWeight="normal"
-          style={
-            {
-              "color": "inherit",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-          textAlign="left"
-        >
-          <Text
-            color="inherit"
-          >
-            Hello world!
-          </Text>
-        </Text>
-      </View>
-    </View>
-  </RCTScrollView>
-  <View
-    flexDirection="row"
-    gap={16}
-    padding={16}
-    style={
-      {
-        "bottom": 0,
-        "height": 80,
-        "justifyContent": "space-evenly",
-        "paddingVertical": 16,
-        "position": "absolute",
-        "width": "100%",
-      }
-    }
-  >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "transparent",
-          "borderColor": "#0376c9",
-          "borderRadius": 24,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#141618",
-            "fontFamily": "EuclidCircularB-Medium",
-            "fontSize": 14,
-            "fontWeight": "500",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-      >
-        Cancel
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#0376c9",
-          "borderRadius": 24,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-      textVariant="sBodyMDMedium"
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "gap": 4,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 50,
-              "borderWidth": 0,
-              "height": 24,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 24,
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#141618",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-          >
-            m
-          </Text>
-        </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "EuclidCircularB-Medium",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-        >
-          <Text
-            color="inherit"
-          >
-            Foo
-          </Text>
-        </Text>
-      </View>
-    </TouchableOpacity>
-  </View>
-  <View
-    data-renders={1}
-    testID="performance"
-  />
-</View>
-`;
-
-exports[`SnapUIRenderer renders loading state 1`] = `
-<ActivityIndicator
-  color="#1292B4"
-  size="large"
-/>
-`;
-
-exports[`SnapUIRenderer supports fields with multiple components 1`] = `
-<View
-  style={
-    {
-      "flexGrow": 1,
-      "minHeight": 667,
-    }
-  }
->
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 0,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <View
-          flexDirection="column"
-          gap={8}
-          style={
-            [
-              {
-                "flexDirection": "column",
-                "gap": 8,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#141618",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-            testID="label"
-          >
-            My Input
-          </Text>
           <View
             style={
               {
@@ -1293,11 +193,106 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
             <View
               style={
                 {
-                  "marginRight": 8,
+                  "flex": 1,
                 }
               }
-              testID="textfield-startacccessory"
-            />
+            >
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "height": 24,
+                    "letterSpacing": 0,
+                    "opacity": 1,
+                    "paddingVertical": 0,
+                  }
+                }
+                testID="input"
+                value="bar"
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "opacity": 1,
+                "paddingHorizontal": 16,
+              }
+            }
+            testID="textfield"
+          >
             <View
               style={
                 {
@@ -1331,70 +326,69 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                 value=""
               />
             </View>
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "opacity": 1,
+                "paddingHorizontal": 16,
+              }
+            }
+            testID="textfield"
+          >
             <View
               style={
                 {
-                  "marginLeft": 8,
+                  "flex": 1,
                 }
               }
-              testID="textfield-endacccessory"
             >
-              <Text
-                accessibilityRole="link"
-                accessible={true}
-                disabled={false}
-                id="submit"
-                onPress={[Function]}
-                onPressIn={[Function]}
-                onPressOut={[Function]}
-                padding={0}
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input2"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
                 style={
                   {
-                    "backgroundColor": "transparent",
-                    "color": "#0376c9",
-                    "fontFamily": "EuclidCircularB-Regular",
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
                     "fontSize": 14,
                     "fontWeight": "400",
+                    "height": 24,
                     "letterSpacing": 0,
-                    "lineHeight": 22,
+                    "opacity": 1,
+                    "paddingVertical": 0,
                   }
                 }
-                suppressHighlighting={true}
-              >
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#0376c9",
-                      "fontFamily": "EuclidCircularB-Medium",
-                      "fontSize": 14,
-                      "fontWeight": "500",
-                      "letterSpacing": 0,
-                      "lineHeight": 22,
-                    }
-                  }
-                >
-                  <Text
-                    color="inherit"
-                  >
-                    Submit
-                  </Text>
-                </Text>
-              </Text>
+                testID="input"
+                value=""
+              />
             </View>
           </View>
         </View>
       </View>
-    </View>
-  </RCTScrollView>
+    </RCTScrollView>
+  </View>
   <View
-    data-renders={1}
+    data-renders={2}
     testID="performance"
   />
 </View>
 `;
 
-exports[`SnapUIRenderer supports forms with fields 1`] = `
+exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 <View
   style={
     {
@@ -1403,60 +397,39 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
     }
   }
 >
-  <RCTScrollView
+  <View
     style={
       {
-        "marginBottom": 0,
+        "flex": 1,
+        "flexDirection": "column",
       }
     }
   >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
         }
-      >
+      }
+    >
+      <View>
         <View
+          color="Default"
           flexDirection="column"
           gap={8}
+          justifyContent="flex-start"
           style={
             [
               {
+                "color": "Default",
                 "flexDirection": "column",
                 "gap": 8,
+                "justifyContent": "flex-start",
               },
               undefined,
             ]
           }
         >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#141618",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-            testID="label"
-          >
-            My Input
-          </Text>
           <View
             style={
               {
@@ -1503,16 +476,852 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
                   }
                 }
                 testID="input"
-                value="abc"
+                value="bar"
               />
             </View>
           </View>
           <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "opacity": 1,
+                "paddingHorizontal": 16,
+              }
+            }
+            testID="textfield"
+          >
+            <View
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input2"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "height": 24,
+                    "letterSpacing": 0,
+                    "opacity": 1,
+                    "paddingVertical": 0,
+                  }
+                }
+                testID="input"
+                value="foo"
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={2}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer renders basic UI 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            fontWeight="normal"
+            style={
+              {
+                "color": "inherit",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+            textAlign="left"
+          >
+            <Text
+              color="inherit"
+            >
+              Hello world!
+            </Text>
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer renders complex nested components 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 80,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            backgroundColor="#f2f4f6"
+            borderRadius={8}
+            color="Default"
             flexDirection="column"
+            gap={8}
+            justifyContent="flex-start"
+            padding={16}
+            style={
+              [
+                {
+                  "backgroundColor": "#f2f4f6",
+                  "color": "Default",
+                  "flexDirection": "column",
+                  "gap": 8,
+                  "justifyContent": "flex-start",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "paddingBottom": 8,
+                  "paddingHorizontal": 8,
+                }
+              }
+              testID="info-row"
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "minHeight": 38,
+                    "paddingEnd": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "alignItems": "center",
+                      "color": "#141618",
+                      "fontFamily": "EuclidCircularB-Bold",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "justifyContent": "center",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  Key
+                </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "marginLeft": "auto",
+                  }
+                }
+              >
+                <View
+                  alignItems="center"
+                  flexDirection="row"
+                  gap={4}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "gap": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#9fa6ae",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    Extra
+                  </Text>
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    Value
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              alignItems="center"
+              flexDirection="row"
+              justifyContent="space-between"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+              testID="snaps-ui-card"
+            >
+              <View
+                alignItems="center"
+                flexDirection="row"
+                gap={16}
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 16,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  flexDirection="column"
+                  style={
+                    [
+                      {
+                        "flexDirection": "column",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    accessibilityRole="text"
+                    ellipsizeMode="tail"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    CardTitle
+                  </Text>
+                  <Text
+                    accessibilityRole="text"
+                    ellipsizeMode="tail"
+                    style={
+                      {
+                        "color": "#6a737d",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    CardDescription
+                  </Text>
+                </View>
+              </View>
+              <View
+                flexDirection="column"
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "textAlign": "right",
+                    },
+                    undefined,
+                  ]
+                }
+                textAlign="right"
+              >
+                <Text
+                  accessibilityRole="text"
+                  ellipsizeMode="tail"
+                  style={
+                    {
+                      "color": "#141618",
+                      "fontFamily": "EuclidCircularB-Medium",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  CardValue
+                </Text>
+                <Text
+                  accessibilityRole="text"
+                  ellipsizeMode="tail"
+                  style={
+                    {
+                      "color": "#6a737d",
+                      "fontFamily": "EuclidCircularB-Regular",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  CardExtra
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      flexDirection="row"
+      gap={16}
+      padding={16}
+      style={
+        {
+          "bottom": 0,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376c9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#141618",
+              "fontFamily": "EuclidCircularB-Medium",
+              "fontSize": 14,
+              "fontWeight": "500",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#0376c9",
+            "borderRadius": 24,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+        textVariant="sBodyMDMedium"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 50,
+                "borderWidth": 0,
+                "height": 24,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 24,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              m
+            </Text>
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "EuclidCircularB-Medium",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            <Text
+              color="inherit"
+            >
+              Foo
+            </Text>
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer renders footers 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 80,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            fontWeight="normal"
+            style={
+              {
+                "color": "inherit",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+            textAlign="left"
+          >
+            <Text
+              color="inherit"
+            >
+              Hello world!
+            </Text>
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      flexDirection="row"
+      gap={16}
+      padding={16}
+      style={
+        {
+          "bottom": 0,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376c9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#141618",
+              "fontFamily": "EuclidCircularB-Medium",
+              "fontSize": 14,
+              "fontWeight": "500",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Cancel
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#0376c9",
+            "borderRadius": 24,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+        textVariant="sBodyMDMedium"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 50,
+                "borderWidth": 0,
+                "height": 24,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 24,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              m
+            </Text>
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "EuclidCircularB-Medium",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            <Text
+              color="inherit"
+            >
+              Foo
+            </Text>
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer renders loading state 1`] = `
+<ActivityIndicator
+  color="#1292B4"
+  size="large"
+/>
+`;
+
+exports[`SnapUIRenderer supports fields with multiple components 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            flexDirection="column"
+            gap={8}
             style={
               [
                 {
                   "flexDirection": "column",
+                  "gap": 8,
                 },
                 undefined,
               ]
@@ -1532,62 +1341,86 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
               }
               testID="label"
             >
-              My Checkbox
+              My Input
             </Text>
-            <TouchableOpacity
-              disabled={false}
-              onPress={[Function]}
+            <View
               style={
                 {
                   "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
                   "flexDirection": "row",
-                  "height": 24,
+                  "height": 48,
                   "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
+              testID="textfield"
             >
               <View
-                accessibilityRole="checkbox"
                 style={
                   {
-                    "alignItems": "center",
-                    "backgroundColor": "#0376c9",
-                    "borderColor": "border-muted",
-                    "borderRadius": 4,
-                    "borderWidth": 2,
-                    "height": 20,
-                    "justifyContent": "center",
-                    "width": 20,
+                    "marginRight": 8,
+                  }
+                }
+                testID="textfield-startacccessory"
+              />
+              <View
+                style={
+                  {
+                    "flex": 1,
                   }
                 }
               >
-                <SvgMock
-                  color="#ffffff"
-                  height={20}
-                  name="CheckBold"
-                  onPress={[Function]}
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
                   style={
                     {
-                      "height": 20,
-                      "width": 20,
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
                     }
                   }
-                  testID="checkbox-icon-component"
-                  width={20}
+                  testID="input"
+                  value=""
                 />
               </View>
               <View
                 style={
                   {
-                    "marginLeft": 12,
+                    "marginLeft": 8,
                   }
                 }
+                testID="textfield-endacccessory"
               >
                 <Text
-                  accessibilityRole="text"
+                  accessibilityRole="link"
+                  accessible={true}
+                  disabled={false}
+                  id="submit"
+                  onPress={[Function]}
+                  onPressIn={[Function]}
+                  onPressOut={[Function]}
+                  padding={0}
                   style={
                     {
-                      "color": "#141618",
+                      "backgroundColor": "transparent",
+                      "color": "#0376c9",
                       "fontFamily": "EuclidCircularB-Regular",
                       "fontSize": 14,
                       "fontWeight": "400",
@@ -1595,57 +1428,303 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
                       "lineHeight": 22,
                     }
                   }
+                  suppressHighlighting={true}
                 >
-                  This is a checkbox
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#0376c9",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    <Text
+                      color="inherit"
+                    >
+                      Submit
+                    </Text>
+                  </Text>
                 </Text>
               </View>
-            </TouchableOpacity>
+            </View>
           </View>
-          <Text
-            accessibilityRole="link"
-            accessible={true}
-            disabled={false}
-            id="submit"
-            onPress={[Function]}
-            onPressIn={[Function]}
-            onPressOut={[Function]}
-            style={
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+  <View
+    data-renders={1}
+    testID="performance"
+  />
+</View>
+`;
+
+exports[`SnapUIRenderer supports forms with fields 1`] = `
+<View
+  style={
+    {
+      "flexGrow": 1,
+      "minHeight": 667,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
+          style={
+            [
               {
-                "backgroundColor": "transparent",
-                "color": "#0376c9",
-                "fontFamily": "EuclidCircularB-Regular",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            flexDirection="column"
+            gap={8}
+            style={
+              [
+                {
+                  "flexDirection": "column",
+                  "gap": 8,
+                },
+                undefined,
+              ]
             }
-            suppressHighlighting={true}
           >
             <Text
               accessibilityRole="text"
               style={
                 {
-                  "color": "#0376c9",
-                  "fontFamily": "EuclidCircularB-Medium",
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Regular",
                   "fontSize": 14,
-                  "fontWeight": "500",
+                  "fontWeight": "400",
                   "letterSpacing": 0,
                   "lineHeight": 22,
                 }
               }
+              testID="label"
+            >
+              My Input
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#848c96",
+                  "borderRadius": 8,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "opacity": 1,
+                  "paddingHorizontal": 16,
+                }
+              }
+              testID="textfield"
+            >
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
+                <TextInput
+                  autoFocus={false}
+                  editable={true}
+                  id="input"
+                  onBlur={[Function]}
+                  onChangeText={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    {
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "transparent",
+                      "borderWidth": 1,
+                      "color": "#141618",
+                      "fontFamily": "Euclid Circular B",
+                      "fontSize": 14,
+                      "fontWeight": "400",
+                      "height": 24,
+                      "letterSpacing": 0,
+                      "opacity": 1,
+                      "paddingVertical": 0,
+                    }
+                  }
+                  testID="input"
+                  value="abc"
+                />
+              </View>
+            </View>
+            <View
+              flexDirection="column"
+              style={
+                [
+                  {
+                    "flexDirection": "column",
+                  },
+                  undefined,
+                ]
+              }
             >
               <Text
-                color="inherit"
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#141618",
+                    "fontFamily": "EuclidCircularB-Regular",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+                testID="label"
               >
-                Submit
+                My Checkbox
+              </Text>
+              <TouchableOpacity
+                disabled={false}
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "height": 24,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="checkbox"
+                  style={
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "#0376c9",
+                      "borderColor": "border-muted",
+                      "borderRadius": 4,
+                      "borderWidth": 2,
+                      "height": 20,
+                      "justifyContent": "center",
+                      "width": 20,
+                    }
+                  }
+                >
+                  <SvgMock
+                    color="#ffffff"
+                    height={20}
+                    name="CheckBold"
+                    onPress={[Function]}
+                    style={
+                      {
+                        "height": 20,
+                        "width": 20,
+                      }
+                    }
+                    testID="checkbox-icon-component"
+                    width={20}
+                  />
+                </View>
+                <View
+                  style={
+                    {
+                      "marginLeft": 12,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Regular",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    This is a checkbox
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <Text
+              accessibilityRole="link"
+              accessible={true}
+              disabled={false}
+              id="submit"
+              onPress={[Function]}
+              onPressIn={[Function]}
+              onPressOut={[Function]}
+              style={
+                {
+                  "backgroundColor": "transparent",
+                  "color": "#0376c9",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#0376c9",
+                    "fontFamily": "EuclidCircularB-Medium",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                <Text
+                  color="inherit"
+                >
+                  Submit
+                </Text>
               </Text>
             </Text>
-          </Text>
+          </View>
         </View>
       </View>
-    </View>
-  </RCTScrollView>
+    </RCTScrollView>
+  </View>
   <View
     data-renders={1}
     testID="performance"
@@ -1662,84 +1741,93 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
     }
   }
 >
-  <RCTScrollView
+  <View
     style={
       {
-        "marginBottom": 0,
+        "flex": 1,
+        "flexDirection": "column",
       }
     }
   >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
         }
-      >
+      }
+    >
+      <View>
         <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#848c96",
-              "borderRadius": 8,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
           }
-          testID="textfield"
         >
           <View
             style={
               {
-                "flex": 1,
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#848c96",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "opacity": 1,
+                "paddingHorizontal": 16,
               }
             }
+            testID="textfield"
           >
-            <TextInput
-              autoFocus={false}
-              editable={true}
-              id="input"
-              onBlur={[Function]}
-              onChangeText={[Function]}
-              onFocus={[Function]}
+            <View
               style={
                 {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "transparent",
-                  "borderWidth": 1,
-                  "color": "#141618",
-                  "fontFamily": "Euclid Circular B",
-                  "fontSize": 14,
-                  "fontWeight": "400",
-                  "height": 24,
-                  "letterSpacing": 0,
-                  "opacity": 1,
-                  "paddingVertical": 0,
+                  "flex": 1,
                 }
               }
-              testID="input"
-              value="a"
-            />
+            >
+              <TextInput
+                autoFocus={false}
+                editable={true}
+                id="input"
+                onBlur={[Function]}
+                onChangeText={[Function]}
+                onFocus={[Function]}
+                style={
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "transparent",
+                    "borderWidth": 1,
+                    "color": "#141618",
+                    "fontFamily": "Euclid Circular B",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "height": 24,
+                    "letterSpacing": 0,
+                    "opacity": 1,
+                    "paddingVertical": 0,
+                  }
+                }
+                testID="input"
+                value="a"
+              />
+            </View>
           </View>
         </View>
       </View>
-    </View>
-  </RCTScrollView>
+    </RCTScrollView>
+  </View>
   <View
     data-renders={1}
     testID="performance"
@@ -1756,164 +1844,45 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
     }
   }
 >
-  <RCTScrollView
-    style={
-      {
-        "marginBottom": 80,
-      }
-    }
-  >
-    <View>
-      <View
-        color="Default"
-        flexDirection="column"
-        gap={8}
-        justifyContent="flex-start"
-        style={
-          [
-            {
-              "color": "Default",
-              "flexDirection": "column",
-              "gap": 8,
-              "justifyContent": "flex-start",
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          fontWeight="normal"
-          style={
-            {
-              "color": "inherit",
-              "fontFamily": "EuclidCircularB-Regular",
-              "fontSize": 14,
-              "fontWeight": "400",
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-          textAlign="left"
-        >
-          <Text
-            color="inherit"
-          >
-            Hello world!
-          </Text>
-        </Text>
-      </View>
-    </View>
-  </RCTScrollView>
   <View
-    flexDirection="row"
-    gap={16}
-    padding={16}
     style={
       {
-        "bottom": 0,
-        "height": 80,
-        "justifyContent": "space-evenly",
-        "paddingVertical": 16,
-        "position": "absolute",
-        "width": "100%",
+        "flex": 1,
+        "flexDirection": "column",
       }
     }
   >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[MockFunction]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
+    <RCTScrollView
       style={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "transparent",
-          "borderColor": "#0376c9",
-          "borderRadius": 24,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
+          "marginBottom": 80,
         }
       }
     >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#141618",
-            "fontFamily": "EuclidCircularB-Medium",
-            "fontSize": 14,
-            "fontWeight": "500",
-            "letterSpacing": 0,
-            "lineHeight": 22,
-          }
-        }
-      >
-        Cancel
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      disabled={false}
-      loading={false}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#0376c9",
-          "borderRadius": 24,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "paddingHorizontal": 16,
-        }
-      }
-      textVariant="sBodyMDMedium"
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "gap": 4,
-            "justifyContent": "center",
-          }
-        }
-      >
+      <View>
         <View
+          color="Default"
+          flexDirection="column"
+          gap={8}
+          justifyContent="flex-start"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 50,
-              "borderWidth": 0,
-              "height": 24,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 24,
-            }
+            [
+              {
+                "color": "Default",
+                "flexDirection": "column",
+                "gap": 8,
+                "justifyContent": "flex-start",
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
+            fontWeight="normal"
             style={
               {
-                "color": "#141618",
+                "color": "inherit",
                 "fontFamily": "EuclidCircularB-Regular",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -1921,15 +1890,62 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
                 "lineHeight": 22,
               }
             }
+            textAlign="left"
           >
-            m
+            <Text
+              color="inherit"
+            >
+              Hello world!
+            </Text>
           </Text>
         </View>
+      </View>
+    </RCTScrollView>
+    <View
+      flexDirection="row"
+      gap={16}
+      padding={16}
+      style={
+        {
+          "bottom": 0,
+          "height": 80,
+          "justifyContent": "space-evenly",
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[MockFunction]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "transparent",
+            "borderColor": "#0376c9",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
         <Text
           accessibilityRole="text"
           style={
             {
-              "color": "#ffffff",
+              "color": "#141618",
               "fontFamily": "EuclidCircularB-Medium",
               "fontSize": 14,
               "fontWeight": "500",
@@ -1938,14 +1954,95 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
             }
           }
         >
-          <Text
-            color="inherit"
-          >
-            Foo
-          </Text>
+          Cancel
         </Text>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        disabled={false}
+        loading={false}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#0376c9",
+            "borderRadius": 24,
+            "flex": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 16,
+          }
+        }
+        textVariant="sBodyMDMedium"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 50,
+                "borderWidth": 0,
+                "height": 24,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 24,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Regular",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              m
+            </Text>
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "EuclidCircularB-Medium",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            <Text
+              color="inherit"
+            >
+              Foo
+            </Text>
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     data-renders={1}

--- a/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
@@ -38,6 +38,7 @@ describe('banner component', () => {
           key: 'mock-key',
           children: [
             {
+              key: '4322bc9dfc78dd5fac77c48bc64efc877ae6265f8cc50c12a63fe3a62674e402_1',
               element: 'RNText',
               props: {
                 color: 'inherit',

--- a/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
@@ -81,6 +81,7 @@ describe('banner component', () => {
           key: 'mock-key',
           children: [
             {
+              key: '4322bc9dfc78dd5fac77c48bc64efc877ae6265f8cc50c12a63fe3a62674e402_2',
               element: 'RNText',
               props: {
                 color: 'inherit',

--- a/app/components/Snaps/SnapUIRenderer/components/box.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/box.test.ts
@@ -39,6 +39,7 @@ describe('box UIComponentFactory', () => {
           key: 'mock-key',
           children: [
             {
+              key: '4322bc9dfc78dd5fac77c48bc64efc877ae6265f8cc50c12a63fe3a62674e402_1',
               element: 'RNText',
               children: 'Test content',
               props: { color: 'inherit' },

--- a/app/components/Snaps/SnapUIRenderer/components/box.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/box.test.ts
@@ -57,6 +57,7 @@ describe('box UIComponentFactory', () => {
         justifyContent: 'flex-start',
         color: TextColor.Default,
         alignItems: undefined,
+        gap: 8,
       },
     });
   });

--- a/app/components/Snaps/SnapUIRenderer/components/box.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/box.ts
@@ -69,5 +69,6 @@ export const box: UIComponentFactory<BoxElement> = ({
     justifyContent: generateJustifyContent(e.props.alignment),
     alignItems: generateAlignItems(e.props.crossAlignment, e.props.center),
     color: TextColor.Default,
+    gap: 8,
   },
 });

--- a/app/components/Snaps/SnapUIRenderer/components/container.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.test.ts
@@ -43,22 +43,35 @@ describe('container', () => {
       theme: mockTheme,
     });
 
-    expect(result).toEqual({
-      element: 'Box',
-      children: [
-        {
-          element: 'text',
-          props: {},
-          children: ['Hello'],
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "children": {
+              "children": [
+                "Hello",
+              ],
+              "element": "text",
+              "props": {},
+            },
+            "element": "ScrollView",
+            "key": "default-scrollview",
+            "props": {
+              "style": {
+                "marginBottom": 0,
+              },
+            },
+          },
+        ],
+        "element": "Box",
+        "props": {
+          "style": {
+            "flex": 1,
+            "flexDirection": "column",
+          },
         },
-      ],
-      props: {
-        style: {
-          flex: 1,
-          flexDirection: 'column',
-        },
-      },
-    });
+      }
+    `);
   });
 
   it('add footer button when useFooter is true and onCancel is provided', () => {
@@ -76,32 +89,43 @@ describe('container', () => {
 
     expect(Array.isArray(result.children)).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((result.children as any[])[0]).toEqual({
-      element: 'Box',
-      props: {
-        flexDirection: 'row',
-        gap: 16,
-        padding: 16,
-        style: {
-          alignItems: 'center',
-          bottom: 0,
-          height: 80,
-          justifyContent: 'space-evenly',
-          paddingVertical: 16,
-          position: 'absolute',
-          width: '100%',
+    expect((result.children as any[])[0]).toMatchInlineSnapshot(`
+      {
+        "children": {
+          "children": {
+            "children": "navigation.close",
+            "element": "SnapUIFooterButton",
+            "key": "default-button",
+            "props": {
+              "isSnapAction": false,
+              "onCancel": [MockFunction],
+            },
+          },
+          "element": "Box",
+          "key": "default-footer",
+          "props": {
+            "flexDirection": "row",
+            "gap": 16,
+            "padding": 16,
+            "style": {
+              "alignItems": "center",
+              "bottom": 0,
+              "height": 80,
+              "justifyContent": "space-evenly",
+              "paddingVertical": 16,
+              "position": "absolute",
+              "width": "100%",
+            },
+          },
         },
-      },
-      key: 'default-footer',
-      children: {
-        element: 'SnapUIFooterButton',
-        key: 'default-button',
-        props: {
-          onCancel: mockOnCancel,
-          isSnapAction: false,
+        "element": "ScrollView",
+        "key": "default-scrollview",
+        "props": {
+          "style": {
+            "marginBottom": 0,
+          },
         },
-        children: 'navigation.close',
-      },
-    });
+      }
+    `);
   });
 });

--- a/app/components/Snaps/SnapUIRenderer/components/container.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.test.ts
@@ -79,8 +79,20 @@ describe('container', () => {
     expect((result.children as any[])[0]).toEqual({
       element: 'Box',
       props: {
-        style: { alignItems: 'center' },
+        flexDirection: 'row',
+        gap: 16,
+        padding: 16,
+        style: {
+          alignItems: 'center',
+          bottom: 0,
+          height: 80,
+          justifyContent: 'space-evenly',
+          paddingVertical: 16,
+          position: 'absolute',
+          width: '100%',
+        },
       },
+      key: 'default-footer',
       children: {
         element: 'SnapUIFooterButton',
         key: 'default-button',
@@ -88,7 +100,7 @@ describe('container', () => {
           onCancel: mockOnCancel,
           isSnapAction: false,
         },
-        children: 'close',
+        children: 'navigation.close',
       },
     });
   });

--- a/app/components/Snaps/SnapUIRenderer/components/container.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.ts
@@ -2,6 +2,7 @@ import { BoxElement, JSXElement } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { mapToTemplate } from '../utils';
 import { UIComponentFactory } from './types';
+import { DEFAULT_FOOTER } from './footer';
 
 export const container: UIComponentFactory<BoxElement> = ({
   element: e,
@@ -28,8 +29,10 @@ export const container: UIComponentFactory<BoxElement> = ({
 
   if (useFooter && onCancel && !children[1]) {
     templateChildren.push({
+      ...DEFAULT_FOOTER,
       props: {
-        style: { alignItems: 'center' },
+        ...DEFAULT_FOOTER.props,
+        style: { ...DEFAULT_FOOTER.props.style, alignItems: 'center' },
       },
       children: {
         element: 'SnapUIFooterButton',
@@ -38,9 +41,8 @@ export const container: UIComponentFactory<BoxElement> = ({
           onCancel,
           isSnapAction: false,
         },
-        children: t('close'),
+        children: t('navigation.close'),
       },
-      element: 'Box',
     });
   }
 

--- a/app/components/Snaps/SnapUIRenderer/components/container.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.ts
@@ -46,9 +46,25 @@ export const container: UIComponentFactory<BoxElement> = ({
     });
   }
 
+  const content = templateChildren[0];
+  const footer = templateChildren[1];
+
   return {
     element: 'Box',
-    children: templateChildren,
+    children: [
+      {
+        element: 'ScrollView',
+        key: 'default-scrollview',
+        children: content,
+        props: {
+          style: {
+            // flex: 1,
+            marginBottom: useFooter && footer ? 80 : 0,
+          },
+        },
+      },
+      ...(footer ? [footer] : []),
+    ],
     props: {
       style: {
         flex: 1,

--- a/app/components/Snaps/SnapUIRenderer/components/container.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/container.ts
@@ -58,7 +58,6 @@ export const container: UIComponentFactory<BoxElement> = ({
         children: content,
         props: {
           style: {
-            // flex: 1,
             marginBottom: useFooter && footer ? 80 : 0,
           },
         },

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -58,8 +58,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           label: e.props.label,
           name: input.props.name,
           form,
-          error: e.props.error !== undefined,
-          helpText: e.props.error,
+          error: e.props.error,
           disabled: child.props.disabled,
         },
         propComponents: {

--- a/app/components/Snaps/SnapUIRenderer/components/footer.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/footer.test.ts
@@ -65,6 +65,7 @@ describe('footer', () => {
           },
           children: [
             {
+              key: '57fd48ba929aa415dc4c3996c826a75f8686418c77765eb14fad2658efa73d87_1',
               element: 'RNText',
               children: 'Button',
               props: { color: 'inherit' },

--- a/app/components/Snaps/SnapUIRenderer/components/footer.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/footer.ts
@@ -13,13 +13,12 @@ export const DEFAULT_FOOTER = {
     gap: 16,
     padding: 16,
     style: {
-      position: 'fixed',
+      position: 'absolute',
       bottom: 0,
       width: '100%',
       justifyContent: 'space-evenly',
-      paddingVertical: 20,
+      paddingVertical: 16,
       height: 80,
-      marginTop: 'auto',
     },
   },
 };

--- a/app/components/Snaps/SnapUIRenderer/components/footer.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/footer.ts
@@ -10,15 +10,16 @@ export const DEFAULT_FOOTER = {
   key: 'default-footer',
   props: {
     flexDirection: 'row',
-    width: '100%',
-    gap: 4,
-    padding: 4,
+    gap: 16,
+    padding: 16,
     style: {
-      position: 'absolute',
+      position: 'fixed',
       bottom: 0,
       width: '100%',
       justifyContent: 'space-evenly',
       paddingVertical: 20,
+      height: 80,
+      marginTop: 'auto',
     },
   },
 };

--- a/app/components/Snaps/SnapUIRenderer/components/input.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/input.ts
@@ -11,6 +11,7 @@ export const input: UIComponentFactory<InputElement> = ({
   props: {
     id: e.props.name,
     placeholder: e.props.placeholder,
+    disabled: e.props.disabled,
     name: e.props.name,
     form,
   },

--- a/app/components/Snaps/SnapUIRenderer/components/text.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/text.test.ts
@@ -27,6 +27,7 @@ describe('text component', () => {
     const result = text({ element: el, ...defaultParams });
 
     expect(result).toEqual({
+      key: 'ac37e9a8c31a35346c51f0f9058d2e2f0aecde724a0d7192561af5625000f3d1_1',
       element: 'Text',
       children: [
         {

--- a/app/components/Snaps/SnapUIRenderer/components/text.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/text.test.ts
@@ -27,10 +27,10 @@ describe('text component', () => {
     const result = text({ element: el, ...defaultParams });
 
     expect(result).toEqual({
-      key: 'ac37e9a8c31a35346c51f0f9058d2e2f0aecde724a0d7192561af5625000f3d1_1',
       element: 'Text',
       children: [
         {
+          key: 'ac37e9a8c31a35346c51f0f9058d2e2f0aecde724a0d7192561af5625000f3d1_1',
           element: 'RNText',
           children: 'Hello World',
           props: { color: 'inherit' },

--- a/app/components/Snaps/SnapUIRenderer/utils.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.test.ts
@@ -29,6 +29,7 @@ describe('SnapUIRenderer utils', () => {
             {
               "children": "Test Content",
               "element": "RNText",
+              "key": "87ada83862ef4cde3ca2a1f8cbfbbc38af6f971cb4d669224ab903ffc2c7d1bd_2",
               "props": {
                 "color": "inherit",
               },

--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -1,4 +1,4 @@
-import { JSXElement, GenericSnapElement } from '@metamask/snaps-sdk/jsx';
+import { JSXElement, GenericSnapElement , Text } from '@metamask/snaps-sdk/jsx';
 import { hasChildren } from '@metamask/snaps-utils';
 import { memoize } from 'lodash';
 import { sha256 } from '@noble/hashes/sha256';
@@ -13,7 +13,6 @@ import { unescape as unescapeFn } from 'he';
 import { FormState, InterfaceState, State } from '@metamask/snaps-sdk';
 import { UIComponent } from './components/types';
 import { Theme } from '../../../util/theme/models';
-import { Text } from '@metamask/snaps-sdk/jsx';
 
 export interface MapToTemplateParams {
   map: Record<string, number>;

--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -13,6 +13,7 @@ import { unescape as unescapeFn } from 'he';
 import { FormState, InterfaceState, State } from '@metamask/snaps-sdk';
 import { UIComponent } from './components/types';
 import { Theme } from '../../../util/theme/models';
+import { Text } from '@metamask/snaps-sdk/jsx';
 
 export interface MapToTemplateParams {
   map: Record<string, number>;
@@ -132,9 +133,12 @@ export const mapTextToTemplate = (
   elements.map((e) => {
     if (typeof e === 'string') {
       // React Native cannot render strings directly, so we map to an element where we control the props.
+      const text = unescapeFn(e);
+      const key = generateKey(params.map, Text({ children: text }));
       return {
         element: 'RNText',
-        children: unescapeFn(e),
+        key,
+        children: text,
         props: { color: 'inherit' },
       };
     }

--- a/app/components/UI/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/UI/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -8,6 +8,7 @@ import HelpText, {
   HelpTextSeverity,
 } from '../../../../component-library/components/Form/HelpText';
 import Label from '../../../../component-library/components/Form/Label';
+import { Box } from '../../Box/Box';
 
 export interface SnapUIInputProps {
   name: string;
@@ -57,7 +58,7 @@ export const SnapUIInput = ({
   const handleBlur = () => setCurrentFocusedInput(null);
 
   return (
-    <>
+    <Box>
       {label && <Label>{label}</Label>}
       <TextField
         {...props}
@@ -75,6 +76,6 @@ export const SnapUIInput = ({
           {error}
         </HelpText>
       )}
-    </>
+    </Box>
   );
 };

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -4,7 +4,7 @@ import Text from '../../../component-library/components/Texts/Text';
 import Icon from '../../../component-library/components/Icons/Icon';
 import BottomSheetFooter from '../../../component-library/components/BottomSheets/BottomSheetFooter';
 import SmartTransactionStatus from '../../Views/SmartTransactionStatus/SmartTransactionStatus';
-import { View, Text as RNText } from 'react-native';
+import { View, Text as RNText, ScrollView } from 'react-native';
 import Checkbox from '../../../component-library/components/Checkbox/Checkbox';
 import { SnapUIImage } from '../../UI/Snaps/SnapUIImage/SnapUIImage';
 import { SnapAvatar } from '../Snaps/SnapAvatar/SnapAvatar';
@@ -51,6 +51,7 @@ export const safeComponentList = {
   SnapUIBanner,
   InfoRow,
   RNText,
+  ScrollView,
 };
 
 export type SafeComponentListValues = typeof safeComponentList;

--- a/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
+++ b/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
@@ -89,7 +89,7 @@ const TemplateRenderer = ({ sections }: TemplateRendererProps) => {
             // be provided a key when a part of an array.
             if (!child.key) {
               throw new Error(
-                'When using array syntax in MetaMask Template Language, you must specify a key for each child of the array' + JSON.stringify(child),
+                'When using array syntax in MetaMask Template Language, you must specify a key for each child of the array',
               );
             }
             if (typeof child?.children === 'object') {

--- a/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
+++ b/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
@@ -31,14 +31,11 @@ function renderElement(section: TemplateRendererComponent) {
     : {};
   return (
     <Element {...section.props} {...propsAsComponents}>
-      {Array.isArray(section.children)
-        ? section.children.map((child) => (
+      {typeof section.children === 'object' ? 
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             <TemplateRenderer
-              key={typeof child === 'string' ? `${random()}` : child.key}
-              sections={child}
+              sections={section.children}
             />
-          ))
         : section.children}
     </Element>
   );
@@ -92,7 +89,7 @@ const TemplateRenderer = ({ sections }: TemplateRendererProps) => {
             // be provided a key when a part of an array.
             if (!child.key) {
               throw new Error(
-                'When using array syntax in MetaMask Template Language, you must specify a key for each child of the array',
+                'When using array syntax in MetaMask Template Language, you must specify a key for each child of the array' + JSON.stringify(child),
               );
             }
             if (typeof child?.children === 'object') {

--- a/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
+++ b/app/components/UI/TemplateRenderer/TemplateRenderer.tsx
@@ -31,12 +31,12 @@ function renderElement(section: TemplateRendererComponent) {
     : {};
   return (
     <Element {...section.props} {...propsAsComponents}>
-      {typeof section.children === 'object' ? 
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            <TemplateRenderer
-              sections={section.children}
-            />
-        : section.children}
+      {typeof section.children === 'object' ? (
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        <TemplateRenderer sections={section.children} />
+      ) : (
+        section.children
+      )}
     </Element>
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a couple of issues with existing components, such as the input component not rendering error text correctly. It also makes footers properly sticky and lets the contents of Snaps UI scroll. Furthermore, it updates the template renderer to match the allowed inputs from the extension.

Note that once again the majority of the diff is snapshots and tests 😄 

## **Manual testing steps**

N/A

## **Screenshots/Recordings**
![Simulator Screenshot - iPhone 16 Pro - 2025-02-27 at 14 40 59](https://github.com/user-attachments/assets/b2853c6e-ba7a-40b9-8a76-216b3bc04dc9)

