### PR TITLE
fix: Max balance for dApp erc20 approval

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.stories.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.stories.tsx
@@ -16,6 +16,7 @@ storiesOf('Component Library / CustomSpendCap', module).add('Default', () => (
   <CustomSpendCap
     ticker={TICKER}
     accountBalance={ACCOUNT_BALANCE}
+    unroundedAccountBalance={ACCOUNT_BALANCE}
     dappProposedValue={DAPP_PROPOSED_VALUE}
     onInputChanged={INPUT_VALUE_CHANGED}
     isEditDisabled={false}

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -23,6 +23,7 @@ function RenderCustomSpendCap(
     <CustomSpendCap
       ticker={TICKER}
       accountBalance={ACCOUNT_BALANCE}
+      unroundedAccountBalance={ACCOUNT_BALANCE}
       dappProposedValue={dappProposedValue}
       onInputChanged={INPUT_VALUE_CHANGED}
       isEditDisabled={false}

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.test.tsx
@@ -1,7 +1,6 @@
+import { fireEvent } from '@testing-library/react-native';
 import { shallow } from 'enzyme';
-// Third party dependencies.
 import React from 'react';
-
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import CustomSpendCap from './CustomSpendCap';
 import {
@@ -11,19 +10,20 @@ import {
   INPUT_VALUE_CHANGED,
   TICKER,
 } from './CustomSpendCap.constants';
-// Internal dependencies.
 import { CustomSpendCapProps } from './CustomSpendCap.types';
 
 function RenderCustomSpendCap(
   tokenSpendValue = '',
   isInputValid: () => boolean = () => true,
   dappProposedValue: string = DAPP_PROPOSED_VALUE,
+  accountBalance: string = ACCOUNT_BALANCE,
+  unroundedAccountBalance: string = ACCOUNT_BALANCE,
 ) {
   return (
     <CustomSpendCap
       ticker={TICKER}
-      accountBalance={ACCOUNT_BALANCE}
-      unroundedAccountBalance={ACCOUNT_BALANCE}
+      accountBalance={accountBalance}
+      unroundedAccountBalance={unroundedAccountBalance}
       dappProposedValue={dappProposedValue}
       onInputChanged={INPUT_VALUE_CHANGED}
       isEditDisabled={false}
@@ -120,5 +120,49 @@ describe('CustomSpendCap', () => {
     );
 
     expect(await findByText(`${inputtedSpendValue} ${TICKER}`)).toBeDefined();
+  });
+
+  it('should render account balance when clicking max if unrounded account balance is empty string', async () => {
+    const inputtedSpendValue = '100';
+
+    const roundedAccountBalance = '3.14';
+    const unroundedAccountBalance = '';
+
+    const { findByTestId, findByText } = renderWithProvider(
+      RenderCustomSpendCap(
+        inputtedSpendValue,
+        isInputValid,
+        DAPP_PROPOSED_VALUE,
+        roundedAccountBalance,
+        unroundedAccountBalance,
+      ),
+    );
+
+    fireEvent.press(await findByText('Max'));
+
+    const input = await findByTestId(`${'custom-spend-cap-input-input-id'}`);
+    expect(input.props.value).toEqual(roundedAccountBalance);
+  });
+
+  it('should render unrounded account balance when clicking max if unrounded account balance is not empty string', async () => {
+    const inputtedSpendValue = '100';
+
+    const roundedAccountBalance = '3.14';
+    const unroundedAccountBalance = '3.141592654';
+
+    const { findByTestId,findByText } = renderWithProvider(
+      RenderCustomSpendCap(
+        inputtedSpendValue,
+        isInputValid,
+        DAPP_PROPOSED_VALUE,
+        roundedAccountBalance,
+        unroundedAccountBalance,
+      ),
+    );
+
+    fireEvent.press(await findByText('Max'));
+
+    const input = await findByTestId(`${'custom-spend-cap-input-input-id'}`);
+    expect(input.props.value).toEqual(unroundedAccountBalance);
   });
 });

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -22,6 +22,7 @@ const CustomSpendCap = ({
   ticker,
   dappProposedValue,
   accountBalance,
+  unroundedAccountBalance,
   onInputChanged,
   isEditDisabled,
   editValue,
@@ -75,8 +76,8 @@ const CustomSpendCap = ({
   };
 
   useEffect(() => {
-    if (maxSelected) setValue(accountBalance);
-  }, [maxSelected, accountBalance]);
+    if (maxSelected) setValue(unroundedAccountBalance || accountBalance);
+  }, [maxSelected, accountBalance, unroundedAccountBalance]);
 
   useEffect(() => {
     if (Number(value) > Number(accountBalance))

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.types.ts
@@ -2,6 +2,7 @@ export interface CustomSpendCapProps {
   ticker: string;
   dappProposedValue: string;
   accountBalance: string;
+  unroundedAccountBalance: string;
   /**
    * @param value - The value of the input field
    */

--- a/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/components/ApproveTransactionReview/index.js
@@ -312,6 +312,7 @@ class ApproveTransactionReview extends PureComponent {
     showBlockExplorerModal: false,
     address: '',
     isCustomSpendInputValid: true,
+    unroundedAccountBalance: null,
   };
 
   customSpendLimitInput = React.createRef();
@@ -383,7 +384,8 @@ class ApproveTransactionReview extends PureComponent {
       tokenName,
       tokenStandard,
       tokenBalance,
-      createdSpendCap;
+      createdSpendCap,
+      unroundedAccountBalance = '';
 
     const { spenderAddress, encodedAmount: encodedHexAmount } =
       decodeApproveData(data);
@@ -429,6 +431,7 @@ class ApproveTransactionReview extends PureComponent {
             erc20TokenBalance,
             decimals,
           );
+          unroundedAccountBalance = fromTokenMinimalUnit(erc20TokenBalance || 0, decimals);
         }
       } catch (e) {
         tokenSymbol = contract?.symbol || 'ERC20 Token';
@@ -484,6 +487,7 @@ class ApproveTransactionReview extends PureComponent {
           ? tokenAllowanceState?.tokenSpendValue
           : '',
         spendLimitCustomValue: minTokenAllowance,
+        unroundedAccountBalance,
       },
       () => {
         this.props.metrics.trackEvent(
@@ -809,6 +813,7 @@ class ApproveTransactionReview extends PureComponent {
       isReadyToApprove,
       isCustomSpendInputValid,
       method,
+      unroundedAccountBalance,
     } = this.state;
 
     const {
@@ -1011,6 +1016,7 @@ class ApproveTransactionReview extends PureComponent {
                               dappProposedValue={originalApproveAmount}
                               tokenSpendValue={tokenSpendValue}
                               accountBalance={tokenBalance}
+                              unroundedAccountBalance={unroundedAccountBalance}
                               tokenDecimal={tokenDecimals}
                               toggleLearnMoreWebPage={
                                 this.toggleLearnMoreWebPage


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When the user clicks "Max" on ERC20 token approvals, the account token balance is set as the spending cap. However, this number is rounded to 5 decimals places, which sometimes results in a value smaller than the actual token balance.

This PR fixes this bug by setting the unrounded account token balance instead.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13122

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2025-03-06 at 14 00 32" src="https://github.com/user-attachments/assets/ccc5c9fe-5809-4d76-9755-5753281664b8" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
