### PR TITLE
feat: add new identity hooks

### DIFF
--- a/app/actions/identity/index.test.ts
+++ b/app/actions/identity/index.test.ts
@@ -36,12 +36,12 @@ describe('Identity actions', () => {
     expect(result).toBeUndefined();
   });
 
-  it('signs out successfully', async () => {
+  it('signs out successfully', () => {
     (
       Engine.context.AuthenticationController.performSignOut as jest.Mock
     ).mockResolvedValue(undefined);
 
-    const result = await performSignOut();
+    const result = performSignOut();
 
     expect(
       Engine.context.AuthenticationController.performSignOut,

--- a/app/actions/identity/index.ts
+++ b/app/actions/identity/index.ts
@@ -22,7 +22,7 @@ export const performSignIn = async () => {
 
 export const performSignOut = async () => {
   try {
-    await Engine.context.AuthenticationController.performSignOut();
+    Engine.context.AuthenticationController.performSignOut();
   } catch (error) {
     return getErrorMessage(error);
   }

--- a/app/actions/identity/index.ts
+++ b/app/actions/identity/index.ts
@@ -20,7 +20,7 @@ export const performSignIn = async () => {
   }
 };
 
-export const performSignOut = async () => {
+export const performSignOut = () => {
   try {
     Engine.context.AuthenticationController.performSignOut();
   } catch (error) {

--- a/app/selectors/keyringController/index.test.ts
+++ b/app/selectors/keyringController/index.test.ts
@@ -1,4 +1,8 @@
-import { selectKeyrings, selectFlattenedKeyringAccounts } from './index';
+import {
+  selectKeyrings,
+  selectFlattenedKeyringAccounts,
+  selectIsUnlocked,
+} from './index';
 import { RootState } from '../../reducers';
 import {
   MOCK_SIMPLE_ACCOUNTS,
@@ -38,6 +42,19 @@ describe('KeyringController Selectors', () => {
           },
         } as RootState),
       ).toEqual(expectedOrderedKeyringAccounts);
+    });
+  });
+  describe('selectIsUnlocked', () => {
+    it('returns isUnlocked', () => {
+      expect(
+        selectIsUnlocked({
+          engine: {
+            backgroundState: {
+              KeyringController: MOCK_KEYRING_CONTROLLER,
+            },
+          },
+        } as RootState),
+      ).toEqual(MOCK_KEYRING_CONTROLLER.isUnlocked);
     });
   });
 });

--- a/app/selectors/keyringController/index.ts
+++ b/app/selectors/keyringController/index.ts
@@ -1,3 +1,4 @@
+import { KeyringControllerState } from '@metamask/keyring-controller';
 import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
 
@@ -14,7 +15,8 @@ const selectKeyringControllerState = (state: RootState) =>
  */
 export const selectKeyrings = createDeepEqualSelector(
   selectKeyringControllerState,
-  (keyringControllerState) => keyringControllerState.keyrings,
+  (keyringControllerState: KeyringControllerState) =>
+    keyringControllerState.keyrings,
 );
 
 /**
@@ -22,10 +24,19 @@ export const selectKeyrings = createDeepEqualSelector(
  */
 export const selectFlattenedKeyringAccounts = createDeepEqualSelector(
   selectKeyrings,
-  (keyrings) => {
+  (keyrings: KeyringControllerState['keyrings']) => {
     const flattenedKeyringAccounts = keyrings.flatMap(
       (keyring) => keyring.accounts,
     );
     return flattenedKeyringAccounts;
   },
+);
+
+/**
+ * A memoized selector that returns if the KeyringController is unlocked.
+ */
+export const selectIsUnlocked = createDeepEqualSelector(
+  selectKeyringControllerState,
+  (keyringControllerState: KeyringControllerState) =>
+    keyringControllerState.isUnlocked,
 );

--- a/app/selectors/wizard/index.test.ts
+++ b/app/selectors/wizard/index.test.ts
@@ -1,0 +1,16 @@
+import { selectCurrentOnboardingStep } from '.';
+import { RootState } from '../../reducers';
+
+describe('Wizard Selectors', () => {
+  const mockState = {
+    wizard: {
+      step: 3,
+    },
+  } as unknown as RootState;
+
+  it('selectCurrentOnboardingStep returns correct value', () => {
+    expect(selectCurrentOnboardingStep(mockState)).toEqual(
+      mockState.wizard.step,
+    );
+  });
+});

--- a/app/selectors/wizard/index.ts
+++ b/app/selectors/wizard/index.ts
@@ -1,0 +1,9 @@
+import { RootState } from '../../reducers';
+import { createSelector } from 'reselect';
+
+const selectWizard = (state: RootState) => state.wizard;
+
+export const selectCurrentOnboardingStep = createSelector(
+  selectWizard,
+  (wizardState: Record<string, unknown>) => wizardState.step as number,
+);

--- a/app/util/identity/hooks/useAuthentication/index.ts
+++ b/app/util/identity/hooks/useAuthentication/index.ts
@@ -1,0 +1,4 @@
+export { useSignIn } from './useSignIn';
+export { useSignOut } from './useSignOut';
+export { useAutoSignIn } from './useAutoSignIn';
+export { useAutoSignOut } from './useAutoSignOut';

--- a/app/util/identity/hooks/useAuthentication/useAutoSignIn.test.ts
+++ b/app/util/identity/hooks/useAuthentication/useAutoSignIn.test.ts
@@ -1,0 +1,169 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+// eslint-disable-next-line import/no-namespace
+import * as actions from '../../../../actions/identity';
+import { useAutoSignIn } from './useAutoSignIn';
+
+interface ArrangeMocksMetamaskStateOverrides {
+  isUnlocked: boolean;
+  useExternalServices: boolean;
+  isSignedIn: boolean;
+  completedOnboarding: boolean;
+  isProfileSyncingEnabled: boolean;
+  participateInMetaMetrics: boolean;
+  isNotificationServicesEnabled: boolean;
+}
+
+const mockMetricsIsEnabled = jest.fn();
+
+jest.mock('../../../../components/hooks/useMetrics', () => ({
+  useMetrics: () => ({
+    isEnabled: mockMetricsIsEnabled,
+  }),
+}));
+
+const arrangeMockState = (
+  stateOverrides: ArrangeMocksMetamaskStateOverrides,
+) => ({
+  engine: {
+    backgroundState: {
+      KeyringController: {
+        isUnlocked: stateOverrides.isUnlocked,
+      },
+      AuthenticationController: {
+        isSignedIn: stateOverrides.isSignedIn,
+      },
+      UserStorageController: {
+        isProfileSyncingEnabled: stateOverrides.isProfileSyncingEnabled,
+      },
+      NotificationServicesController: {
+        isNotificationServicesEnabled:
+          stateOverrides.isNotificationServicesEnabled,
+      },
+    },
+  },
+  wizard: {
+    step: stateOverrides.completedOnboarding ? 0 : 1,
+  },
+  settings: {
+    basicFunctionalityEnabled: stateOverrides.useExternalServices,
+  },
+});
+
+const arrangeMocks = (stateOverrides: ArrangeMocksMetamaskStateOverrides) => {
+  jest.clearAllMocks();
+  const state = arrangeMockState(stateOverrides);
+
+  mockMetricsIsEnabled.mockReturnValue(stateOverrides.participateInMetaMetrics);
+
+  const mockPerformSignInAction = jest.spyOn(actions, 'performSignIn');
+  return {
+    state,
+    mockPerformSignInAction,
+  };
+};
+
+const prerequisitesStateKeys = [
+  'isUnlocked',
+  'useExternalServices',
+  'isSignedIn',
+  'completedOnboarding',
+];
+
+const authDependentFeaturesStateKeys = [
+  'isProfileSyncingEnabled',
+  'participateInMetaMetrics',
+  'isNotificationServicesEnabled',
+];
+
+const shouldAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
+const shouldNotAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
+
+// We generate all possible combinations of the prerequisites and auth-dependent features here
+const generateCombinations = (keys: string[]) => {
+  const result: ArrangeMocksMetamaskStateOverrides[] = [];
+  const total = 2 ** keys.length;
+  for (let i = 0; i < total; i++) {
+    const state = {} as ArrangeMocksMetamaskStateOverrides;
+    keys.forEach((key, index) => {
+      state[key as keyof ArrangeMocksMetamaskStateOverrides] = Boolean(
+        Math.floor(i / 2 ** index) % 2,
+      );
+    });
+    result.push(state);
+  }
+  return result;
+};
+
+const prerequisiteCombinations = generateCombinations(prerequisitesStateKeys);
+const authDependentCombinations = generateCombinations(
+  authDependentFeaturesStateKeys,
+);
+
+prerequisiteCombinations.forEach((prerequisiteState) => {
+  authDependentCombinations.forEach((authDependentState) => {
+    const combinedState = {
+      ...prerequisiteState,
+      ...authDependentState,
+    };
+    if (
+      combinedState.isUnlocked &&
+      combinedState.useExternalServices &&
+      combinedState.completedOnboarding &&
+      !combinedState.isSignedIn &&
+      authDependentFeaturesStateKeys.some(
+        (key) => combinedState[key as keyof ArrangeMocksMetamaskStateOverrides],
+      )
+    ) {
+      shouldAutoSignInTestCases.push(combinedState);
+    } else {
+      shouldNotAutoSignInTestCases.push(combinedState);
+    }
+  });
+});
+
+describe('useAutoSignIn', () => {
+  it('should initialize correctly', () => {
+    const { state } = arrangeMocks({
+      isUnlocked: false,
+      isProfileSyncingEnabled: false,
+      isSignedIn: false,
+      completedOnboarding: false,
+      participateInMetaMetrics: false,
+      useExternalServices: false,
+      isNotificationServicesEnabled: false,
+    });
+    const hook = renderHookWithProvider(() => useAutoSignIn(), {
+      state,
+    });
+
+    expect(hook.result.current.autoSignIn).toBeDefined();
+    expect(hook.result.current.shouldAutoSignIn).toBeDefined();
+  });
+
+  shouldNotAutoSignInTestCases.forEach((stateOverrides) => {
+    it(`should not call performSignIn if conditions are not met`, async () => {
+      const { state, mockPerformSignInAction } = arrangeMocks(stateOverrides);
+      const hook = renderHookWithProvider(() => useAutoSignIn(), { state });
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+    });
+  });
+
+  shouldAutoSignInTestCases.forEach((stateOverrides) => {
+    it(`should call performSignIn if conditions are met`, async () => {
+      const { state, mockPerformSignInAction } = arrangeMocks(stateOverrides);
+      const hook = renderHookWithProvider(() => useAutoSignIn(), { state });
+
+      await act(async () => {
+        await hook.result.current.autoSignIn();
+      });
+
+      expect(mockPerformSignInAction).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/util/identity/hooks/useAuthentication/useAutoSignIn.ts
+++ b/app/util/identity/hooks/useAuthentication/useAutoSignIn.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useSignIn } from './useSignIn';
+import { selectIsUnlocked } from '../../../../selectors/keyringController';
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import {
+  selectIsProfileSyncingEnabled,
+  selectIsSignedIn,
+} from '../../../../selectors/identity';
+import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/notifications';
+import { selectCurrentOnboardingStep } from '../../../../selectors/wizard';
+import { useMetrics } from '../../../../components/hooks/useMetrics';
+
+/**
+ * Custom hook to manage automatically signing in a user based on the app state.
+ *
+ * @returns An object containing:
+ * - `autoSignIn`: A function to automatically sign in the user if necessary.
+ * - `shouldAutoSignIn`: A boolean indicating whether the user should be automatically signed in.
+ */
+export function useAutoSignIn(): {
+  autoSignIn: () => Promise<void>;
+  shouldAutoSignIn: boolean;
+} {
+  const { signIn } = useSignIn();
+  const { isEnabled } = useMetrics();
+
+  // Base prerequisites
+  const isUnlocked = Boolean(useSelector(selectIsUnlocked));
+  const isBasicFunctionalityEnabled = Boolean(
+    useSelector(selectBasicFunctionalityEnabled),
+  );
+
+  const completedOnboarding = useSelector(selectCurrentOnboardingStep) === 0;
+  const isSignedIn = useSelector(selectIsSignedIn);
+
+  const areBasePrerequisitesMet = useMemo(
+    () =>
+      !isSignedIn &&
+      isUnlocked &&
+      isBasicFunctionalityEnabled &&
+      completedOnboarding,
+    [isSignedIn, isUnlocked, isBasicFunctionalityEnabled, completedOnboarding],
+  );
+
+  // Auth dependent features
+  // Since MetaMetrics is not a controller that extends BaseController,
+  // and it is not stored in the redux store, we programmatically trigger `autoSignIn`
+  // in the following file: app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
+  const isProfileSyncingEnabled = useSelector(selectIsProfileSyncingEnabled);
+  const isParticipateInMetaMetrics = isEnabled();
+  const isNotificationServicesEnabled = useSelector(
+    selectIsMetamaskNotificationsEnabled,
+  );
+
+  const isAtLeastOneAuthDependentFeatureEnabled = useMemo(
+    () =>
+      isProfileSyncingEnabled ||
+      isParticipateInMetaMetrics ||
+      isNotificationServicesEnabled,
+    [
+      isProfileSyncingEnabled,
+      isParticipateInMetaMetrics,
+      isNotificationServicesEnabled,
+    ],
+  );
+
+  const shouldAutoSignIn = useMemo(
+    () => areBasePrerequisitesMet && isAtLeastOneAuthDependentFeatureEnabled,
+    [areBasePrerequisitesMet, isAtLeastOneAuthDependentFeatureEnabled],
+  );
+
+  const autoSignIn = useCallback(async () => {
+    if (shouldAutoSignIn) {
+      await signIn();
+    }
+  }, [shouldAutoSignIn, signIn]);
+
+  return {
+    autoSignIn,
+    shouldAutoSignIn,
+  };
+}

--- a/app/util/identity/hooks/useAuthentication/useAutoSignOut.test.ts
+++ b/app/util/identity/hooks/useAuthentication/useAutoSignOut.test.ts
@@ -76,7 +76,7 @@ prerequisiteCombinations.forEach((combinedState) => {
   }
 });
 
-describe('useAutoSignIn', () => {
+describe('useAutoSignOut', () => {
   it('should initialize correctly', () => {
     const { state } = arrangeMocks({
       isUnlocked: false,

--- a/app/util/identity/hooks/useAuthentication/useAutoSignOut.test.ts
+++ b/app/util/identity/hooks/useAuthentication/useAutoSignOut.test.ts
@@ -1,0 +1,118 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+// eslint-disable-next-line import/no-namespace
+import * as actions from '../../../../actions/identity';
+import { useAutoSignOut } from './useAutoSignOut';
+
+interface ArrangeMocksMetamaskStateOverrides {
+  isUnlocked: boolean;
+  useExternalServices: boolean;
+  isSignedIn: boolean;
+}
+
+const arrangeMockState = (
+  stateOverrides: ArrangeMocksMetamaskStateOverrides,
+) => ({
+  engine: {
+    backgroundState: {
+      KeyringController: {
+        isUnlocked: stateOverrides.isUnlocked,
+      },
+      AuthenticationController: {
+        isSignedIn: stateOverrides.isSignedIn,
+      },
+    },
+  },
+  settings: {
+    basicFunctionalityEnabled: stateOverrides.useExternalServices,
+  },
+});
+
+const arrangeMocks = (stateOverrides: ArrangeMocksMetamaskStateOverrides) => {
+  jest.clearAllMocks();
+  const state = arrangeMockState(stateOverrides);
+  const mockPerformSignInAction = jest.spyOn(actions, 'performSignOut');
+  return {
+    state,
+    mockPerformSignInAction,
+  };
+};
+
+const prerequisitesStateKeys = [
+  'isUnlocked',
+  'useExternalServices',
+  'isSignedIn',
+];
+
+const shouldAutoSignOutTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
+const shouldNotAutoSignOutTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
+
+const generateCombinations = (keys: string[]) => {
+  const result: ArrangeMocksMetamaskStateOverrides[] = [];
+  const total = 2 ** keys.length;
+  for (let i = 0; i < total; i++) {
+    const state = {} as ArrangeMocksMetamaskStateOverrides;
+    keys.forEach((key, index) => {
+      state[key as keyof ArrangeMocksMetamaskStateOverrides] = Boolean(
+        Math.floor(i / 2 ** index) % 2,
+      );
+    });
+    result.push(state);
+  }
+  return result;
+};
+
+const prerequisiteCombinations = generateCombinations(prerequisitesStateKeys);
+
+prerequisiteCombinations.forEach((combinedState) => {
+  if (
+    combinedState.isUnlocked &&
+    !combinedState.useExternalServices &&
+    combinedState.isSignedIn
+  ) {
+    shouldAutoSignOutTestCases.push(combinedState);
+  } else {
+    shouldNotAutoSignOutTestCases.push(combinedState);
+  }
+});
+
+describe('useAutoSignIn', () => {
+  it('should initialize correctly', () => {
+    const { state } = arrangeMocks({
+      isUnlocked: false,
+      isSignedIn: false,
+      useExternalServices: false,
+    });
+
+    const hook = renderHookWithProvider(() => useAutoSignOut(), { state });
+
+    expect(hook.result.current.autoSignOut).toBeDefined();
+    expect(hook.result.current.shouldAutoSignOut).toBeDefined();
+  });
+
+  shouldNotAutoSignOutTestCases.forEach((stateOverrides) => {
+    it(`should not call performSignOut if conditions are not met`, async () => {
+      const { state, mockPerformSignInAction } = arrangeMocks(stateOverrides);
+      const hook = renderHookWithProvider(() => useAutoSignOut(), { state });
+
+      await act(async () => {
+        hook.result.current.autoSignOut();
+      });
+
+      expect(mockPerformSignInAction).not.toHaveBeenCalled();
+    });
+  });
+
+  shouldAutoSignOutTestCases.forEach((stateOverrides) => {
+    it(`should call performSignOut if conditions are met`, async () => {
+      const { state, mockPerformSignInAction } = arrangeMocks(stateOverrides);
+      const hook = renderHookWithProvider(() => useAutoSignOut(), { state });
+
+      await act(async () => {
+        await hook.result.current.autoSignOut();
+      });
+
+      expect(mockPerformSignInAction).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/util/identity/hooks/useAuthentication/useAutoSignOut.ts
+++ b/app/util/identity/hooks/useAuthentication/useAutoSignOut.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useSignOut } from './useSignOut';
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectIsSignedIn } from '../../../../selectors/identity';
+import { selectIsUnlocked } from '../../../../selectors/keyringController';
+
+/**
+ * Custom hook to manage automatically signing out a user based on the app state.
+ *
+ * @returns An object containing:
+ * - `autoSignOut`: A function to automatically sign out the user if necessary.
+ * - `shouldAutoSignOut`: A boolean indicating whether the user should be automatically signed out.
+ */
+export function useAutoSignOut(): {
+  autoSignOut: () => void;
+  shouldAutoSignOut: boolean;
+} {
+  const { signOut } = useSignOut();
+
+  // Base prerequisites
+  const isUnlocked = Boolean(useSelector(selectIsUnlocked));
+  const isBasicFunctionalityEnabled = Boolean(
+    useSelector(selectBasicFunctionalityEnabled),
+  );
+  const isSignedIn = useSelector(selectIsSignedIn);
+
+  const areBasePrerequisitesMet = useMemo(
+    () => isSignedIn && isUnlocked && !isBasicFunctionalityEnabled,
+    [isSignedIn, isUnlocked, isBasicFunctionalityEnabled],
+  );
+
+  const shouldAutoSignOut = useMemo(
+    () => areBasePrerequisitesMet,
+    [areBasePrerequisitesMet],
+  );
+
+  const autoSignOut = useCallback(() => {
+    if (shouldAutoSignOut) {
+      signOut();
+    }
+  }, [shouldAutoSignOut, signOut]);
+
+  return {
+    autoSignOut,
+    shouldAutoSignOut,
+  };
+}

--- a/app/util/identity/hooks/useAuthentication/useSignIn.test.ts
+++ b/app/util/identity/hooks/useAuthentication/useSignIn.test.ts
@@ -1,0 +1,75 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+// eslint-disable-next-line import/no-namespace
+import * as actions from '../../../../actions/identity';
+import { useSignIn } from './useSignIn';
+
+interface ArrangeMocksMetamaskStateOverrides {
+  isSignedIn: boolean;
+}
+
+const arrangeMockState = (
+  stateOverrides: ArrangeMocksMetamaskStateOverrides,
+) => ({
+  engine: {
+    backgroundState: {
+      AuthenticationController: {
+        isSignedIn: stateOverrides.isSignedIn,
+      },
+    },
+  },
+});
+
+const arrangeMocks = (stateOverrides: ArrangeMocksMetamaskStateOverrides) => {
+  jest.clearAllMocks();
+  const state = arrangeMockState(stateOverrides);
+
+  const mockPerformSignInAction = jest.spyOn(actions, 'performSignIn');
+
+  const mockDisableProfileSyncingAction = jest.spyOn(
+    actions,
+    'disableProfileSyncing',
+  );
+  return {
+    state,
+    mockPerformSignInAction,
+    mockDisableProfileSyncingAction,
+  };
+};
+
+describe('useSignIn', () => {
+  it('should initialize correctly', () => {
+    const { state } = arrangeMocks({
+      isSignedIn: false,
+    });
+    const hook = renderHookWithProvider(() => useSignIn(), { state });
+
+    expect(hook.result.current.signIn).toBeDefined();
+  });
+
+  it('should call performSignIn if a user is not already signed in', async () => {
+    const { state, mockPerformSignInAction } = arrangeMocks({
+      isSignedIn: false,
+    });
+    const hook = renderHookWithProvider(() => useSignIn(), { state });
+
+    await act(async () => {
+      await hook.result.current.signIn();
+    });
+
+    expect(mockPerformSignInAction).toHaveBeenCalled();
+  });
+
+  it('should not call performSignIn if a user is already signed in', async () => {
+    const { state, mockPerformSignInAction } = arrangeMocks({
+      isSignedIn: true,
+    });
+    const hook = renderHookWithProvider(() => useSignIn(), { state });
+
+    await act(async () => {
+      await hook.result.current.signIn();
+    });
+
+    expect(mockPerformSignInAction).not.toHaveBeenCalled();
+  });
+});

--- a/app/util/identity/hooks/useAuthentication/useSignIn.ts
+++ b/app/util/identity/hooks/useAuthentication/useSignIn.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { selectIsSignedIn } from '../../../../selectors/identity';
+import { performSignIn } from '../../../../actions/identity';
+
+/**
+ * Custom hook to manage sign-in
+ * Use this hook to manually sign in the user.
+ * Any automatic sign-in should be handled by the `useIdentityEffects->useAutoSignIn` hook.
+ *
+ * This hook encapsulates the logic for initiating a sign-in process if the user is not already signed in
+ * and at least one auth dependent feature is enabled. It needs the user to have basic functionality on.
+ * It handles loading state and errors during the sign-in process.
+ *
+ * @returns An object containing:
+ * - `signIn`: A function to initiate the sign-in process.
+ */
+export function useSignIn(): {
+  signIn: () => Promise<void>;
+} {
+  const isSignedIn = useSelector(selectIsSignedIn);
+
+  const shouldSignIn = useMemo(() => !isSignedIn, [isSignedIn]);
+
+  const signIn = useCallback(async () => {
+    if (shouldSignIn) {
+      try {
+        await performSignIn();
+      } catch (e) {
+        // If an error occurs during the sign-in process, silently fail
+      }
+    }
+  }, [shouldSignIn]);
+
+  return {
+    signIn,
+  };
+}

--- a/app/util/identity/hooks/useAuthentication/useSignOut.test.ts
+++ b/app/util/identity/hooks/useAuthentication/useSignOut.test.ts
@@ -1,0 +1,70 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+// eslint-disable-next-line import/no-namespace
+import * as actions from '../../../../actions/identity';
+import { useSignOut } from './useSignOut';
+
+interface ArrangeMocksMetamaskStateOverrides {
+  isSignedIn: boolean;
+}
+
+const arrangeMockState = (
+  stateOverrides: ArrangeMocksMetamaskStateOverrides,
+) => ({
+  engine: {
+    backgroundState: {
+      AuthenticationController: {
+        isSignedIn: stateOverrides.isSignedIn,
+      },
+    },
+  },
+});
+
+const arrangeMocks = (stateOverrides: ArrangeMocksMetamaskStateOverrides) => {
+  jest.clearAllMocks();
+  const state = arrangeMockState(stateOverrides);
+
+  const mockPerformSignOutAction = jest.spyOn(actions, 'performSignOut');
+
+  return {
+    state,
+    mockPerformSignOutAction,
+  };
+};
+
+describe('useSignOut', () => {
+  it('should initialize correctly', () => {
+    const { state } = arrangeMocks({
+      isSignedIn: true,
+    });
+    const hook = renderHookWithProvider(() => useSignOut(), { state });
+
+    expect(hook.result.current.signOut).toBeDefined();
+  });
+
+  it('should call performSignOut if the user is signed in', async () => {
+    const { state, mockPerformSignOutAction } = arrangeMocks({
+      isSignedIn: true,
+    });
+    const hook = renderHookWithProvider(() => useSignOut(), { state });
+
+    await act(async () => {
+      await hook.result.current.signOut();
+    });
+
+    expect(mockPerformSignOutAction).toHaveBeenCalled();
+  });
+
+  it('should not call performSignOut if the user is already signed out', async () => {
+    const { state, mockPerformSignOutAction } = arrangeMocks({
+      isSignedIn: false,
+    });
+    const hook = renderHookWithProvider(() => useSignOut(), { state });
+
+    await act(async () => {
+      await hook.result.current.signOut();
+    });
+
+    expect(mockPerformSignOutAction).not.toHaveBeenCalled();
+  });
+});

--- a/app/util/identity/hooks/useAuthentication/useSignOut.ts
+++ b/app/util/identity/hooks/useAuthentication/useSignOut.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { selectIsSignedIn } from '../../../../selectors/identity';
+import { performSignOut } from '../../../../actions/identity';
+
+/**
+ * Custom hook to manage sign-out
+ *
+ * Use this hook to manually sign out the user.
+ * Any automatic sign-out should be handled by the `useIdentityEffects->useAutoSignOut` hook.
+ * IMPORTANT: nothing other than basic functionality being turned off should trigger a sign out.
+ * The only exception being when deleting the wallet.
+ *
+ * This hook encapsulates the logic for initiating a sign-out process if the user is signed in.
+ * It handles loading state and errors during the sign-out process.
+ *
+ * @returns An object containing:
+ * - `signOut`: A function to initiate the sign-out process.
+ */
+export function useSignOut(): {
+  signOut: () => void;
+} {
+  const isSignedIn = useSelector(selectIsSignedIn);
+
+  const shouldSignOut = useMemo(() => Boolean(isSignedIn), [isSignedIn]);
+
+  const signOut = useCallback(() => {
+    if (shouldSignOut) {
+      try {
+        performSignOut();
+      } catch (e) {
+        // If an error occurs during the sign-out process, silently fail
+      }
+    }
+  }, [shouldSignOut]);
+
+  return {
+    signOut,
+  };
+}

--- a/app/util/identity/hooks/useIdentityEffects/index.ts
+++ b/app/util/identity/hooks/useIdentityEffects/index.ts
@@ -1,0 +1,1 @@
+export { useIdentityEffects } from './useIdentityEffects';

--- a/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.test.ts
+++ b/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.test.ts
@@ -1,0 +1,74 @@
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+import { useAutoSignIn, useAutoSignOut } from '../useAuthentication';
+import { useIdentityEffects } from './useIdentityEffects';
+
+jest.mock('../useAuthentication');
+
+describe('useIdentityEffects', () => {
+  const mockUseAutoSignIn = jest.mocked(useAutoSignIn);
+  const mockUseAutoSignOut = jest.mocked(useAutoSignOut);
+
+  beforeEach(() => {
+    mockUseAutoSignIn.mockReturnValue({
+      autoSignIn: jest.fn(),
+      shouldAutoSignIn: false,
+    });
+
+    mockUseAutoSignOut.mockReturnValue({
+      autoSignOut: jest.fn(),
+      shouldAutoSignOut: false,
+    });
+  });
+
+  it('calls autoSignIn if shouldAutoSignIn returns true', () => {
+    const autoSignIn = jest.fn();
+    const shouldAutoSignIn = true;
+    mockUseAutoSignIn.mockReturnValue({
+      autoSignIn,
+      shouldAutoSignIn,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(autoSignIn).toHaveBeenCalled();
+  });
+
+  it('does not call autoSignIn if shouldAutoSignIn returns false', () => {
+    const autoSignIn = jest.fn();
+    const shouldAutoSignIn = false;
+    mockUseAutoSignIn.mockReturnValue({
+      autoSignIn,
+      shouldAutoSignIn,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(autoSignIn).not.toHaveBeenCalled();
+  });
+
+  it('calls autoSignOut if shouldAutoSignOut returns true', () => {
+    const autoSignOut = jest.fn();
+    const shouldAutoSignOut = true;
+    mockUseAutoSignOut.mockReturnValue({
+      autoSignOut,
+      shouldAutoSignOut,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(autoSignOut).toHaveBeenCalled();
+  });
+
+  it('does not call autoSignOut if shouldAutoSignOut returns false', () => {
+    const autoSignOut = jest.fn();
+    const shouldAutoSignOut = false;
+    mockUseAutoSignOut.mockReturnValue({
+      autoSignOut,
+      shouldAutoSignOut,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(autoSignOut).not.toHaveBeenCalled();
+  });
+});

--- a/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.ts
+++ b/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useAutoSignIn, useAutoSignOut } from '../useAuthentication';
+
+/**
+ * Takes care of various identity effects.
+ * - Automatically signs users in or out based on the app state.
+ */
+export const useIdentityEffects = () => {
+  const { autoSignIn, shouldAutoSignIn } = useAutoSignIn();
+  const { autoSignOut, shouldAutoSignOut } = useAutoSignOut();
+
+  /**
+   * Authentication effects
+   *
+   * - Users should be automatically signed in based on various conditions. (see `useAutoSignIn`).
+   * - Users should be signed out if basic functionality is disabled. (see `useAutoSignOut`)
+   */
+  useEffect(() => {
+    if (shouldAutoSignIn) {
+      autoSignIn();
+    }
+  }, [shouldAutoSignIn, autoSignIn]);
+
+  useEffect(() => {
+    if (shouldAutoSignOut) {
+      autoSignOut();
+    }
+  }, [shouldAutoSignOut, autoSignOut]);
+};

--- a/app/util/identity/hooks/useProfileSyncing/index.ts
+++ b/app/util/identity/hooks/useProfileSyncing/index.ts
@@ -1,0 +1,4 @@
+export {
+  useDisableProfileSyncing,
+  useEnableProfileSyncing,
+} from './useProfileSyncing';

--- a/app/util/identity/hooks/useProfileSyncing/useProfileSyncing.test.ts
+++ b/app/util/identity/hooks/useProfileSyncing/useProfileSyncing.test.ts
@@ -1,0 +1,44 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+// eslint-disable-next-line import/no-namespace
+import * as actions from '../../../../actions/identity';
+import {
+  useDisableProfileSyncing,
+  useEnableProfileSyncing,
+} from './useProfileSyncing';
+
+describe('useEnableProfileSyncing()', () => {
+  it('should enable profile syncing', async () => {
+    const mockEnableProfileSyncingAction = jest.spyOn(
+      actions,
+      'enableProfileSyncing',
+    );
+
+    const { result } = renderHookWithProvider(
+      () => useEnableProfileSyncing(),
+      {},
+    );
+    await act(async () => {
+      await result.current.enableProfileSyncing();
+    });
+
+    expect(mockEnableProfileSyncingAction).toHaveBeenCalled();
+  });
+});
+
+describe('useDisableProfileSyncing()', () => {
+  it('should disable profile syncing', async () => {
+    const mockDisableProfileSyncingAction = jest.spyOn(
+      actions,
+      'disableProfileSyncing',
+    );
+
+    const { result } = renderHookWithProvider(() => useDisableProfileSyncing());
+
+    await act(async () => {
+      await result.current.disableProfileSyncing();
+    });
+
+    expect(mockDisableProfileSyncingAction).toHaveBeenCalled();
+  });
+});

--- a/app/util/identity/hooks/useProfileSyncing/useProfileSyncing.ts
+++ b/app/util/identity/hooks/useProfileSyncing/useProfileSyncing.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from 'react';
+import {
+  disableProfileSyncing as disableProfileSyncingAction,
+  enableProfileSyncing as enableProfileSyncingAction,
+} from '../../../../actions/identity';
+
+/**
+ * Custom hook to enable profile syncing. This hook handles the process of signing in
+ * and enabling profile syncing.
+ *
+ * @returns An object containing the `enableProfileSyncing` function, loading state, and error state.
+ */
+export function useEnableProfileSyncing(): {
+  enableProfileSyncing: () => Promise<void>;
+  error: string | null;
+  isLoading: boolean;
+} {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enableProfileSyncing = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await enableProfileSyncingAction();
+    } catch (e) {
+      const errorMessage =
+        e instanceof Error ? e.message : JSON.stringify(e ?? '');
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { enableProfileSyncing, error, isLoading };
+}
+
+/**
+ * Custom hook to disable profile syncing. This hook handles the process of
+ * disabling profile syncing.
+ *
+ * @returns An object containing the `disableProfileSyncing` function, current profile syncing state,
+ * loading state, and error state.
+ */
+export function useDisableProfileSyncing(): {
+  disableProfileSyncing: () => Promise<void>;
+  error: string | null;
+  isLoading: boolean;
+} {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const disableProfileSyncing = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await disableProfileSyncingAction();
+    } catch (e) {
+      const errorMessage =
+        e instanceof Error ? e.message : JSON.stringify(e ?? '');
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { disableProfileSyncing, error, isLoading };
+}


### PR DESCRIPTION
## **Description**

This PR adds new identity hooks. This is part of a wider effort to make sure that mobile has the same logic that extension has regarding auth & profile syncing. Note that this PR, as being part 1 of this effort, doesn't introduce any changes, it only adds code pieces that'll be linked to wider logic changes in subsequent PRs.

This PR: 
- Introduces `useIdentityEffects` "master" hook that encapsulates any automatic identity actions dispatch (for now, authentication, but in the future it will contain syncing effects)
- Introduces `useAutoSignIn` and `useAutoSignOut` hooks, that reactively manages the user's authentication state based on the current application state

## **Related issues**

Related to: 
- https://consensyssoftware.atlassian.net/browse/IDENTITY-25
- https://consensyssoftware.atlassian.net/browse/IDENTITY-52

## **Manual testing steps**

1. No changes to test, the new code is not used yet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
