### PR TITLE
feat(snaps): Add icon next to SnapUILink

### DIFF
--- a/app/components/Snaps/SnapUIRenderer/components/link.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/link.test.ts
@@ -1,0 +1,41 @@
+import { link } from './link';
+import { LinkElement } from '@metamask/snaps-sdk/jsx';
+import { mockTheme } from '../../../../util/theme';
+
+describe('link component', () => {
+  const defaultParams = {
+    map: {},
+    t: jest.fn(),
+    theme: mockTheme,
+  };
+
+  it('should return the correct element structure with href', () => {
+    const linkElement: LinkElement = {
+      type: 'Link',
+      props: {
+        href: 'https://metamask.io',
+        children: ['link'],
+      },
+      key: null,
+    };
+
+    const result = link({ element: linkElement, ...defaultParams });
+
+    expect(result).toEqual({
+      element: 'SnapUILink',
+      children: [
+        {
+          element: 'RNText',
+          children: 'link',
+          key: expect.any(String),
+          props: {
+            color: 'inherit',
+          },
+        },
+      ],
+      props: {
+        href: 'https://metamask.io',
+      },
+    });
+  });
+});

--- a/app/components/UI/Snaps/SnapUILink/SnapUILink.test.tsx
+++ b/app/components/UI/Snaps/SnapUILink/SnapUILink.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import { SnapUILink } from './SnapUILink';
+import ButtonLink from '../../../../component-library/components/Buttons/Button/variants/ButtonLink';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../component-library/components/Icons/Icon';
+import { TextColor } from '../../../../component-library/components/Texts/Text';
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(),
+}));
+
+describe('SnapUILink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const validProps = {
+    href: 'https://metamask.io',
+    children: 'Visit MetaMask',
+  };
+
+  it('renders correctly with valid props', () => {
+    const { UNSAFE_getByType } = render(
+      <SnapUILink {...validProps} />,
+    );
+
+    const button = UNSAFE_getByType(ButtonLink);
+    const icon = UNSAFE_getByType(Icon);
+
+    expect(button).toBeTruthy();
+    expect(button.props.testID).toBe('snaps-ui-link');
+    expect(button.props.color).toBe(TextColor.Info);
+    expect(icon.props.name).toBe(IconName.Export);
+    expect(icon.props.color).toBe(IconColor.Primary);
+    expect(icon.props.size).toBe(IconSize.Sm);
+    expect(icon.props.style).toEqual({
+      marginLeft: 2,
+      justifyContent: 'center',
+      alignItems: 'center',
+      alignSelf: 'center',
+    });
+  });
+
+  it('opens URL when pressed with valid https URL', () => {
+    const { getByTestId } = render(<SnapUILink {...validProps} />);
+
+    const button = getByTestId('snaps-ui-link');
+    fireEvent.press(button);
+
+    expect(Linking.openURL).toHaveBeenCalledWith(validProps.href);
+    expect(Linking.openURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws error when URL does not start with https://', () => {
+    const invalidProps = {
+      href: 'http://example.com',
+      children: 'Invalid Link',
+    };
+
+    const { getByTestId } = render(<SnapUILink {...invalidProps} />);
+
+    const button = getByTestId('snaps-ui-link');
+
+    expect(() => {
+      fireEvent.press(button);
+    }).toThrow('Invalid URL');
+
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Snaps/SnapUILink/SnapUILink.tsx
+++ b/app/components/UI/Snaps/SnapUILink/SnapUILink.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 import { Linking } from 'react-native';
 import ButtonLink from '../../../../component-library/components/Buttons/Button/variants/ButtonLink';
 import { TextColor } from '../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../component-library/components/Icons/Icon';
 
 export interface SnapUILinkProps {
   children: LinkChildren;
@@ -22,14 +27,26 @@ const onPress = (href: string) => {
 };
 
 // TODO: This component should show a modal for links when not using preinstalled Snaps
-// TODO: This component should have an icon next to it
-export const SnapUILink: React.FC<SnapUILinkProps> = ({ href, children }) => (
-  <ButtonLink
-    testID="snaps-ui-link"
-    // @ts-expect-error This prop is not part of the type but it works.
-    color={TextColor.Info}
-    onPress={() => onPress(href)}
-    label={children}
-  />
-);
+export const SnapUILink: React.FC<SnapUILinkProps> = ({ href, children }) => {
+  const label = (
+    <>
+      {children}{' '}
+      <Icon
+        name={IconName.Export}
+        color={IconColor.Primary}
+        size={IconSize.Sm}
+      />
+    </>
+  );
+
+  return (
+    <ButtonLink
+      testID="snaps-ui-link"
+      // @ts-expect-error This prop is not part of the type but it works.
+      color={TextColor.Info}
+      onPress={() => onPress(href)}
+      label={label}
+    />
+  );
+};
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Snaps/SnapUILink/SnapUILink.tsx
+++ b/app/components/UI/Snaps/SnapUILink/SnapUILink.tsx
@@ -30,11 +30,18 @@ const onPress = (href: string) => {
 export const SnapUILink: React.FC<SnapUILinkProps> = ({ href, children }) => {
   const label = (
     <>
-      {children}{' '}
+      {children}
       <Icon
         name={IconName.Export}
         color={IconColor.Primary}
         size={IconSize.Sm}
+        /* eslint-disable-next-line react-native/no-inline-styles */
+        style={{
+          marginLeft: 2,
+          justifyContent: 'center',
+          alignItems: 'center',
+          alignSelf: 'center',
+        }}
       />
     </>
   );


### PR DESCRIPTION
## **Description**
This PR adds icon next to `SnapUILink` component.

## **Related issues**
Fixes: https://github.com/MetaMask/snaps/issues/3182

## **Manual testing steps**
1. Try testing with a Snap using `<Link>` component (e.g. `<Link href="https://metamask.io">Click to open</Link>`).

## **Screenshots/Recordings**
### **Before**
Link icon was just not available before.

### **After**
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-03-06 at 15 59 06](https://github.com/user-attachments/assets/c3478b89-3226-4ee3-b314-6c3c01c91888)

Compared to extension:
<img width="772" alt="Screenshot 2025-03-06 at 15 58 57" src="https://github.com/user-attachments/assets/1d6f4af3-5e23-40fd-8425-c39a3ae875c1" />

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
