### PR TITLE
fix: account name / label overflow on re-designed confirmation pages

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.styles.ts
+++ b/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.styles.ts
@@ -3,8 +3,14 @@ import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../../../util/theme/models';
 import { fontStyles } from '../../../../../../../styles/common';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+const styleSheet = (params: {
+  theme: Theme;
+  vars: { accountNameWide: boolean };
+}) => {
+  const {
+    theme,
+    vars: { accountNameWide },
+  } = params;
 
   return StyleSheet.create({
     container: {
@@ -19,9 +25,11 @@ const styleSheet = (params: { theme: Theme }) => {
       display: 'flex',
       flexDirection: 'row',
       alignItems: 'center',
+      width: '100%',
     },
     accountName: {
       color: theme.colors.text.default,
+      width: accountNameWide ? '86%' : '40%',
       ...fontStyles.bold,
       fontSize: 14,
     },

--- a/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.tsx
+++ b/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.tsx
@@ -33,7 +33,9 @@ const AccountNetworkInfoCollapsed = () => {
   const fromAddress = signatureRequest?.messageParams?.from as string;
   const { accountName } = useAccountInfo(fromAddress);
   const accountLabel = getLabelTextByAddress(fromAddress);
-  const { styles } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {
+    accountNameWide: Boolean(!accountLabel),
+  });
 
   return (
     <View style={styles.container}>
@@ -59,7 +61,13 @@ const AccountNetworkInfoCollapsed = () => {
       </BadgeWrapper>
       <View>
         <View style={styles.accountInfo}>
-          <Text style={styles.accountName}>{accountName}</Text>
+          <Text
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={styles.accountName}
+          >
+            {accountName} {accountName} {accountName}
+          </Text>
           {accountLabel && (
             <TagBase
               style={styles.accountLabel}

--- a/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.tsx
+++ b/app/components/Views/confirmations/components/Confirm/AccountNetworkInfo/AccountNetworkInfoCollapsed/AccountNetworkInfoCollapsed.tsx
@@ -66,7 +66,7 @@ const AccountNetworkInfoCollapsed = () => {
             numberOfLines={1}
             style={styles.accountName}
           >
-            {accountName} {accountName} {accountName}
+            {accountName}
           </Text>
           {accountLabel && (
             <TagBase


### PR DESCRIPTION
## **Description**

Fix account name / label overflow on re-designed confirmation pages

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13975

## **Manual testing steps**

1. Go to test dapp
2. Select account with large name
3. Check re-designed signature page

## **Screenshots/Recordings**
<img width="395" alt="Screenshot 2025-03-17 at 4 04 39 PM" src="https://github.com/user-attachments/assets/93cf21a5-a402-451d-a4ad-97ef89cb524e" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
