### PR TITLE
fix: Persist scrypt derived storage keys to Keychain/Keystore on iOS/Android

### DIFF
--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -61,5 +61,3 @@ export const REVIEW_SHOWN_TIME = 'reviewShownTime';
 export const themeAppearanceLight = 'light';
 
 export const USE_TERMS = `${prefix}UserTermsAccepted${USE_TERMS_VERSION}`;
-
-export const SCRYPT_COMPUTED_KEY = 'scryptComputedKey';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`scrypt` derivation of storage keys for UserStorage (ProfileSync/Notifications/etc) takes very long (~2 seconds) so we need to cache the results.
This PR upgrades the previous cache strategy that used a single slot to an persistent cache with unlimited slots while additionally encrypting the data while at rest using the Keychain on iOS and KeyStore on Android.

The performance impact of the additional encryption is negligible, measuring around 7-9ms on a typical device.

## **Related issues**

Fixes: [IDENTITY-51](https://consensyssoftware.atlassian.net/browse/IDENTITY-51)

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A

### **After**

<!-- [screenshots/recordings] -->
N/A

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[IDENTITY-51]: https://consensyssoftware.atlassian.net/browse/IDENTITY-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ