### PR TITLE
fix(storybook): replace 'any' type with 'StoryFn' in withSafeArea dec…

### DIFF
--- a/storybook/decorators/withSafeArea.tsx
+++ b/storybook/decorators/withSafeArea.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { StoryFn } from '@storybook/react-native';
 
-// TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const withSafeArea = (story: any) => (
+const withSafeArea = (story: StoryFn) => (
   <SafeAreaProvider>{story()}</SafeAreaProvider>
 );
 


### PR DESCRIPTION
…orator

## **Description**

This commit replaces the 'any' type with the proper 'StoryFn' type from '@storybook/react-native' in the withSafeArea decorator. This improves type safety and removes the need for the eslint-disable comment.

The change addresses a TODO comment in the code that requested replacing the 'any' type with a more specific type.

## **Related issues**

Fixes: TODO


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
