### PR TITLE
fix: [cherry-pick | 7.42.0] Confirm Scroll and close on swipe down and backdrop click

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.styles.ts
+++ b/app/components/Views/confirmations/Confirm/Confirm.styles.ts
@@ -10,6 +10,10 @@ const styleSheet = (params: {
     bottomSheetDialogSheet: {
       backgroundColor: theme.colors.background.alternative,
     },
+    confirmContainer: {
+      display: 'flex',
+      maxHeight: '100%',
+    },
     flatContainer: {
       position: 'absolute',
       top: 0,

--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -63,12 +63,11 @@ export const Confirm = () => {
 
   return (
     <BottomSheet
-      isInteractable={false}
       onClose={onReject}
       style={styles.bottomSheetDialogSheet}
       testID="modal-confirmation-container"
     >
-      <View testID={approvalRequest?.type}>
+      <View testID={approvalRequest?.type} style={styles.confirmContainer}>
         <ConfirmWrapped styles={styles} />
       </View>
     </BottomSheet>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-picks 3/3 BottomSheet fix https://github.com/MetaMask/metamask-mobile/pull/13913 into 7.42.0

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13870

Cherry-pick PRs:
1/3: https://github.com/MetaMask/metamask-mobile/pull/13914 (BottomModal → BottomSheet)
2/3: https://github.com/MetaMask/metamask-mobile/pull/13926 (bitrise failure testID)
3/3: https://github.com/MetaMask/metamask-mobile/pull/13927 (scroll and close on swipe down & backdrop click)

## **Manual testing steps**

Test redesign confirmation page behavior

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
