### PR TITLE
fix: cp-7.42.0 Confirm ScrollView and readd drag down and backdrop click to close

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.styles.ts
+++ b/app/components/Views/confirmations/Confirm/Confirm.styles.ts
@@ -10,6 +10,10 @@ const styleSheet = (params: {
     bottomSheetDialogSheet: {
       backgroundColor: theme.colors.background.alternative,
     },
+    confirmContainer: {
+      display: 'flex',
+      maxHeight: '100%',
+    },
     flatContainer: {
       position: 'absolute',
       top: 0,

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -69,7 +69,6 @@ export const Confirm = ({ route }: ConfirmProps) => {
 
   return (
     <BottomSheet
-      isInteractable={false}
       onClose={onReject}
       style={styles.bottomSheetDialogSheet}
       testID="modal-confirmation-container"

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -74,7 +74,7 @@ export const Confirm = ({ route }: ConfirmProps) => {
       style={styles.bottomSheetDialogSheet}
       testID="modal-confirmation-container"
     >
-      <View testID={approvalRequest?.type}>
+      <View testID={approvalRequest?.type} style={styles.confirmContainer}>
         <ConfirmWrapped styles={styles} route={route} />
       </View>
     </BottomSheet>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Scroll does not currently work. Confirmation overflows rather than become scrollable. This PR fixes it by wrapping the content in a flex container.

This PR also readds feature to close the confirmation on drag down or backdrop close.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13267 (ScrollView)
Fixes: https://github.com/MetaMask/metamask-mobile/issues/13924 (Readd drag down or backdrop click to close) 

## **Manual testing steps**

1. Go to test-dapp 
2. Trigger Malicious Permit signature or another redesign signature with significant content
3. Observe scroll

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8f8e2344-7706-49a4-b773-a5226b7826d4

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
