### PR TITLE
fix: cp-7.43.0 add remote feature flag for notifications

### DIFF
--- a/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
+++ b/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
@@ -11,7 +11,6 @@ import {
   deleteRegToken,
   isPushNotificationsEnabled,
 } from './push-utils';
-import { isNotificationsFeatureEnabled } from '../../../../util/notifications';
 
 export const createNotificationServicesPushController = (props: {
   messenger: NotificationServicesPushControllerMessenger;
@@ -23,7 +22,7 @@ export const createNotificationServicesPushController = (props: {
       state: { ...defaultState, ...props.initialState },
       config: {
         platform: 'mobile',
-        isPushFeatureEnabled: isNotificationsFeatureEnabled(),
+        isPushFeatureEnabled: true,
         pushService: {
           createRegToken,
           deleteRegToken,

--- a/app/util/notifications/constants/config.ts
+++ b/app/util/notifications/constants/config.ts
@@ -1,5 +1,18 @@
+import Engine from '../../../core/Engine';
+
+/**
+ * This feature flag compromises of a build-time flag as well as a remote flag.
+ * NOTE: this does not use the remote flag redux selectors, so UI is prone to being stale.
+ * - This is okay in our case as we make this function call on all notification actions.
+ *
+ * @returns boolean if notifications feature is enabled.
+ */
 export const isNotificationsFeatureEnabled = () =>
-  process.env.MM_NOTIFICATIONS_UI_ENABLED === 'true';
+  process.env.MM_NOTIFICATIONS_UI_ENABLED === 'true' &&
+  Boolean(
+    Engine?.context?.RemoteFeatureFlagController?.state?.remoteFeatureFlags
+      ?.assetsNotificationsEnabled,
+  );
 
 export enum ModalFieldType {
   ASSET = 'ModalField-Asset',


### PR DESCRIPTION
## **Description**

Adds remote feature flag for notifications (so we can turn on/off dynamically without the build flag)

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
