### PR TITLE
feat: Implement redesigned staking withdrawals component

### DIFF
--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.tsx
@@ -111,6 +111,10 @@ const StakeInputView = ({ route }: StakeInputViewProps) => {
     const amountWeiString = amountWei.toString();
 
     if (isStakingDepositRedesignedEnabled) {
+      // Here we add the transaction to the transaction controller. The
+      // redesigned confirmations architecture relies on the transaction
+      // metadata object being defined by the time the confirmation is displayed
+      // to the user.
       await attemptDepositTransaction(
         amountWeiString,
         activeAccount?.address as string,

--- a/app/components/UI/Stake/Views/UnstakeInputView/UnstakeInputView.tsx
+++ b/app/components/UI/Stake/Views/UnstakeInputView/UnstakeInputView.tsx
@@ -89,6 +89,10 @@ const UnstakeInputView = () => {
       confirmationRedesignFlags?.staking_transactions;
 
     if (isStakingDepositRedesignedEnabled) {
+      // Here we add the transaction to the transaction controller. The
+      // redesigned confirmations architecture relies on the transaction
+      // metadata object being defined by the time the confirmation is displayed
+      // to the user.
       await attemptUnstakeTransaction(
         amountWei.toString(),
         activeAccount?.address as string,

--- a/app/components/UI/Stake/Views/UnstakeInputView/UnstakeInputView.tsx
+++ b/app/components/UI/Stake/Views/UnstakeInputView/UnstakeInputView.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useEffect } from 'react';
-import UnstakeInputViewBanner from './UnstakeBanner';
+import { View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import Button, {
   ButtonSize,
@@ -8,24 +9,32 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { TextVariant } from '../../../../../component-library/components/Texts/Text';
+import Routes from '../../../../../constants/navigation/Routes';
+import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
 import Keypad from '../../../../Base/Keypad';
+import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { useStyles } from '../../../../hooks/useStyles';
 import { getStakingNavbar } from '../../../Navbar';
 import ScreenLayout from '../../../Ramp/components/ScreenLayout';
-import QuickAmounts from '../../components/QuickAmounts';
-import { View } from 'react-native';
-import styleSheet from './UnstakeInputView.styles';
 import InputDisplay from '../../components/InputDisplay';
-import Routes from '../../../../../constants/navigation/Routes';
-import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
+import QuickAmounts from '../../components/QuickAmounts';
+import { EVENT_LOCATIONS, EVENT_PROVIDERS } from '../../constants/events';
+import usePoolStakedUnstake from '../../hooks/usePoolStakedUnstake';
 import useUnstakingInputHandlers from '../../hooks/useUnstakingInput';
 import { withMetaMetrics } from '../../utils/metaMetrics/withMetaMetrics';
-import { EVENT_LOCATIONS, EVENT_PROVIDERS } from '../../constants/events';
+import UnstakeInputViewBanner from './UnstakeBanner';
+import styleSheet from './UnstakeInputView.styles';
+import { selectConfirmationRedesignFlags } from '../../../../../selectors/featureFlagController';
 
 const UnstakeInputView = () => {
   const title = strings('stake.unstake_eth');
   const navigation = useNavigation();
   const { styles, theme } = useStyles(styleSheet, {});
+  const { attemptUnstakeTransaction } = usePoolStakedUnstake();
+  const activeAccount = useSelector(selectSelectedInternalAccount);
+  const confirmationRedesignFlags = useSelector(
+      selectConfirmationRedesignFlags,
+    );
 
   const { trackEvent, createEventBuilder } = useMetrics();
 
@@ -75,14 +84,32 @@ const UnstakeInputView = () => {
     );
   }, [navigation, theme.colors, title]);
 
-  const handleUnstakePress = useCallback(() => {
-    navigation.navigate('StakeScreens', {
-      screen: Routes.STAKING.UNSTAKE_CONFIRMATION,
-      params: {
-        amountWei: amountWei.toString(),
-        amountFiat: fiatAmount,
-      },
-    });
+  const handleUnstakePress = useCallback(async () => {
+    const isStakingDepositRedesignedEnabled =
+      confirmationRedesignFlags?.staking_transactions;
+
+    if (isStakingDepositRedesignedEnabled) {
+      await attemptUnstakeTransaction(
+        amountWei.toString(),
+        activeAccount?.address as string,
+      );
+
+      navigation.navigate('StakeScreens', {
+        screen: Routes.STANDALONE_CONFIRMATIONS.STAKE_WITHDRAWAL,
+        params: {
+          amountWei: amountWei.toString(),
+          amountFiat: fiatAmount,
+        },
+      });
+    } else {
+      navigation.navigate('StakeScreens', {
+        screen: Routes.STAKING.UNSTAKE_CONFIRMATION,
+        params: {
+          amountWei: amountWei.toString(),
+          amountFiat: fiatAmount,
+        },
+      });
+    }
     trackEvent(
       createEventBuilder(MetaMetricsEvents.REVIEW_UNSTAKE_BUTTON_CLICKED)
         .addProperties({
@@ -99,6 +126,9 @@ const UnstakeInputView = () => {
     fiatAmount,
     navigation,
     trackEvent,
+    attemptUnstakeTransaction,
+    activeAccount?.address,
+    confirmationRedesignFlags?.staking_transactions,
   ]);
 
   return (

--- a/app/components/UI/Stake/routes/index.tsx
+++ b/app/components/UI/Stake/routes/index.tsx
@@ -49,6 +49,10 @@ const StakeScreenStack = () => (
         name={Routes.STANDALONE_CONFIRMATIONS.STAKE_DEPOSIT}
         component={Confirm}
       />
+      <Stack.Screen
+        name={Routes.STANDALONE_CONFIRMATIONS.STAKE_WITHDRAWAL}
+        component={Confirm}
+      />
     </Stack.Navigator>
   </StakeSDKProvider>
 );

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -5,25 +5,27 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-
 import BottomSheet from '../../../../component-library/components/BottomSheets/BottomSheet';
 import { useStyles } from '../../../../component-library/hooks';
+import { UnstakeConfirmationViewProps } from '../../../UI/Stake/Views/UnstakeConfirmationView/UnstakeConfirmationView.types';
 import { Footer } from '../components/Confirm/Footer';
 import Info from '../components/Confirm/Info';
-import { LedgerContextProvider } from '../context/LedgerContext';
-import { QRHardwareContextProvider } from '../context/QRHardwareContext/QRHardwareContext';
 import SignatureBlockaidBanner from '../components/Confirm/SignatureBlockaidBanner';
 import Title from '../components/Confirm/Title';
-import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
-import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
+import { LedgerContextProvider } from '../context/LedgerContext';
+import { QRHardwareContextProvider } from '../context/QRHardwareContext/QRHardwareContext';
 import useApprovalRequest from '../hooks/useApprovalRequest';
 import { useConfirmActions } from '../hooks/useConfirmActions';
+import { useConfirmationRedesignEnabled } from '../hooks/useConfirmationRedesignEnabled';
+import { useFlatConfirmation } from '../hooks/useFlatConfirmation';
 import styleSheet from './Confirm.styles';
 
 const ConfirmWrapped = ({
   styles,
+  route,
 }: {
   styles: StyleSheet.NamedStyles<Record<string, unknown>>;
+  route?: UnstakeConfirmationViewProps['route'];
 }) => (
   <QRHardwareContextProvider>
     <LedgerContextProvider>
@@ -32,7 +34,7 @@ const ConfirmWrapped = ({
         <TouchableWithoutFeedback>
           <>
             <SignatureBlockaidBanner />
-            <Info />
+            <Info route={route} />
           </>
         </TouchableWithoutFeedback>
       </ScrollView>
@@ -41,7 +43,11 @@ const ConfirmWrapped = ({
   </QRHardwareContextProvider>
 );
 
-export const Confirm = () => {
+interface ConfirmProps {
+  route?: UnstakeConfirmationViewProps['route'];
+}
+
+export const Confirm = ({ route }: ConfirmProps) => {
   const { approvalRequest } = useApprovalRequest();
   const { isFlatConfirmation } = useFlatConfirmation();
   const { isRedesignedEnabled } = useConfirmationRedesignEnabled();
@@ -56,7 +62,7 @@ export const Confirm = () => {
   if (isFlatConfirmation) {
     return (
       <View style={styles.flatContainer} testID="flat-confirmation-container">
-        <ConfirmWrapped styles={styles} />
+        <ConfirmWrapped styles={styles} route={route} />
       </View>
     );
   }
@@ -69,7 +75,7 @@ export const Confirm = () => {
       testID="modal-confirmation-container"
     >
       <View testID={approvalRequest?.type}>
-        <ConfirmWrapped styles={styles} />
+        <ConfirmWrapped styles={styles} route={route} />
       </View>
     </BottomSheet>
   );

--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.tsx
@@ -1,24 +1,24 @@
-import { TransactionType } from '@metamask/transaction-controller';
 import React, { useMemo } from 'react';
 import { Linking, View } from 'react-native';
 import { ConfirmationFooterSelectorIDs } from '../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { strings } from '../../../../../../../locales/i18n';
+import BottomSheetFooter from '../../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import { ButtonsAlignment } from '../../../../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.types';
 import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../../component-library/components/Buttons/Button';
-import BottomSheetFooter from '../../../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import { ButtonsAlignment } from '../../../../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.types';
 import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import AppConstants from '../../../../../../core/AppConstants';
+import { useLedgerContext } from '../../../context/LedgerContext';
 import { useQRHardwareContext } from '../../../context/QRHardwareContext/QRHardwareContext';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
-import { useLedgerContext } from '../../../context/LedgerContext';
 import { useSecurityAlertResponse } from '../../../hooks/useSecurityAlertResponse';
 import { useTransactionMetadataRequest } from '../../../hooks/useTransactionMetadataRequest';
+import { isStakingConfirmation } from '../../../utils/confirm';
 import { ResultType } from '../../BlockaidBanner/BlockaidBanner.types';
 import styleSheet from './Footer.styles';
 
@@ -30,14 +30,12 @@ export const Footer = () => {
   const { isLedgerAccount } = useLedgerContext();
   const confirmDisabled = needsCameraPermission;
   const transactionMetadata = useTransactionMetadataRequest();
-  const isStakingConfirmation = [
-    TransactionType.stakingDeposit,
-    TransactionType.stakingUnstake,
-    TransactionType.stakingClaim,
-  ].includes(transactionMetadata?.type as TransactionType);
+  const isStakingConfirmationBool = isStakingConfirmation(
+    transactionMetadata?.type as string,
+  );
   const { styles } = useStyles(styleSheet, {
     confirmDisabled,
-    isStakingConfirmation,
+    isStakingConfirmationBool,
   });
 
   const confirmButtonLabel = useMemo(() => {
@@ -76,7 +74,7 @@ export const Footer = () => {
         buttonPropsArray={buttons}
         style={styles.base}
       />
-      {isStakingConfirmation && (
+      {isStakingConfirmationBool && (
         <View style={styles.textContainer}>
           <Text variant={TextVariant.BodySM}>
             {strings('confirm.staking_footer.part1')}

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
-import { stakingDepositConfirmationState } from '../../../../../../../util/test/confirm-data-helpers';
+import { stakingWithdrawalConfirmationState } from '../../../../../../../util/test/confirm-data-helpers';
 import { useConfirmActions } from '../../../../hooks/useConfirmActions';
-import StakingDeposit from './StakingDeposit';
+import StakingWithdrawal from './StakingWithdrawal';
 import { getNavbar } from '../../Navbar/Navbar';
 
 jest.mock('../../../../../../../core/Engine', () => ({
@@ -38,7 +38,7 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
-describe('StakingDeposit', () => {
+describe('StakingWithdrawal', () => {
   const mockGetNavbar = jest.mocked(getNavbar);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
 
@@ -57,8 +57,15 @@ describe('StakingDeposit', () => {
       onReject: mockOnReject,
     }));
 
-    const { getByText } = renderWithProvider(<StakingDeposit />, {
-      state: stakingDepositConfirmationState,
+    const { getByText } = renderWithProvider(<StakingWithdrawal route={{
+      params: {
+        amountWei: '1000000000000000000',
+        amountFiat: '1000000000000000000'
+      },
+      key: 'mockRouteKey',
+      name: 'params'
+    }} />, {
+      state: stakingWithdrawalConfirmationState,
     });
     expect(getByText('APR')).toBeDefined();
     expect(getByText('Est. annual reward')).toBeDefined();
@@ -69,7 +76,7 @@ describe('StakingDeposit', () => {
 
     expect(mockGetNavbar).toHaveBeenCalled();
     expect(mockGetNavbar).toHaveBeenCalledWith({
-      title: 'Stake',
+      title: 'Unstake',
       onReject: mockOnReject,
     });
   });

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useEffect } from 'react';
 import { strings } from '../../../../../../../../locales/i18n';
+import { UnstakeConfirmationViewProps } from '../../../../../../UI/Stake/Views/UnstakeConfirmationView/UnstakeConfirmationView.types';
 import { useConfirmActions } from '../../../../hooks/useConfirmActions';
 import AdvancedDetails from '../../AdvancedDetails/AdvancedDetails';
 import { getNavbar } from '../../Navbar/Navbar';
@@ -8,14 +9,14 @@ import StakingDetails from '../../StakingDetails';
 import TokenHero from '../../TokenHero';
 import GasFeesDetails from '../GasFeesDetails';
 
-const StakingDeposit = () => {
+const StakingWithdrawal = ({ route }: UnstakeConfirmationViewProps) => {
   const navigation = useNavigation();
   const { onReject } = useConfirmActions();
 
   useEffect(() => {
     navigation.setOptions(
       getNavbar({
-        title: strings('stake.stake'),
+        title: strings('stake.unstake'),
         onReject,
       }),
     );
@@ -23,11 +24,11 @@ const StakingDeposit = () => {
 
   return (
     <>
-      <TokenHero />
+      <TokenHero amountWei={route?.params?.amountWei} />
       <StakingDetails />
       <GasFeesDetails />
       <AdvancedDetails />
     </>
   );
 };
-export default StakingDeposit;
+export default StakingWithdrawal;

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/index.ts
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StakingWithdrawal';

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { getStakingDepositNavbar } from './Navbar';
+import { getNavbar } from './Navbar';
 
 describe('getStakingDepositNavbar', () => {
   it('renders the header title correctly', () => {
     const title = 'Test Title';
     const { getByText } = render(
       <>
-        {getStakingDepositNavbar({ title, onReject: jest.fn() }).headerTitle()}
+        {getNavbar({ title, onReject: jest.fn() }).headerTitle()}
       </>,
     );
 
@@ -18,14 +18,14 @@ describe('getStakingDepositNavbar', () => {
     const onRejectMock = jest.fn();
     const { getByTestId } = render(
       <>
-        {getStakingDepositNavbar({
+        {getNavbar({
           title: 'Test Title',
           onReject: onRejectMock,
         }).headerLeft()}
       </>,
     );
 
-    const backButton = getByTestId('staking-deposit-navbar-back-button');
+    const backButton = getByTestId('Test Title-navbar-back-button');
     backButton.props.onPress();
 
     expect(onRejectMock).toHaveBeenCalled();

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
@@ -3,13 +3,13 @@ import { StyleSheet, View } from 'react-native';
 import {
   default as MorphText,
   TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
+} from '../../../../../../component-library/components/Texts/Text';
 import ButtonIcon, {
   ButtonIconSizes,
-} from '../../../../../../../component-library/components/Buttons/ButtonIcon';
-import { IconName } from '../../../../../../../component-library/components/Icons/Icon';
+} from '../../../../../../component-library/components/Buttons/ButtonIcon';
+import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 
-export function getStakingDepositNavbar({
+export function getNavbar({
   title,
   onReject,
 }: {
@@ -43,7 +43,7 @@ export function getStakingDepositNavbar({
         iconName={IconName.ArrowLeft}
         onPress={handleBackPress}
         style={innerStyles.headerLeft}
-        testID="staking-deposit-navbar-back-button"
+        testID={`${title}-navbar-back-button`}
       />
     ),
   };

--- a/app/components/Views/confirmations/components/Confirm/Navbar/index.ts
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/index.ts
@@ -1,0 +1,1 @@
+export { getNavbar as getStakingNavbar } from './Navbar';

--- a/app/components/Views/confirmations/components/Confirm/TokenHero/TokenHero.tsx
+++ b/app/components/Views/confirmations/components/Confirm/TokenHero/TokenHero.tsx
@@ -71,9 +71,9 @@ const AssetFiatConversion = ({
   </Text>
 );
 
-const TokenHero = () => {
+const TokenHero = ({ amountWei }: { amountWei?: string }) => {
   const { styles } = useStyles(styleSheet, {});
-  const { tokenAmountValue, tokenAmountDisplayValue, fiatDisplayValue } = useTokenValues();
+  const { tokenAmountValue, tokenAmountDisplayValue, fiatDisplayValue } = useTokenValues({ amountWei });
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   const displayTokenAmountIsRounded = tokenAmountValue !== tokenAmountDisplayValue;

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -1,28 +1,31 @@
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { ApprovalType } from '@metamask/controller-utils';
 import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { ApprovalType } from '@metamask/controller-utils';
-
-import {
-  isExternalHardwareAccount,
-  isHardwareAccount,
-} from '../../../../util/address';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import {
   type ConfirmationRedesignRemoteFlags,
   selectConfirmationRedesignFlags,
 } from '../../../../selectors/featureFlagController';
-import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
+import {
+  isExternalHardwareAccount,
+  isHardwareAccount,
+} from '../../../../util/address';
+import { isStakingConfirmation } from '../utils/confirm';
 import useApprovalRequest from './useApprovalRequest';
+import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 
 const REDESIGNED_SIGNATURE_TYPES = [
   ApprovalType.EthSignTypedData,
   ApprovalType.PersonalSign,
 ];
 
-const REDESIGNED_TRANSACTION_TYPES = [TransactionType.stakingDeposit];
+const REDESIGNED_TRANSACTION_TYPES = [
+  TransactionType.stakingDeposit,
+  TransactionType.stakingUnstake,
+];
 
 function isRedesignedSignature({
   approvalRequestType,
@@ -65,7 +68,7 @@ function isRedesignedTransaction({
     return false;
   }
 
-  if (transactionMetadata.type === TransactionType.stakingDeposit) {
+  if (isStakingConfirmation(transactionMetadata?.type as string)) {
     return confirmationRedesignFlags?.staking_transactions;
   }
 

--- a/app/components/Views/confirmations/hooks/useFlatConfirmation.ts
+++ b/app/components/Views/confirmations/hooks/useFlatConfirmation.ts
@@ -4,6 +4,7 @@ import { useTransactionMetadataRequest } from '../hooks/useTransactionMetadataRe
 
 const FLAT_TRANSACTION_CONFIRMATIONS: TransactionType[] = [
   TransactionType.stakingDeposit,
+  TransactionType.stakingUnstake,
 ];
 
 export const useFlatConfirmation = () => {

--- a/app/components/Views/confirmations/hooks/useStandaloneConfirmation.ts
+++ b/app/components/Views/confirmations/hooks/useStandaloneConfirmation.ts
@@ -3,6 +3,7 @@ import { useTransactionMetadataRequest } from '../hooks/useTransactionMetadataRe
 
 const STANDALONE_TRANSACTION_CONFIRMATIONS: TransactionType[] = [
   TransactionType.stakingDeposit,
+  TransactionType.stakingUnstake,
 ];
 
 export const useStandaloneConfirmation = () => {

--- a/app/components/Views/confirmations/hooks/useTokenValues.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenValues.test.ts
@@ -4,8 +4,8 @@ import { stakingDepositConfirmationState } from '../../../../util/test/confirm-d
 
 describe('useTokenValues', () => {
   describe('staking deposit', () => {
-    it('returns token and fiat values', () => {
-      const { result } = renderHookWithProvider(useTokenValues, {
+    it('returns token and fiat values if from transaction metadata', () => {
+      const { result } = renderHookWithProvider(() => useTokenValues({ amountWei: undefined }), {
         state: stakingDepositConfirmationState,
       });
 
@@ -13,6 +13,18 @@ describe('useTokenValues', () => {
         tokenAmountValue: '0.0001',
         tokenAmountDisplayValue: '0.0001',
         fiatDisplayValue: '$0.36',
+      });
+    });
+
+    it('returns token and fiat values if amountWei is defined', () => {
+      const { result } = renderHookWithProvider(() => useTokenValues({ amountWei: '1000000000000000' }), {
+        state: stakingDepositConfirmationState,
+      });
+
+      expect(result.current).toEqual({
+        tokenAmountValue: '0.001',
+        tokenAmountDisplayValue: '0.001',
+        fiatDisplayValue: '$3.60',
       });
     });
   });

--- a/app/components/Views/confirmations/hooks/useTokenValues.ts
+++ b/app/components/Views/confirmations/hooks/useTokenValues.ts
@@ -6,14 +6,22 @@ import { useTransactionMetadataRequest } from '../hooks/useTransactionMetadataRe
 import { selectConversionRateByChainId } from '../../../../selectors/currencyRateController';
 import I18n from '../../../../../locales/i18n';
 import { formatAmount } from '../../../../components/UI/SimulationDetails/formatAmount';
-import { fromWei, hexToBN } from '../../../../util/number';
+import { fromWei, hexToBN, toBigNumber } from '../../../../util/number';
 import useFiatFormatter from '../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { RootState } from '../../../../reducers';
 
 // TODO: This hook will be extended to calculate token and fiat information from transaction metadata on upcoming redesigned confirmations
-export const useTokenValues = () => {
+export const useTokenValues = ({ amountWei }: { amountWei?: string }) => {
+
   const transactionMetadata = useTransactionMetadataRequest();
-  const ethAmountInWei = hexToBN(transactionMetadata?.txParams?.value);
+
+  let ethAmountInWei;
+  if (amountWei) {
+    ethAmountInWei = toBigNumber.dec(amountWei);
+  } else {
+    ethAmountInWei = hexToBN(transactionMetadata?.txParams?.value);
+  }
+
   const ethAmountInBN = new BigNumber(fromWei(ethAmountInWei, 'ether'));
 
   const tokenAmountValue = ethAmountInBN.toFixed();

--- a/app/components/Views/confirmations/utils/confirm.ts
+++ b/app/components/Views/confirmations/utils/confirm.ts
@@ -12,5 +12,8 @@ export function isSignatureRequest(requestType: string) {
 }
 
 export function isStakingConfirmation(requestType: string) {
-  return requestType === TransactionType.stakingDeposit;
+  return [
+    TransactionType.stakingDeposit,
+    TransactionType.stakingUnstake,
+  ].includes(requestType as TransactionType);
 }

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -162,6 +162,7 @@ const Routes = {
   },
   STANDALONE_CONFIRMATIONS: {
     STAKE_DEPOSIT: 'RedesignedStakeDeposit',
+    STAKE_WITHDRAWAL: 'RedesignedStakeWithdrawal',
   },
   ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   SNAPS: {

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -37,7 +37,7 @@ export const hexToBN = (inputHex) =>
     : controllerHexToBN(inputHex);
 
 // Setter Maps
-const toBigNumber = {
+export const toBigNumber = {
   hex: (n) => new BigNumber(stripHexPrefix(n), 16),
   dec: (n) => new BigNumber(String(n), 10),
   BN: (n) => new BigNumber(n.toString(16), 16),

--- a/app/util/test/confirm-data-helpers.ts
+++ b/app/util/test/confirm-data-helpers.ts
@@ -1,3 +1,4 @@
+import { GasFeeState } from '@metamask/gas-fee-controller';
 import {
   MessageParamsPersonal,
   MessageParamsTyped,
@@ -5,14 +6,15 @@ import {
   SignatureRequestStatus,
   SignatureRequestType,
 } from '@metamask/signature-controller';
-import { GasFeeState } from '@metamask/gas-fee-controller';
-import { Hex } from '@metamask/utils';
 import {
   TransactionControllerState,
   TransactionEnvelopeType,
+  TransactionType,
 } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 
 import { backgroundState } from './initial-root-state';
+import { merge } from 'lodash';
 export const confirmationRedesignRemoteFlagsState = {
   remoteFeatureFlags: {
     confirmation_redesign: {
@@ -503,7 +505,7 @@ export const securityAlertResponse = {
   chainId: '0x1',
 };
 
-export const stakingDepositConfirmationState = {
+const stakingConfirmationBaseState = {
   engine: {
     backgroundState: {
       ...backgroundState,
@@ -571,7 +573,7 @@ export const stakingDepositConfirmationState = {
               value: '0x5af3107a4000',
               type: TransactionEnvelopeType.feeMarket,
             },
-            type: 'stakingDeposit',
+            type: TransactionType.stakingUnstake,
             userEditedGasLimit: false,
             userFeeLevel: 'medium',
             verifiedOnBlockchain: false,
@@ -665,3 +667,33 @@ export const stakingDepositConfirmationState = {
     showFiatOnTestnets: true,
   },
 };
+
+export const stakingDepositConfirmationState = merge(
+  stakingConfirmationBaseState,
+  {
+    engine: {
+      TransactionController: {
+        transactions: [
+          {
+            type: TransactionType.stakingDeposit,
+          },
+        ],
+      } as unknown as TransactionControllerState,
+    },
+  },
+);
+
+export const stakingWithdrawalConfirmationState = merge(
+  stakingConfirmationBaseState,
+  {
+    engine: {
+      TransactionController: {
+        transactions: [
+          {
+            type: TransactionType.stakingUnstake,
+          },
+        ],
+      } as unknown as TransactionControllerState,
+    },
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Implements new Staking Withdrawal redesigned confirmation. Includes changes to the TokenHero component to allow an native amount to be set from arguments, so the withdrawn amount is set from the input field that precedes the confirmation.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4347

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2025-03-04 at 11 26 03" src="https://github.com/user-attachments/assets/30c45e6d-eba1-4b8e-9d16-86eb2a5fb042" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
