### PR TITLE
feat: STAKE-934: added earn-controller pooled staking selectors

### DIFF
--- a/app/components/UI/Stake/testUtils/index.ts
+++ b/app/components/UI/Stake/testUtils/index.ts
@@ -3,6 +3,21 @@ import {
   CreateMockTokenOptions,
   TOKENS_WITH_DEFAULT_OPTIONS,
 } from './testUtils.types';
+import { PooledStakingState } from '@metamask/earn-controller';
+import {
+  VaultData,
+  VaultApyAverages,
+  VaultDailyApy,
+} from '@metamask/stake-sdk';
+import {
+  MOCK_POOLED_STAKES_DATA,
+  MOCK_VAULT_DATA,
+  MOCK_EXCHANGE_RATE,
+} from '../__mocks__/earnControllerMockData';
+import {
+  MOCK_VAULT_APY_AVERAGES,
+  MOCK_VAULT_DAILY_APYS,
+} from '../components/PoolStakingLearnMoreModal/mockVaultRewards';
 
 export const HOLESKY_CHAIN_ID = '0x4268';
 
@@ -108,3 +123,36 @@ export const getCreateMockTokenOptions = (
     ...tokenOptions[token],
   };
 };
+
+export const mockEarnControllerRootState = ({
+  isEligible = true,
+  pooledStakes = MOCK_POOLED_STAKES_DATA,
+  vaultMetadata = MOCK_VAULT_DATA,
+  exchangeRate = MOCK_EXCHANGE_RATE,
+  vaultApyAverages = MOCK_VAULT_APY_AVERAGES,
+  vaultDailyApys = MOCK_VAULT_DAILY_APYS,
+}: {
+  isEligible?: boolean;
+  pooledStakes?: PooledStakingState['pooledStakes'];
+  vaultMetadata?: VaultData;
+  exchangeRate?: string;
+  vaultApyAverages?: VaultApyAverages;
+  vaultDailyApys?: VaultDailyApy[];
+} = {}) => ({
+  engine: {
+    backgroundState: {
+      EarnController: {
+        lastUpdated: 0,
+        pooled_staking: {
+          isEligible,
+          pooledStakes,
+          vaultMetadata,
+          exchangeRate,
+          vaultApyAverages,
+          vaultDailyApys,
+        },
+        stablecoin_lending: {},
+      },
+    },
+  },
+});

--- a/app/components/UI/Stake/testUtils/testUtils.test.ts
+++ b/app/components/UI/Stake/testUtils/testUtils.test.ts
@@ -1,6 +1,12 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { createMockToken, getCreateMockTokenOptions } from '.';
+import {
+  createMockToken,
+  getCreateMockTokenOptions,
+  mockEarnControllerRootState,
+} from '.';
 import { TOKENS_WITH_DEFAULT_OPTIONS } from './testUtils.types';
+
+const MOCK_ROOT_STATE_WITH_EARN_CONTROLLER = mockEarnControllerRootState();
 
 describe('Staking Test Utils', () => {
   describe('createMockToken', () => {
@@ -91,6 +97,24 @@ describe('Staking Test Utils', () => {
         symbol: 'USDC',
         ticker: 'USDC',
       });
+    });
+  });
+
+  describe('mockEarnControllerRootState', () => {
+    it('returns default mock earn controller root state', () => {
+      const result = mockEarnControllerRootState();
+
+      expect(result).toStrictEqual(MOCK_ROOT_STATE_WITH_EARN_CONTROLLER);
+    });
+
+    it('returns correct state when overriding default values', () => {
+      const result = mockEarnControllerRootState({
+        isEligible: false,
+      });
+
+      expect(
+        result.engine.backgroundState.EarnController.pooled_staking.isEligible,
+      ).toBe(false);
     });
   });
 });

--- a/app/selectors/earnController/index.ts
+++ b/app/selectors/earnController/index.ts
@@ -1,0 +1,1 @@
+export * from './pooledStaking/index';

--- a/app/selectors/earnController/pooledStaking/index.test.ts
+++ b/app/selectors/earnController/pooledStaking/index.test.ts
@@ -1,0 +1,91 @@
+import { pooledStakingSelectors } from '.';
+import { RootState } from '../../../reducers';
+import {
+  MOCK_VAULT_APY_AVERAGES,
+  MOCK_VAULT_DAILY_APYS,
+} from '../../../components/UI/Stake/components/PoolStakingLearnMoreModal/mockVaultRewards';
+import {
+  MOCK_VAULT_DATA,
+  MOCK_POOLED_STAKES_DATA,
+  MOCK_EXCHANGE_RATE,
+} from '../../../components/UI/Stake/__mocks__/earnControllerMockData';
+import { mockEarnControllerRootState } from '../../../components/UI/Stake/testUtils';
+
+const MOCK_ROOT_STATE_WITH_EARN_CONTROLLER = mockEarnControllerRootState();
+
+describe('Earn Controller Selectors', () => {
+  describe('Pooled Staking Selectors', () => {
+    describe('selectEligibility', () => {
+      it('returns selected pooled-staking eligibility', () => {
+        expect(
+          pooledStakingSelectors.selectEligibility(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toBe(true);
+      });
+    });
+
+    describe('selectVaultMetadata', () => {
+      it('returns selected pooled-staking vault data', () => {
+        expect(
+          pooledStakingSelectors.selectVaultMetadata(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual(MOCK_VAULT_DATA);
+      });
+    });
+
+    describe('selectPoolStakes', () => {
+      it('returns selected pooled-staking pooled stakes data', () => {
+        expect(
+          pooledStakingSelectors.selectPoolStakes(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual(MOCK_POOLED_STAKES_DATA);
+      });
+    });
+
+    describe('selectExchangeRate', () => {
+      it('returns selected pooled-staking exchange rate', () => {
+        expect(
+          pooledStakingSelectors.selectExchangeRate(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual(MOCK_EXCHANGE_RATE);
+      });
+    });
+
+    describe('selectVaultDailyApys', () => {
+      it('returns selected pooled-staking vault daily apys', () => {
+        expect(
+          pooledStakingSelectors.selectVaultDailyApys(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual(MOCK_VAULT_DAILY_APYS);
+      });
+    });
+
+    describe('selectVaultApyAverages', () => {
+      it('returns selected pooled-staking vault apy averages', () => {
+        expect(
+          pooledStakingSelectors.selectVaultApyAverages(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual(MOCK_VAULT_APY_AVERAGES);
+      });
+    });
+
+    describe('selectVaultApy', () => {
+      it('returns selected pooled-staking vault daily apy in decimal and percent string formats', () => {
+        expect(
+          pooledStakingSelectors.selectVaultApy(
+            MOCK_ROOT_STATE_WITH_EARN_CONTROLLER as RootState,
+          ),
+        ).toStrictEqual({
+          apyDecimal: 0.03257560263513173,
+          apyPercentString: '3.3%',
+        });
+      });
+    });
+  });
+});

--- a/app/selectors/earnController/pooledStaking/index.ts
+++ b/app/selectors/earnController/pooledStaking/index.ts
@@ -1,0 +1,84 @@
+import { createSelector } from 'reselect';
+import { RootState } from '../../../reducers';
+import { EarnControllerState } from '@metamask/earn-controller';
+import { createDeepEqualSelector } from '../../util';
+import { VaultApyAverages } from '@metamask/stake-sdk';
+import BigNumber from 'bignumber.js';
+import {
+  CommonPercentageInputUnits,
+  formatPercent,
+  PercentageOutputFormat,
+} from '../../../components/UI/Stake/utils/value';
+
+// Raw State Selectors
+const selectEarnControllerState = (state: RootState) =>
+  state.engine.backgroundState.EarnController;
+
+const selectEligibility = createSelector(
+  selectEarnControllerState,
+  (earnControllerState: EarnControllerState) =>
+    earnControllerState.pooled_staking.isEligible,
+);
+
+const selectVaultMetadata = createDeepEqualSelector(
+  selectEarnControllerState,
+  (earnControllerState: EarnControllerState) =>
+    earnControllerState.pooled_staking.vaultMetadata,
+);
+
+const selectPoolStakes = createDeepEqualSelector(
+  selectEarnControllerState,
+  (earnControllerState: EarnControllerState) =>
+    earnControllerState.pooled_staking.pooledStakes,
+);
+
+const selectExchangeRate = createSelector(
+  selectEarnControllerState,
+  (earnControllerState: EarnControllerState) =>
+    earnControllerState.pooled_staking.exchangeRate,
+);
+
+const selectVaultDailyApys = createDeepEqualSelector(
+  selectEarnControllerState,
+  (earnControllerSate: EarnControllerState) =>
+    earnControllerSate.pooled_staking.vaultDailyApys,
+);
+
+const selectVaultApyAverages = createDeepEqualSelector(
+  selectEarnControllerState,
+  (earnControllerSate: EarnControllerState) =>
+    earnControllerSate.pooled_staking.vaultApyAverages,
+);
+
+// Derived State Selectors
+const selectVaultApy = createSelector(
+  selectVaultApyAverages,
+  (vaultApyAverages: VaultApyAverages) => {
+    const { oneWeek } = vaultApyAverages;
+
+    const apyPercentString = formatPercent(oneWeek, {
+      inputFormat: CommonPercentageInputUnits.PERCENTAGE,
+      outputFormat: PercentageOutputFormat.PERCENT_SIGN,
+      fixed: 1,
+    });
+
+    const apyDecimal = new BigNumber(oneWeek).dividedBy(100).toNumber();
+
+    return {
+      // e.g. "2.5%"
+      apyPercentString,
+      // 0.02522049624725908
+      apyDecimal,
+    };
+  },
+);
+
+export const pooledStakingSelectors = {
+  selectEligibility,
+  selectVaultMetadata,
+  selectPoolStakes,
+  selectExchangeRate,
+  selectVaultDailyApys,
+  selectVaultApyAverages,
+  selectVaultApy,
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds the pooled staking selectors for the earn controller
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

- [STAKE-934: Integrate Earn Controller Package in MM Mobile](https://consensyssoftware.atlassian.net/browse/STAKE-934)

## **Manual testing steps**

N/A since the selectors aren't in use yet.

## **Screenshots/Recordings**

n/a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.