### PR TITLE
feat(snaps): Add support for full border radius for SnapUIImage

### DIFF
--- a/app/components/Snaps/SnapUICard/SnapUICard.tsx
+++ b/app/components/Snaps/SnapUICard/SnapUICard.tsx
@@ -41,7 +41,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       alignItems={AlignItems.center}
     >
       {image && (
-        <SnapUIImage width={32} height={32} borderRadius={999} value={image} />
+        <SnapUIImage width={32} height={32} borderRadius={100} value={image} />
       )}
       <Box flexDirection={FlexDirection.Column}>
         <Text variant={TextVariant.BodyMDMedium} ellipsizeMode="tail">

--- a/app/components/Snaps/SnapUICard/SnapUICard.tsx
+++ b/app/components/Snaps/SnapUICard/SnapUICard.tsx
@@ -41,7 +41,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       alignItems={AlignItems.center}
     >
       {image && (
-        <SnapUIImage width={32} height={32} borderRadius={100} value={image} />
+        <SnapUIImage width={32} height={32} borderRadius="full" value={image} />
       )}
       <Box flexDirection={FlexDirection.Column}>
         <Text variant={TextVariant.BodyMDMedium} ellipsizeMode="tail">

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -848,6 +848,45 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
                   ]
                 }
               >
+                <RNSVGSvgView
+                  bbHeight={32}
+                  bbWidth={32}
+                  focusable={false}
+                  height={32}
+                  onLayout={[Function]}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      [
+                        {
+                          "borderRadius": 0,
+                          "overflow": "hidden",
+                        },
+                        undefined,
+                      ],
+                      {
+                        "flex": 0,
+                        "height": 32,
+                        "width": 32,
+                      },
+                    ]
+                  }
+                  testID="snaps-ui-image"
+                  width={32}
+                  xml="<svg />"
+                >
+                  <RNSVGGroup
+                    fill={
+                      {
+                        "payload": 4278190080,
+                        "type": 0,
+                      }
+                    }
+                  />
+                </RNSVGSvgView>
                 <View
                   flexDirection="column"
                   style={
@@ -1419,7 +1458,45 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                     }
                   }
                   testID="textfield-startacccessory"
-                />
+                >
+                  <RNSVGSvgView
+                    bbHeight="100%"
+                    bbWidth="100%"
+                    focusable={false}
+                    onLayout={[Function]}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        [
+                          {
+                            "borderRadius": 0,
+                            "overflow": "hidden",
+                          },
+                          undefined,
+                        ],
+                        {
+                          "flex": 0,
+                          "height": "100%",
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                    testID="snaps-ui-image"
+                    xml="<svg />"
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4278190080,
+                          "type": 0,
+                        }
+                      }
+                    />
+                  </RNSVGSvgView>
+                </View>
                 <View
                   style={
                     {

--- a/app/components/Snaps/SnapUIRenderer/components/image.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.test.ts
@@ -1,0 +1,32 @@
+import { image } from './image';
+import { mockTheme } from '../../../../util/theme';
+import { ImageElement } from '@metamask/snaps-sdk/jsx';
+
+describe('image component', () => {
+  const defaultParams = {
+    map: {},
+    t: jest.fn(),
+    theme: mockTheme,
+  };
+
+  it('should render image with some props', () => {
+    const imageElement: ImageElement = {
+      type: 'Image',
+      props: {
+        src: 'https://example.com/image.svg',
+        borderRadius: 'full',
+      },
+      key: null,
+    };
+
+    const result = image({ element: imageElement, ...defaultParams });
+
+    expect(result).toEqual({
+      element: 'SnapUIImage',
+      props: {
+        borderRadius: 'full',
+        value: 'https://example.com/image.svg',
+      },
+    });
+  });
+});

--- a/app/components/Snaps/SnapUIRenderer/components/image.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.test.ts
@@ -13,7 +13,7 @@ describe('image component', () => {
     const imageElement: ImageElement = {
       type: 'Image',
       props: {
-        src: 'https://example.com/image.svg',
+        src: '<svg />',
         borderRadius: 'full',
       },
       key: null,
@@ -25,7 +25,7 @@ describe('image component', () => {
       element: 'SnapUIImage',
       props: {
         borderRadius: 'full',
-        value: 'https://example.com/image.svg',
+        value: '<svg />',
       },
     });
   });

--- a/app/components/Snaps/SnapUIRenderer/components/image.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.ts
@@ -3,7 +3,7 @@ import { UIComponentFactory } from './types';
 
 function generateBorderRadius(
   borderRadius?: ImageElement['props']['borderRadius'],
-) {
+): number | 'full' {
   switch (borderRadius) {
     default:
     case 'none':
@@ -13,7 +13,7 @@ function generateBorderRadius(
       return 6;
 
     case 'full':
-      return 100;
+      return 'full';
   }
 }
 

--- a/app/components/Snaps/SnapUIRenderer/components/image.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.ts
@@ -12,7 +12,8 @@ function generateBorderRadius(
     case 'medium':
       return 6;
 
-    // TODO: Support Full border radius (50%)
+    case 'full':
+      return 100;
   }
 }
 

--- a/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,7 +1,7 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { ImageStyle, StyleProp } from 'react-native';
-import { SvgUri } from 'react-native-svg';
+import { SvgXml } from 'react-native-svg';
 
 export interface SnapUIImageProps {
   value: string;
@@ -19,13 +19,9 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
   borderRadius,
 }) => {
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  const uri = useMemo(
-    () => `data:image/svg+xml;utf8,${encodeURIComponent(value)}`,
-    [value],
-  );
 
   return (
-    <SvgUri
+    <SvgXml
       testID="snaps-ui-image"
       style={[
         // eslint-disable-next-line react-native/no-inline-styles
@@ -38,7 +34,7 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
         },
         style,
       ]}
-      uri={uri}
+      xml={value}
       {...(width ? { width } : {})}
       {...(height ? { height } : {})}
       onLayout={(layoutChangeEvent) => {

--- a/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,6 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import React, { useMemo } from 'react';
-import { ImageStyle, StyleProp } from 'react-native';
+import React, { useMemo, useState } from 'react';
+import { ImageStyle, StyleProp, View } from 'react-native';
 import { SvgUri } from 'react-native-svg';
 
 export interface SnapUIImageProps {
@@ -18,17 +18,48 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
   style,
   borderRadius,
 }) => {
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const uri = useMemo(
     () => `data:image/svg+xml;utf8,${encodeURIComponent(value)}`,
     [value],
   );
 
   return (
-    <SvgUri
-      testID="snaps-ui-image"
-      uri={uri}
-      style={[{ width, height, borderRadius }, style]}
-    />
+    <View
+      style={[
+        // eslint-disable-next-line react-native/no-inline-styles
+        {
+          borderRadius:
+            borderRadius === 100
+              ? Math.min(dimensions.width, dimensions.height) / 2
+              : borderRadius,
+          overflow: 'hidden',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: width ?? dimensions?.width,
+          height: height ?? dimensions?.height
+        },
+        style,
+      ]}
+    >
+      <SvgUri
+        testID="snaps-ui-image"
+        uri={uri}
+        {...(width ? { width } : {})}
+        {...(height ? { height } : {})}
+        onLayout={(layoutChangeEvent) => {
+          if (!dimensions.width || !dimensions.height) {
+            const { width: layoutWidth, height: layoutHeight } =
+              layoutChangeEvent.nativeEvent.layout;
+
+            setDimensions({
+              width: layoutWidth,
+              height: layoutHeight,
+            });
+          }
+        }}
+      />
+    </View>
   );
 };
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -8,7 +8,7 @@ export interface SnapUIImageProps {
   style?: StyleProp<ImageStyle>;
   width?: number;
   height?: number;
-  borderRadius?: number;
+  borderRadius?: number | string;
 }
 
 export const SnapUIImage: React.FC<SnapUIImageProps> = ({
@@ -24,35 +24,41 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
     [value],
   );
 
-  return (
-      <SvgUri
-        testID="snaps-ui-image"
-        style={[
-          // eslint-disable-next-line react-native/no-inline-styles
-          {
-            borderRadius:
-              borderRadius === 100
-                ? Math.min(dimensions.width, dimensions.height) / 2
-                : borderRadius,
-            overflow: 'hidden',
-          },
-          style,
-        ]}
-        uri={uri}
-        {...(width ? { width } : {})}
-        {...(height ? { height } : {})}
-        onLayout={(layoutChangeEvent) => {
-          if (!dimensions.width || !dimensions.height) {
-            const { width: layoutWidth, height: layoutHeight } =
-              layoutChangeEvent.nativeEvent.layout;
+  function getRNSvgBorderRadiusValue(
+    borderRadiusValue: number | string | undefined,
+  ): number {
+    if (typeof borderRadiusValue === 'string' && borderRadiusValue === 'full') {
+      return Math.min(dimensions.width, dimensions.height) / 2;
+    }
+    return typeof borderRadiusValue === 'number' ? borderRadiusValue : 0;
+  }
 
-            setDimensions({
-              width: layoutWidth,
-              height: layoutHeight,
-            });
-          }
-        }}
-      />
+  return (
+    <SvgUri
+      testID="snaps-ui-image"
+      style={[
+        // eslint-disable-next-line react-native/no-inline-styles
+        {
+          borderRadius: getRNSvgBorderRadiusValue(borderRadius),
+          overflow: 'hidden',
+        },
+        style,
+      ]}
+      uri={uri}
+      {...(width ? { width } : {})}
+      {...(height ? { height } : {})}
+      onLayout={(layoutChangeEvent) => {
+        if (!dimensions.width || !dimensions.height) {
+          const { width: layoutWidth, height: layoutHeight } =
+            layoutChangeEvent.nativeEvent.layout;
+
+          setDimensions({
+            width: layoutWidth,
+            height: layoutHeight,
+          });
+        }
+      }}
+    />
   );
 };
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,6 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { useMemo, useState } from 'react';
-import { ImageStyle, StyleProp, View } from 'react-native';
+import { ImageStyle, StyleProp } from 'react-native';
 import { SvgUri } from 'react-native-svg';
 
 export interface SnapUIImageProps {
@@ -25,25 +25,19 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
   );
 
   return (
-    <View
-      style={[
-        // eslint-disable-next-line react-native/no-inline-styles
-        {
-          borderRadius:
-            borderRadius === 100
-              ? Math.min(dimensions.width, dimensions.height) / 2
-              : borderRadius,
-          overflow: 'hidden',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: width ?? dimensions?.width,
-          height: height ?? dimensions?.height
-        },
-        style,
-      ]}
-    >
       <SvgUri
         testID="snaps-ui-image"
+        style={[
+          // eslint-disable-next-line react-native/no-inline-styles
+          {
+            borderRadius:
+              borderRadius === 100
+                ? Math.min(dimensions.width, dimensions.height) / 2
+                : borderRadius,
+            overflow: 'hidden',
+          },
+          style,
+        ]}
         uri={uri}
         {...(width ? { width } : {})}
         {...(height ? { height } : {})}
@@ -59,7 +53,6 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
           }
         }}
       />
-    </View>
   );
 };
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/UI/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -8,7 +8,7 @@ export interface SnapUIImageProps {
   style?: StyleProp<ImageStyle>;
   width?: number;
   height?: number;
-  borderRadius?: number | string;
+  borderRadius?: number | 'full';
 }
 
 export const SnapUIImage: React.FC<SnapUIImageProps> = ({
@@ -24,22 +24,16 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
     [value],
   );
 
-  function getRNSvgBorderRadiusValue(
-    borderRadiusValue: number | string | undefined,
-  ): number {
-    if (typeof borderRadiusValue === 'string' && borderRadiusValue === 'full') {
-      return Math.min(dimensions.width, dimensions.height) / 2;
-    }
-    return typeof borderRadiusValue === 'number' ? borderRadiusValue : 0;
-  }
-
   return (
     <SvgUri
       testID="snaps-ui-image"
       style={[
         // eslint-disable-next-line react-native/no-inline-styles
         {
-          borderRadius: getRNSvgBorderRadiusValue(borderRadius),
+          borderRadius:
+            borderRadius === 'full'
+              ? Math.min(dimensions.width, dimensions.height) / 2
+              : borderRadius,
           overflow: 'hidden',
         },
         style,


### PR DESCRIPTION
## **Description**
This PR adds support for having full border radius on `SnapUIImage`component (_full circle image shape_).

The implementation on this PR is what is currently found to be the perfect combination and balance between React Native and SVG (`SvgUri`) way of working and possibilities around having full circle border radius on SVG images used by `SnapUIImage` component and combination of its properties.

Notes:
- Given that React Native border radius works only with pixels, added is some type of ratio calculation which is most likely the best one for having images displayed with full border radius (full circle) `(Math.min(dimensions.width, dimensions.height) / 2)`.
- Because there are severe unwanted effects of having width and height props present on the `SvgUri` when they're undefined, these props are added conditionally.
- In order to support full circle border radius when `width` and `height` are not defined explicitly, and ratio cannot be calculated, added is `onLayout` listener which manages to capture the actual `width` and `height` rendered from the layout event.

## **Related issues**
Fixes: https://github.com/MetaMask/snaps/issues/3178

## **Manual testing steps**
1. Try Snap with several images added to it, with different border radius values.
2. Try Snap UI Card with an image.
3. Confirm that results are as expected.

Snap code used for testing:
```typescript
export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          type: 'confirmation',
          content: (
            <Container backgroundColor="default">
              <Box>
                <Card
                  title="Option 1"
                  value="option1"
                  description="Description"
                  image={snapSvg}
                />
                <Text>Border radius: full</Text>
                <Image src={snapSvg} borderRadius="full" />
                <Text>Border radius: medium</Text>
                <Image src={snapSvg} borderRadius="medium" />
                <Text>Border radius: none</Text>
                <Image src={snapSvg} borderRadius="none" />
              </Box>
            </Container>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};
```

## **Screenshots/Recordings**
### **Before**

### **After**
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-03-04 at 00 36 43](https://github.com/user-attachments/assets/64fddaa3-1194-4c73-9546-1bc0e9392c42)

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
