### PR TITLE
fix: Revert "chore: upgrade Xcode 16 on bitrise.yml"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1861,7 +1861,7 @@ app:
       COREPACK_VERSION: 0.28.0
 meta:
   bitrise.io:
-    stack: osx-xcode-16.2.x
+    stack: osx-xcode-15.0.x
     machine_type_id: g2.mac.large
 trigger_map:
   - push_branch: release/*


### PR DESCRIPTION
This PR Reverts MetaMask/metamask-mobile#13807 it introduced an issue that caused build failures for iOS. [Here](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/dbadd000-571b-4f49-b9c8-c4803fe9c0e3)