### PR TITLE
fix: Not report invalid URL errors to sentry

### DIFF
--- a/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
+++ b/app/components/Views/confirmations/components/UI/InfoRow/InfoValue/DisplayURL/DisplayURL.tsx
@@ -7,7 +7,6 @@ import Icon, {
   IconSize,
 } from '../../../../../../../../component-library/components/Icons/Icon';
 import Text from '../../../../../../../../component-library/components/Texts/Text';
-import Logger from '../../../../../../../../util/Logger';
 import { useStyles } from '../../../../../../../../component-library/hooks';
 import styleSheet from './DisplayURL.styles';
 
@@ -29,7 +28,7 @@ const DisplayURL = ({ url }: DisplayURLProps) => {
     try {
       urlObject = new URL(url);
     } catch (e) {
-      Logger.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
+      console.error(e as Error, `DisplayURL: new URL(url) cannot parse ${url}`);
     }
     setIsHTTP(urlObject?.protocol === 'http:');
   }, [url]);

--- a/app/components/Views/confirmations/utils/generic.ts
+++ b/app/components/Views/confirmations/utils/generic.ts
@@ -1,4 +1,3 @@
-import Logger from '../../../../util/Logger';
 import { TokenI } from '../../../UI/Tokens/types';
 
 export const getHostFromUrl = (url: string) => {
@@ -8,9 +7,10 @@ export const getHostFromUrl = (url: string) => {
   try {
     return new URL(url).host;
   } catch (error) {
-    Logger.error(error as Error);
+    console.error(error as Error);
   }
   return;
 };
 
-export const isNativeToken = (selectedAsset: TokenI) => selectedAsset.isNative || selectedAsset.isETH;
+export const isNativeToken = (selectedAsset: TokenI) =>
+  selectedAsset.isNative || selectedAsset.isETH;


### PR DESCRIPTION
## **Description**

We are now using correct field to get origin for signatures but there are still few occurrences of this issue. `Logger.error` report these issues to sentry which is not needed hence removing it.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13957

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
