### PR TITLE
fix: cp-7.42.0 Disable signature re-designs for ledger account

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
@@ -3,7 +3,10 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { merge, cloneDeep } from 'lodash';
 
 // eslint-disable-next-line import/no-namespace
-import { isHardwareAccount } from '../../../../util/address';
+import {
+  isExternalHardwareAccount,
+  isHardwareAccount,
+} from '../../../../util/address';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import {
   personalSignatureConfirmationState,
@@ -14,6 +17,7 @@ import { useConfirmationRedesignEnabled } from './useConfirmationRedesignEnabled
 jest.mock('../../../../util/address', () => ({
   ...jest.requireActual('../../../../util/address'),
   isHardwareAccount: jest.fn(),
+  isExternalHardwareAccount: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -42,6 +46,18 @@ describe('useConfirmationRedesignEnabled', () => {
       );
 
       expect(result.current.isRedesignedEnabled).toBe(true);
+    });
+
+    it('returns false for external accounts', async () => {
+      (isExternalHardwareAccount as jest.Mock).mockReturnValue(true);
+      const { result } = renderHookWithProvider(
+        useConfirmationRedesignEnabled,
+        {
+          state: personalSignatureConfirmationState,
+        },
+      );
+
+      expect(result.current.isRedesignedEnabled).toBe(false);
     });
 
     it('returns false when remote flag is disabled', async () => {

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -6,7 +6,10 @@ import {
 } from '@metamask/transaction-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 
-import { isHardwareAccount } from '../../../../util/address';
+import {
+  isExternalHardwareAccount,
+  isHardwareAccount,
+} from '../../../../util/address';
 import {
   type ConfirmationRedesignRemoteFlags,
   selectConfirmationRedesignFlags,
@@ -24,14 +27,17 @@ const REDESIGNED_TRANSACTION_TYPES = [TransactionType.stakingDeposit];
 function isRedesignedSignature({
   approvalRequestType,
   confirmationRedesignFlags,
+  fromAddress,
 }: {
   approvalRequestType: ApprovalType;
   confirmationRedesignFlags: ConfirmationRedesignRemoteFlags;
+  fromAddress: string;
 }) {
   return (
     confirmationRedesignFlags?.signatures &&
     approvalRequestType &&
-    REDESIGNED_SIGNATURE_TYPES.includes(approvalRequestType as ApprovalType)
+    REDESIGNED_SIGNATURE_TYPES.includes(approvalRequestType as ApprovalType) &&
+    !isExternalHardwareAccount(fromAddress)
   );
 }
 
@@ -81,6 +87,7 @@ export const useConfirmationRedesignEnabled = () => {
       isRedesignedSignature({
         approvalRequestType,
         confirmationRedesignFlags,
+        fromAddress,
       }) ||
       isRedesignedTransaction({
         approvalRequestType,


### PR DESCRIPTION
## **Description**

Disabled signature re-designs for ledger account.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13792

## **Manual testing steps**

1. Switch to ledger account
2. To to test dapp
3. Submit any signature, it should work as expected

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
