### PR TITLE
fix: cp-7.43.0 updated root to use themeprovider

### DIFF
--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -7,7 +7,7 @@ import SecureKeychain from '../../../core/SecureKeychain';
 import EntryScriptWeb3 from '../../../core/EntryScriptWeb3';
 import Logger from '../../../util/Logger';
 import ErrorBoundary from '../ErrorBoundary';
-import { ThemeContext, mockTheme } from '../../../util/theme';
+import ThemeProvider from '../../../component-library/providers/ThemeProvider/ThemeProvider';
 import { ToastContextWrapper } from '../../../component-library/components/Toast';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { RootProps } from './types';
@@ -68,7 +68,7 @@ const Root = ({ foxCode }: RootProps) => {
             <SnapsExecutionWebView />
             ///: END:ONLY_INCLUDE_IF
           }
-          <ThemeContext.Provider value={mockTheme}>
+          <ThemeProvider>
             <NavigationProvider>
               <ControllersGate>
                 <ToastContextWrapper>
@@ -78,7 +78,7 @@ const Root = ({ foxCode }: RootProps) => {
                 </ToastContextWrapper>
               </ControllersGate>
             </NavigationProvider>
-          </ThemeContext.Provider>
+          </ThemeProvider>
         </PersistGate>
       </Provider>
     </SafeAreaProvider>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the Root file to use `ThemeProvider`
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14039

## **Manual testing steps**

1. Go to home
2. Toggle theme
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/9a38ceb0-89d7-402c-b8f6-ce9c589ff16d


<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/d6bba8ea-9499-48e3-81d3-556a9aedea89


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
