### PR TITLE
fix: Add staking claim event location

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmationLocation.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationLocation.test.ts
@@ -116,6 +116,22 @@ describe('useConfirmationLocation', () => {
     );
   });
 
+  it('returns STAKING_CLAIM location for staking claim transactions', () => {
+    mockUseApprovalRequest.mockReturnValue(
+      createApprovalRequestMock({
+        type: ApprovalType.Transaction,
+        requestData: {},
+      }),
+    );
+
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: TransactionType.stakingClaim,
+    } as unknown as TransactionMeta);
+
+    const { result } = renderHook(() => useConfirmationLocation());
+    expect(result.current).toBe(CONFIRMATION_EVENT_LOCATIONS.STAKING_CLAIM);
+  });
+
   it('returns undefined for transaction approvals with unknown transaction type', () => {
     mockUseApprovalRequest.mockReturnValue(
       createApprovalRequestMock({

--- a/app/components/Views/confirmations/hooks/useConfirmationLocation.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationLocation.ts
@@ -33,6 +33,8 @@ const ConfirmationLocationMap = {
           return CONFIRMATION_EVENT_LOCATIONS.STAKING_DEPOSIT;
         case TransactionType.stakingUnstake:
           return CONFIRMATION_EVENT_LOCATIONS.STAKING_WITHDRAWAL;
+        case TransactionType.stakingClaim:
+          return CONFIRMATION_EVENT_LOCATIONS.STAKING_CLAIM;
         default:
           return undefined;
       }

--- a/app/components/Views/confirmations/hooks/useConfirmationMetricEvents.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationMetricEvents.test.ts
@@ -4,6 +4,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import {
   CONFIRMATION_EVENTS,
   CONFIRMATION_EVENT_LOCATIONS,
+  TOOLTIP_TYPES,
 } from '../../../../core/Analytics/events/confirmations';
 import { updateConfirmationMetric } from '../../../../core/redux/slices/confirmationMetrics';
 import { useMetrics } from '../../../hooks/useMetrics';
@@ -96,7 +97,7 @@ describe('useConfirmationMetricEvents', () => {
   it('tracks tooltip clicked event', () => {
     const expectedProperties = {
       location: MOCK_LOCATION,
-      tooltip: 'test-tooltip',
+      tooltip: 'test-tooltip' as TOOLTIP_TYPES,
     };
 
     mockBuild.mockReturnValue(expectedProperties);
@@ -104,8 +105,7 @@ describe('useConfirmationMetricEvents', () => {
     const { result } = renderHook(() => useConfirmationMetricEvents());
 
     result.current.trackTooltipClickedEvent({
-      location: MOCK_LOCATION,
-      tooltip: 'test-tooltip',
+      tooltip: 'test-tooltip' as TOOLTIP_TYPES,
     });
 
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(

--- a/app/components/Views/confirmations/hooks/useConfirmationMetricEvents.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationMetricEvents.ts
@@ -5,7 +5,10 @@ import {
   JsonMap,
 } from '../../../../core/Analytics/MetaMetrics.types';
 import { useMetrics } from '../../../hooks/useMetrics';
-import { CONFIRMATION_EVENTS } from '../../../../core/Analytics/events/confirmations';
+import {
+  CONFIRMATION_EVENTS,
+  TOOLTIP_TYPES,
+} from '../../../../core/Analytics/events/confirmations';
 import {
   ConfirmationMetrics,
   updateConfirmationMetric,
@@ -35,7 +38,11 @@ export function useConfirmationMetricEvents() {
       trackEvent(event);
     };
 
-    const trackTooltipClickedEvent = ({ tooltip }: JsonMap) => {
+    const trackTooltipClickedEvent = ({
+      tooltip,
+    }: {
+      tooltip: TOOLTIP_TYPES;
+    }) => {
       const event = generateEvent({
         createEventBuilder,
         metametricsEvent: CONFIRMATION_EVENTS.TOOLTIP_CLICKED,

--- a/app/core/Analytics/events/confirmations/constants.ts
+++ b/app/core/Analytics/events/confirmations/constants.ts
@@ -10,4 +10,5 @@ export enum CONFIRMATION_EVENT_LOCATIONS {
   TYPED_SIGN_V3_V4 = 'TypedSignV3V4',
   STAKING_DEPOSIT = 'StakingDeposit',
   STAKING_WITHDRAWAL = 'StakingWithdrawal',
+  STAKING_CLAIM = 'StakingClaim',
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add staking claim location type into enum and add it into `useConfirmationLocation` hook to return it. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4481

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
