### PR TITLE
fix(close bug report action): target branch name has been renamed stable

### DIFF
--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -3,7 +3,7 @@ name: Close release bug report issue when release branch gets merged
 on:
   pull_request:
     branches:
-      - main
+      - stable
     types:
       - closed
     


### PR DESCRIPTION
## **Description**

The Github action that was automatically closing release bug report when release branch was merged stopped working after release [7.37.0](https://github.com/MetaMask/metamask-mobile/actions/workflows/close-bug-report.yml?query=is%3Asuccess), because the name of the target branch for the release PR has changed: the release PR now gets merged into `stable`.

This is a fix for the Github action.

## **Related issues**

Fixes: None

## **Manual testing steps**

1. Merge a release PR such as [7.41.0](https://github.com/MetaMask/metamask-mobile/pull/13751)
2. Close bug report Github action shall be executed successfully, and 7.41.0 shall appear in this [list](https://github.com/MetaMask/metamask-mobile/actions/workflows/close-bug-report.yml?query=is%3Asuccess)

(we'll only be able to test this for next release though)

## **Screenshots/Recordings**

- None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
