### PR TITLE
fix: android BottomSheet missing padding bottom

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/Footer/Footer.styles.ts
@@ -1,5 +1,6 @@
 import { Theme } from '@metamask/design-tokens';
 import { StyleSheet } from 'react-native';
+import Device from '../../../../../../util/device';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme: { colors }} = params;
@@ -8,7 +9,7 @@ const styleSheet = (params: { theme: Theme }) => {
     base: {
       backgroundColor: colors.background.alternative,
       paddingHorizontal: 16,
-      paddingBottom: 8,
+      paddingBottom: Device.isIos() ? 8 : 28,
       paddingTop: 16,
     },
     linkText: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix BottomSheet footer instance in confirmation that is missing padding on android. 

Holding off on merge while we confirm BottomSheet footer has 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13976

## **Manual testing steps**

Open any redesign confirmation that has a lot of content in mobile e.g. test-dapp Permit. Observe footer. See issue for more details and video.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
