### PR TITLE
fix: xcode version 15.0 is removed in bitrise, it needs to be 15.1 or 15.2

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1861,7 +1861,7 @@ app:
       COREPACK_VERSION: 0.28.0
 meta:
   bitrise.io:
-    stack: osx-xcode-15.1.x
+    stack: osx-xcode-15.2.x
     machine_type_id: g2.mac.large
 trigger_map:
   - push_branch: release/*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -584,7 +584,7 @@ workflows:
       - TEST_TYPE: 'performance'
     meta:
       bitrise.io:
-        stack: osx-xcode-15.0.x
+        stack: osx-xcode-15.1.x
         machine_type_id: g2.mac.large
     after_run:
       - wdio_ios_e2e_test
@@ -1861,7 +1861,7 @@ app:
       COREPACK_VERSION: 0.28.0
 meta:
   bitrise.io:
-    stack: osx-xcode-15.0.x
+    stack: osx-xcode-15.1.x
     machine_type_id: g2.mac.large
 trigger_map:
   - push_branch: release/*

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -584,7 +584,7 @@ workflows:
       - TEST_TYPE: 'performance'
     meta:
       bitrise.io:
-        stack: osx-xcode-15.1.x
+        stack: osx-xcode-15.2.x
         machine_type_id: g2.mac.large
     after_run:
       - wdio_ios_e2e_test


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Something changed at bitrise and it doens't seem to be published yet to the changelog: https://stacks.bitrise.io/changelogs/osx-xcode-15.0.x/

The errors in bitrise are not giving much information "RCTFatalException: Unhandled JS Exception: RangeError: Maximum call stack size exceeded."

Here the intention is to see if the version 15.1 can make our ios e2e pipeline work again

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
