### PR TITLE
fix: Display correct snap name when connecting

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -14,7 +14,6 @@ import {
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 } from './components';
-import { ApprovalRequest } from '@metamask/approval-controller';
 import { useSelector } from 'react-redux';
 import { selectSnapsMetadata, getPermissions } from '../../../selectors/snaps';
 import {

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -16,11 +16,14 @@ import {
 } from './components';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { useSelector } from 'react-redux';
-import { selectSnapsMetadata } from '../../../selectors/snaps/snapController';
+import { selectSnapsMetadata, getPermissions } from '../../../selectors/snaps';
 import {
   WALLET_SNAP_PERMISSION_KEY,
   stripSnapPrefix,
 } from '@metamask/snaps-utils';
+import { isObject } from '@metamask/utils';
+import { PermissionConstraint } from '@metamask/permission-controller';
+import { RootState } from '../../../reducers';
 
 const InstallSnapApproval = () => {
   const snapsMetadata = useSelector(selectSnapsMetadata);
@@ -36,6 +39,10 @@ const InstallSnapApproval = () => {
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   const { approvalRequest, onConfirm, onReject } = useApprovalRequest();
+
+  const currentPermissions = useSelector((state: RootState) =>
+    getPermissions(state, approvalRequest?.origin),
+  );
 
   useEffect(() => {
     if (approvalRequest) {
@@ -59,20 +66,23 @@ const InstallSnapApproval = () => {
 
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const getSnapId = (request: ApprovalRequest<any>): string => {
-    // We first look for the name inside the snapId approvalRequest data
-    const snapId = request?.requestData?.snapId;
-    if (typeof snapId === 'string') {
-      return snapId;
+  const getSnapIds = (request: ApprovalRequest<any>, permissions?: Record<string, PermissionConstraint>): string[] => {
+    const permission = request?.requestData?.permissions?.[WALLET_SNAP_PERMISSION_KEY];
+    const requestedSnaps = permission?.caveats[0].value;
+    const currentSnaps =
+      permissions?.[WALLET_SNAP_PERMISSION_KEY]?.caveats?.[0].value;
+  
+    if (!isObject(currentSnaps) && requestedSnaps) {
+      return Object.keys(requestedSnaps);
     }
-    // If there is no snapId present in the approvalRequest data, we look for the name inside the snapIds caveat
-    const snapIdsCaveat =
-      request?.requestData?.permissions?.wallet_snap?.caveats?.find(
-        // TODO: Replace "any" with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (c: any) => c.type === 'snapIds',
-      );
-    return Object.keys(snapIdsCaveat.value)[0];
+  
+    const requestedSnapKeys = requestedSnaps ? Object.keys(requestedSnaps) : [];
+    const currentSnapKeys = currentSnaps ? Object.keys(currentSnaps) : [];
+    const dedupedSnaps = requestedSnapKeys.filter(
+      (snapId) => !currentSnapKeys.includes(snapId),
+    );
+  
+    return dedupedSnaps.length > 0 ? dedupedSnaps : requestedSnapKeys;
   };
 
   const getSnapMetadata = (snapId: string) =>
@@ -100,7 +110,7 @@ const InstallSnapApproval = () => {
 
   if (!approvalRequest || installState === undefined) return null;
 
-  const snapId = getSnapId(approvalRequest);
+  const snapId = getSnapIds(approvalRequest, currentPermissions)[0];
   const snapName = getSnapMetadata(snapId).name;
 
   // TODO: This component should support connecting to multiple Snaps at once.

--- a/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
@@ -133,6 +133,9 @@ describe('InstallSnapApprovalFlow', () => {
     settings: {},
     engine: {
       backgroundState: {
+        PermissionController: {
+          subjects: {},
+        },
         SubjectMetadataController: {
           subjectMetadata: {},
         },

--- a/app/selectors/snaps/index.ts
+++ b/app/selectors/snaps/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaceController';
+export * from './permissionController';
+export * from './snapController';

--- a/app/selectors/snaps/permissionController.ts
+++ b/app/selectors/snaps/permissionController.ts
@@ -1,9 +1,18 @@
 import { RootState } from '../../reducers';
 import { memoize } from 'lodash';
-import { SubjectType } from '@metamask/permission-controller';
+import { GenericPermissionController, SubjectType } from '@metamask/permission-controller';
+import { createDeepEqualSelector } from '../util';
 
 export const selectPermissionControllerState = (state: RootState) =>
-  state.engine.backgroundState.PermissionController;
+  state.engine.backgroundState.PermissionController as GenericPermissionController['state'];
+
+const selectOrigin = (_state: RootState, origin?: string) =>
+  origin;
+
+export const getPermissions = createDeepEqualSelector(
+  [selectPermissionControllerState, selectOrigin],
+  (state, origin) => origin ? state.subjects[origin]?.permissions : undefined,
+);
 
 export const selectSubjectMetadataControllerState = (state: RootState) =>
   state.engine.backgroundState.SubjectMetadataController;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We weren't showing Snap names correctly when connecting to a Snap if the dapp already had connected to one Snap. The connection flow logic was flawed and didn't have proper handling for parsing the permissions. This PR adds that.

Note: We still need to support multiple connections in this flow.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3160

## **Manual testing steps**

1. Go to https://metamask.github.io/snaps/test-snaps/latest/ 
2. Install one Snap
3. Install a second Snap
4. Notice that the second Snap ID shows up correctly when installing
