### PR TITLE
fix: when cancelling signature by swiping modal out it should not navigate back

### DIFF
--- a/app/components/Views/confirmations/Confirm/Confirm.tsx
+++ b/app/components/Views/confirmations/Confirm/Confirm.tsx
@@ -34,21 +34,21 @@ const ConfirmWrapped = ({
   alerts: Alert[];
 }) => (
   <AlertsContextProvider alerts={alerts}>
-  <QRHardwareContextProvider>
-    <LedgerContextProvider>
-      <Title />
-      <ScrollView style={styles.scrollView}>
-        <TouchableWithoutFeedback>
-          <>
-            <GeneralAlertBanner />
-            <Info route={route} />
-          </>
-        </TouchableWithoutFeedback>
-      </ScrollView>
-      <Footer />
-    </LedgerContextProvider>
-    <MultipleAlertModal />
-  </QRHardwareContextProvider>
+    <QRHardwareContextProvider>
+      <LedgerContextProvider>
+        <Title />
+        <ScrollView style={styles.scrollView}>
+          <TouchableWithoutFeedback>
+            <>
+              <GeneralAlertBanner />
+              <Info route={route} />
+            </>
+          </TouchableWithoutFeedback>
+        </ScrollView>
+        <Footer />
+      </LedgerContextProvider>
+      <MultipleAlertModal />
+    </QRHardwareContextProvider>
   </AlertsContextProvider>
 );
 
@@ -80,6 +80,7 @@ export const Confirm = ({ route }: ConfirmProps) => {
   return (
     <BottomSheet
       onClose={onReject}
+      shouldNavigateBack={false}
       style={styles.bottomSheetDialogSheet}
       testID="modal-confirmation-container"
     >


### PR DESCRIPTION
## **Description**

When cancelling signature by swiping modal out it should not navigate back

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13982

## **Manual testing steps**

1. Go to test dapp
2. Submit signature
3. Drag down signature modal
4. Ensure that signature is rejected and you are still on the dapp

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
