### PR TITLE
feat: add bridge slippage component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,8 @@ module.exports = {
     '../app/component-library/base-components/**/*.stories.?(ts|tsx|js|jsx)',
     '../app/component-library/components-temp/TagColored/**/*.stories.?(ts|tsx|js|jsx)',
     '../app/component-library/components-temp/KeyValueRow/**/*.stories.?(ts|tsx|js|jsx)',
+    '../app/component-library/components-temp/Buttons/ButtonToggle/**/*.stories.?(ts|tsx|js|jsx)',
+    '../app/component-library/components-temp/SegmentedControl/**/*.stories.?(ts|tsx|js|jsx)',
   ],
   addons: ['@storybook/addon-ondevice-controls'],
   framework: '@storybook/react-native',

--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -37,6 +37,20 @@ global.STORIES = [
     importPathMatcher:
       "^\\.[\\\\/](?:app\\/component-library\\/components-temp\\/KeyValueRow(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
   },
+  {
+    titlePrefix: "",
+    directory: "./app/component-library/components-temp/Buttons/ButtonToggle",
+    files: "**/*.stories.?(ts|tsx|js|jsx)",
+    importPathMatcher:
+      "^\\.[\\\\/](?:app\\/component-library\\/components-temp\\/Buttons\\/ButtonToggle(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
+  },
+  {
+    titlePrefix: "",
+    directory: "./app/component-library/components-temp/SegmentedControl",
+    files: "**/*.stories.?(ts|tsx|js|jsx)",
+    importPathMatcher:
+      "^\\.[\\\\/](?:app\\/component-library\\/components-temp\\/SegmentedControl(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
+  },
 ];
 
 import "@storybook/addon-ondevice-controls/register";
@@ -126,12 +140,8 @@ const getStories = () => {
     "./app/component-library/base-components/TagBase/TagBase.stories.tsx": require("../app/component-library/base-components/TagBase/TagBase.stories.tsx"),
     "./app/component-library/components-temp/TagColored/TagColored.stories.tsx": require("../app/component-library/components-temp/TagColored/TagColored.stories.tsx"),
     "./app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx": require("../app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx"),
-    "./app/components/Views/confirmations/components/UI/InfoRow/InfoRow.stories.tsx": require("../app/components/Views/confirmations/components/UI/InfoRow/InfoRow.stories.tsx"),
-    "./app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.stories.tsx": require("../app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.stories.tsx"),
-    "./app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories.tsx": require("../app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories.tsx"),
-    "./app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx": require("../app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories.tsx"),
-    "./app/component-library/components/Texts/SensitiveText/SensitiveText.stories.tsx": require("../app/component-library/components/Texts/SensitiveText/SensitiveText.stories.tsx"),
-    "./app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx": require("../app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx"),
+    "./app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx": require("../app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx"),
+    "./app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx": require("../app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx"),
   };
 };
 

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.constants.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.constants.ts
@@ -13,11 +13,8 @@ import { ButtonToggleProps } from './ButtonToggle.types';
 // Defaults
 export const DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT =
   DEFAULT_BUTTONBASE_LABEL_TEXTVARIANT;
-export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR = TextColor.Primary;
+export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR = TextColor.Default;
 export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE = TextColor.Primary;
-export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED = TextColor.Inverse;
-export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED =
-  TextColor.Inverse;
 
 // Samples
 export const SAMPLE_BUTTONTOGGLE_PROPS: ButtonToggleProps = {

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.constants.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.constants.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/prefer-default-export */
+
+// External dependencies.
+import {
+  DEFAULT_BUTTONBASE_LABEL_TEXTVARIANT,
+  SAMPLE_BUTTONBASE_PROPS,
+} from '../../../components/Buttons/Button/foundation/ButtonBase/ButtonBase.constants';
+import { TextColor } from '../../../components/Texts/Text';
+
+// Internal dependencies.
+import { ButtonToggleProps } from './ButtonToggle.types';
+
+// Defaults
+export const DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT =
+  DEFAULT_BUTTONBASE_LABEL_TEXTVARIANT;
+export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR = TextColor.Primary;
+export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE = TextColor.Primary;
+export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED = TextColor.Inverse;
+export const DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED =
+  TextColor.Inverse;
+
+// Samples
+export const SAMPLE_BUTTONTOGGLE_PROPS: ButtonToggleProps = {
+  ...SAMPLE_BUTTONBASE_PROPS,
+  isActive: false,
+};

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx
@@ -1,0 +1,77 @@
+// Third party dependencies.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+// External dependencies.
+import { IconName } from '../../../components/Icons/Icon';
+import Title from '../../../../components/Base/Title';
+import Text, { TextVariant } from '../../../components/Texts/Text';
+
+// Internal dependencies.
+import { default as ButtonToggleComponent } from './ButtonToggle';
+
+const ButtonToggleStoryMeta = {
+  title: 'Components Temp / Buttons / ButtonToggle',
+  component: ButtonToggleComponent,
+};
+export default ButtonToggleStoryMeta;
+
+// No-op function for handling button presses in the story
+const handlePress = () => {
+  /* For demo purposes only */
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  section: {
+    marginVertical: 16,
+  },
+});
+
+export const ButtonToggle = {
+  render: () => (
+    <View style={styles.container}>
+      <Title>ButtonToggle Component</Title>
+      <Text variant={TextVariant.BodySM}>
+        A button that can be toggled between active and inactive states.
+      </Text>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Default (Inactive)</Text>
+        <ButtonToggleComponent
+          label="Mode 1"
+          isActive={false}
+          onPress={handlePress}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Active</Text>
+        <ButtonToggleComponent label="Mode 1" isActive onPress={handlePress} />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>With Icons</Text>
+        <ButtonToggleComponent
+          label="Mode 1"
+          isActive={false}
+          startIconName={IconName.Lock}
+          endIconName={IconName.Arrow2Right}
+          onPress={handlePress}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Loading</Text>
+        <ButtonToggleComponent
+          label="Loading"
+          isActive={false}
+          loading
+          onPress={handlePress}
+        />
+      </View>
+    </View>
+  ),
+};

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories.tsx
@@ -62,16 +62,6 @@ export const ButtonToggle = {
           onPress={handlePress}
         />
       </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>Loading</Text>
-        <ButtonToggleComponent
-          label="Loading"
-          isActive={false}
-          loading
-          onPress={handlePress}
-        />
-      </View>
     </View>
   ),
 };

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.styles.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.styles.ts
@@ -20,21 +20,15 @@ const styleSheet = (params: {
 }) => {
   const { vars, theme } = params;
   const { colors } = theme;
-  const { style, isActive, pressed } = vars;
+  const { style, isActive } = vars;
   const colorObj = colors.primary;
 
   return StyleSheet.create({
     base: Object.assign(
       {
-        backgroundColor: isActive
-          ? pressed
-            ? colorObj.alternative
-            : colorObj.default
-          : pressed
-          ? colorObj.alternative
-          : 'transparent',
+        backgroundColor: isActive ? colorObj.muted : 'transparent',
         borderWidth: 1,
-        borderColor: colorObj.default,
+        borderColor: isActive ? colorObj.default : colors.border.default,
       } as ViewStyle,
       style,
     ) as ViewStyle,

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.styles.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.styles.ts
@@ -1,0 +1,44 @@
+// Third party dependencies.
+import { StyleSheet, ViewStyle } from 'react-native';
+
+// External dependencies.
+import { Theme } from '../../../../util/theme/models';
+
+// Internal dependencies.
+import { ButtonToggleStyleSheetVars } from './ButtonToggle.types';
+
+/**
+ * Style sheet function for ButtonToggle component.
+ *
+ * @param params Style sheet params.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: {
+  theme: Theme;
+  vars: ButtonToggleStyleSheetVars;
+}) => {
+  const { vars, theme } = params;
+  const { colors } = theme;
+  const { style, isActive, pressed } = vars;
+  const colorObj = colors.primary;
+
+  return StyleSheet.create({
+    base: Object.assign(
+      {
+        backgroundColor: isActive
+          ? pressed
+            ? colorObj.alternative
+            : colorObj.default
+          : pressed
+          ? colorObj.alternative
+          : 'transparent',
+        borderWidth: 1,
+        borderColor: colorObj.default,
+      } as ViewStyle,
+      style,
+    ) as ViewStyle,
+  });
+};
+
+export default styleSheet;

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.test.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.test.tsx
@@ -1,0 +1,54 @@
+// Third party dependencies.
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+// Internal dependencies.
+import ButtonToggle from './ButtonToggle';
+
+describe('ButtonToggle', () => {
+  it('should render correctly in inactive state', () => {
+    const { toJSON, getByText } = render(
+      <ButtonToggle isActive={false} label="Mode 1" onPress={jest.fn()} />,
+    );
+
+    expect(getByText('Mode 1')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should render correctly in active state', () => {
+    const { toJSON, getByText } = render(
+      <ButtonToggle isActive label="Mode 1" onPress={jest.fn()} />,
+    );
+
+    expect(getByText('Mode 1')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should call onPress handler when pressed', () => {
+    const mockOnPress = jest.fn();
+    const { getByText } = render(
+      <ButtonToggle isActive={false} label="Mode 1" onPress={mockOnPress} />,
+    );
+
+    const button = getByText('Mode 1');
+    fireEvent.press(button);
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('should apply the correct text color based on active state', () => {
+    const { rerender, getByText } = render(
+      <ButtonToggle isActive={false} label="Mode 1" onPress={jest.fn()} />,
+    );
+
+    const inactiveText = getByText('Mode 1');
+    // We can't directly test computed styles in React Native, but we can verify the component was rendered
+    expect(inactiveText).toBeTruthy();
+
+    // Re-render with active state
+    rerender(<ButtonToggle isActive label="Mode 1" onPress={jest.fn()} />);
+
+    const activeText = getByText('Mode 1');
+    expect(activeText).toBeTruthy();
+  });
+});

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.test.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.test.tsx
@@ -6,7 +6,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import ButtonToggle from './ButtonToggle';
 
 describe('ButtonToggle', () => {
-  it('should render correctly in inactive state', () => {
+  it('renders correctly in inactive state', () => {
     const { toJSON, getByText } = render(
       <ButtonToggle isActive={false} label="Mode 1" onPress={jest.fn()} />,
     );
@@ -15,7 +15,7 @@ describe('ButtonToggle', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render correctly in active state', () => {
+  it('renders correctly in active state', () => {
     const { toJSON, getByText } = render(
       <ButtonToggle isActive label="Mode 1" onPress={jest.fn()} />,
     );
@@ -24,7 +24,7 @@ describe('ButtonToggle', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should call onPress handler when pressed', () => {
+  it('calls onPress handler when pressed', () => {
     const mockOnPress = jest.fn();
     const { getByText } = render(
       <ButtonToggle isActive={false} label="Mode 1" onPress={mockOnPress} />,
@@ -36,7 +36,7 @@ describe('ButtonToggle', () => {
     expect(mockOnPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should apply the correct text color based on active state', () => {
+  it('applies the correct text color based on active state', () => {
     const { rerender, getByText } = render(
       <ButtonToggle isActive={false} label="Mode 1" onPress={jest.fn()} />,
     );

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable react/prop-types */
+
+// Third party dependencies.
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, GestureResponderEvent } from 'react-native';
+
+// External dependencies.
+import { useStyles } from '../../../hooks';
+import Button from '../../../components/Buttons/Button/foundation/ButtonBase';
+import Text from '../../../components/Texts/Text/Text';
+
+// Internal dependencies.
+import { ButtonToggleProps } from './ButtonToggle.types';
+import styleSheet from './ButtonToggle.styles';
+import {
+  DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT,
+  DEFAULT_BUTTONTOGGLE_LABEL_COLOR,
+  DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE,
+  DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED,
+  DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED,
+} from './ButtonToggle.constants';
+
+const ButtonToggle = ({
+  style,
+  onPressIn,
+  onPressOut,
+  isActive = false,
+  label,
+  ...props
+}: ButtonToggleProps) => {
+  const [pressed, setPressed] = useState(false);
+  const { styles } = useStyles(styleSheet, {
+    style,
+    isActive,
+    pressed,
+  });
+
+  const triggerOnPressedIn = useCallback(
+    (e: GestureResponderEvent) => {
+      setPressed(true);
+      onPressIn?.(e);
+    },
+    [setPressed, onPressIn],
+  );
+
+  const triggerOnPressedOut = useCallback(
+    (e: GestureResponderEvent) => {
+      setPressed(false);
+      onPressOut?.(e);
+    },
+    [setPressed, onPressOut],
+  );
+
+  const getLabelColor = () =>
+    isActive
+      ? pressed
+        ? DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED
+        : DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE
+      : pressed
+      ? DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED
+      : DEFAULT_BUTTONTOGGLE_LABEL_COLOR;
+
+  const renderLabel = () =>
+    typeof label === 'string' ? (
+      <Text
+        variant={DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT}
+        color={getLabelColor()}
+      >
+        {label}
+      </Text>
+    ) : (
+      label
+    );
+
+  const renderLoading = () => (
+    <ActivityIndicator
+      size="small"
+      color={DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT}
+    />
+  );
+
+  return (
+    <Button
+      style={styles.base}
+      label={!props.loading ? renderLabel() : renderLoading()}
+      labelColor={getLabelColor()}
+      onPressIn={triggerOnPressedIn}
+      onPressOut={triggerOnPressedOut}
+      {...props}
+    />
+  );
+};
+
+export default ButtonToggle;

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/prop-types */
 
 // Third party dependencies.
-import React, { useCallback, useState } from 'react';
-import { ActivityIndicator, GestureResponderEvent } from 'react-native';
+import React from 'react';
 
 // External dependencies.
 import { useStyles } from '../../../hooks';
@@ -16,48 +15,22 @@ import {
   DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT,
   DEFAULT_BUTTONTOGGLE_LABEL_COLOR,
   DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE,
-  DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED,
-  DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED,
 } from './ButtonToggle.constants';
 
 const ButtonToggle = ({
   style,
-  onPressIn,
-  onPressOut,
   isActive = false,
   label,
   ...props
 }: ButtonToggleProps) => {
-  const [pressed, setPressed] = useState(false);
   const { styles } = useStyles(styleSheet, {
     style,
     isActive,
-    pressed,
   });
-
-  const triggerOnPressedIn = useCallback(
-    (e: GestureResponderEvent) => {
-      setPressed(true);
-      onPressIn?.(e);
-    },
-    [setPressed, onPressIn],
-  );
-
-  const triggerOnPressedOut = useCallback(
-    (e: GestureResponderEvent) => {
-      setPressed(false);
-      onPressOut?.(e);
-    },
-    [setPressed, onPressOut],
-  );
 
   const getLabelColor = () =>
     isActive
-      ? pressed
-        ? DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE_PRESSED
-        : DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE
-      : pressed
-      ? DEFAULT_BUTTONTOGGLE_LABEL_COLOR_PRESSED
+      ? DEFAULT_BUTTONTOGGLE_LABEL_COLOR_ACTIVE
       : DEFAULT_BUTTONTOGGLE_LABEL_COLOR;
 
   const renderLabel = () =>
@@ -72,20 +45,11 @@ const ButtonToggle = ({
       label
     );
 
-  const renderLoading = () => (
-    <ActivityIndicator
-      size="small"
-      color={DEFAULT_BUTTONTOGGLE_LABEL_TEXTVARIANT}
-    />
-  );
-
   return (
     <Button
       style={styles.base}
-      label={!props.loading ? renderLabel() : renderLoading()}
+      label={renderLabel()}
       labelColor={getLabelColor()}
-      onPressIn={triggerOnPressedIn}
-      onPressOut={triggerOnPressedOut}
       {...props}
     />
   );

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.types.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.types.ts
@@ -16,5 +16,4 @@ export type ButtonToggleProps = Omit<ButtonBaseProps, 'labelColor'> & {
  */
 export type ButtonToggleStyleSheetVars = Pick<ButtonToggleProps, 'style'> & {
   isActive: boolean;
-  pressed: boolean;
 };

--- a/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.types.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.types.ts
@@ -1,0 +1,20 @@
+// External dependencies.
+import { ButtonBaseProps } from '../../../components/Buttons/Button/foundation/ButtonBase';
+
+/**
+ * ButtonToggle component props.
+ */
+export type ButtonToggleProps = Omit<ButtonBaseProps, 'labelColor'> & {
+  /**
+   * Boolean indicating if the button is in active state.
+   */
+  isActive?: boolean;
+};
+
+/**
+ * Style sheet input parameters.
+ */
+export type ButtonToggleStyleSheetVars = Pick<ButtonToggleProps, 'style'> & {
+  isActive: boolean;
+  pressed: boolean;
+};

--- a/app/component-library/components-temp/Buttons/ButtonToggle/__snapshots__/ButtonToggle.test.tsx.snap
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/__snapshots__/ButtonToggle.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonToggle should render correctly in active state 1`] = `
+exports[`ButtonToggle renders correctly in active state 1`] = `
 <TouchableOpacity
   accessibilityRole="button"
   accessible={true}
@@ -39,7 +39,7 @@ exports[`ButtonToggle should render correctly in active state 1`] = `
 </TouchableOpacity>
 `;
 
-exports[`ButtonToggle should render correctly in inactive state 1`] = `
+exports[`ButtonToggle renders correctly in inactive state 1`] = `
 <TouchableOpacity
   accessibilityRole="button"
   accessible={true}

--- a/app/component-library/components-temp/Buttons/ButtonToggle/__snapshots__/ButtonToggle.test.tsx.snap
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/__snapshots__/ButtonToggle.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonToggle should render correctly in active state 1`] = `
+<TouchableOpacity
+  accessibilityRole="button"
+  accessible={true}
+  activeOpacity={1}
+  onPress={[MockFunction]}
+  style={
+    {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "#0376C91A",
+      "borderColor": "#0376c9",
+      "borderRadius": 20,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "height": 40,
+      "justifyContent": "center",
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      {
+        "color": "#0376c9",
+        "fontFamily": "EuclidCircularB-Medium",
+        "fontSize": 14,
+        "fontWeight": "500",
+        "letterSpacing": 0,
+        "lineHeight": 22,
+      }
+    }
+  >
+    Mode 1
+  </Text>
+</TouchableOpacity>
+`;
+
+exports[`ButtonToggle should render correctly in inactive state 1`] = `
+<TouchableOpacity
+  accessibilityRole="button"
+  accessible={true}
+  activeOpacity={1}
+  onPress={[MockFunction]}
+  style={
+    {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "transparent",
+      "borderColor": "#848c96",
+      "borderRadius": 20,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "height": 40,
+      "justifyContent": "center",
+      "paddingHorizontal": 16,
+    }
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      {
+        "color": "#141618",
+        "fontFamily": "EuclidCircularB-Medium",
+        "fontSize": 14,
+        "fontWeight": "500",
+        "letterSpacing": 0,
+        "lineHeight": 22,
+      }
+    }
+  >
+    Mode 1
+  </Text>
+</TouchableOpacity>
+`;

--- a/app/component-library/components-temp/Buttons/ButtonToggle/index.ts
+++ b/app/component-library/components-temp/Buttons/ButtonToggle/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ButtonToggle';
+export type { ButtonToggleProps } from './ButtonToggle.types';

--- a/app/component-library/components-temp/SegmentedControl/README.md
+++ b/app/component-library/components-temp/SegmentedControl/README.md
@@ -1,8 +1,10 @@
 # SegmentedControl
 
-A SegmentedControl is a set of buttons grouped together to switch between related views or modes within the same context.
+A SegmentedControl is a set of buttons grouped together to switch between related views or modes within the same context. It supports both single-select and multi-select modes.
 
 ## Props
+
+### Common Props
 
 ### `options`
 
@@ -12,21 +14,17 @@ Array of options to display in the segmented control. Each option should have a 
 | :----------------------- | :------- |
 | SegmentedControlOption[] | Yes      |
 
-### `selectedValue`
+#### SegmentedControlOption Properties
 
-Value of the currently selected option. Should match one of the option values.
-
-| Type   | Required |
-| :----- | :------- |
-| string | No       |
-
-### `onValueChange`
-
-Callback when an option is selected. Receives the selected option's value as an argument.
-
-| Type                    | Required |
-| :---------------------- | :------- |
-| (value: string) => void | No       |
+| Property           | Type        | Required | Description                                 |
+| :----------------- | :---------- | :------- | :------------------------------------------ |
+| value              | string      | Yes      | Unique value for the option                 |
+| label              | string      | Yes      | Label text to display                       |
+| startIconName      | IconName    | No       | Optional icon to display before the label   |
+| endIconName        | IconName    | No       | Optional icon to display after the label    |
+| labelTextVariant   | TextVariant | No       | Optional text variant for the label         |
+| testID             | string      | No       | Optional test ID for the option             |
+| accessibilityLabel | string      | No       | Optional accessibility label for the option |
 
 ### `size`
 
@@ -44,11 +42,66 @@ Whether the control is disabled.
 | :------ | :------- | :------ |
 | boolean | No       | false   |
 
+### `isMultiSelect`
+
+Whether the control allows selecting multiple options.
+
+| Type    | Required | Default |
+| :------ | :------- | :------ |
+| boolean | No       | false   |
+
+### `isScrollable`
+
+Whether the control should be horizontally scrollable. Useful when there are many options that may not fit on the screen.
+
+| Type    | Required | Default |
+| :------ | :------- | :------ |
+| boolean | No       | false   |
+
+### Single-Select Mode Props (isMultiSelect = false)
+
+### `selectedValue`
+
+Value of the currently selected option. Should match one of the option values.
+
+| Type   | Required |
+| :----- | :------- |
+| string | No       |
+
+### `onValueChange`
+
+Callback when an option is selected. Receives the selected option's value as an argument.
+
+| Type                    | Required |
+| :---------------------- | :------- |
+| (value: string) => void | No       |
+
+### Multi-Select Mode Props (isMultiSelect = true)
+
+### `selectedValues`
+
+Array of selected option values. Each value should match one of the option values.
+
+| Type     | Required |
+| :------- | :------- |
+| string[] | No       |
+
+### `onValueChange`
+
+Callback when selected options change. Receives an array of selected option values as an argument.
+
+| Type                       | Required |
+| :------------------------- | :------- |
+| (values: string[]) => void | No       |
+
 ## Usage
+
+### Single-Select Mode (Default)
 
 ```javascript
 import SegmentedControl from 'app/component-library/components-temp/SegmentedControl';
 import { ButtonSize } from 'app/component-library/components/Buttons/Button/Button.types';
+import { IconName } from 'app/component-library/components/Icons/Icon';
 
 const options = [
   { value: 'mode1', label: 'Mode 1' },
@@ -63,5 +116,73 @@ const [selectedValue, setSelectedValue] = useState('mode1');
   selectedValue={selectedValue}
   onValueChange={setSelectedValue}
   size={ButtonSize.Md}
+/>;
+```
+
+### Multi-Select Mode
+
+```javascript
+import SegmentedControl from 'app/component-library/components-temp/SegmentedControl';
+import { ButtonSize } from 'app/component-library/components/Buttons/Button/Button.types';
+
+const options = [
+  { value: 'mode1', label: 'Mode 1' },
+  { value: 'mode2', label: 'Mode 2' },
+  { value: 'mode3', label: 'Mode 3' },
+];
+
+const [selectedValues, setSelectedValues] = useState(['mode1', 'mode3']);
+
+<SegmentedControl
+  options={options}
+  selectedValues={selectedValues}
+  onValueChange={setSelectedValues}
+  isMultiSelect
+  size={ButtonSize.Md}
+/>;
+```
+
+### With Icons
+
+```javascript
+import SegmentedControl from 'app/component-library/components-temp/SegmentedControl';
+import { IconName } from 'app/component-library/components/Icons/Icon';
+
+const optionsWithIcons = [
+  { value: 'home', label: 'Home', startIconName: IconName.Home },
+  { value: 'settings', label: 'Settings', startIconName: IconName.Setting },
+  { value: 'wallet', label: 'Wallet', startIconName: IconName.Wallet },
+];
+
+const [selectedValue, setSelectedValue] = useState('home');
+
+<SegmentedControl
+  options={optionsWithIcons}
+  selectedValue={selectedValue}
+  onValueChange={setSelectedValue}
+/>;
+```
+
+### Scrollable Control
+
+```javascript
+import SegmentedControl from 'app/component-library/components-temp/SegmentedControl';
+
+const manyOptions = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  { value: 'option4', label: 'Option 4' },
+  { value: 'option5', label: 'Option 5' },
+  { value: 'option6', label: 'Option 6' },
+];
+
+const [selectedValue, setSelectedValue] = useState('option1');
+
+<SegmentedControl
+  options={manyOptions}
+  selectedValue={selectedValue}
+  onValueChange={setSelectedValue}
+  isScrollable
 />;
 ```

--- a/app/component-library/components-temp/SegmentedControl/README.md
+++ b/app/component-library/components-temp/SegmentedControl/README.md
@@ -34,6 +34,14 @@ Size of the control and its buttons. Uses the same sizes as buttons.
 | :--------- | :------- | :------------ |
 | ButtonSize | No       | ButtonSize.Md |
 
+### `isButtonWidthFlexible`
+
+Whether buttons should size to their content instead of having equal widths.
+
+| Type    | Required | Default |
+| :------ | :------- | :------ |
+| boolean | No       | true    |
+
 ### `isDisabled`
 
 Whether the control is disabled.

--- a/app/component-library/components-temp/SegmentedControl/README.md
+++ b/app/component-library/components-temp/SegmentedControl/README.md
@@ -1,0 +1,67 @@
+# SegmentedControl
+
+A SegmentedControl is a set of buttons grouped together to switch between related views or modes within the same context.
+
+## Props
+
+### `options`
+
+Array of options to display in the segmented control. Each option should have a `value` and `label`.
+
+| Type                     | Required |
+| :----------------------- | :------- |
+| SegmentedControlOption[] | Yes      |
+
+### `selectedValue`
+
+Value of the currently selected option. Should match one of the option values.
+
+| Type   | Required |
+| :----- | :------- |
+| string | No       |
+
+### `onValueChange`
+
+Callback when an option is selected. Receives the selected option's value as an argument.
+
+| Type                    | Required |
+| :---------------------- | :------- |
+| (value: string) => void | No       |
+
+### `size`
+
+Size of the control and its buttons. Uses the same sizes as buttons.
+
+| Type       | Required | Default       |
+| :--------- | :------- | :------------ |
+| ButtonSize | No       | ButtonSize.Md |
+
+### `isDisabled`
+
+Whether the control is disabled.
+
+| Type    | Required | Default |
+| :------ | :------- | :------ |
+| boolean | No       | false   |
+
+## Usage
+
+```javascript
+import SegmentedControl from 'app/component-library/components-temp/SegmentedControl';
+import { ButtonSize } from 'app/component-library/components/Buttons/Button/Button.types';
+
+const options = [
+  { value: 'mode1', label: 'Mode 1' },
+  { value: 'mode2', label: 'Mode 2' },
+  { value: 'mode3', label: 'Mode 3' },
+];
+
+const [selectedValue, setSelectedValue] = useState('mode1');
+
+<SegmentedControl
+  options={options}
+  selectedValue={selectedValue}
+  onValueChange={setSelectedValue}
+  size={ButtonSize.Md}
+/>;
+```

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
@@ -1,10 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 // External dependencies.
-import {
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../components/Buttons/Button/Button.types';
+import { ButtonSize } from '../../components/Buttons/Button/Button.types';
 
 // Internal dependencies.
 import {
@@ -18,7 +15,7 @@ export const DEFAULT_SEGMENTEDCONTROL_SIZE = ButtonSize.Md;
 
 // Samples
 export const SAMPLE_SEGMENTEDCONTROL_OPTIONS = [
-  { value: 'mode1', label: 'Mode 1 2 3 4 ', width: ButtonWidthTypes.Auto },
+  { value: 'mode1', label: 'Mode 1' },
   { value: 'mode2', label: 'Mode 2' },
   { value: 'mode3', label: 'Mode 3' },
   { value: 'mode4', label: 'Mode 4' },

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/prefer-default-export */
+
+// External dependencies.
+import { ButtonSize } from '../../components/Buttons/Button/Button.types';
+
+// Internal dependencies.
+import { SegmentedControlProps } from './SegmentedControl.types';
+
+// Defaults
+export const DEFAULT_SEGMENTEDCONTROL_SIZE = ButtonSize.Md;
+
+// Samples
+export const SAMPLE_SEGMENTEDCONTROL_OPTIONS = [
+  { value: 'mode1', label: 'Mode 1' },
+  { value: 'mode2', label: 'Mode 2' },
+  { value: 'mode3', label: 'Mode 3' },
+  { value: 'mode4', label: 'Mode 4' },
+  { value: 'mode5', label: 'Mode 5' },
+];
+
+export const SAMPLE_SEGMENTEDCONTROL_PROPS: SegmentedControlProps = {
+  options: SAMPLE_SEGMENTEDCONTROL_OPTIONS,
+  selectedValue: SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+  size: DEFAULT_SEGMENTEDCONTROL_SIZE,
+};

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
@@ -1,7 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 
 // External dependencies.
-import { ButtonSize } from '../../components/Buttons/Button/Button.types';
+import {
+  ButtonSize,
+  ButtonWidthTypes,
+} from '../../components/Buttons/Button/Button.types';
 
 // Internal dependencies.
 import {
@@ -15,7 +18,7 @@ export const DEFAULT_SEGMENTEDCONTROL_SIZE = ButtonSize.Md;
 
 // Samples
 export const SAMPLE_SEGMENTEDCONTROL_OPTIONS = [
-  { value: 'mode1', label: 'Mode 1' },
+  { value: 'mode1', label: 'Mode 1 2 3 4 ', width: ButtonWidthTypes.Auto },
   { value: 'mode2', label: 'Mode 2' },
   { value: 'mode3', label: 'Mode 3' },
   { value: 'mode4', label: 'Mode 4' },

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.constants.ts
@@ -4,7 +4,11 @@
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
 
 // Internal dependencies.
-import { SegmentedControlProps } from './SegmentedControl.types';
+import {
+  SegmentedControlProps,
+  MultiSelectSegmentedControlProps,
+  SingleSelectSegmentedControlProps,
+} from './SegmentedControl.types';
 
 // Defaults
 export const DEFAULT_SEGMENTEDCONTROL_SIZE = ButtonSize.Md;
@@ -15,11 +19,27 @@ export const SAMPLE_SEGMENTEDCONTROL_OPTIONS = [
   { value: 'mode2', label: 'Mode 2' },
   { value: 'mode3', label: 'Mode 3' },
   { value: 'mode4', label: 'Mode 4' },
-  { value: 'mode5', label: 'Mode 5' },
 ];
 
-export const SAMPLE_SEGMENTEDCONTROL_PROPS: SegmentedControlProps = {
-  options: SAMPLE_SEGMENTEDCONTROL_OPTIONS,
-  selectedValue: SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
-  size: DEFAULT_SEGMENTEDCONTROL_SIZE,
-};
+export const SAMPLE_SINGLE_SEGMENTEDCONTROL_PROPS: SingleSelectSegmentedControlProps =
+  {
+    options: SAMPLE_SEGMENTEDCONTROL_OPTIONS,
+    selectedValue: SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+    size: DEFAULT_SEGMENTEDCONTROL_SIZE,
+    isMultiSelect: false,
+  };
+
+export const SAMPLE_MULTI_SEGMENTEDCONTROL_PROPS: MultiSelectSegmentedControlProps =
+  {
+    options: SAMPLE_SEGMENTEDCONTROL_OPTIONS,
+    selectedValues: [
+      SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+      SAMPLE_SEGMENTEDCONTROL_OPTIONS[2].value,
+    ],
+    size: DEFAULT_SEGMENTEDCONTROL_SIZE,
+    isMultiSelect: true,
+  };
+
+// For backward compatibility
+export const SAMPLE_SEGMENTEDCONTROL_PROPS: SegmentedControlProps =
+  SAMPLE_SINGLE_SEGMENTEDCONTROL_PROPS;

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,6 @@
 // Third party dependencies.
 import React, { useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
 
 // External dependencies.
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
@@ -24,13 +24,9 @@ const handleSingleValueChange = (_value: string) => {
   /* For demo purposes only */
 };
 
-const handleMultiValueChange = (_values: string[]) => {
-  /* For demo purposes only */
-};
-
 // Sample options with many items to demonstrate scrollable behavior
 const MANY_OPTIONS = [
-  { value: 'option1', label: 'Option 1' },
+  { value: 'option1', label: 'Option 1 5 6 7  8 ' },
   { value: 'option2', label: 'Option 2' },
   { value: 'option3', label: 'Option 3' },
   { value: 'option4', label: 'Option 4' },
@@ -52,12 +48,29 @@ const OPTIONS_WITH_ICONS = [
   { value: 'uni', label: 'UNI', startIconName: IconName.Refresh },
 ];
 
+// Sample options with varying text lengths for width examples
+const VARIED_TEXT_LENGTH_OPTIONS = [
+  { value: 'short', label: 'S' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'long', label: 'Very Long Text Label' },
+  { value: 'another', label: 'Another Option' },
+];
+
 const styles = StyleSheet.create({
   container: {
     padding: 16,
   },
+  scrollContainer: {
+    flexGrow: 1,
+  },
   section: {
     marginVertical: 16,
+  },
+  description: {
+    marginBottom: 8,
+  },
+  spacer: {
+    height: 40,
   },
 });
 
@@ -127,72 +140,147 @@ const MultiSelectIconsScrollableDemo = () => {
   );
 };
 
-export const SegmentedControl = {
-  render: () => (
-    <View style={styles.container}>
-      <Title>SegmentedControl Component</Title>
-      <Text variant={TextVariant.BodySM}>
-        A set of buttons grouped together to switch between related views or
-        modes.
-      </Text>
+// Demo component for flexible width buttons
+const FlexibleWidthDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    VARIED_TEXT_LENGTH_OPTIONS[0].value,
+  );
 
+  return (
+    <SegmentedControlComponent
+      options={VARIED_TEXT_LENGTH_OPTIONS}
+      selectedValue={selectedValue}
+      isButtonWidthFlexible
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// Demo component showing width comparison (fixed vs flexible)
+const WidthComparisonDemo = () => {
+  const [selectedValueFixed, setSelectedValueFixed] = useState<string>(
+    VARIED_TEXT_LENGTH_OPTIONS[0].value,
+  );
+  const [selectedValueFlexible, setSelectedValueFlexible] = useState<string>(
+    VARIED_TEXT_LENGTH_OPTIONS[0].value,
+  );
+
+  return (
+    <View>
       <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>
-          Single Select (Controlled Demo)
+        <Text variant={TextVariant.BodySM} style={styles.description}>
+          Fixed Width (default): Buttons have equal widths regardless of content
         </Text>
-        <SingleSelectDemo />
-      </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>
-          Multi-Select (Controlled Demo)
-        </Text>
-        <MultiSelectDemo />
-      </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>
-          Scrollable SegmentedControl
-        </Text>
-        <ScrollableSingleSelectDemo />
-      </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>
-          Multi-Select with Icons (Scrollable)
-        </Text>
-        <MultiSelectIconsScrollableDemo />
-      </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>Large Size</Text>
         <SegmentedControlComponent
-          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-          size={ButtonSize.Lg}
-          onValueChange={handleSingleValueChange}
+          options={VARIED_TEXT_LENGTH_OPTIONS}
+          selectedValue={selectedValueFixed}
+          onValueChange={(value) => setSelectedValueFixed(value)}
         />
       </View>
 
       <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>Small Size</Text>
+        <Text variant={TextVariant.BodySM} style={styles.description}>
+          Flexible Width: Buttons size based on their content
+        </Text>
         <SegmentedControlComponent
-          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-          size={ButtonSize.Sm}
-          onValueChange={handleSingleValueChange}
-        />
-      </View>
-
-      <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>Disabled</Text>
-        <SegmentedControlComponent
-          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-          isDisabled
-          onValueChange={handleSingleValueChange}
+          options={VARIED_TEXT_LENGTH_OPTIONS}
+          selectedValue={selectedValueFlexible}
+          isButtonWidthFlexible
+          onValueChange={(value) => setSelectedValueFlexible(value)}
         />
       </View>
     </View>
+  );
+};
+
+export const SegmentedControl = {
+  render: () => (
+    <ScrollView contentContainerStyle={styles.scrollContainer}>
+      <View style={styles.container}>
+        <Title>SegmentedControl Component</Title>
+        <Text variant={TextVariant.BodySM}>
+          A set of buttons grouped together to switch between related views or
+          modes.
+        </Text>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>Button Width Options</Text>
+          <Text variant={TextVariant.BodySM} style={styles.description}>
+            SegmentedControl supports both fixed width and flexible width
+            buttons
+          </Text>
+          <WidthComparisonDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>
+            Single Select (Controlled Demo)
+          </Text>
+          <SingleSelectDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>
+            Multi-Select (Controlled Demo)
+          </Text>
+          <MultiSelectDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>Flexible Width Example</Text>
+          <Text variant={TextVariant.BodySM} style={styles.description}>
+            When isButtonWidthFlexible is true, buttons size to fit their
+            content
+          </Text>
+          <FlexibleWidthDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>
+            Scrollable SegmentedControl
+          </Text>
+          <ScrollableSingleSelectDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>
+            Multi-Select with Icons (Scrollable)
+          </Text>
+          <MultiSelectIconsScrollableDemo />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>Large Size</Text>
+          <SegmentedControlComponent
+            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+            size={ButtonSize.Lg}
+            onValueChange={handleSingleValueChange}
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>Small Size</Text>
+          <SegmentedControlComponent
+            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+            size={ButtonSize.Sm}
+            onValueChange={handleSingleValueChange}
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text variant={TextVariant.BodyMDBold}>Disabled</Text>
+          <SegmentedControlComponent
+            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+            isDisabled
+            onValueChange={handleSingleValueChange}
+          />
+        </View>
+
+        <View style={styles.spacer} />
+      </View>
+    </ScrollView>
   ),
 };

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,84 @@
+// Third party dependencies.
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+// External dependencies.
+import { ButtonSize } from '../../components/Buttons/Button/Button.types';
+import Title from '../../../components/Base/Title';
+import Text, { TextVariant } from '../../components/Texts/Text';
+
+// Internal dependencies.
+import { default as SegmentedControlComponent } from './SegmentedControl';
+import { SAMPLE_SEGMENTEDCONTROL_OPTIONS } from './SegmentedControl.constants';
+
+const SegmentedControlStoryMeta = {
+  title: 'Components Temp / SegmentedControl',
+  component: SegmentedControlComponent,
+};
+
+export default SegmentedControlStoryMeta;
+
+// No-op function for handling value changes in the story
+const handleValueChange = (_value: string) => {
+  /* For demo purposes only */
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  section: {
+    marginVertical: 16,
+  },
+});
+
+export const SegmentedControl = {
+  render: () => (
+    <View style={styles.container}>
+      <Title>SegmentedControl Component</Title>
+      <Text variant={TextVariant.BodySM}>
+        A set of buttons grouped together to switch between related views or
+        modes.
+      </Text>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Default</Text>
+        <SegmentedControlComponent
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          onValueChange={handleValueChange}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Large Size</Text>
+        <SegmentedControlComponent
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          size={ButtonSize.Lg}
+          onValueChange={handleValueChange}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Small Size</Text>
+        <SegmentedControlComponent
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          size={ButtonSize.Sm}
+          onValueChange={handleValueChange}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>Disabled</Text>
+        <SegmentedControlComponent
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          isDisabled
+          onValueChange={handleValueChange}
+        />
+      </View>
+    </View>
+  ),
+};

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,12 +1,12 @@
 // Third party dependencies.
 import React, { useState } from 'react';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 // External dependencies.
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
-import Title from '../../../components/Base/Title';
 import Text, { TextVariant } from '../../components/Texts/Text';
 import { IconName } from '../../components/Icons/Icon';
+import { Theme } from '../../../util/theme/models';
 
 // Internal dependencies.
 import { default as SegmentedControlComponent } from './SegmentedControl';
@@ -19,14 +19,9 @@ const SegmentedControlStoryMeta = {
 
 export default SegmentedControlStoryMeta;
 
-// No-op function for handling value changes in the story
-const handleSingleValueChange = (_value: string) => {
-  /* For demo purposes only */
-};
-
 // Sample options with many items to demonstrate scrollable behavior
 const MANY_OPTIONS = [
-  { value: 'option1', label: 'Option 1 5 6 7  8 ' },
+  { value: 'option1', label: 'Option 1' },
   { value: 'option2', label: 'Option 2' },
   { value: 'option3', label: 'Option 3' },
   { value: 'option4', label: 'Option 4' },
@@ -56,25 +51,86 @@ const VARIED_TEXT_LENGTH_OPTIONS = [
   { value: 'another', label: 'Another Option' },
 ];
 
-const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-  },
-  scrollContainer: {
-    flexGrow: 1,
-  },
-  section: {
-    marginVertical: 16,
-  },
-  description: {
-    marginBottom: 8,
-  },
-  spacer: {
-    height: 40,
-  },
-});
+// Button size options
+const SIZE_OPTIONS = [
+  { value: 'sm', label: 'Small' },
+  { value: 'md', label: 'Medium' },
+  { value: 'lg', label: 'Large' },
+];
 
-// Demo component with state for multi-select
+const createStyles = ({ colors }: Theme) =>
+  StyleSheet.create({
+    container: {
+      padding: 16,
+    },
+    scrollContainer: {
+      flexGrow: 1,
+      paddingHorizontal: 16,
+    },
+    section: {
+      marginVertical: 16,
+      paddingBottom: 16,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border.muted,
+    },
+    description: {
+      marginBottom: 12,
+    },
+    spacer: {
+      height: 24,
+    },
+    demoWrapper: {
+      marginTop: 12,
+    },
+    sideBySide: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginTop: 12,
+    },
+    halfWidth: {
+      width: '48%',
+    },
+    fullWidth: {
+      width: '100%',
+    },
+    sizeDemo: {
+      marginBottom: 16,
+    },
+    disabled: {
+      opacity: 0.5,
+    },
+    customStyle: {
+      backgroundColor: colors.background.alternative,
+      padding: 12,
+      borderRadius: 8,
+      marginTop: 12,
+    },
+    customControlStyle: {
+      backgroundColor: colors.background.default,
+      borderRadius: 12,
+    },
+  });
+
+// ========================
+// Demo Components
+// ========================
+
+// 1. Basic Single-Select Control
+const BasicSingleSelectDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+  );
+
+  return (
+    <SegmentedControlComponent
+      options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+      selectedValue={selectedValue}
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// 2. Multi-Select Control
 const MultiSelectDemo = () => {
   const [selectedValues, setSelectedValues] = useState<string[]>([
     SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
@@ -91,23 +147,8 @@ const MultiSelectDemo = () => {
   );
 };
 
-// Demo component with state for single-select
-const SingleSelectDemo = () => {
-  const [selectedValue, setSelectedValue] = useState<string>(
-    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
-  );
-
-  return (
-    <SegmentedControlComponent
-      options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-      selectedValue={selectedValue}
-      onValueChange={(value) => setSelectedValue(value)}
-    />
-  );
-};
-
-// Demo component for scrollable single-select
-const ScrollableSingleSelectDemo = () => {
+// 3. Scrollable Single-Select with Flexible Width
+const ScrollableFlexibleWidthDemo = () => {
   const [selectedValue, setSelectedValue] = useState<string>(
     MANY_OPTIONS[0].value,
   );
@@ -117,13 +158,47 @@ const ScrollableSingleSelectDemo = () => {
       options={MANY_OPTIONS}
       selectedValue={selectedValue}
       isScrollable
+      isButtonWidthFlexible
       onValueChange={(value) => setSelectedValue(value)}
     />
   );
 };
 
-// Demo component for multi-select with icons and scrolling
-const MultiSelectIconsScrollableDemo = () => {
+// 4. Scrollable Single-Select with Fixed Width
+const ScrollableFixedWidthDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    MANY_OPTIONS[0].value,
+  );
+
+  return (
+    <SegmentedControlComponent
+      options={MANY_OPTIONS}
+      selectedValue={selectedValue}
+      isScrollable
+      isButtonWidthFlexible={false}
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// 7. Single-Select with Icons (Now with Flexible Width)
+const SingleSelectWithIconsDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    OPTIONS_WITH_ICONS[0].value,
+  );
+
+  return (
+    <SegmentedControlComponent
+      options={OPTIONS_WITH_ICONS}
+      selectedValue={selectedValue}
+      isButtonWidthFlexible
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// 8. Multi-Select with Icons (Scrollable)
+const MultiSelectWithIconsScrollableDemo = () => {
   const [selectedValues, setSelectedValues] = useState<string[]>([
     OPTIONS_WITH_ICONS[0].value,
     OPTIONS_WITH_ICONS[2].value,
@@ -140,24 +215,69 @@ const MultiSelectIconsScrollableDemo = () => {
   );
 };
 
-// Demo component for flexible width buttons
-const FlexibleWidthDemo = () => {
-  const [selectedValue, setSelectedValue] = useState<string>(
-    VARIED_TEXT_LENGTH_OPTIONS[0].value,
+// 9. Button Size Variations
+const ButtonSizesDemo = ({
+  styles,
+}: {
+  styles: ReturnType<typeof createStyles>;
+}) => {
+  const [selectedSmall, setSelectedSmall] = useState<string>(
+    SIZE_OPTIONS[0].value,
+  );
+  const [selectedMedium, setSelectedMedium] = useState<string>(
+    SIZE_OPTIONS[0].value,
+  );
+  const [selectedLarge, setSelectedLarge] = useState<string>(
+    SIZE_OPTIONS[0].value,
   );
 
   return (
-    <SegmentedControlComponent
-      options={VARIED_TEXT_LENGTH_OPTIONS}
-      selectedValue={selectedValue}
-      isButtonWidthFlexible
-      onValueChange={(value) => setSelectedValue(value)}
-    />
+    <View>
+      <View style={styles.sizeDemo}>
+        <Text variant={TextVariant.BodySM} style={styles.description}>
+          Small Size
+        </Text>
+        <SegmentedControlComponent
+          options={SIZE_OPTIONS}
+          selectedValue={selectedSmall}
+          onValueChange={(value) => setSelectedSmall(value)}
+          size={ButtonSize.Sm}
+        />
+      </View>
+
+      <View style={styles.sizeDemo}>
+        <Text variant={TextVariant.BodySM} style={styles.description}>
+          Medium Size (Default)
+        </Text>
+        <SegmentedControlComponent
+          options={SIZE_OPTIONS}
+          selectedValue={selectedMedium}
+          onValueChange={(value) => setSelectedMedium(value)}
+          size={ButtonSize.Md}
+        />
+      </View>
+
+      <View style={styles.sizeDemo}>
+        <Text variant={TextVariant.BodySM} style={styles.description}>
+          Large Size
+        </Text>
+        <SegmentedControlComponent
+          options={SIZE_OPTIONS}
+          selectedValue={selectedLarge}
+          onValueChange={(value) => setSelectedLarge(value)}
+          size={ButtonSize.Lg}
+        />
+      </View>
+    </View>
   );
 };
 
-// Demo component showing width comparison (fixed vs flexible)
-const WidthComparisonDemo = () => {
+// 10. Width Comparison Demo
+const WidthComparisonDemo = ({
+  styles,
+}: {
+  styles: ReturnType<typeof createStyles>;
+}) => {
   const [selectedValueFixed, setSelectedValueFixed] = useState<string>(
     VARIED_TEXT_LENGTH_OPTIONS[0].value,
   );
@@ -167,20 +287,21 @@ const WidthComparisonDemo = () => {
 
   return (
     <View>
-      <View style={styles.section}>
+      <View style={styles.demoWrapper}>
         <Text variant={TextVariant.BodySM} style={styles.description}>
-          Fixed Width (default): Buttons have equal widths regardless of content
+          Fixed Width: Buttons have equal widths regardless of content
         </Text>
         <SegmentedControlComponent
           options={VARIED_TEXT_LENGTH_OPTIONS}
           selectedValue={selectedValueFixed}
           onValueChange={(value) => setSelectedValueFixed(value)}
+          isButtonWidthFlexible={false}
         />
       </View>
 
-      <View style={styles.section}>
+      <View style={styles.demoWrapper}>
         <Text variant={TextVariant.BodySM} style={styles.description}>
-          Flexible Width: Buttons size based on their content
+          Flexible Width (default): Buttons size based on their content
         </Text>
         <SegmentedControlComponent
           options={VARIED_TEXT_LENGTH_OPTIONS}
@@ -193,94 +314,60 @@ const WidthComparisonDemo = () => {
   );
 };
 
-export const SegmentedControl = {
-  render: () => (
-    <ScrollView contentContainerStyle={styles.scrollContainer}>
-      <View style={styles.container}>
-        <Title>SegmentedControl Component</Title>
-        <Text variant={TextVariant.BodySM}>
-          A set of buttons grouped together to switch between related views or
-          modes.
-        </Text>
+// 11. Disabled State
+const DisabledStateDemo = ({
+  styles,
+}: {
+  styles: ReturnType<typeof createStyles>;
+}) => (
+  <View style={styles.demoWrapper}>
+    <SegmentedControlComponent
+      options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+      selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].value}
+      onValueChange={(value) => {
+        // This function intentionally left empty as the component is disabled
+        // eslint-disable-next-line no-console
+        console.log('Disabled component clicked:', value);
+      }}
+      isDisabled
+    />
+  </View>
+);
 
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>Button Width Options</Text>
-          <Text variant={TextVariant.BodySM} style={styles.description}>
-            SegmentedControl supports both fixed width and flexible width
-            buttons
-          </Text>
-          <WidthComparisonDemo />
-        </View>
+// 12. Custom Styling Examples
+const CustomStylingDemo = ({
+  styles,
+}: {
+  styles: ReturnType<typeof createStyles>;
+}) => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+  );
 
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>
-            Single Select (Controlled Demo)
-          </Text>
-          <SingleSelectDemo />
-        </View>
+  return (
+    <View style={styles.customStyle}>
+      <SegmentedControlComponent
+        options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+        selectedValue={selectedValue}
+        onValueChange={(value) => setSelectedValue(value)}
+        style={styles.customControlStyle}
+      />
+    </View>
+  );
+};
 
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>
-            Multi-Select (Controlled Demo)
-          </Text>
-          <MultiSelectDemo />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>Flexible Width Example</Text>
-          <Text variant={TextVariant.BodySM} style={styles.description}>
-            When isButtonWidthFlexible is true, buttons size to fit their
-            content
-          </Text>
-          <FlexibleWidthDemo />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>
-            Scrollable SegmentedControl
-          </Text>
-          <ScrollableSingleSelectDemo />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>
-            Multi-Select with Icons (Scrollable)
-          </Text>
-          <MultiSelectIconsScrollableDemo />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>Large Size</Text>
-          <SegmentedControlComponent
-            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-            size={ButtonSize.Lg}
-            onValueChange={handleSingleValueChange}
-          />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>Small Size</Text>
-          <SegmentedControlComponent
-            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-            size={ButtonSize.Sm}
-            onValueChange={handleSingleValueChange}
-          />
-        </View>
-
-        <View style={styles.section}>
-          <Text variant={TextVariant.BodyMDBold}>Disabled</Text>
-          <SegmentedControlComponent
-            options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-            selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-            isDisabled
-            onValueChange={handleSingleValueChange}
-          />
-        </View>
-
-        <View style={styles.spacer} />
-      </View>
-    </ScrollView>
-  ),
+// This is needed to suppress the unused variable warnings
+// These components are used in the story but ESLint doesn't recognize it
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _unusedComponents = {
+  BasicSingleSelectDemo,
+  MultiSelectDemo,
+  ScrollableFlexibleWidthDemo,
+  ScrollableFixedWidthDemo,
+  SingleSelectWithIconsDemo,
+  MultiSelectWithIconsScrollableDemo,
+  ButtonSizesDemo,
+  WidthComparisonDemo,
+  DisabledStateDemo,
+  CustomStylingDemo,
 };

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,11 +1,12 @@
 // Third party dependencies.
-import React from 'react';
+import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 // External dependencies.
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
 import Title from '../../../components/Base/Title';
 import Text, { TextVariant } from '../../components/Texts/Text';
+import { IconName } from '../../components/Icons/Icon';
 
 // Internal dependencies.
 import { default as SegmentedControlComponent } from './SegmentedControl';
@@ -19,9 +20,37 @@ const SegmentedControlStoryMeta = {
 export default SegmentedControlStoryMeta;
 
 // No-op function for handling value changes in the story
-const handleValueChange = (_value: string) => {
+const handleSingleValueChange = (_value: string) => {
   /* For demo purposes only */
 };
+
+const handleMultiValueChange = (_values: string[]) => {
+  /* For demo purposes only */
+};
+
+// Sample options with many items to demonstrate scrollable behavior
+const MANY_OPTIONS = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  { value: 'option4', label: 'Option 4' },
+  { value: 'option5', label: 'Option 5' },
+  { value: 'option6', label: 'Option 6' },
+  { value: 'option7', label: 'Option 7' },
+  { value: 'option8', label: 'Option 8' },
+];
+
+// Sample options with icons
+const OPTIONS_WITH_ICONS = [
+  { value: 'eth', label: 'ETH', startIconName: IconName.Ethereum },
+  { value: 'btc', label: 'BTC', startIconName: IconName.Wallet },
+  { value: 'sol', label: 'SOL', startIconName: IconName.Star },
+  { value: 'avax', label: 'AVAX', startIconName: IconName.Warning },
+  { value: 'matic', label: 'MATIC', startIconName: IconName.Security },
+  { value: 'usdt', label: 'USDT', startIconName: IconName.Coin },
+  { value: 'link', label: 'LINK', startIconName: IconName.Link },
+  { value: 'uni', label: 'UNI', startIconName: IconName.Refresh },
+];
 
 const styles = StyleSheet.create({
   container: {
@@ -31,6 +60,72 @@ const styles = StyleSheet.create({
     marginVertical: 16,
   },
 });
+
+// Demo component with state for multi-select
+const MultiSelectDemo = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([
+    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+    SAMPLE_SEGMENTEDCONTROL_OPTIONS[2].value,
+  ]);
+
+  return (
+    <SegmentedControlComponent
+      options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+      selectedValues={selectedValues}
+      isMultiSelect
+      onValueChange={(values) => setSelectedValues(values)}
+    />
+  );
+};
+
+// Demo component with state for single-select
+const SingleSelectDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+  );
+
+  return (
+    <SegmentedControlComponent
+      options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+      selectedValue={selectedValue}
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// Demo component for scrollable single-select
+const ScrollableSingleSelectDemo = () => {
+  const [selectedValue, setSelectedValue] = useState<string>(
+    MANY_OPTIONS[0].value,
+  );
+
+  return (
+    <SegmentedControlComponent
+      options={MANY_OPTIONS}
+      selectedValue={selectedValue}
+      isScrollable
+      onValueChange={(value) => setSelectedValue(value)}
+    />
+  );
+};
+
+// Demo component for multi-select with icons and scrolling
+const MultiSelectIconsScrollableDemo = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([
+    OPTIONS_WITH_ICONS[0].value,
+    OPTIONS_WITH_ICONS[2].value,
+  ]);
+
+  return (
+    <SegmentedControlComponent
+      options={OPTIONS_WITH_ICONS}
+      selectedValues={selectedValues}
+      isMultiSelect
+      isScrollable
+      onValueChange={(values) => setSelectedValues(values)}
+    />
+  );
+};
 
 export const SegmentedControl = {
   render: () => (
@@ -42,12 +137,31 @@ export const SegmentedControl = {
       </Text>
 
       <View style={styles.section}>
-        <Text variant={TextVariant.BodyMDBold}>Default</Text>
-        <SegmentedControlComponent
-          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
-          onValueChange={handleValueChange}
-        />
+        <Text variant={TextVariant.BodyMDBold}>
+          Single Select (Controlled Demo)
+        </Text>
+        <SingleSelectDemo />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>
+          Multi-Select (Controlled Demo)
+        </Text>
+        <MultiSelectDemo />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>
+          Scrollable SegmentedControl
+        </Text>
+        <ScrollableSingleSelectDemo />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant={TextVariant.BodyMDBold}>
+          Multi-Select with Icons (Scrollable)
+        </Text>
+        <MultiSelectIconsScrollableDemo />
       </View>
 
       <View style={styles.section}>
@@ -56,7 +170,7 @@ export const SegmentedControl = {
           options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
           selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
           size={ButtonSize.Lg}
-          onValueChange={handleValueChange}
+          onValueChange={handleSingleValueChange}
         />
       </View>
 
@@ -66,7 +180,7 @@ export const SegmentedControl = {
           options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
           selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
           size={ButtonSize.Sm}
-          onValueChange={handleValueChange}
+          onValueChange={handleSingleValueChange}
         />
       </View>
 
@@ -76,7 +190,7 @@ export const SegmentedControl = {
           options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
           selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
           isDisabled
-          onValueChange={handleValueChange}
+          onValueChange={handleSingleValueChange}
         />
       </View>
     </View>

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,12 +1,13 @@
 // Third party dependencies.
 import React, { useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
 
 // External dependencies.
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
 import Text, { TextVariant } from '../../components/Texts/Text';
 import { IconName } from '../../components/Icons/Icon';
 import { Theme } from '../../../util/theme/models';
+import { mockTheme } from '../../../util/theme';
 
 // Internal dependencies.
 import { default as SegmentedControlComponent } from './SegmentedControl';
@@ -41,14 +42,6 @@ const OPTIONS_WITH_ICONS = [
   { value: 'usdt', label: 'USDT', startIconName: IconName.Coin },
   { value: 'link', label: 'LINK', startIconName: IconName.Link },
   { value: 'uni', label: 'UNI', startIconName: IconName.Refresh },
-];
-
-// Sample options with varying text lengths for width examples
-const VARIED_TEXT_LENGTH_OPTIONS = [
-  { value: 'short', label: 'S' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'long', label: 'Very Long Text Label' },
-  { value: 'another', label: 'Another Option' },
 ];
 
 // Button size options
@@ -192,6 +185,7 @@ const SingleSelectWithIconsDemo = () => {
       options={OPTIONS_WITH_ICONS}
       selectedValue={selectedValue}
       isButtonWidthFlexible
+      isScrollable
       onValueChange={(value) => setSelectedValue(value)}
     />
   );
@@ -272,49 +266,7 @@ const ButtonSizesDemo = ({
   );
 };
 
-// 10. Width Comparison Demo
-const WidthComparisonDemo = ({
-  styles,
-}: {
-  styles: ReturnType<typeof createStyles>;
-}) => {
-  const [selectedValueFixed, setSelectedValueFixed] = useState<string>(
-    VARIED_TEXT_LENGTH_OPTIONS[0].value,
-  );
-  const [selectedValueFlexible, setSelectedValueFlexible] = useState<string>(
-    VARIED_TEXT_LENGTH_OPTIONS[0].value,
-  );
-
-  return (
-    <View>
-      <View style={styles.demoWrapper}>
-        <Text variant={TextVariant.BodySM} style={styles.description}>
-          Fixed Width: Buttons have equal widths regardless of content
-        </Text>
-        <SegmentedControlComponent
-          options={VARIED_TEXT_LENGTH_OPTIONS}
-          selectedValue={selectedValueFixed}
-          onValueChange={(value) => setSelectedValueFixed(value)}
-          isButtonWidthFlexible={false}
-        />
-      </View>
-
-      <View style={styles.demoWrapper}>
-        <Text variant={TextVariant.BodySM} style={styles.description}>
-          Flexible Width (default): Buttons size based on their content
-        </Text>
-        <SegmentedControlComponent
-          options={VARIED_TEXT_LENGTH_OPTIONS}
-          selectedValue={selectedValueFlexible}
-          isButtonWidthFlexible
-          onValueChange={(value) => setSelectedValueFlexible(value)}
-        />
-      </View>
-    </View>
-  );
-};
-
-// 11. Disabled State
+// 10. Disabled State
 const DisabledStateDemo = ({
   styles,
 }: {
@@ -334,28 +286,6 @@ const DisabledStateDemo = ({
   </View>
 );
 
-// 12. Custom Styling Examples
-const CustomStylingDemo = ({
-  styles,
-}: {
-  styles: ReturnType<typeof createStyles>;
-}) => {
-  const [selectedValue, setSelectedValue] = useState<string>(
-    SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
-  );
-
-  return (
-    <View style={styles.customStyle}>
-      <SegmentedControlComponent
-        options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
-        selectedValue={selectedValue}
-        onValueChange={(value) => setSelectedValue(value)}
-        style={styles.customControlStyle}
-      />
-    </View>
-  );
-};
-
 // This is needed to suppress the unused variable warnings
 // These components are used in the story but ESLint doesn't recognize it
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -367,7 +297,98 @@ const _unusedComponents = {
   SingleSelectWithIconsDemo,
   MultiSelectWithIconsScrollableDemo,
   ButtonSizesDemo,
-  WidthComparisonDemo,
   DisabledStateDemo,
-  CustomStylingDemo,
+};
+
+// Replace all the individual exports with a single comprehensive view
+export const SegmentedControl = {
+  render: () => {
+    const styles = createStyles(mockTheme);
+
+    return (
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
+        <View style={styles.container}>
+          <Text variant={TextVariant.HeadingSM}>
+            SegmentedControl Component
+          </Text>
+          <Text variant={TextVariant.BodySM}>
+            A set of buttons grouped together to switch between related views or
+            modes.
+          </Text>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>Basic Single-Select</Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              The default configuration with single-select behavior
+            </Text>
+            <BasicSingleSelectDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>Multi-Select</Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Allows selecting multiple options simultaneously
+            </Text>
+            <MultiSelectDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>
+              Scrollable with Flexible Width
+            </Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Horizontally scrollable with button width based on content
+            </Text>
+            <ScrollableFlexibleWidthDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>
+              Scrollable with Fixed Width
+            </Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Horizontally scrollable with equal button widths
+            </Text>
+            <ScrollableFixedWidthDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>
+              Single-Select with Icons
+            </Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Buttons with both text and icons for enhanced visual cues
+            </Text>
+            <SingleSelectWithIconsDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>
+              Multi-Select with Icons (Scrollable)
+            </Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Multi-select with icons in a scrollable container
+            </Text>
+            <MultiSelectWithIconsScrollableDemo />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>Size Variations</Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Small, medium (default), and large button sizes
+            </Text>
+            <ButtonSizesDemo styles={styles} />
+          </View>
+
+          <View style={styles.section}>
+            <Text variant={TextVariant.BodyMDBold}>Disabled State</Text>
+            <Text variant={TextVariant.BodySM} style={styles.description}>
+              Control in a disabled state with interaction prevented
+            </Text>
+            <DisabledStateDemo styles={styles} />
+          </View>
+        </View>
+      </ScrollView>
+    );
+  },
 };

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
@@ -11,6 +11,7 @@ import { SegmentedControlStyleSheetVars } from './SegmentedControl.types';
  * Style sheet function for SegmentedControl component.
  *
  * @param params Style sheet params.
+ * @param params.theme App theme from ThemeContext.
  * @param params.vars Inputs that the style sheet depends on.
  * @returns StyleSheet object.
  */
@@ -19,26 +20,26 @@ const styleSheet = (params: {
   vars: SegmentedControlStyleSheetVars;
 }) => {
   const { vars } = params;
-  const { style } = vars;
+  const { style, isButtonWidthFlexible } = vars;
 
   return StyleSheet.create({
     base: Object.assign(
       {
         flexDirection: 'row',
         alignItems: 'center',
-        justifyContent: 'flex-start',
+        justifyContent: 'center',
+        gap: 12,
       } as ViewStyle,
       style,
     ) as ViewStyle,
+
     buttonContainer: {
-      marginRight: 12,
+      // Only use flex: 1 when buttons should have equal widths (default)
+      ...(isButtonWidthFlexible ? {} : { flex: 1 }),
+      alignItems: 'center',
+      justifyContent: 'center',
     } as ViewStyle,
-    button: {
-      marginRight: 0,
-    } as ViewStyle,
-    lastButton: {
-      marginRight: 0,
-    } as ViewStyle,
+
     scrollContentContainer: {
       alignItems: 'center',
     } as ViewStyle,

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
@@ -30,11 +30,17 @@ const styleSheet = (params: {
       } as ViewStyle,
       style,
     ) as ViewStyle,
+    buttonContainer: {
+      marginRight: 12,
+    } as ViewStyle,
     button: {
-      marginRight: 8,
+      marginRight: 0,
     } as ViewStyle,
     lastButton: {
       marginRight: 0,
+    } as ViewStyle,
+    scrollContentContainer: {
+      alignItems: 'center',
     } as ViewStyle,
   });
 };

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
@@ -34,7 +34,7 @@ const styleSheet = (params: {
     ) as ViewStyle,
 
     buttonContainer: {
-      // Only use flex: 1 when buttons should have equal widths (default)
+      // Only use flex: 1 when buttons should have fixed equal widths (not the default)
       ...(isButtonWidthFlexible ? {} : { flex: 1 }),
       alignItems: 'center',
       justifyContent: 'center',

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.styles.ts
@@ -1,0 +1,42 @@
+// Third party dependencies.
+import { StyleSheet, ViewStyle } from 'react-native';
+
+// External dependencies.
+import { Theme } from '../../../util/theme/models';
+
+// Internal dependencies.
+import { SegmentedControlStyleSheetVars } from './SegmentedControl.types';
+
+/**
+ * Style sheet function for SegmentedControl component.
+ *
+ * @param params Style sheet params.
+ * @param params.vars Inputs that the style sheet depends on.
+ * @returns StyleSheet object.
+ */
+const styleSheet = (params: {
+  theme: Theme;
+  vars: SegmentedControlStyleSheetVars;
+}) => {
+  const { vars } = params;
+  const { style } = vars;
+
+  return StyleSheet.create({
+    base: Object.assign(
+      {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+      } as ViewStyle,
+      style,
+    ) as ViewStyle,
+    button: {
+      marginRight: 8,
+    } as ViewStyle,
+    lastButton: {
+      marginRight: 0,
+    } as ViewStyle,
+  });
+};
+
+export default styleSheet;

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.test.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,198 @@
+// Third party dependencies.
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+// Internal dependencies.
+import SegmentedControl from './SegmentedControl';
+import { SAMPLE_SEGMENTEDCONTROL_OPTIONS } from './SegmentedControl.constants';
+
+describe('SegmentedControl', () => {
+  // Single-select mode tests
+  describe('Single-select mode', () => {
+    it('renders correctly with default selection', () => {
+      const { toJSON, getAllByRole } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          onValueChange={jest.fn()}
+        />,
+      );
+
+      // Renders all options
+      expect(getAllByRole('button')).toHaveLength(
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS.length,
+      );
+      expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('calls onValueChange when an option is pressed', () => {
+      const mockOnValueChange = jest.fn();
+      const { getByText } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+          onValueChange={mockOnValueChange}
+        />,
+      );
+
+      // Press the second option
+      const secondOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].label);
+      fireEvent.press(secondOption);
+
+      // Callback is called with the second option's value
+      expect(mockOnValueChange).toHaveBeenCalledWith(
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].value,
+      );
+    });
+
+    it('works in uncontrolled mode', () => {
+      const mockOnValueChange = jest.fn();
+      const { getByText } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          onValueChange={mockOnValueChange}
+        />,
+      );
+
+      // First option is selected by default
+      const firstOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].label);
+      expect(firstOption).toBeTruthy();
+
+      // Press the second option
+      const secondOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].label);
+      fireEvent.press(secondOption);
+
+      // Callback is called with the second option's value
+      expect(mockOnValueChange).toHaveBeenCalledWith(
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].value,
+      );
+    });
+  });
+
+  // Multi-select mode tests
+  describe('Multi-select mode', () => {
+    it('renders correctly with default selections', () => {
+      const selectedValues = [
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[2].value,
+      ];
+
+      const { toJSON, getAllByRole } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValues={selectedValues}
+          isMultiSelect
+          onValueChange={jest.fn()}
+        />,
+      );
+
+      // Renders all options
+      expect(getAllByRole('button')).toHaveLength(
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS.length,
+      );
+      expect(toJSON()).toMatchSnapshot();
+    });
+
+    it('adds value to selection when unselected option is pressed', () => {
+      const selectedValues = [SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value];
+      const mockOnValueChange = jest.fn();
+
+      const { getByText } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValues={selectedValues}
+          isMultiSelect
+          onValueChange={mockOnValueChange}
+        />,
+      );
+
+      // Press the second option (which is not selected)
+      const secondOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].label);
+      fireEvent.press(secondOption);
+
+      // Callback is called with both values
+      expect(mockOnValueChange).toHaveBeenCalledWith([
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].value,
+      ]);
+    });
+
+    it('removes value from selection when selected option is pressed', () => {
+      const selectedValues = [
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[2].value,
+      ];
+      const mockOnValueChange = jest.fn();
+
+      const { getByText } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          selectedValues={selectedValues}
+          isMultiSelect
+          onValueChange={mockOnValueChange}
+        />,
+      );
+
+      // Press the first option (which is already selected)
+      const firstOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].label);
+      fireEvent.press(firstOption);
+
+      // Callback is called with only the second selected value
+      expect(mockOnValueChange).toHaveBeenCalledWith([
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[2].value,
+      ]);
+    });
+
+    it('works in uncontrolled mode', () => {
+      const mockOnValueChange = jest.fn();
+
+      const { getByText } = render(
+        <SegmentedControl
+          options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+          isMultiSelect
+          onValueChange={mockOnValueChange}
+        />,
+      );
+
+      // Press the first option
+      const firstOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].label);
+      fireEvent.press(firstOption);
+
+      // Callback is called with the first option's value
+      expect(mockOnValueChange).toHaveBeenCalledWith([
+        SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value,
+      ]);
+
+      // Simulate component updating its internal state
+      mockOnValueChange.mockClear();
+
+      // Press the second option
+      const secondOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].label);
+      fireEvent.press(secondOption);
+
+      // This is a bit tricky to test properly in this context since we can't
+      // easily verify the internal state, but the callback is called
+      expect(mockOnValueChange).toHaveBeenCalled();
+    });
+  });
+
+  // Disabled state tests
+  it('ignores presses when disabled', () => {
+    const mockOnValueChange = jest.fn();
+    const { getByText } = render(
+      <SegmentedControl
+        options={SAMPLE_SEGMENTEDCONTROL_OPTIONS}
+        selectedValue={SAMPLE_SEGMENTEDCONTROL_OPTIONS[0].value}
+        isDisabled
+        onValueChange={mockOnValueChange}
+      />,
+    );
+
+    // Press the second option
+    const secondOption = getByText(SAMPLE_SEGMENTEDCONTROL_OPTIONS[1].label);
+    fireEvent.press(secondOption);
+
+    // Callback is not called
+    expect(mockOnValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
@@ -5,6 +5,7 @@ import { View, ScrollView } from 'react-native';
 // External dependencies.
 import { useStyles } from '../../hooks';
 import ButtonToggle from '../../components-temp/Buttons/ButtonToggle';
+import { ButtonWidthTypes } from '../../components/Buttons/Button/Button.types';
 
 // Internal dependencies.
 import {
@@ -18,6 +19,7 @@ import { DEFAULT_SEGMENTEDCONTROL_SIZE } from './SegmentedControl.constants';
 const SegmentedControl = ({
   options,
   size = DEFAULT_SEGMENTEDCONTROL_SIZE,
+  isButtonWidthFlexible = false,
   isDisabled = false,
   isMultiSelect = false,
   isScrollable = false,
@@ -27,6 +29,7 @@ const SegmentedControl = ({
   const { styles } = useStyles(styleSheet, {
     style,
     size,
+    isButtonWidthFlexible,
   });
 
   // Single select state
@@ -153,23 +156,23 @@ const SegmentedControl = ({
 
   // Render the buttons with gap between them
   const renderButtons = () =>
-    options.map((option, index) => {
+    options.map((option) => {
       // Extract standard props and any additional props that might be in the option
       const { value, label, ...optionProps } = option;
 
       return (
-        <View
-          key={value}
-          style={
-            index < options.length - 1 ? styles.buttonContainer : undefined
-          }
-        >
+        <View key={value} style={styles.buttonContainer}>
           <ButtonToggle
             label={label}
             isActive={isOptionActive(value)}
             onPress={() => handleButtonPress(value)}
             size={size}
             isDisabled={isDisabled}
+            width={
+              isButtonWidthFlexible
+                ? ButtonWidthTypes.Auto
+                : ButtonWidthTypes.Full
+            }
             {...optionProps}
           />
         </View>

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,55 @@
+// Third party dependencies.
+import React, { useCallback } from 'react';
+import { View } from 'react-native';
+
+// External dependencies.
+import { useStyles } from '../../hooks';
+import ButtonToggle from '../../components-temp/Buttons/ButtonToggle';
+
+// Internal dependencies.
+import { SegmentedControlProps } from './SegmentedControl.types';
+import styleSheet from './SegmentedControl.styles';
+import { DEFAULT_SEGMENTEDCONTROL_SIZE } from './SegmentedControl.constants';
+
+const SegmentedControl = ({
+  options,
+  selectedValue,
+  onValueChange,
+  size = DEFAULT_SEGMENTEDCONTROL_SIZE,
+  isDisabled = false,
+  style,
+  ...props
+}: SegmentedControlProps) => {
+  const { styles } = useStyles(styleSheet, {
+    style,
+    size,
+  });
+
+  const handlePress = useCallback(
+    (value: string) => {
+      onValueChange?.(value);
+    },
+    [onValueChange],
+  );
+
+  return (
+    <View style={styles.base} {...props}>
+      {options.map((option, index) => (
+        <ButtonToggle
+          key={option.value}
+          label={option.label}
+          isActive={selectedValue === option.value}
+          onPress={() => handlePress(option.value)}
+          size={size}
+          isDisabled={isDisabled}
+          style={[
+            styles.button,
+            index === options.length - 1 ? styles.lastButton : null,
+          ]}
+        />
+      ))}
+    </View>
+  );
+};
+
+export default SegmentedControl;

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.tsx
@@ -19,7 +19,7 @@ import { DEFAULT_SEGMENTEDCONTROL_SIZE } from './SegmentedControl.constants';
 const SegmentedControl = ({
   options,
   size = DEFAULT_SEGMENTEDCONTROL_SIZE,
-  isButtonWidthFlexible = false,
+  isButtonWidthFlexible = true,
   isDisabled = false,
   isMultiSelect = false,
   isScrollable = false,

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
@@ -1,0 +1,59 @@
+// Third party dependencies.
+import { ViewProps } from 'react-native';
+
+// External dependencies.
+import { ButtonSize } from '../../components/Buttons/Button/Button.types';
+
+/**
+ * Segmented control option type
+ */
+export interface SegmentedControlOption {
+  /**
+   * Unique value for the option
+   */
+  value: string;
+  /**
+   * Label text to display
+   */
+  label: string;
+}
+
+/**
+ * SegmentedControl component props.
+ */
+export interface SegmentedControlProps extends ViewProps {
+  /**
+   * Array of options to display in the segmented control
+   */
+  options: SegmentedControlOption[];
+
+  /**
+   * Value of the currently selected option
+   */
+  selectedValue?: string;
+
+  /**
+   * Callback when an option is selected
+   */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * Size of the control and its buttons
+   * @default ButtonSize.Md
+   */
+  size?: ButtonSize;
+
+  /**
+   * Whether the control is disabled
+   * @default false
+   */
+  isDisabled?: boolean;
+}
+
+/**
+ * Style sheet input parameters.
+ */
+export interface SegmentedControlStyleSheetVars {
+  style?: ViewProps['style'];
+  size?: ButtonSize;
+}

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
@@ -3,6 +3,8 @@ import { ViewProps } from 'react-native';
 
 // External dependencies.
 import { ButtonSize } from '../../components/Buttons/Button/Button.types';
+import { IconName } from '../../components/Icons/Icon';
+import { TextVariant } from '../../components/Texts/Text';
 
 /**
  * Segmented control option type
@@ -16,26 +18,36 @@ export interface SegmentedControlOption {
    * Label text to display
    */
   label: string;
+  /**
+   * Optional icon to display before the label
+   */
+  startIconName?: IconName;
+  /**
+   * Optional icon to display after the label
+   */
+  endIconName?: IconName;
+  /**
+   * Optional text variant for the label
+   */
+  labelTextVariant?: TextVariant;
+  /**
+   * Optional test ID for the option
+   */
+  testID?: string;
+  /**
+   * Optional accessibility label for the option
+   */
+  accessibilityLabel?: string;
 }
 
 /**
- * SegmentedControl component props.
+ * Base props for the SegmentedControl component.
  */
-export interface SegmentedControlProps extends ViewProps {
+export interface BaseSegmentedControlProps extends ViewProps {
   /**
    * Array of options to display in the segmented control
    */
   options: SegmentedControlOption[];
-
-  /**
-   * Value of the currently selected option
-   */
-  selectedValue?: string;
-
-  /**
-   * Callback when an option is selected
-   */
-  onValueChange?: (value: string) => void;
 
   /**
    * Size of the control and its buttons
@@ -48,7 +60,64 @@ export interface SegmentedControlProps extends ViewProps {
    * @default false
    */
   isDisabled?: boolean;
+
+  /**
+   * Whether the control should be horizontally scrollable.
+   * Useful when there are many options that may not fit on the screen.
+   * @default false
+   */
+  isScrollable?: boolean;
 }
+
+/**
+ * Props for single-select mode.
+ */
+export interface SingleSelectSegmentedControlProps
+  extends BaseSegmentedControlProps {
+  /**
+   * Whether the control allows multiple selections
+   * @default false
+   */
+  isMultiSelect?: false;
+
+  /**
+   * Value of the currently selected option
+   */
+  selectedValue?: string;
+
+  /**
+   * Callback when an option is selected
+   */
+  onValueChange?: (value: string) => void;
+}
+
+/**
+ * Props for multi-select mode.
+ */
+export interface MultiSelectSegmentedControlProps
+  extends BaseSegmentedControlProps {
+  /**
+   * Whether the control allows multiple selections
+   */
+  isMultiSelect: true;
+
+  /**
+   * Values of the currently selected options
+   */
+  selectedValues?: string[];
+
+  /**
+   * Callback when selected options change
+   */
+  onValueChange?: (values: string[]) => void;
+}
+
+/**
+ * Union type for all possible SegmentedControl props
+ */
+export type SegmentedControlProps =
+  | SingleSelectSegmentedControlProps
+  | MultiSelectSegmentedControlProps;
 
 /**
  * Style sheet input parameters.

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
@@ -57,9 +57,9 @@ export interface BaseSegmentedControlProps extends ViewProps {
 
   /**
    * Whether buttons should size to their content instead of having equal widths.
-   * When false (default), all buttons have equal widths filling the container.
-   * When true, buttons will size based on their content.
-   * @default false
+   * When true (default), buttons will size based on their content.
+   * When false, all buttons have equal widths filling the container.
+   * @default true
    */
   isButtonWidthFlexible?: boolean;
 

--- a/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
+++ b/app/component-library/components-temp/SegmentedControl/SegmentedControl.types.ts
@@ -56,6 +56,14 @@ export interface BaseSegmentedControlProps extends ViewProps {
   size?: ButtonSize;
 
   /**
+   * Whether buttons should size to their content instead of having equal widths.
+   * When false (default), all buttons have equal widths filling the container.
+   * When true, buttons will size based on their content.
+   * @default false
+   */
+  isButtonWidthFlexible?: boolean;
+
+  /**
    * Whether the control is disabled
    * @default false
    */
@@ -125,4 +133,5 @@ export type SegmentedControlProps =
 export interface SegmentedControlStyleSheetVars {
   style?: ViewProps['style'];
   size?: ButtonSize;
+  isButtonWidthFlexible?: boolean;
 }

--- a/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -69,7 +68,6 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -83,7 +81,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -116,7 +114,6 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -130,7 +127,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "#0376C91A",
           "borderColor": "#0376c9",
           "borderRadius": 20,
@@ -163,7 +160,6 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -177,7 +173,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -226,7 +222,6 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -273,7 +268,6 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -287,7 +281,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -320,7 +314,6 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -334,7 +327,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -367,7 +360,6 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
     style={
       {
         "alignItems": "center",
-        "flex": 1,
         "justifyContent": "center",
       }
     }
@@ -381,7 +373,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "flex-start",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,

--- a/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -13,14 +13,17 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
     {
       "alignItems": "center",
       "flexDirection": "row",
-      "justifyContent": "flex-start",
+      "gap": 12,
+      "justifyContent": "center",
     }
   }
 >
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -58,14 +61,16 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
           }
         }
       >
-        Mode 1
+        Mode 1 2 3 4 
       </Text>
     </TouchableOpacity>
   </View>
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -78,7 +83,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -110,7 +115,9 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -123,7 +130,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "#0376C91A",
           "borderColor": "#0376c9",
           "borderRadius": 20,
@@ -152,7 +159,15 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       </Text>
     </TouchableOpacity>
   </View>
-  <View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
     <TouchableOpacity
       accessibilityRole="button"
       accessible={true}
@@ -162,7 +177,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -202,14 +217,17 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
     {
       "alignItems": "center",
       "flexDirection": "row",
-      "justifyContent": "flex-start",
+      "gap": 12,
+      "justifyContent": "center",
     }
   }
 >
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -247,14 +265,16 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
           }
         }
       >
-        Mode 1
+        Mode 1 2 3 4 
       </Text>
     </TouchableOpacity>
   </View>
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -267,7 +287,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -299,7 +319,9 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
   <View
     style={
       {
-        "marginRight": 12,
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
       }
     }
   >
@@ -312,7 +334,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,
@@ -341,7 +363,15 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       </Text>
     </TouchableOpacity>
   </View>
-  <View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      }
+    }
+  >
     <TouchableOpacity
       accessibilityRole="button"
       accessible={true}
@@ -351,7 +381,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
       style={
         {
           "alignItems": "center",
-          "alignSelf": "flex-start",
+          "alignSelf": "stretch",
           "backgroundColor": "transparent",
           "borderColor": "#848c96",
           "borderRadius": 20,

--- a/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -1,0 +1,384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SegmentedControl Multi-select mode renders correctly with default selections 1`] = `
+<View
+  onValueChange={[MockFunction]}
+  selectedValues={
+    [
+      "mode1",
+      "mode3",
+    ]
+  }
+  style={
+    {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "flex-start",
+    }
+  }
+>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376C91A",
+          "borderColor": "#0376c9",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#0376c9",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 1
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#848c96",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 2
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376C91A",
+          "borderColor": "#0376c9",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#0376c9",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 3
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#848c96",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 4
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`SegmentedControl Single-select mode renders correctly with default selection 1`] = `
+<View
+  onValueChange={[MockFunction]}
+  selectedValue="mode1"
+  style={
+    {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "flex-start",
+    }
+  }
+>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "#0376C91A",
+          "borderColor": "#0376c9",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#0376c9",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 1
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#848c96",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 2
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View
+    style={
+      {
+        "marginRight": 12,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#848c96",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 3
+      </Text>
+    </TouchableOpacity>
+  </View>
+  <View>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "alignSelf": "flex-start",
+          "backgroundColor": "transparent",
+          "borderColor": "#848c96",
+          "borderRadius": 20,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 40,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#141618",
+            "fontFamily": "EuclidCircularB-Medium",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          }
+        }
+      >
+        Mode 4
+      </Text>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/app/component-library/components-temp/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`SegmentedControl Multi-select mode renders correctly with default selec
           }
         }
       >
-        Mode 1 2 3 4 
+        Mode 1
       </Text>
     </TouchableOpacity>
   </View>
@@ -260,7 +260,7 @@ exports[`SegmentedControl Single-select mode renders correctly with default sele
           }
         }
       >
-        Mode 1 2 3 4 
+        Mode 1
       </Text>
     </TouchableOpacity>
   </View>

--- a/app/component-library/components-temp/SegmentedControl/index.ts
+++ b/app/component-library/components-temp/SegmentedControl/index.ts
@@ -1,0 +1,5 @@
+export { default } from './SegmentedControl';
+export type {
+  SegmentedControlProps,
+  SegmentedControlOption,
+} from './SegmentedControl.types';

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -135,6 +135,7 @@ import { selectUserLoggedIn } from '../../../reducers/user/selectors';
 import { Confirm } from '../../Views/confirmations/Confirm';
 import NavigationService from '../../../core/NavigationService';
 import { BridgeTokenSelector } from '../../UI/Bridge/BridgeTokenSelector';
+import { SlippageModal } from '../../UI/Bridge/components/SlippageModal';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -458,6 +459,10 @@ const RootModalFlow = () => (
     <Stack.Screen
       name={Routes.SHEET.BRIDGE_TOKEN_SELECTOR}
       component={BridgeTokenSelector}
+    />
+    <Stack.Screen
+      name={Routes.SHEET.SLIPPAGE_MODAL}
+      component={SlippageModal}
     />
   </Stack.Navigator>
 );

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.styles.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.styles.ts
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { fontStyles } from '../../../../../styles/common';
+import { Theme } from '../../../../../util/theme/models';
+
+const createStyles = ({ colors }: Theme) =>
+  StyleSheet.create({
+    container: {
+      padding: 24,
+      paddingBottom: 21,
+      alignItems: 'center',
+    },
+    title: {
+      textAlign: 'center',
+    },
+    description: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: colors.text.default,
+      ...fontStyles.normal,
+    },
+    optionsContainer: {
+      alignItems: 'center',
+      marginBottom: 12,
+      paddingHorizontal: 24,
+      paddingVertical: 16,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { SafeAreaProvider, Metrics } from 'react-native-safe-area-context';
+
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../locales/i18n';
+import SlippageModal from './index';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: jest.fn(() => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+    })),
+  };
+});
+
+const props = {
+  route: {
+    params: {
+      selectedSlippage: '0.5',
+      onSelectSlippage: jest.fn(),
+    },
+  },
+};
+
+const initialMetrics: Metrics = {
+  frame: { x: 0, y: 0, width: 320, height: 640 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+const renderSlippageModal = () =>
+  renderWithProvider(
+    <SafeAreaProvider initialMetrics={initialMetrics}>
+      <SlippageModal {...props} />
+    </SafeAreaProvider>,
+  );
+
+describe('SlippageModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all UI elements with the proper slippage options and apply button', () => {
+    const { toJSON, getByText } = renderSlippageModal();
+
+    expect(getByText(strings('bridge.slippage'))).toBeDefined();
+    expect(getByText(strings('bridge.slippage_info'))).toBeDefined();
+    expect(getByText('0.5%')).toBeDefined();
+    expect(getByText('1%')).toBeDefined();
+    expect(getByText('3%')).toBeDefined();
+    expect(getByText('10%')).toBeDefined();
+    expect(getByText(strings('bridge.apply'))).toBeDefined();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('updates slippage value when segment is selected and sends value back when applied', () => {
+    const { getByText, getByTestId } = renderSlippageModal();
+
+    // Click on the 3% option
+    const option3Percent = getByTestId('slippage-option-3');
+    fireEvent.press(option3Percent);
+
+    // Click on the apply button
+    const applyButton = getByText(strings('bridge.apply'));
+    fireEvent.press(applyButton);
+
+    // Check if the callback was called with the correct value
+    expect(props.route.params.onSelectSlippage).toHaveBeenCalledWith('3');
+    // Check that navigation.goBack was called
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
@@ -2,13 +2,3 @@ export interface SlippageOption {
   label: string;
   value: string;
 }
-
-export interface SlippageModalRef {
-  show: () => void;
-  hide: () => void;
-}
-
-export interface SlippageModalProps {
-  onSlippageSelected: (slippage: string) => void;
-  selectedSlippage: string;
-}

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
@@ -1,0 +1,14 @@
+export interface SlippageOption {
+  label: string;
+  value: string;
+}
+
+export interface SlippageModalRef {
+  show: () => void;
+  hide: () => void;
+}
+
+export interface SlippageModalProps {
+  onSlippageSelected: (slippage: string) => void;
+  selectedSlippage: string;
+}

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -1,0 +1,523 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SlippageModal renders all UI elements with the proper slippage options and apply button 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#00000099",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#BBC0C566",
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderWidth": 1,
+              "maxHeight": 1334,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001A",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 1334,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#BBC0C566",
+                "borderRadius": 2,
+                "height": 4,
+                "width": 40,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            />
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "marginHorizontal": 16,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontSize": 18,
+                  "fontWeight": "700",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Slippage
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <TouchableOpacity
+                accessible={true}
+                activeOpacity={1}
+                disabled={false}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "borderRadius": 8,
+                    "height": 24,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 24,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#141618"
+                  height={16}
+                  name="Close"
+                  style={
+                    {
+                      "height": 16,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "padding": 24,
+              "paddingBottom": 21,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 20,
+              }
+            }
+          >
+            If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here.
+          </Text>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 12,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
+            }
+          >
+            <View
+              onValueChange={[Function]}
+              selectedValue="0.5"
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 12,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "#0376C91A",
+                      "borderColor": "#0376c9",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-0.5"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#0376c9",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    0.5%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-1"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    1%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-3"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    3%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-10"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    10%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+            testID="bottomsheetfooter"
+          >
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessible={true}
+              activeOpacity={1}
+              onPress={[Function]}
+              onPressIn={[Function]}
+              onPressOut={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "transparent",
+                  "borderColor": "#0376c9",
+                  "borderRadius": 24,
+                  "borderWidth": 1,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 16,
+                }
+              }
+              testID="bottomsheetfooter-button"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#0376c9",
+                    "fontFamily": "EuclidCircularB-Medium",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Apply
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/app/components/UI/Bridge/components/SlippageModal/index.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/index.tsx
@@ -1,0 +1,100 @@
+import React, { useRef, useState } from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import createStyles from './SlippageModal.styles';
+import { SlippageOption } from './SlippageModal.types';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import SegmentedControl from '../../../../../component-library/components-temp/SegmentedControl';
+
+const SLIPPAGE_OPTIONS: SlippageOption[] = [
+  { label: '0.5%', value: '0.5' },
+  { label: '1%', value: '1' },
+  { label: '3%', value: '3' },
+  { label: '10%', value: '10' },
+];
+
+interface SlippageModalProps {
+  route: {
+    params: {
+      selectedSlippage: string;
+      onSelectSlippage: (slippage: string) => void;
+    };
+  };
+}
+
+export const SlippageModal = ({ route }: SlippageModalProps) => {
+  const { selectedSlippage, onSelectSlippage } = route.params;
+  const [selectedValue, setSelectedValue] = useState(selectedSlippage);
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
+
+  const handleOptionSelected = (option: string) => {
+    setSelectedValue(option);
+  };
+
+  const handleApply = () => {
+    onSelectSlippage(selectedValue);
+    navigation.goBack();
+  };
+
+  const handleClose = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <BottomSheet ref={sheetRef}>
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingMD}>
+          {strings('bridge.slippage')}
+        </Text>
+      </BottomSheetHeader>
+      <View style={styles.container}>
+        <Text style={styles.description}>
+          {strings('bridge.slippage_info')}
+        </Text>
+
+        <View style={styles.optionsContainer}>
+          <SegmentedControl
+            options={SLIPPAGE_OPTIONS.map((option) => ({
+              label: option.label,
+              value: option.value,
+              testID: `slippage-option-${option.value}`,
+              buttonWidth: ButtonWidthTypes.Full,
+            }))}
+            selectedValue={selectedValue}
+            onValueChange={handleOptionSelected}
+            size={ButtonSize.Sm}
+          />
+        </View>
+        <BottomSheetFooter
+          buttonPropsArray={[
+            {
+              variant: ButtonVariants.Secondary,
+              label: strings('bridge.apply'),
+              onPress: handleApply,
+              size: ButtonSize.Lg,
+            },
+          ]}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default SlippageModal;

--- a/app/components/UI/Bridge/components/SlippageModal/index.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/index.tsx
@@ -80,6 +80,7 @@ export const SlippageModal = ({ route }: SlippageModalProps) => {
             selectedValue={selectedValue}
             onValueChange={handleOptionSelected}
             size={ButtonSize.Sm}
+            isButtonWidthFlexible={false}
           />
         </View>
         <BottomSheetFooter

--- a/app/components/UI/Bridge/index.test.tsx
+++ b/app/components/UI/Bridge/index.test.tsx
@@ -1,4 +1,7 @@
-import { renderScreen, DeepPartial } from '../../../util/test/renderWithProvider';
+import {
+  renderScreen,
+  DeepPartial,
+} from '../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import { RootState } from '../../../reducers';
 import BridgeView from '../Bridge';

--- a/app/components/UI/Bridge/index.tsx
+++ b/app/components/UI/Bridge/index.tsx
@@ -109,7 +109,7 @@ const BridgeView = () => {
   const destChainId = useSelector(selectDestChainId);
 
   // Add state for slippage
-  const [slippage, setSlippage] = useState('auto');
+  const [slippage, setSlippage] = useState('0.5');
 
   const sourceBalance = useLatestBalance(
     {

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -116,6 +116,7 @@ const Routes = {
     TOKEN_FILTER: 'TokenFilter',
     CHANGE_IN_SIMULATION_MODAL: 'ChangeInSimulationModal',
     BRIDGE_TOKEN_SELECTOR: 'BridgeTokenSelector',
+    SLIPPAGE_MODAL: 'SlippageModal',
   },
   BROWSER: {
     HOME: 'BrowserTabHome',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3726,6 +3726,9 @@
   "bridge": {
     "continue": "Continue",
     "terms_and_conditions": "Terms & Conditions",
-    "select_token": "Select token"
-  }
+    "select_token": "Select token",
+    "slippage": "Slippage",
+    "apply": "Apply",
+    "slippage_info": "If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here."
+    }
 }

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -51,6 +51,7 @@ function loadStories() {
   require('../app/component-library/components/Navigation/TabBarItem/TabBarItem.stories');
   require('../app/component-library/components/Overlay/Overlay.stories');
   require('../app/component-library/components/Pickers/PickerAccount/PickerAccount.stories');
+  require('../app/component-library/components/Pickers/PickerBase/PickerBase.stories');
   require('../app/component-library/components/Pickers/PickerNetwork/PickerNetwork.stories');
   require('../app/component-library/components/RadioButton/RadioButton.stories');
   require('../app/component-library/components/Select/SelectButton/SelectButton.stories');
@@ -58,8 +59,10 @@ function loadStories() {
   require('../app/component-library/components/Select/SelectValue/SelectValue.stories');
   require('../app/component-library/components/Sheet/SheetBottom/SheetBottom.stories');
   require('../app/component-library/components/Sheet/SheetHeader/SheetHeader.stories');
+  require('../app/component-library/components/Skeleton/Skeleton.stories');
   require('../app/component-library/components/Tags/Tag/Tag.stories');
   require('../app/component-library/components/Tags/TagUrl/TagUrl.stories');
+  require('../app/component-library/components/Texts/SensitiveText/SensitiveText.stories');
   require('../app/component-library/components/Texts/Text/Text.stories');
   require('../app/component-library/components/Texts/TextWithPrefixIcon/TextWithPrefixIcon.stories');
   require('../app/component-library/components/Toast/Toast.stories');
@@ -72,11 +75,18 @@ function loadStories() {
   require('../app/components/UI/Name/Name.stories');
   require('../app/components/UI/SimulationDetails/SimulationDetails.stories');
   require('../app/components/UI/StyledButton/StyledButton.stories');
+  require('../app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories');
   require('../app/components/UI/WarningAlert/WarningAlert.stories');
   require('../app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories');
   require('../app/components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.stories');
+  require('../app/components/Views/confirmations/components/UI/CopyButton/CopyButton.stories');
+  require('../app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.stories');
+  require('../app/components/Views/confirmations/components/UI/InfoRow/InfoRow.stories');
+  require('../app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories');
+  require('../app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories');
   require('../app/components/Views/QRAccountDisplay/QRAccountDisplay.stories');
   require('../app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.stories');
+  require('../app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories');
   require('../app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories');
   require('../app/component-library/components-temp/Contracts/ContractBox/ContractBox.stories');
   require('../app/component-library/components-temp/CustomSpendCap/CustomSpendCap.stories');
@@ -84,6 +94,7 @@ function loadStories() {
   require('../app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories');
   require('../app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.stories');
   require('../app/component-library/components-temp/Price/PercentageChange/PercentageChange.stories');
+  require('../app/component-library/components-temp/SegmentedControl/SegmentedControl.stories');
   require('../app/component-library/components-temp/TagColored/TagColored.stories');
 }
 
@@ -135,6 +146,7 @@ const stories = [
   '../app/component-library/components/Navigation/TabBarItem/TabBarItem.stories',
   '../app/component-library/components/Overlay/Overlay.stories',
   '../app/component-library/components/Pickers/PickerAccount/PickerAccount.stories',
+  '../app/component-library/components/Pickers/PickerBase/PickerBase.stories',
   '../app/component-library/components/Pickers/PickerNetwork/PickerNetwork.stories',
   '../app/component-library/components/RadioButton/RadioButton.stories',
   '../app/component-library/components/Select/SelectButton/SelectButton.stories',
@@ -142,8 +154,10 @@ const stories = [
   '../app/component-library/components/Select/SelectValue/SelectValue.stories',
   '../app/component-library/components/Sheet/SheetBottom/SheetBottom.stories',
   '../app/component-library/components/Sheet/SheetHeader/SheetHeader.stories',
+  '../app/component-library/components/Skeleton/Skeleton.stories',
   '../app/component-library/components/Tags/Tag/Tag.stories',
   '../app/component-library/components/Tags/TagUrl/TagUrl.stories',
+  '../app/component-library/components/Texts/SensitiveText/SensitiveText.stories',
   '../app/component-library/components/Texts/Text/Text.stories',
   '../app/component-library/components/Texts/TextWithPrefixIcon/TextWithPrefixIcon.stories',
   '../app/component-library/components/Toast/Toast.stories',
@@ -156,11 +170,18 @@ const stories = [
   '../app/components/UI/Name/Name.stories',
   '../app/components/UI/SimulationDetails/SimulationDetails.stories',
   '../app/components/UI/StyledButton/StyledButton.stories',
+  '../app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories',
   '../app/components/UI/WarningAlert/WarningAlert.stories',
   '../app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories',
   '../app/components/Views/confirmations/components/BlockaidBanner/BlockaidBanner.stories',
+  '../app/components/Views/confirmations/components/UI/CopyButton/CopyButton.stories',
+  '../app/components/Views/confirmations/components/UI/ExpandableSection/ExpandableSection.stories',
+  '../app/components/Views/confirmations/components/UI/InfoRow/InfoRow.stories',
+  '../app/components/Views/confirmations/components/UI/TextWithTooltip/TextWithTooltip.stories',
+  '../app/components/Views/confirmations/components/UI/Tooltip/Tooltip.stories',
   '../app/components/Views/QRAccountDisplay/QRAccountDisplay.stories',
   '../app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.stories',
+  '../app/component-library/components-temp/Buttons/ButtonToggle/ButtonToggle.stories',
   '../app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories',
   '../app/component-library/components-temp/Contracts/ContractBox/ContractBox.stories',
   '../app/component-library/components-temp/CustomSpendCap/CustomSpendCap.stories',
@@ -168,6 +189,7 @@ const stories = [
   '../app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories',
   '../app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.stories',
   '../app/component-library/components-temp/Price/PercentageChange/PercentageChange.stories',
+  '../app/component-library/components-temp/SegmentedControl/SegmentedControl.stories',
   '../app/component-library/components-temp/TagColored/TagColored.stories',
 ];
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces enhancements to our component library and adds slippage tolerance functionality to the Bridge feature:

### Component Library Enhancements

- ButtonToggle: A new toggle button component that visually indicates active/inactive states with appropriate styling changes
- SegmentedControl: A versatile control component supporting both single and multi-select modes, with options for scrollable content and icon integration

### Bridge Feature Enhancement

- SlippageModal: A new modal component allowing users to select slippage tolerance percentage when performing bridge transactions
- Added slippage state management and navigation integration to the Bridge component

Figma Designs:

Slippage Modal: https://www.figma.com/design/rAno3BswRHFtwjc3wXy7nL/Swaps-on-Mobile?node-id=1410-14806&t=nx6iaXOx6peTO7w8-4

Button Toggle: https://www.figma.com/design/HKpPKij9V3TpsyMV1TpV7C/DS-Components?node-id=25363-3401&t=h4Y3QeK29FY8VgjR-4

Segmented Control : https://www.figma.com/design/HKpPKij9V3TpsyMV1TpV7C/DS-Components?node-id=21177-52932&t=h4Y3QeK29FY8VgjR-4


## **Related issues**

Fixes: [MMS-1988](https://consensyssoftware.atlassian.net/browse/MMS-1988)

## **Manual testing steps**

### 1. ButtonToggle Component

- Navigate to Storybook and locate the ButtonToggle stories
- Verify the button appears correctly in both active and inactive states

### 2. SegmentedControl Component

- Navigate to Storybook and locate the SegmentedControl stories
- Test single-select mode:
        - Verify only one option can be selected at a time
        - Confirm the selected option is visually distinguished

- Test multi-select mode:
        - Verify multiple options can be selected simultaneously
        - Confirm selected options are visually distinguished
        - Test adding and removing selections
        - Test scrollable configuration with many options
        - Verify options with icons render correctly

### 3. SlippageModal and Bridge Integration

- Navigate to the Bridge screen in the app
- Locate and tap on the slippage option
- Verify the SlippageModal opens correctly
- Test selecting different slippage percentage options
- Verify the selected option is visually distinguished
- Tap "Apply" and confirm the modal closes
- Verify the selected slippage value is displayed correctly on the Bridge screen
- Test canceling without applying changes (modal should close without updating slippage)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

## Button Toggle and Segmented Control Storybook

https://github.com/user-attachments/assets/55f1b312-c061-422b-a774-8d9cfd9c9538

## Slippage Modal 

https://github.com/user-attachments/assets/ba08c2fa-97f6-43c5-96ff-e8e378c45db2


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMS-1988]: https://consensyssoftware.atlassian.net/browse/MMS-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ