### PR TITLE
fix: Improve redesigned staking deposit confirmation navigation

### DIFF
--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.test.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { ChainId, PooledStakingContract } from '@metamask/stake-sdk';
+import { Contract } from 'ethers';
 import StakeInputView from './StakeInputView';
 import renderWithProvider, {
   DeepPartial,
 } from '../../../../../util/test/renderWithProvider';
 import Routes from '../../../../../constants/navigation/Routes';
 import { Stake } from '../../sdk/stakeSdkProvider';
-import { ChainId, PooledStakingContract } from '@metamask/stake-sdk';
-import { Contract } from 'ethers';
 import { MOCK_ETH_MAINNET_ASSET } from '../../__mocks__/mockData';
 import { toWei } from '../../../../../util/number';
 import { strings } from '../../../../../../locales/i18n';
@@ -21,11 +22,27 @@ import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../../util/test/account
 import { RootState } from '../../../../../reducers';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { MOCK_VAULT_APY_AVERAGES } from '../../components/PoolStakingLearnMoreModal/mockVaultRewards';
+import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import {
+  selectConfirmationRedesignFlags,
+  type ConfirmationRedesignRemoteFlags,
+} from '../../../../../selectors/featureFlagController';
+import { flushPromises } from '../../../../../util/test/utils';
+import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
+
+const MOCK_SELECTED_INTERNAL_ACCOUNT = {
+  address: '0x123',
+} as InternalAccount;
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
 const mockPop = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn().mockImplementation((selector) => selector()),
+}));
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -63,6 +80,15 @@ jest.mock('../../../../../selectors/multichain', () => ({
       },
     ],
   })),
+}));
+
+jest.mock('../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../selectors/accountsController'),
+  selectSelectedInternalAccount: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/featureFlagController', () => ({
+  selectConfirmationRedesignFlags: jest.fn(),
 }));
 
 const mockBalanceBN = toWei('1.5'); // 1.5 ETH
@@ -134,6 +160,11 @@ jest.mock('../../hooks/useVaultApyAverages', () => ({
   }),
 }));
 
+jest.mock('../../hooks/usePoolStakedDeposit', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockInitialState: DeepPartial<RootState> = {
   settings: {},
   engine: {
@@ -145,6 +176,13 @@ const mockInitialState: DeepPartial<RootState> = {
 };
 
 describe('StakeInputView', () => {
+  const usePoolStakedDepositMock = jest.mocked(usePoolStakedDeposit);
+  const selectConfirmationRedesignFlagsMock = jest.mocked(
+    selectConfirmationRedesignFlags,
+  );
+  const selectSelectedInternalAccountMock = jest.mocked(
+    selectSelectedInternalAccount,
+  );
   const baseProps: StakeInputViewProps = {
     route: {
       params: {
@@ -155,6 +193,22 @@ describe('StakeInputView', () => {
       name: 'params',
     },
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    selectSelectedInternalAccountMock.mockImplementation(
+      () => MOCK_SELECTED_INTERNAL_ACCOUNT,
+    );
+    selectConfirmationRedesignFlagsMock.mockImplementation(
+      () =>
+        ({
+          staking_transactions: false,
+        } as ConfirmationRedesignRemoteFlags),
+    );
+    usePoolStakedDepositMock.mockReturnValue({
+      attemptDepositTransaction: jest.fn(),
+    });
+  });
 
   const renderComponent = () =>
     renderWithProvider(<StakeInputView {...baseProps} />, {
@@ -238,31 +292,85 @@ describe('StakeInputView', () => {
       });
     });
 
-    it('navigates to gas impact modal when gas cost is 30% or more of deposit amount', async () => {
-      jest.spyOn(useStakingGasFee, 'default').mockReturnValue({
-        estimatedGasFeeWei: toWei('0.25'),
-        isLoadingStakingGasFee: false,
-        isStakingGasFeeError: false,
-        refreshGasValues: jest.fn(),
+    describe('navigates to ', () => {
+      it('gas impact modal when gas cost is 30% or more of deposit amount', async () => {
+        jest.spyOn(useStakingGasFee, 'default').mockReturnValue({
+          estimatedGasFeeWei: toWei('0.25'),
+          isLoadingStakingGasFee: false,
+          isStakingGasFeeError: false,
+          refreshGasValues: jest.fn(),
+        });
+
+        const { getByText } = renderComponent();
+
+        fireEvent.press(getByText('25%'));
+
+        fireEvent.press(getByText(strings('stake.review')));
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenLastCalledWith('StakeModals', {
+          screen: Routes.STAKING.MODALS.GAS_IMPACT,
+          params: {
+            amountFiat: '750',
+            amountWei: '375000000000000000',
+            annualRewardRate: '3.3%',
+            annualRewardsETH: '0.01222 ETH',
+            annualRewardsFiat: '24.43 USD',
+            estimatedGasFee: '0.25',
+            estimatedGasFeePercentage: '66%',
+          },
+        });
       });
 
-      const { getByText } = renderComponent();
+      it('redesigned stake deposit confirmation view', async () => {
+        const attemptDepositTransactionMock = jest.fn().mockResolvedValue({});
+        selectConfirmationRedesignFlagsMock.mockReturnValue({
+          staking_transactions: true,
+        } as ConfirmationRedesignRemoteFlags);
 
-      fireEvent.press(getByText('25%'));
+        usePoolStakedDepositMock.mockReturnValue({
+          attemptDepositTransaction: attemptDepositTransactionMock,
+        });
 
-      fireEvent.press(getByText(strings('stake.review')));
+        const { getByText } = renderComponent();
 
-      expect(mockNavigate).toHaveBeenLastCalledWith('StakeModals', {
-        screen: Routes.STAKING.MODALS.GAS_IMPACT,
-        params: {
-          amountFiat: '750',
-          amountWei: '375000000000000000',
-          annualRewardRate: '3.3%',
-          annualRewardsETH: '0.01222 ETH',
-          annualRewardsFiat: '24.43 USD',
-          estimatedGasFee: '0.25',
-          estimatedGasFeePercentage: '66%',
-        },
+        fireEvent.press(getByText('25%'));
+
+        fireEvent.press(getByText(strings('stake.review')));
+
+        // Wait for approval to be processed
+        await flushPromises();
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenLastCalledWith('StakeScreens', {
+          screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
+        });
+
+        expect(attemptDepositTransactionMock).toHaveBeenCalledTimes(1);
+        expect(attemptDepositTransactionMock).toHaveBeenCalledWith(
+          '375000000000000000',
+          MOCK_SELECTED_INTERNAL_ACCOUNT.address,
+        );
+      });
+
+      it('stake confirmation view', async () => {
+        const { getByText } = renderComponent();
+
+        fireEvent.press(getByText('25%'));
+
+        fireEvent.press(getByText(strings('stake.review')));
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenLastCalledWith('StakeScreens', {
+          screen: Routes.STAKING.STAKE_CONFIRMATION,
+          params: {
+            amountFiat: '750',
+            amountWei: '375000000000000000',
+            annualRewardRate: '3.3%',
+            annualRewardsETH: '0.01222 ETH',
+            annualRewardsFiat: '24.43 USD',
+          },
+        });
       });
     });
   });

--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
@@ -77,17 +77,6 @@ const StakeInputView = ({ route }: StakeInputViewProps) => {
   };
 
   const handleStakePress = useCallback(async () => {
-    if (isStakingDepositRedesignedEnabled) {
-      await attemptDepositTransaction(
-        amountWei.toString(),
-        activeAccount?.address as string,
-      );
-      navigation.navigate('StakeScreens', {
-        screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
-      });
-      return;
-    }
-
     if (isHighGasCostImpact()) {
       trackEvent(
         createEventBuilder(
@@ -119,16 +108,27 @@ const StakeInputView = ({ route }: StakeInputViewProps) => {
       return;
     }
 
+    const amount = amountWei.toString();
+
+    if (isStakingDepositRedesignedEnabled) {
+      await attemptDepositTransaction(amount, activeAccount?.address as string);
+      navigation.navigate('StakeScreens', {
+        screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
+      });
+      return;
+    }
+
     navigation.navigate('StakeScreens', {
       screen: Routes.STAKING.STAKE_CONFIRMATION,
       params: {
-        amountWei: amountWei.toString(),
+        amountWei: amount,
         amountFiat: fiatAmount,
         annualRewardsETH,
         annualRewardsFiat,
         annualRewardRate,
       },
     });
+
     trackEvent(
       createEventBuilder(MetaMetricsEvents.REVIEW_STAKE_BUTTON_CLICKED)
         .addProperties({

--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
@@ -108,10 +108,13 @@ const StakeInputView = ({ route }: StakeInputViewProps) => {
       return;
     }
 
-    const amount = amountWei.toString();
+    const amountWeiString = amountWei.toString();
 
     if (isStakingDepositRedesignedEnabled) {
-      await attemptDepositTransaction(amount, activeAccount?.address as string);
+      await attemptDepositTransaction(
+        amountWeiString,
+        activeAccount?.address as string,
+      );
       navigation.navigate('StakeScreens', {
         screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
       });
@@ -121,7 +124,7 @@ const StakeInputView = ({ route }: StakeInputViewProps) => {
     navigation.navigate('StakeScreens', {
       screen: Routes.STAKING.STAKE_CONFIRMATION,
       params: {
-        amountWei: amount,
+        amountWei: amountWeiString,
         amountFiat: fiatAmount,
         annualRewardsETH,
         annualRewardsFiat,

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -1,24 +1,52 @@
 import React from 'react';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { fireEvent } from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
+import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
+
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { flushPromises } from '../../../../../util/test/utils';
+import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import {
+  selectConfirmationRedesignFlags,
+  type ConfirmationRedesignRemoteFlags,
+} from '../../../../../selectors/featureFlagController';
+import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
 import { GasImpactModalProps } from './GasImpactModal.types';
 import GasImpactModal from './index';
-import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
-import { fireEvent } from '@testing-library/react-native';
-import { strings } from '../../../../../../locales/i18n';
 
-const mockNavigate = jest.fn();
-const mockGoBack = jest.fn();
+const MOCK_SELECTED_INTERNAL_ACCOUNT = {
+  address: '0x123',
+} as InternalAccount;
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
     ...actualReactNavigation,
-    useNavigation: () => ({
-      navigate: mockNavigate,
-      goBack: mockGoBack,
-    }),
+    useNavigation: jest.fn(),
   };
 });
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn().mockImplementation((selector) => selector()),
+}));
+
+jest.mock('../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../selectors/accountsController'),
+  selectSelectedInternalAccount: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/featureFlagController', () => ({
+  selectConfirmationRedesignFlags: jest.fn(),
+}));
+
+jest.mock('../../hooks/usePoolStakedDeposit', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 
 const props: GasImpactModalProps = {
   route: {
@@ -49,20 +77,42 @@ const renderGasImpactModal = () =>
   );
 
 describe('GasImpactModal', () => {
+  const usePoolStakedDepositMock = jest.mocked(usePoolStakedDeposit);
+  const selectConfirmationRedesignFlagsMock = jest.mocked(
+    selectConfirmationRedesignFlags,
+  );
+  const selectSelectedInternalAccountMock = jest.mocked(
+    selectSelectedInternalAccount,
+  );
+  const useNavigationMock = jest.mocked(useNavigation);
+  const mockNavigate = jest.fn();
+  const mockGoBack = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    usePoolStakedDepositMock.mockReturnValue({
+      attemptDepositTransaction: jest.fn(),
+    });
+
+    selectSelectedInternalAccountMock.mockReturnValue(
+      MOCK_SELECTED_INTERNAL_ACCOUNT,
+    );
+
+    selectConfirmationRedesignFlagsMock.mockReturnValue({
+      staking_transactions: false,
+    } as ConfirmationRedesignRemoteFlags);
+
+    useNavigationMock.mockReturnValue({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+    } as unknown as ReturnType<typeof useNavigation>);
+  });
+
   it('render matches snapshot', () => {
     const { toJSON } = renderGasImpactModal();
 
     expect(toJSON()).toMatchSnapshot();
-  });
-
-  it('navigates to StakeConfirmationView on approval', () => {
-    const { getByText } = renderGasImpactModal();
-
-    const proceedAnywayButton = getByText(strings('stake.proceed_anyway'));
-
-    fireEvent.press(proceedAnywayButton);
-
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
   it('closes gas impact modal on cancel', () => {
@@ -73,5 +123,58 @@ describe('GasImpactModal', () => {
     fireEvent.press(proceedAnywayButton);
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  describe('navigates to', () => {
+    it('StakeConfirmationView on approval', () => {
+      const { getByText } = renderGasImpactModal();
+
+      const proceedAnywayButton = getByText(strings('stake.proceed_anyway'));
+
+      fireEvent.press(proceedAnywayButton);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
+        screen: Routes.STAKING.STAKE_CONFIRMATION,
+        params: {
+          amountWei: props.route.params.amountWei,
+          amountFiat: props.route.params.amountFiat,
+          annualRewardsETH: props.route.params.annualRewardsETH,
+          annualRewardsFiat: props.route.params.annualRewardsFiat,
+          annualRewardRate: props.route.params.annualRewardRate,
+        },
+      });
+    });
+
+    it('redesigned stake deposit confirmation view', async () => {
+      const attemptDepositTransactionMock = jest.fn().mockResolvedValue({});
+      selectConfirmationRedesignFlagsMock.mockReturnValue({
+        staking_transactions: true,
+      } as ConfirmationRedesignRemoteFlags);
+
+      usePoolStakedDepositMock.mockReturnValue({
+        attemptDepositTransaction: attemptDepositTransactionMock,
+      });
+
+      const { getByText } = renderGasImpactModal();
+
+      const proceedAnywayButton = getByText(strings('stake.proceed_anyway'));
+
+      fireEvent.press(proceedAnywayButton);
+
+      // Wait for approval to be processed
+      await flushPromises();
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
+        screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
+      });
+
+      expect(attemptDepositTransactionMock).toHaveBeenCalledTimes(1);
+      expect(attemptDepositTransactionMock).toHaveBeenCalledWith(
+        props.route.params.amountWei,
+        MOCK_SELECTED_INTERNAL_ACCOUNT.address,
+      );
+    });
   });
 });

--- a/app/components/UI/Stake/components/GasImpactModal/index.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/index.tsx
@@ -1,4 +1,11 @@
 import React, { useCallback, useRef } from 'react';
+import { formatEther } from 'ethers/lib/utils';
+import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import { View } from 'react-native';
+
+import { selectConfirmationRedesignFlags } from '../../../../../selectors/featureFlagController';
+import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -6,7 +13,6 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import { View } from 'react-native';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import BottomSheetFooter, {
   ButtonsAlignment,
@@ -18,17 +24,22 @@ import {
 } from '../../../../../component-library/components/Buttons/Button/Button.types';
 import styleSheet from './GasImpactModal.styles';
 import { useStyles } from '../../../../hooks/useStyles';
-import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { GasImpactModalProps } from './GasImpactModal.types';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
-import { formatEther } from 'ethers/lib/utils';
 import { EVENT_LOCATIONS, EVENT_PROVIDERS } from '../../constants/events';
+import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
 
 const GasImpactModal = ({ route }: GasImpactModalProps) => {
   const { styles } = useStyles(styleSheet, {});
-
+  const confirmationRedesignFlags = useSelector(
+    selectConfirmationRedesignFlags,
+  );
+  const isStakingDepositRedesignedEnabled =
+    confirmationRedesignFlags?.staking_transactions;
+  const { attemptDepositTransaction } = usePoolStakedDeposit();
+  const activeAccount = useSelector(selectSelectedInternalAccount);
   const { navigate } = useNavigation();
 
   const { trackEvent, createEventBuilder } = useMetrics();
@@ -79,19 +90,39 @@ const GasImpactModal = ({ route }: GasImpactModalProps) => {
     sheetRef.current?.onCloseBottomSheet();
   };
 
-  const handleNavigateToStakeReviewScreen = () => {
+  const handleNavigateToStakeReviewScreen = useCallback(async () => {
+    const amount = amountWei.toString();
+
+    if (isStakingDepositRedesignedEnabled) {
+      await attemptDepositTransaction(amount, activeAccount?.address as string);
+      navigate('StakeScreens', {
+        screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
+      });
+    } else {
+      navigate('StakeScreens', {
+        screen: Routes.STAKING.STAKE_CONFIRMATION,
+        params: {
+          amountWei: amount,
+          amountFiat,
+          annualRewardsETH,
+          annualRewardsFiat,
+          annualRewardRate,
+        },
+      });
+    }
     metricsEvent(MetaMetricsEvents.STAKE_GAS_COST_IMPACT_PROCEEDED_CLICKED);
-    navigate('StakeScreens', {
-      screen: Routes.STAKING.STAKE_CONFIRMATION,
-      params: {
-        amountWei: amountWei.toString(),
-        amountFiat,
-        annualRewardsETH,
-        annualRewardsFiat,
-        annualRewardRate,
-      },
-    });
-  };
+  }, [
+    activeAccount?.address,
+    amountFiat,
+    amountWei,
+    annualRewardsETH,
+    annualRewardsFiat,
+    annualRewardRate,
+    attemptDepositTransaction,
+    isStakingDepositRedesignedEnabled,
+    metricsEvent,
+    navigate,
+  ]);
 
   const footerButtons: ButtonProps[] = [
     {

--- a/app/components/UI/Stake/components/GasImpactModal/index.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/index.tsx
@@ -91,10 +91,13 @@ const GasImpactModal = ({ route }: GasImpactModalProps) => {
   };
 
   const handleNavigateToStakeReviewScreen = useCallback(async () => {
-    const amount = amountWei.toString();
+    const amountWeiString = amountWei.toString();
 
     if (isStakingDepositRedesignedEnabled) {
-      await attemptDepositTransaction(amount, activeAccount?.address as string);
+      await attemptDepositTransaction(
+        amountWeiString,
+        activeAccount?.address as string,
+      );
       navigate('StakeScreens', {
         screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT,
       });
@@ -102,7 +105,7 @@ const GasImpactModal = ({ route }: GasImpactModalProps) => {
       navigate('StakeScreens', {
         screen: Routes.STAKING.STAKE_CONFIRMATION,
         params: {
-          amountWei: amount,
+          amountWei: amountWeiString,
           amountFiat,
           annualRewardsETH,
           annualRewardsFiat,

--- a/app/components/Views/confirmations/components/Confirm/Info/GasFeesDetails/GasFeesDetails.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/GasFeesDetails/GasFeesDetails.tsx
@@ -24,7 +24,10 @@ const GasFeesDetails = () => {
   return (
     <View style={styles.container}>
       <InfoSection>
-        <InfoRow label={strings('transactions.network_fee')}>
+        <InfoRow
+          label={strings('transactions.network_fee')}
+          tooltip={strings('transactions.network_fee_tooltip')}
+        >
           <View style={styles.valueContainer}>
             {!hideFiatForTestnet && feeCalculations.estimatedFeeFiat && (
               <Text style={styles.secondaryValue}>

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingDeposit/StakingDeposit.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingDeposit/StakingDeposit.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../../../locales/i18n';
+import { useConfirmActions } from '../../../../hooks/useConfirmActions';
 import AdvancedDetails from '../../AdvancedDetails/AdvancedDetails';
 import StakingDetails from '../../StakingDetails';
 import TokenHero from '../../TokenHero';
@@ -9,19 +10,18 @@ import { getStakingDepositNavbar } from './Navbar';
 
 const StakingDeposit = () => {
   const navigation = useNavigation();
+  const { onReject } = useConfirmActions();
 
   const updateNavBar = useCallback(() => {
     navigation.setOptions(
       getStakingDepositNavbar({
         title: strings('stake.stake'),
-        onReject: () => navigation.goBack(),
+        onReject,
       }),
     );
-  }, [navigation]);
+  }, [navigation, onReject]);
 
-  useEffect(() => {
-    updateNavBar();
-  }, [updateNavBar]);
+  useEffect(updateNavBar, [updateNavBar]);
 
   return (
     <>

--- a/app/components/Views/confirmations/utils/confirm.test.ts
+++ b/app/components/Views/confirmations/utils/confirm.test.ts
@@ -1,5 +1,7 @@
+import { TransactionType } from '@metamask/transaction-controller';
+
 import { ApprovalTypes } from '../../../../core/RPCMethods/RPCMethodMiddleware';
-import { isSignatureRequest } from './confirm';
+import { isSignatureRequest, isStakingConfirmation } from './confirm';
 
 describe('Confirmation utils', () => {
   describe('isSignatureRequest', () => {
@@ -9,6 +11,15 @@ describe('Confirmation utils', () => {
         isSignatureRequest(ApprovalTypes.ETH_SIGN_TYPED_DATA),
       ).toBeTruthy();
       expect(isSignatureRequest(ApprovalTypes.TRANSACTION)).toBeFalsy();
+    });
+  });
+
+  describe('isStakingConfirmation', () => {
+    it('should return correct value', async () => {
+      expect(
+        isStakingConfirmation(TransactionType.stakingDeposit),
+      ).toBeTruthy();
+      expect(isStakingConfirmation(TransactionType.bridge)).toBeFalsy();
     });
   });
 });

--- a/app/components/Views/confirmations/utils/confirm.ts
+++ b/app/components/Views/confirmations/utils/confirm.ts
@@ -1,3 +1,5 @@
+import { TransactionType } from '@metamask/transaction-controller';
+
 import { ApprovalTypes } from '../../../../core/RPCMethods/RPCMethodMiddleware';
 
 export const TOKEN_VALUE_UNLIMITED_THRESHOLD = 10 ** 15;
@@ -9,3 +11,6 @@ export function isSignatureRequest(requestType: string) {
   ].includes(requestType as ApprovalTypes);
 }
 
+export function isStakingConfirmation(requestType: string) {
+  return requestType === TransactionType.stakingDeposit;
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1744,7 +1744,8 @@
     "sign_description_1": "After you have signed with your hardware wallet,",
     "sign_description_2": "tap on Get Signature",
     "sign_get_signature": "Get Signature",
-    "network_fee": "Network Fee"
+    "network_fee": "Network Fee",
+    "network_fee_tooltip": "Amount paid to process the transaction on network."
   },
   "smart_transactions": {
     "status_submitting_header": "Submitting your transaction",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to improve staking deposit confirmation navigation.
- Fixes to not prevent `GasImpactModal` flow if redesign enabled.
- Fixes to navigate redesigned staking deposit confirmation in `GasImpactModal`
- Fixes to navigate `Transactions` view on confirm of redesigned staking deposit confirmation. 
- Adds tooltip to `GasFeeDetails`
- Fixes to remove approval when going back from redesigned staking deposit confirmation in navigation bar.

Also adds detailed test given cases above. 

## **Related issues**

Fixes: 
- https://github.com/MetaMask/MetaMask-planning/issues/4285
- https://github.com/MetaMask/mobile-planning/issues/2137

## **Manual testing steps**

Redesigned staking deposit flow works as expected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Smart transactions enabled: (Note that styling might be broken in STX modal - it's not related with this PR)

https://github.com/user-attachments/assets/e86a2ed3-ad2c-4047-88f8-fc43f30a16c4

Without smart transactions:

https://github.com/user-attachments/assets/4c27d096-3eb6-4ce4-a8e3-bb66cec192ff

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
