### PR TITLE
feat: Multi chain send flow

### DIFF
--- a/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.tsx
+++ b/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.tsx
@@ -50,7 +50,8 @@ const SnapAccountCustomNameApproval = () => {
     internalAccounts.some((account) => account.metadata.name === name);
 
   useEffect(() => {
-    const suggestedName = approvalRequest?.requestData.snapSuggestedAccountName;
+    const suggestedName =
+      approvalRequest?.requestData?.snapSuggestedAccountName;
     const initialName = suggestedName
       ? getUniqueAccountName(internalAccounts, suggestedName)
       : Engine.context.AccountsController.getNextAvailableAccountName(

--- a/app/components/UI/AddressCopy/AddressCopy.tsx
+++ b/app/components/UI/AddressCopy/AddressCopy.tsx
@@ -22,7 +22,7 @@ import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletV
 import styleSheet from './AddressCopy.styles';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { useMetrics } from '../../../components/hooks/useMetrics';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { getFormattedAddressFromInternalAccount } from '../../../core/Multichain/utils';
 
 const AddressCopy = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -48,7 +48,7 @@ const AddressCopy = () => {
   const copyAccountToClipboard = async () => {
     if (selectedInternalAccount?.address) {
       await ClipboardManager.setString(
-        toChecksumHexAddress(selectedInternalAccount.address),
+        getFormattedAddressFromInternalAccount(selectedInternalAccount),
       );
     }
     handleShowAlert({

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { selectChainId } from '../../../selectors/networkController';
+import {
+  selectSelectedInternalAccount,
+  selectCanSignTransactions,
+} from '../../../selectors/accountsController';
+import { isSwapsAllowed } from '../../../components/UI/Swaps/utils';
+import isBridgeAllowed from '../../UI/Bridge/utils/isBridgeAllowed';
 
 import renderWithProvider, {
   DeepPartial,
@@ -17,6 +24,12 @@ import {
 } from '../../../util/test/accountsControllerTestUtils';
 import Engine from '../../../core/Engine';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
+import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
+import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
+
+jest.mock('../../../core/SnapKeyring/utils/sendMultichainTransaction', () => ({
+  sendMultichainTransaction: jest.fn(),
+}));
 
 jest.mock('../../../components/UI/Stake/constants', () => ({
   isStablecoinLendingFeatureEnabled: jest.fn(),
@@ -30,6 +43,86 @@ jest.mock('../../../core/Engine', () => ({
     MultichainNetworkController: {
       setActiveNetwork: jest.fn(),
     },
+  },
+}));
+
+jest.mock('../../../selectors/networkController', () => ({
+  selectChainId: jest.fn().mockReturnValue('0x1'),
+  selectEvmChainId: jest.fn().mockReturnValue('0x1'),
+  chainIdSelector: jest.fn().mockReturnValue('0x1'),
+  selectProviderConfig: jest.fn().mockReturnValue({
+    chainId: '0x1',
+    type: 'mainnet',
+    rpcUrl: 'https://mainnet.infura.io/v3/123',
+    ticker: 'ETH',
+    nickname: 'Ethereum Mainnet',
+  }),
+  selectEvmTicker: jest.fn().mockReturnValue('ETH'),
+}));
+
+jest.mock('../../../selectors/accountsController', () => {
+  const {
+    EthAccountType: MockEthAccountType,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  } = require('@metamask/keyring-api');
+  return {
+    selectSelectedInternalAccount: jest.fn().mockReturnValue({
+      id: 'mock-account-id',
+      type: MockEthAccountType.Eoa,
+      metadata: {},
+    }),
+    selectSelectedInternalAccountAddress: jest.fn().mockReturnValue('0x123'),
+    selectCanSignTransactions: jest.fn().mockReturnValue(true),
+  };
+});
+
+jest.mock('../../../selectors/tokensController', () => ({
+  selectAllTokens: jest.fn().mockReturnValue([]),
+  selectTokens: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../../selectors/tokenBalancesController', () => ({
+  selectTokenBalancesControllerState: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../reducers/swaps', () => ({
+  swapsLivenessSelector: jest.fn().mockReturnValue(true),
+  swapsTokensWithBalanceSelector: jest.fn().mockReturnValue([]),
+  swapsControllerAndUserTokens: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../../selectors/tokenListController', () => ({
+  selectTokenList: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../../components/UI/Swaps/utils', () => ({
+  isSwapsAllowed: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../UI/Bridge/utils/isBridgeAllowed', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../UI/Ramp/hooks/useRampNetwork', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue([true]),
+}));
+
+jest.mock('../../../core/AppConstants', () => ({
+  SWAPS: {
+    ACTIVE: true,
+  },
+  BUNDLE_IDS: {
+    ANDROID: 'io.metamask',
+    IOS: '1438144202',
+  },
+  MM_UNIVERSAL_LINK_HOST: 'metamask.app.link',
+  WALLET_CONNECT: {
+    PROJECT_ID: 'test-project-id',
+  },
+  BRIDGE: {
+    URL: 'https://bridge.metamask.io',
   },
 }));
 
@@ -132,6 +225,12 @@ describe('WalletActions', () => {
   });
 
   it('should not show the buy button and swap button if the chain does not allow buying', () => {
+    (isSwapsAllowed as jest.Mock).mockReturnValue(false);
+    (isBridgeAllowed as jest.Mock).mockReturnValue(false);
+    jest
+      .requireMock('../../UI/Ramp/hooks/useRampNetwork')
+      .default.mockReturnValue([false]);
+
     const mockState: DeepPartial<RootState> = {
       swaps: { '0x1': { isLive: false }, hasOnboarded: false, isLive: true },
       fiatOrders: {
@@ -182,6 +281,9 @@ describe('WalletActions', () => {
   });
 
   it('should call the onBuy function when the Buy button is pressed', () => {
+    jest
+      .requireMock('../../UI/Ramp/hooks/useRampNetwork')
+      .default.mockReturnValue([true]);
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
     });
@@ -205,6 +307,7 @@ describe('WalletActions', () => {
   });
 
   it('should call the goToSwaps function when the Swap button is pressed', () => {
+    (isSwapsAllowed as jest.Mock).mockReturnValue(true);
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
     });
@@ -217,6 +320,7 @@ describe('WalletActions', () => {
   });
 
   it('should call the goToBridge function when the Bridge button is pressed', () => {
+    (isBridgeAllowed as jest.Mock).mockReturnValue(true);
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
     });
@@ -246,6 +350,13 @@ describe('WalletActions', () => {
 
   it('disables action buttons when the account cannot sign transactions', () => {
     (isStablecoinLendingFeatureEnabled as jest.Mock).mockReturnValue(true);
+    (selectCanSignTransactions as unknown as jest.Mock).mockReturnValue(false);
+    (isSwapsAllowed as jest.Mock).mockReturnValue(true);
+    (isBridgeAllowed as jest.Mock).mockReturnValue(true);
+    jest
+      .requireMock('../../UI/Ramp/hooks/useRampNetwork')
+      .default.mockReturnValue([true]);
+
     const mockStateWithoutSigning: DeepPartial<RootState> = {
       ...mockInitialState,
       engine: {
@@ -296,5 +407,92 @@ describe('WalletActions', () => {
     expect(swapButton.props.disabled).toBe(true);
     expect(bridgeButton.props.disabled).toBe(true);
     expect(earnButton.props.disabled).toBe(true);
+  });
+
+  describe('onSend', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls sendMultichainTransaction for a Solana snap account', async () => {
+      (selectChainId as unknown as jest.Mock).mockReturnValue('solana:mainnet');
+      (selectSelectedInternalAccount as unknown as jest.Mock).mockReturnValue({
+        id: expectedUuid2,
+        type: SolAccountType.DataAccount,
+        metadata: {
+          snap: {
+            id: 'npm:@metamask/solana-wallet-snap',
+            name: 'Solana Wallet Snap',
+            enabled: true,
+          },
+        },
+      });
+
+      const { getByTestId } = renderWithProvider(<WalletActions />, {
+        state: mockInitialState,
+      });
+
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.SEND_BUTTON),
+      );
+
+      expect(sendMultichainTransaction).toHaveBeenCalledWith(
+        'npm:@metamask/solana-wallet-snap',
+        {
+          account: expectedUuid2,
+          scope: 'solana:mainnet',
+        },
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('calls native send flow for an EVM account', async () => {
+      (selectSelectedInternalAccount as unknown as jest.Mock).mockReturnValue({
+        id: expectedUuid2,
+        type: EthAccountType.Eoa,
+        metadata: {},
+      });
+
+      const { getByTestId } = renderWithProvider(<WalletActions />, {
+        state: mockInitialState,
+      });
+
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.SEND_BUTTON),
+      );
+
+      expect(sendMultichainTransaction).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('SendFlowView');
+    });
+
+    it('handles errors in sendMultichainTransaction gracefully', async () => {
+      (selectChainId as unknown as jest.Mock).mockReturnValue('solana:mainnet');
+      (selectSelectedInternalAccount as unknown as jest.Mock).mockReturnValue({
+        id: expectedUuid2,
+        type: SolAccountType.DataAccount,
+        metadata: {
+          snap: {
+            id: 'npm:@metamask/solana-wallet-snap',
+            name: 'Solana Wallet Snap',
+            enabled: true,
+          },
+        },
+      });
+
+      (sendMultichainTransaction as jest.Mock).mockRejectedValue(
+        new Error('Test error'),
+      );
+
+      const { getByTestId } = renderWithProvider(<WalletActions />, {
+        state: mockInitialState,
+      });
+
+      fireEvent.press(
+        getByTestId(WalletActionsBottomSheetSelectorsIDs.SEND_BUTTON),
+      );
+
+      expect(sendMultichainTransaction).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -38,6 +38,7 @@ import {
   createBuyNavigationDetails,
   createSellNavigationDetails,
 } from '../../UI/Ramp/routes/utils';
+// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
 import { selectCanSignTransactions } from '../../../selectors/accountsController';
 import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
@@ -46,6 +47,7 @@ import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constan
 import { CaipChainId, SnapId } from '@metamask/snaps-sdk';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { isMultichainWalletSnap } from '../../../core/SnapKeyring/utils/snaps';
+// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -38,11 +38,6 @@ import {
   createBuyNavigationDetails,
   createSellNavigationDetails,
 } from '../../UI/Ramp/routes/utils';
-import {
-  selectCanSignTransactions,
-  selectSelectedInternalAccount,
-} from '../../../selectors/accountsController';
-import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
@@ -50,6 +45,11 @@ import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constan
 import { CaipChainId, SnapId } from '@metamask/snaps-sdk';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { isMultichainWalletSnap } from '../../../core/SnapKeyring/utils/snaps';
+import {
+  selectCanSignTransactions,
+  selectSelectedInternalAccount,
+} from '../../../selectors/accountsController';
+import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 ///: END:ONLY_INCLUDE_IF
 
 const WalletActions = () => {
@@ -63,7 +63,9 @@ const WalletActions = () => {
   const dispatch = useDispatch();
   const [isNetworkRampSupported] = useRampNetwork();
   const { trackEvent, createEventBuilder } = useMetrics();
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const selectedAccount = useSelector(selectSelectedInternalAccount);
+  ///: END:ONLY_INCLUDE_IF
 
   const canSignTransactions = useSelector(selectCanSignTransactions);
 
@@ -217,13 +219,13 @@ const WalletActions = () => {
       ticker && dispatch(newAssetTransaction(getEther(ticker)));
     });
   }, [
-    trackEvent,
-    createEventBuilder,
-    chainId,
     closeBottomSheetAndNavigate,
     navigate,
     ticker,
     dispatch,
+    trackEvent,
+    chainId,
+    createEventBuilder,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     selectedAccount,
     ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -38,6 +38,7 @@ import {
   createBuyNavigationDetails,
   createSellNavigationDetails,
 } from '../../UI/Ramp/routes/utils';
+import { selectCanSignTransactions } from '../../../selectors/accountsController';
 import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
@@ -45,10 +46,7 @@ import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constan
 import { CaipChainId, SnapId } from '@metamask/snaps-sdk';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { isMultichainWalletSnap } from '../../../core/SnapKeyring/utils/snaps';
-import {
-  selectCanSignTransactions,
-  selectSelectedInternalAccount,
-} from '../../../selectors/accountsController';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 ///: END:ONLY_INCLUDE_IF
 

--- a/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
+++ b/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
@@ -1,0 +1,30 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { handleSnapRequest } from '../../Snaps/utils';
+import Engine from '../../Engine';
+import { SnapId } from '@metamask/snaps-sdk';
+
+const controllerMessenger = Engine.controllerMessenger;
+
+export async function sendMultichainTransaction(
+  snapId: SnapId,
+  {
+    account,
+    scope,
+  }: {
+    account: string;
+    scope: string;
+  },
+) {
+  await handleSnapRequest(controllerMessenger, {
+    snapId,
+    origin: 'metamask',
+    handler: HandlerType.OnRpcRequest,
+    request: {
+      method: 'startSendTransactionFlow',
+      params: {
+        account,
+        scope,
+      },
+    },
+  });
+}

--- a/app/core/SnapKeyring/utils/snaps.ts
+++ b/app/core/SnapKeyring/utils/snaps.ts
@@ -1,5 +1,7 @@
 import { SnapId } from '@metamask/snaps-sdk';
 import PREINSTALLED_SNAPS from '../../../lib/snaps/preinstalled-snaps';
+import { BITCOIN_WALLET_SNAP_ID } from '../BitcoinWalletSnap';
+import { SOLANA_WALLET_SNAP_ID } from '../SolanaWalletSnap';
 
 /**
  * Check if a Snap is a preinstalled Snap.
@@ -9,4 +11,24 @@ import PREINSTALLED_SNAPS from '../../../lib/snaps/preinstalled-snaps';
  */
 export function isSnapPreinstalled(snapId: SnapId) {
   return PREINSTALLED_SNAPS.some((snap) => snap.snapId === snapId);
+}
+
+/**
+ * A constant array that contains the IDs of whitelisted multichain
+ * wallet Snaps. These Snaps can be used by the extension to implement
+ * core features (e.g. Send flow).
+ *
+ * @constant
+ * @type {SnapId[]}
+ */
+const ALLOW_LISTED_SNAPS = [BITCOIN_WALLET_SNAP_ID, SOLANA_WALLET_SNAP_ID];
+
+/**
+ * Checks if the given Snap ID corresponds to a multichain wallet Snap.
+ *
+ * @param id - The ID of the Snap to check.
+ * @returns True if the Snap ID is in the whitelist, false otherwise.
+ */
+export function isMultichainWalletSnap(id: SnapId): boolean {
+  return ALLOW_LISTED_SNAPS.includes(id);
 }

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectFlattenedKeyringAccounts } from './keyringController';
-import { EthMethod, SolMethod } from '@metamask/keyring-api';
+import { BtcMethod, EthMethod, SolMethod } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   getFormattedAddressFromInternalAccount,
@@ -100,7 +100,9 @@ export const selectCanSignTransactions = createSelector(
     (selectedAccount?.methods?.includes(EthMethod.SignTransaction) ||
       selectedAccount?.methods?.includes(SolMethod.SignTransaction) ||
       selectedAccount?.methods?.includes(SolMethod.SignMessage) ||
-      selectedAccount?.methods?.includes(SolMethod.SignAndSendTransaction)) ??
+      selectedAccount?.methods?.includes(SolMethod.SendAndConfirmTransaction) ||
+      selectedAccount?.methods?.includes(SolMethod.SignAndSendTransaction) ||
+      selectedAccount?.methods?.includes(BtcMethod.SendBitcoin)) ??
     false,
 );
 

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectFlattenedKeyringAccounts } from './keyringController';
-import { EthMethod } from '@metamask/keyring-api';
+import { EthMethod, SolMethod } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   getFormattedAddressFromInternalAccount,
@@ -97,7 +97,11 @@ export const selectSelectedInternalAccountAddress = createSelector(
 export const selectCanSignTransactions = createSelector(
   selectSelectedInternalAccount,
   (selectedAccount) =>
-    selectedAccount?.methods?.includes(EthMethod.SignTransaction) ?? false,
+    (selectedAccount?.methods?.includes(EthMethod.SignTransaction) ||
+      selectedAccount?.methods?.includes(SolMethod.SignTransaction) ||
+      selectedAccount?.methods?.includes(SolMethod.SignMessage) ||
+      selectedAccount?.methods?.includes(SolMethod.SignAndSendTransaction)) ??
+    false,
 );
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR enables the Solana send flow. The send flow UI is all created from the snap using the snaps dynamic UI components. Creating the send flow is as simple as calling the `startSendTransactionFlow` RPC method on the snap. This will trigger the dynamic UI which allows sending.

To enable this I did the following...

1. enable send button on non evm accounts by modifying the `selectCanSignTransactions` selector to look for SOL and BTC signing methods.
2. created a `sendMultichainTransaction` util function that calls the `startSendTransactionFlow` on the snap.
3. edit the Wallet Actions to conditionally call the `sendMultichainTransaction` if the current account is non evm.

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/809

## **Manual testing steps**

1. ensure you are building mobile flask by changing the `export METAMASK_BUILD_TYPE="flask"` and running yarn setup
2. Import a wallet that has SOL funds. I can provide you with an SRP that has funds from 1Password. 
3. Alternatively you can fund your SOL address after you have created an account with the below steps.
4. Create a sol account by opening the account list menu, clicking on "Add account or hardware wallet"
5. Then click on add Solana account. ideally this first account has funds already
6. create a new Solana account by repeating the same step as above
7. select the sol account that has funds, then open the buttom tab navigator (big blue button on the bottom) and click send. The send button should be enabled.
8. this should open the send flow 
9. enter your other address and then complete the send flow.
10. Clicking on the view transaction button inside the send flow should open the solana block explorer.
11. after a few seconds/minutes, refresh your token balance by pulling down on the main wallet view
12. your other sol account should now have an updated balance.

#### Testing that EVM send still works.
1. select your eth account from the top menu.
2. open the send flow via the bottom nav
3. the "native" (original) send  flow should open.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/8f892dd4-993d-496a-a4fd-18691d067e2d


### **After**


https://github.com/user-attachments/assets/03d7c3fa-94d2-4266-8d01-1f51ffb99f44


The native send flow still works as expected.

https://github.com/user-attachments/assets/1ba78c61-a617-4103-b119-1338c4a75094


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
