### PR TITLE
fix: prevent unintentional remote feature flag override

### DIFF
--- a/app/core/Engine/controllers/remote-feature-flag-controller/utils.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller/utils.ts
@@ -30,7 +30,7 @@ const getFeatureFlagAppDistribution = () => {
   }
 };
 
-export const isRemoteFeatureFlagOverrideActivated = process.env.OVERRIDE_REMOTE_FEATURE_FLAGS;
+export const isRemoteFeatureFlagOverrideActivated = process.env.OVERRIDE_REMOTE_FEATURE_FLAGS === 'true';
 
 export const createRemoteFeatureFlagController = ({
   state,


### PR DESCRIPTION
## **Description**

If you add `export OVERRIDE_REMOTE_FEATURE_FLAGS = "false"` in your `.js.env` ([as recommended in our .js.env.example file](https://github.com/MetaMask/metamask-mobile/blob/main/.js.env.example#L119)) , it would not turn off the override feature. Instead you would need to fully remove this flag for the remote feature flags to not be overwritten.

This was because we never checked the "value" of this env variable, and so almost any string would return a truthy value

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
