### PR TITLE
fix: Use proper implementation for `getUnlockPromise`

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -554,9 +554,17 @@ export class Engine {
       return keyring.mnemonic;
     };
 
-    const getAppState = () => {
-      const state = AppState.currentState;
-      return state === 'active';
+    const getUnlockPromise = () => {
+      if (this.keyringController.isUnlocked()) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        this.controllerMessenger.subscribeOnceIf(
+          'KeyringController:unlock',
+          resolve,
+          () => true,
+        );
+      });
     };
 
     const snapRestrictedMethods = {
@@ -567,7 +575,7 @@ export class Engine {
         SnapControllerClearSnapStateAction,
       ),
       getMnemonic: getPrimaryKeyringMnemonic.bind(this),
-      getUnlockPromise: getAppState.bind(this),
+      getUnlockPromise: getUnlockPromise.bind(this),
       getSnap: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         SnapControllerGetSnapAction,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -14,7 +14,6 @@ import {
   CodefiTokenPricesServiceV2,
 } from '@metamask/assets-controllers';
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import { AppState } from 'react-native';
 import PREINSTALLED_SNAPS from '../../lib/snaps/preinstalled-snaps';
 ///: END:ONLY_INCLUDE_IF
 import { AccountsController } from '@metamask/accounts-controller';

--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -36,7 +36,18 @@ const snapMethodMiddlewareBuilder = (
   subjectType: SubjectType,
 ) =>
   createSnapsMethodMiddleware(subjectType === SubjectType.Snap, {
-    getUnlockPromise: () => Promise.resolve(),
+    getUnlockPromise: () => {
+      if (engineContext.KeyringController.isUnlocked()) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        controllerMessenger.subscribeOnceIf(
+          'KeyringController:unlock',
+          resolve,
+          () => true,
+        );
+      });
+    },
     getSnaps: controllerMessenger.call.bind(
       controllerMessenger,
       SnapControllerGetPermittedSnapsAction,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`getUnlockPromise` was erroneously implemented as being tied to the React Native AppState. It should be tied to the KeyringController state. This PR fixes that.

## **Related issues**

Closes https://github.com/MetaMask/snaps/issues/3212

