### PR TITLE
feat: add bridge slippage modal component using segmented control

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -136,6 +136,7 @@ import { selectUserLoggedIn } from '../../../reducers/user/selectors';
 import { Confirm } from '../../Views/confirmations/Confirm';
 import NavigationService from '../../../core/NavigationService';
 import { BridgeTokenSelector } from '../../UI/Bridge/BridgeTokenSelector';
+import { SlippageModal } from '../../UI/Bridge/components/SlippageModal';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -459,6 +460,10 @@ const RootModalFlow = () => (
     <Stack.Screen
       name={Routes.SHEET.BRIDGE_TOKEN_SELECTOR}
       component={BridgeTokenSelector}
+    />
+    <Stack.Screen
+      name={Routes.SHEET.SLIPPAGE_MODAL}
+      component={SlippageModal}
     />
   </Stack.Navigator>
 );

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.styles.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.styles.ts
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { fontStyles } from '../../../../../styles/common';
+import { Theme } from '../../../../../util/theme/models';
+
+const createStyles = ({ colors }: Theme) =>
+  StyleSheet.create({
+    container: {
+      padding: 24,
+      paddingBottom: 21,
+      alignItems: 'center',
+    },
+    title: {
+      textAlign: 'center',
+    },
+    description: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: colors.text.default,
+      ...fontStyles.normal,
+    },
+    optionsContainer: {
+      alignItems: 'center',
+      marginBottom: 12,
+      paddingHorizontal: 24,
+      paddingVertical: 16,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { SafeAreaProvider, Metrics } from 'react-native-safe-area-context';
+
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../locales/i18n';
+import SlippageModal from './index';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: jest.fn(() => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+    })),
+  };
+});
+
+const props = {
+  route: {
+    params: {
+      selectedSlippage: '0.5',
+      onSelectSlippage: jest.fn(),
+    },
+  },
+};
+
+const initialMetrics: Metrics = {
+  frame: { x: 0, y: 0, width: 320, height: 640 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+const renderSlippageModal = () =>
+  renderWithProvider(
+    <SafeAreaProvider initialMetrics={initialMetrics}>
+      <SlippageModal {...props} />
+    </SafeAreaProvider>,
+  );
+
+describe('SlippageModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all UI elements with the proper slippage options and apply button', () => {
+    const { toJSON, getByText } = renderSlippageModal();
+
+    expect(getByText(strings('bridge.slippage'))).toBeDefined();
+    expect(getByText(strings('bridge.slippage_info'))).toBeDefined();
+    expect(getByText('0.5%')).toBeDefined();
+    expect(getByText('1%')).toBeDefined();
+    expect(getByText('3%')).toBeDefined();
+    expect(getByText('10%')).toBeDefined();
+    expect(getByText(strings('bridge.apply'))).toBeDefined();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('updates slippage value when segment is selected and sends value back when applied', () => {
+    const { getByText, getByTestId } = renderSlippageModal();
+
+    // Click on the 3% option
+    const option3Percent = getByTestId('slippage-option-3');
+    fireEvent.press(option3Percent);
+
+    // Click on the apply button
+    const applyButton = getByText(strings('bridge.apply'));
+    fireEvent.press(applyButton);
+
+    // Check if the callback was called with the correct value
+    expect(props.route.params.onSelectSlippage).toHaveBeenCalledWith('3');
+    // Check that navigation.goBack was called
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/SlippageModal.types.ts
@@ -1,0 +1,4 @@
+export interface SlippageOption {
+  label: string;
+  value: string;
+}

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -1,0 +1,523 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SlippageModal renders all UI elements with the proper slippage options and apply button 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#00000099",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#BBC0C566",
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderWidth": 1,
+              "maxHeight": 1334,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001A",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 1334,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#BBC0C566",
+                "borderRadius": 2,
+                "height": 4,
+                "width": 40,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            />
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "marginHorizontal": 16,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontSize": 18,
+                  "fontWeight": "700",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Slippage
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <TouchableOpacity
+                accessible={true}
+                activeOpacity={1}
+                disabled={false}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "borderRadius": 8,
+                    "height": 24,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 24,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#141618"
+                  height={16}
+                  name="Close"
+                  style={
+                    {
+                      "height": 16,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "padding": 24,
+              "paddingBottom": 21,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 20,
+              }
+            }
+          >
+            If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here.
+          </Text>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 12,
+                "paddingHorizontal": 24,
+                "paddingVertical": 16,
+              }
+            }
+          >
+            <View
+              onValueChange={[Function]}
+              selectedValue="0.5"
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 12,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "#0376C91A",
+                      "borderColor": "#0376c9",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-0.5"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#0376c9",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    0.5%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-1"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    1%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-3"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    3%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  buttonWidth="full"
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "transparent",
+                      "borderColor": "#848c96",
+                      "borderRadius": 16,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 32,
+                      "justifyContent": "center",
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                  testID="slippage-option-10"
+                >
+                  <Text
+                    accessibilityRole="text"
+                    style={
+                      {
+                        "color": "#141618",
+                        "fontFamily": "EuclidCircularB-Medium",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    10%
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "paddingHorizontal": 8,
+                "paddingVertical": 4,
+              }
+            }
+            testID="bottomsheetfooter"
+          >
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessible={true}
+              activeOpacity={1}
+              onPress={[Function]}
+              onPressIn={[Function]}
+              onPressOut={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "transparent",
+                  "borderColor": "#0376c9",
+                  "borderRadius": 24,
+                  "borderWidth": 1,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 16,
+                }
+              }
+              testID="bottomsheetfooter-button"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#0376c9",
+                    "fontFamily": "EuclidCircularB-Medium",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Apply
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/app/components/UI/Bridge/components/SlippageModal/index.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/index.tsx
@@ -1,0 +1,101 @@
+import React, { useRef, useState } from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import createStyles from './SlippageModal.styles';
+import { SlippageOption } from './SlippageModal.types';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import SegmentedControl from '../../../../../component-library/components-temp/SegmentedControl';
+
+const SLIPPAGE_OPTIONS: SlippageOption[] = [
+  { label: '0.5%', value: '0.5' },
+  { label: '1%', value: '1' },
+  { label: '3%', value: '3' },
+  { label: '10%', value: '10' },
+];
+
+interface SlippageModalProps {
+  route: {
+    params: {
+      selectedSlippage: string;
+      onSelectSlippage: (slippage: string) => void;
+    };
+  };
+}
+
+export const SlippageModal = ({ route }: SlippageModalProps) => {
+  const { selectedSlippage, onSelectSlippage } = route.params;
+  const [selectedValue, setSelectedValue] = useState(selectedSlippage);
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
+
+  const handleOptionSelected = (option: string) => {
+    setSelectedValue(option);
+  };
+
+  const handleApply = () => {
+    onSelectSlippage(selectedValue);
+    navigation.goBack();
+  };
+
+  const handleClose = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <BottomSheet ref={sheetRef}>
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingMD}>
+          {strings('bridge.slippage')}
+        </Text>
+      </BottomSheetHeader>
+      <View style={styles.container}>
+        <Text style={styles.description}>
+          {strings('bridge.slippage_info')}
+        </Text>
+
+        <View style={styles.optionsContainer}>
+          <SegmentedControl
+            options={SLIPPAGE_OPTIONS.map((option) => ({
+              label: option.label,
+              value: option.value,
+              testID: `slippage-option-${option.value}`,
+              buttonWidth: ButtonWidthTypes.Full,
+            }))}
+            selectedValue={selectedValue}
+            onValueChange={handleOptionSelected}
+            size={ButtonSize.Sm}
+            isButtonWidthFlexible={false}
+          />
+        </View>
+        <BottomSheetFooter
+          buttonPropsArray={[
+            {
+              variant: ButtonVariants.Secondary,
+              label: strings('bridge.apply'),
+              onPress: handleApply,
+              size: ButtonSize.Lg,
+            },
+          ]}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default SlippageModal;

--- a/app/components/UI/Bridge/index.tsx
+++ b/app/components/UI/Bridge/index.tsx
@@ -1,16 +1,24 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import ScreenView from '../../Base/ScreenView';
 import Keypad from '../../Base/Keypad';
 import { TokenInputArea } from './TokenInputArea';
-import Button, { ButtonVariants } from '../../../component-library/components/Buttons/Button';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../component-library/hooks';
 import { Theme } from '../../../util/theme/models';
 import { Box } from '../Box/Box';
 import { FlexDirection, JustifyContent, AlignItems } from '../Box/box.types';
-import Text, { TextColor } from '../../../component-library/components/Texts/Text';
-import Icon, { IconName, IconSize } from '../../../component-library/components/Icons/Icon';
+import Text, {
+  TextColor,
+} from '../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../component-library/components/Icons/Icon';
 import { getNetworkImageSource } from '../../../util/networks';
 import { useLatestBalance } from './useLatestBalance';
 import {
@@ -31,6 +39,7 @@ import { useTheme } from '../../../util/theme';
 import { strings } from '../../../../locales/i18n';
 import useSubmitBridgeTx from '../../../util/bridge/hooks/useSubmitBridgeTx';
 import { QuoteResponse } from './types';
+import Routes from '../../../constants/navigation/Routes';
 
 const createStyles = (params: { theme: Theme }) => {
   const { theme } = params;
@@ -99,30 +108,52 @@ const BridgeView = () => {
   const sourceChainId = useSelector(selectSourceChainId);
   const destChainId = useSelector(selectDestChainId);
 
-  const sourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-  }, sourceChainId);
+  // Add state for slippage
+  const [slippage, setSlippage] = useState('0.5');
+
+  const sourceBalance = useLatestBalance(
+    {
+      address: sourceToken?.address,
+      decimals: sourceToken?.decimals,
+    },
+    sourceChainId,
+  );
 
   const hasInsufficientBalance = useMemo(() => {
-    if (!sourceAmount || !sourceBalance?.atomicBalance || !sourceToken?.decimals) {
+    if (
+      !sourceAmount ||
+      !sourceBalance?.atomicBalance ||
+      !sourceToken?.decimals
+    ) {
       return false;
     }
 
-    const sourceAmountAtomic = ethers.utils.parseUnits(sourceAmount, sourceToken.decimals);
+    const sourceAmountAtomic = ethers.utils.parseUnits(
+      sourceAmount,
+      sourceToken.decimals,
+    );
     return sourceAmountAtomic.gt(sourceBalance.atomicBalance);
   }, [sourceAmount, sourceBalance?.atomicBalance, sourceToken?.decimals]);
 
   // Reset bridge state when component unmounts
-  useEffect(() => () => {
+  useEffect(
+    () => () => {
       dispatch(resetBridgeState());
-    }, [dispatch]);
+    },
+    [dispatch],
+  );
 
   useEffect(() => {
     navigation.setOptions(getBridgeNavbar(navigation, route, colors));
   }, [navigation, route, colors]);
 
-  const handleKeypadChange = ({ value }: { value: string; valueAsNumber: number; pressedKey: string }) => {
+  const handleKeypadChange = ({
+    value,
+  }: {
+    value: string;
+    valueAsNumber: number;
+    pressedKey: string;
+  }) => {
     dispatch(setSourceAmount(value || undefined));
   };
 
@@ -131,7 +162,7 @@ const BridgeView = () => {
     // TESTING: Paste a quote from the Bridge API here to test the bridge flow
     const quoteResponse = undefined;
     if (quoteResponse) {
-        submitBridgeTx({quoteResponse: quoteResponse as QuoteResponse});
+      submitBridgeTx({ quoteResponse: quoteResponse as QuoteResponse });
     }
   };
 
@@ -145,21 +176,28 @@ const BridgeView = () => {
     }
   };
 
+  // Add function to navigate to slippage modal
+  const handleSlippagePress = () => {
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.SLIPPAGE_MODAL,
+      params: {
+        selectedSlippage: slippage,
+        onSelectSlippage: setSlippage,
+      },
+    });
+  };
+
   const renderBottomContent = () => {
-    if (!sourceAmount || (sourceToken?.decimals && ethers.utils.parseUnits(sourceAmount, sourceToken.decimals).isZero())) {
-      return (
-        <Text color={TextColor.Alternative}>
-          Select amount
-        </Text>
-      );
+    if (
+      !sourceAmount ||
+      (sourceToken?.decimals &&
+        ethers.utils.parseUnits(sourceAmount, sourceToken.decimals).isZero())
+    ) {
+      return <Text color={TextColor.Alternative}>Select amount</Text>;
     }
 
     if (hasInsufficientBalance) {
-      return (
-        <Text color={TextColor.Error}>
-          Insufficient balance
-        </Text>
-      );
+      return <Text color={TextColor.Error}>Insufficient balance</Text>;
     }
 
     return (
@@ -172,7 +210,11 @@ const BridgeView = () => {
         />
         <Button
           variant={ButtonVariants.Link}
-          label={<Text color={TextColor.Alternative}>{strings('bridge.terms_and_conditions')}</Text>}
+          label={
+            <Text color={TextColor.Alternative}>
+              {strings('bridge.terms_and_conditions')}
+            </Text>
+          }
           onPress={handleTermsPress}
         />
       </>
@@ -196,7 +238,9 @@ const BridgeView = () => {
             tokenIconUrl={sourceToken?.image}
             tokenAddress={sourceToken?.address}
             //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
-            networkImageSource={getNetworkImageSource({ chainId: sourceChainId })}
+            networkImageSource={getNetworkImageSource({
+              chainId: sourceChainId,
+            })}
             autoFocus
             isReadonly
             testID="source-token-area"
@@ -215,12 +259,23 @@ const BridgeView = () => {
             tokenSymbol={destToken?.symbol}
             tokenAddress={destToken?.address}
             tokenIconUrl={destToken?.image}
-            //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
-            networkImageSource={destChainId ? getNetworkImageSource({ chainId: destChainId }) : undefined}
+            networkImageSource={
+              destChainId
+                ? //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
+                  getNetworkImageSource({ chainId: destChainId })
+                : undefined
+            }
             isReadonly
             testID="dest-token-area"
           />
         </Box>
+        <Button
+          variant={ButtonVariants.Secondary}
+          label={strings('bridge.slippage') + ' ' + slippage + '%'}
+          onPress={handleSlippagePress}
+          style={styles.button}
+          size={ButtonSize.Sm}
+        />
         <Box style={styles.bottomSection}>
           <Keypad
             value={sourceAmount}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -117,6 +117,7 @@ const Routes = {
     TOKEN_FILTER: 'TokenFilter',
     CHANGE_IN_SIMULATION_MODAL: 'ChangeInSimulationModal',
     BRIDGE_TOKEN_SELECTOR: 'BridgeTokenSelector',
+    SLIPPAGE_MODAL: 'SlippageModal',
   },
   BROWSER: {
     HOME: 'BrowserTabHome',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3729,6 +3729,9 @@
   "bridge": {
     "continue": "Continue",
     "terms_and_conditions": "Terms & Conditions",
-    "select_token": "Select token"
-  }
+    "select_token": "Select token",
+    "slippage": "Slippage",
+    "apply": "Apply",
+    "slippage_info": "If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here."
+    }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds the SlippageModal to the BridgeView component, allowing users to select their desired slippage percentage during bridge transactions. The modal is accessible via a new temporary button in the UI.

_**P.S. This is currently behind a feature flag.**_


Figma Designs:

Slippage Modal: https://www.figma.com/design/rAno3BswRHFtwjc3wXy7nL/Swaps-on-Mobile?node-id=1410-14806&t=nx6iaXOx6peTO7w8-4

## **Related issues**

Fixes: [MMS-1988](https://consensyssoftware.atlassian.net/browse/MMS-1988)

## **Manual testing steps**

###SlippageModal and Bridge Integration

- Navigate to the Bridge screen in the app
- Locate and tap on the slippage option
- Verify the SlippageModal opens correctly
- Test selecting different slippage percentage options
- Verify the selected option is visually distinguished
- Tap "Apply" and confirm the modal closes
- Verify the selected slippage value is displayed correctly on the Bridge screen
- Test canceling without applying changes (modal should close without updating slippage)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

## Slippage Modal 

https://github.com/user-attachments/assets/ba08c2fa-97f6-43c5-96ff-e8e378c45db2

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMS-1988]: https://consensyssoftware.atlassian.net/browse/MMS-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ