### PR TITLE
feat: publish event when receiving a push notification

### DIFF
--- a/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
+++ b/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
@@ -27,7 +27,9 @@ export const createNotificationServicesPushController = (props: {
         pushService: {
           createRegToken,
           deleteRegToken,
-          subscribeToPushNotifications: createSubscribeToPushNotifications(),
+          subscribeToPushNotifications: createSubscribeToPushNotifications(
+            props.messenger,
+          ),
         },
       },
     });

--- a/app/core/Engine/controllers/notifications/push-utils.test.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.test.ts
@@ -1,0 +1,61 @@
+import NotificationsService from '../../../../util/notifications/services/NotificationService';
+import FCMService from '../../../../util/notifications/services/FCMService';
+import { createSubscribeToPushNotifications } from './push-utils';
+import { processNotification } from '@metamask/notification-services-controller/notification-services';
+import { createMockNotificationEthSent } from '@metamask/notification-services-controller/notification-services/mocks';
+import type { NotificationServicesPushControllerMessenger } from '@metamask/notification-services-controller/push-services';
+
+describe('push-utils - createSubscribeToPushNotifications tests', () => {
+  const arrange = () => {
+    const mockListenToPushNotificationsReceived = jest.spyOn(
+      FCMService,
+      'listenToPushNotificationsReceived',
+    );
+    const mockDisplayNotification = jest.spyOn(
+      NotificationsService,
+      'displayNotification',
+    );
+    const mockMessenger = {
+      publish: jest.fn(),
+    } as unknown as NotificationServicesPushControllerMessenger;
+    return {
+      mockListenToPushNotificationsReceived,
+      mockDisplayNotification,
+      mockMessenger,
+    };
+  };
+
+  it('subscribes to push listener', async () => {
+    // Arrange
+    const mocks = arrange();
+    const subscribeFn = createSubscribeToPushNotifications(mocks.mockMessenger);
+
+    // Act
+    subscribeFn();
+
+    // Assert
+    expect(mocks.mockListenToPushNotificationsReceived).toHaveBeenCalled();
+  });
+
+  it('invokes subscription handler', async () => {
+    // Arrange
+    const mocks = arrange();
+    const subscribeFn = createSubscribeToPushNotifications(mocks.mockMessenger);
+    const mockNotification = processNotification(
+      createMockNotificationEthSent(),
+    );
+
+    // Act
+    subscribeFn();
+    const handler =
+      mocks.mockListenToPushNotificationsReceived.mock.lastCall?.[0];
+    handler?.(mockNotification);
+
+    // Assert
+    expect(mocks.mockMessenger.publish).toHaveBeenCalledWith(
+      'NotificationServicesPushController:onNewNotifications',
+      mockNotification,
+    );
+    expect(mocks.mockDisplayNotification).toHaveBeenCalled();
+  });
+});

--- a/app/core/Engine/controllers/notifications/push-utils.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.ts
@@ -2,24 +2,31 @@ import FCMService from '../../../../util/notifications/services/FCMService';
 import NotificationsService from '../../../../util/notifications/services/NotificationService';
 import { PressActionId } from '../../../../util/notifications';
 import { createNotificationMessage } from './create-push-message';
+import type { NotificationServicesPushControllerMessenger } from '@metamask/notification-services-controller/push-services';
 
 export const createRegToken = FCMService.createRegToken;
 export const deleteRegToken = FCMService.deleteRegToken;
 
-export const createSubscribeToPushNotifications = () => async () =>
-  FCMService.listenToPushNotificationsReceived(async (notification) => {
-    const notificationMessage = createNotificationMessage(notification);
-    if (!notificationMessage) {
-      return;
-    }
+export const createSubscribeToPushNotifications =
+  (messenger: NotificationServicesPushControllerMessenger) => async () =>
+    FCMService.listenToPushNotificationsReceived(async (notification) => {
+      messenger.publish(
+        'NotificationServicesPushController:onNewNotifications',
+        notification,
+      );
 
-    await NotificationsService.displayNotification({
-      id: notification.id,
-      pressActionId: PressActionId.OPEN_NOTIFICATIONS_VIEW,
-      title: notificationMessage.title,
-      body: notificationMessage.description,
-      data: notification,
+      const notificationMessage = createNotificationMessage(notification);
+      if (!notificationMessage) {
+        return;
+      }
+
+      await NotificationsService.displayNotification({
+        id: notification.id,
+        pressActionId: PressActionId.OPEN_NOTIFICATIONS_VIEW,
+        title: notificationMessage.title,
+        body: notificationMessage.description,
+        data: notification,
+      });
     });
-  });
 
 export const isPushNotificationsEnabled = FCMService.isPushNotificationsEnabled;


### PR DESCRIPTION
WIP

We need to investigate if it is possible to have foreground messages since IOS and Android behave differently.
This is important since we can only attach JS on foreground messages.

IOS:
- Only sometimes shows foreground messages. It tends to not show foreground messages if you also send a background message.

Android:
- I believe this does show background and foreground messages.

-----

We did not dynamically update out list when we received a push notification, now we will correctly update this list when you receive a push notification.

This does mean however that we don't have dynamic updates when push notifications are disabled.
I think this is okay, since in-app notifications aren't meant to be "real-time".

And foreground notifications are not consistent.

## **Description**

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13933

## **Manual testing steps**

1. You may need to enable/disable notifications (to clear up some weird state)
2. Create a transfer some funds.
3. You should now see notifications/bell icon updating when the transaction succeeds.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See 1st vid in bug.

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
