### PR TITLE
feat: added **/__mocks__/** to sonar.coverage.exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.exclusions=**.stories.**, e2e/**, wdio/**
 sonar.test.inclusions=**.test.**
 
 # Excluded project files from coverage.
-sonar.coverage.exclusions=**util/test**
+sonar.coverage.exclusions=**util/test**, **/__mocks__/**
 
 # Test coverage path in GitHub action
 sonar.javascript.lcov.reportPaths=/coverage/lcov.info


### PR DESCRIPTION
## **Description**
This PR adds `**/__mocks__/**` to the sonarcloud coverage exclusions list.