### PR TITLE
fix: use correct updating text when toggling notifications

### DIFF
--- a/app/util/notifications/hooks/useSwitchNotifications.test.tsx
+++ b/app/util/notifications/hooks/useSwitchNotifications.test.tsx
@@ -1,7 +1,6 @@
 import { act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
-// eslint-disable-next-line import/no-namespace
-import * as I18nModule from '../../../../locales/i18n';
+import { strings } from '../../../../locales/i18n';
 // eslint-disable-next-line import/no-namespace
 import * as Actions from '../../../actions/notification/helpers';
 // eslint-disable-next-line import/no-namespace
@@ -409,17 +408,12 @@ describe('useSwitchNotifications - useSwitchNotificationLoadingText()', () => {
       .spyOn(Selectors, 'selectIsUpdatingMetamaskNotificationsAccount')
       .mockReturnValue([]);
 
-    const mockStrings = jest
-      .spyOn(I18nModule, 'strings')
-      .mockReturnValue('Some Translation');
-
     return {
       mockSelectIsUpdatingMetamaskNotifications,
       mockSelectIsMetamaskNotificationsEnabled,
       mockSelectIsMetaMaskPushNotificationsLoading,
       mockSelectIsMetaMaskPushNotificationsEnabled,
       mockSelectIsUpdatingMetamaskNotificationsAccount,
-      mockStrings,
     };
   };
 
@@ -437,64 +431,58 @@ describe('useSwitchNotifications - useSwitchNotificationLoadingText()', () => {
   };
 
   it('returns disabling notifications text when notifications are being disabled', () => {
-    const { hook, mocks } = arrangeAct((m) => {
+    const { hook } = arrangeAct((m) => {
       m.mockSelectIsUpdatingMetamaskNotifications.mockReturnValue(true);
       m.mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(true);
     });
-    expect(hook.result.current).toBeDefined();
-    expect(mocks.mockStrings).toHaveBeenCalledWith(
-      'app_settings.disabling_notifications',
+    expect(hook.result.current).toBe(
+      strings('app_settings.updating_notifications'),
     );
   });
 
   it('returns enabling notifications text when notifications are being enabled', () => {
-    const { hook, mocks } = arrangeAct((m) => {
+    const { hook } = arrangeAct((m) => {
       m.mockSelectIsUpdatingMetamaskNotifications.mockReturnValue(true);
       m.mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(false);
     });
-    expect(hook.result.current).toBeDefined();
-    expect(mocks.mockStrings).toHaveBeenCalledWith(
-      'app_settings.enabling_notifications',
+    expect(hook.result.current).toBe(
+      strings('app_settings.updating_notifications'),
     );
   });
 
   it('returns disabling notifications text when push notifications are being disabled', () => {
-    const { hook, mocks } = arrangeAct((m) => {
+    const { hook } = arrangeAct((m) => {
       m.mockSelectIsMetaMaskPushNotificationsEnabled.mockReturnValue(true);
       m.mockSelectIsMetaMaskPushNotificationsLoading.mockReturnValue(true);
     });
-    expect(hook.result.current).toBeDefined();
-    expect(mocks.mockStrings).toHaveBeenCalledWith(
-      'app_settings.disabling_notifications',
+    expect(hook.result.current).toBe(
+      strings('app_settings.updating_notifications'),
     );
   });
 
   it('returns enabling notifications text when push notifications are being enabled', () => {
-    const { hook, mocks } = arrangeAct((m) => {
+    const { hook } = arrangeAct((m) => {
       m.mockSelectIsMetaMaskPushNotificationsEnabled.mockReturnValue(false);
       m.mockSelectIsMetaMaskPushNotificationsLoading.mockReturnValue(true);
     });
-    expect(hook.result.current).toBeDefined();
-    expect(mocks.mockStrings).toHaveBeenCalledWith(
-      'app_settings.enabling_notifications',
+    expect(hook.result.current).toBe(
+      strings('app_settings.updating_notifications'),
     );
   });
 
   it('returns updating account settings text when accounts are being updated', () => {
-    const { hook, mocks } = arrangeAct((m) => {
+    const { hook } = arrangeAct((m) => {
       m.mockSelectIsUpdatingMetamaskNotificationsAccount.mockReturnValue([
         '0xAddr1',
       ]);
     });
-    expect(hook.result.current).toBeDefined();
-    expect(mocks.mockStrings).toHaveBeenCalledWith(
-      'app_settings.updating_account_settings',
+    expect(hook.result.current).toBe(
+      strings('app_settings.updating_account_settings'),
     );
   });
 
   it('returns undefined when no loading state is active', () => {
-    const { mocks, hook } = arrangeAct();
+    const { hook } = arrangeAct();
     expect(hook.result.current).toBeUndefined();
-    expect(mocks.mockStrings).not.toHaveBeenCalled();
   });
 });

--- a/app/util/notifications/hooks/useSwitchNotifications.ts
+++ b/app/util/notifications/hooks/useSwitchNotifications.ts
@@ -12,7 +12,6 @@ import { debounce } from 'lodash';
 import {
   selectIsFeatureAnnouncementsEnabled,
   selectIsMetamaskNotificationsEnabled,
-  selectIsMetaMaskPushNotificationsEnabled,
   selectIsMetaMaskPushNotificationsLoading,
   selectIsUpdatingMetamaskNotifications,
   selectIsUpdatingMetamaskNotificationsAccount,
@@ -170,14 +169,10 @@ export function useSwitchNotificationLoadingText(): string | undefined {
   const notificationsLoading = useSelector(
     selectIsUpdatingMetamaskNotifications,
   );
-  const notificationEnabled = useSelector(selectIsMetamaskNotificationsEnabled);
 
   // Push Notification Settings
   const pushNotificationsLoading = useSelector(
     selectIsMetaMaskPushNotificationsLoading,
-  );
-  const pushNotificationsEnabled = useSelector(
-    selectIsMetaMaskPushNotificationsEnabled,
   );
 
   const accountsLoading = useSelector(
@@ -188,16 +183,8 @@ export function useSwitchNotificationLoadingText(): string | undefined {
     return strings('app_settings.updating_account_settings');
   }
 
-  if (pushNotificationsLoading) {
-    return pushNotificationsEnabled
-      ? strings('app_settings.disabling_notifications')
-      : strings('app_settings.enabling_notifications');
-  }
-
-  if (notificationsLoading) {
-    return notificationEnabled
-      ? strings('app_settings.disabling_notifications')
-      : strings('app_settings.enabling_notifications');
+  if (notificationsLoading || pushNotificationsLoading) {
+    return strings('app_settings.updating_notifications');
   }
 
   return undefined;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -790,7 +790,7 @@
   },
   "app_settings": {
     "enabling_notifications": "Enabling notifications...",
-    "disabling_notifications": "Disabling notifications...",
+    "updating_notifications": "Updating notifications...",
     "updating_account_settings": "Updating account settings...",
     "reset_notifications_title": "Reset notifications",
     "reset_notifications_description": "Resetting notifications, means you're deleting your notifications storage keys and resetting all your notification history. Are you sure you want to do this?",


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Using Enabling/Disabling text as loading indicators (in the notificiation settings page) are inconsistent as our controllers do not toggle loading and new state as 1 state update. This causes a flicker in the UI where the final loading indicator is incorrect.

So instead of using seperate loading strings based on new state, we are now using 1 consistent loading toggle for notificiations and push notifications.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Notification Settings Page
2. Toggle Notifications, inspect loading indicator
3. Toggle Push Notifications, inspect loading indicator

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
