### PR TITLE
fix: permit simulation overflow

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Info/TypedSignV3V4/Simulation/components/ValueDisplay/ValueDisplay.styles.ts
@@ -23,6 +23,7 @@ const styleSheet = (colors: Theme['colors']) =>
       borderColor: importedColors.transparent,
       borderWidth: 0,
       padding: 0,
+      flexWrap: 'wrap',
     },
     loadingFiatValue: {
       height: 24,
@@ -44,10 +45,13 @@ const styleSheet = (colors: Theme['colors']) =>
     valueAndAddress: {
       paddingVertical: 4,
       paddingLeft: 8,
-      gap: 5,
+      columnGap: 5,
+      rowGap: 8,
       flexDirection: 'row',
       alignItems: 'center',
       alignSelf: 'center',
+      justifyContent: 'flex-end',
+      flexWrap: 'wrap',
     },
     valueIsCredit: {
       backgroundColor: colors.success.muted,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13728

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="320" src="https://github.com/user-attachments/assets/55e9f424-a572-4aa4-80bd-50764e31e810">
<img width="320" src="https://github.com/user-attachments/assets/cdfab509-9a9e-4e77-b4b1-8f82ab0eaebf">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
