### PR TITLE
fix: Fix a number of rendering problems with `AvatarFavicon`

### DIFF
--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.constants.ts
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.constants.ts
@@ -18,6 +18,7 @@ export const TEST_REMOTE_SVG_IMAGE_URL =
 
 // Test IDs
 export const AVATARFAVICON_IMAGE_TESTID = 'favicon-avatar-image';
+export const AVATARFAVICON_IMAGE_SVG_TESTID = 'favicon-avatar-svg-image';
 
 // Sample consts
 export const SAMPLE_AVATARFAVICON_IMAGESOURCE_REMOTE: ImageSourcePropType = {

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.test.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.test.tsx
@@ -1,17 +1,23 @@
 // Third party dependencies.
 import React from 'react';
 import { shallow } from 'enzyme';
+import { render, waitFor } from '@testing-library/react-native';
 
 // Internal dependencies.
 import AvatarFavicon from './AvatarFavicon';
 import {
   AVATARFAVICON_IMAGE_TESTID,
+  AVATARFAVICON_IMAGE_SVG_TESTID,
   SAMPLE_AVATARFAVICON_PROPS,
   SAMPLE_AVATARFAVICON_IMAGESOURCE_LOCAL,
   SAMPLE_AVATARFAVICON_SVGIMAGESOURCE_REMOTE,
 } from './AvatarFavicon.constants';
 
 describe('AvatarFavicon', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
   it('should match the snapshot', () => {
     const wrapper = shallow(<AvatarFavicon {...SAMPLE_AVATARFAVICON_PROPS} />);
     expect(wrapper).toMatchSnapshot();
@@ -38,15 +44,19 @@ describe('AvatarFavicon', () => {
     expect(imageComponent.exists()).toBe(true);
   });
 
-  it('should render SVG', () => {
-    const wrapper = shallow(
+  it('should render SVG', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, headers: new Headers({'Content-Type': 'image/svg+xml'}), text: () => '<svg />' });
+
+    const { getByTestId, toJSON } = render(
       <AvatarFavicon
         {...SAMPLE_AVATARFAVICON_PROPS}
         imageSource={SAMPLE_AVATARFAVICON_SVGIMAGESOURCE_REMOTE}
       />,
     );
 
-    expect(wrapper).toMatchSnapshot();
+    await waitFor(() => expect(getByTestId(AVATARFAVICON_IMAGE_SVG_TESTID)).toBeDefined());
+
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should render fallback', () => {

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
@@ -15,6 +15,7 @@ import AvatarBase from '../../foundation/AvatarBase';
 import { isFaviconSVG } from '../../../../../../util/favicon';
 import {
   AVATARFAVICON_IMAGE_TESTID,
+  AVATARFAVICON_IMAGE_SVG_TESTID,
   DEFAULT_AVATARFAVICON_ERROR_ICON,
   DEFAULT_AVATARFAVICON_SIZE,
 } from './AvatarFavicon.constants';
@@ -94,7 +95,7 @@ const AvatarFavicon = ({
       const xml = decodeURIComponent(svgSource.slice(24));
       return (
         <SvgXml
-          testID={AVATARFAVICON_IMAGE_TESTID}
+          testID={AVATARFAVICON_IMAGE_SVG_TESTID}
           width="100%"
           height="100%"
           xml={xml}
@@ -106,7 +107,7 @@ const AvatarFavicon = ({
 
     return (
       <SvgUri
-        testID={AVATARFAVICON_IMAGE_TESTID}
+        testID={AVATARFAVICON_IMAGE_SVG_TESTID}
         width="100%"
         height="100%"
         uri={svgSource}

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/__snapshots__/AvatarFavicon.test.tsx.snap
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/__snapshots__/AvatarFavicon.test.tsx.snap
@@ -26,28 +26,55 @@ exports[`AvatarFavicon should match the snapshot 1`] = `
 `;
 
 exports[`AvatarFavicon should render SVG 1`] = `
-<AvatarBase
-  size="32"
-  style={{}}
+<View
+  style={
+    {
+      "backgroundColor": "#ffffff",
+      "borderRadius": 16,
+      "height": 32,
+      "overflow": "hidden",
+      "width": 32,
+    }
+  }
 >
-  <Image
+  <RNSVGSvgView
+    bbHeight="100%"
+    bbWidth="100%"
+    focusable={false}
+    height="100%"
     onError={[Function]}
-    resizeMode="contain"
-    source={
-      {
-        "uri": "https://metamask.github.io/test-dapp/metamask-fox.svg",
-      }
-    }
     style={
-      {
-        "flex": 1,
-        "height": undefined,
-        "width": undefined,
-      }
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderWidth": 0,
+        },
+        {
+          "flex": 1,
+          "height": undefined,
+          "width": undefined,
+        },
+        {
+          "flex": 0,
+          "height": "100%",
+          "width": "100%",
+        },
+      ]
     }
-    testID="favicon-avatar-image"
-  />
-</AvatarBase>
+    testID="favicon-avatar-svg-image"
+    uri="https://metamask.github.io/test-dapp/metamask-fox.svg"
+    width="100%"
+  >
+    <RNSVGGroup
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
+    />
+  </RNSVGSvgView>
+</View>
 `;
 
 exports[`AvatarFavicon should render fallback when svg has error 1`] = `


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a number of issues with the `AvatarFavicon` that prevented both Snaps and dapp icons from rendering.
- SVG dapp icons would not render when the `error` state value had already been set
- SVGs passed as data URIs would not render on Android at all

## **Manual testing steps**

1. Go to https://docs.metamask.io/developer-tools/faucet/
2. Connect
3. See that it works

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="364" alt="Screenshot 2025-03-21 at 16 00 19" src="https://github.com/user-attachments/assets/8c7eadab-7182-46e0-9d0e-c18dd86e1b98" />

### **After**

<img width="364" alt="Screenshot 2025-03-21 at 16 00 19" src="https://github.com/user-attachments/assets/85ace832-7d17-4fbb-ba7e-0681e4b8f7ed" />
