### PR TITLE
fix: cp-7.43.0 correctly fetch token rates during onboarding

### DIFF
--- a/patches/@metamask+assets-controllers+51.0.2.patch
+++ b/patches/@metamask+assets-controllers+51.0.2.patch
@@ -166,3 +166,29 @@ index 7b0580e..e783176 100644
      collection?: Collection;
      address?: string;
      attributes?: Attributes[];
+diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.cjs b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.cjs
+index c6d715d..696a24b 100644
+--- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.cjs
++++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.cjs
+@@ -165,7 +165,7 @@ class TokenRatesController extends (0, polling_controller_1.StaticIntervalPollin
+             return;
+         }
+         const tokenAddresses = __classPrivateFieldGet(this, _TokenRatesController_instances, "m", _TokenRatesController_getTokenAddresses).call(this, chainId);
+-        const updateKey = `${chainId}:${nativeCurrency}`;
++        const updateKey = `${chainId}:${nativeCurrency}:${tokenAddresses.length}`;
+         if (updateKey in __classPrivateFieldGet(this, _TokenRatesController_inProcessExchangeRateUpdates, "f")) {
+             // This prevents redundant updates
+             // This promise is resolved after the in-progress update has finished,
+diff --git a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.mjs b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.mjs
+index 396f361..9469ba4 100644
+--- a/node_modules/@metamask/assets-controllers/dist/TokenRatesController.mjs
++++ b/node_modules/@metamask/assets-controllers/dist/TokenRatesController.mjs
+@@ -162,7 +162,7 @@ export class TokenRatesController extends StaticIntervalPollingController() {
+             return;
+         }
+         const tokenAddresses = __classPrivateFieldGet(this, _TokenRatesController_instances, "m", _TokenRatesController_getTokenAddresses).call(this, chainId);
+-        const updateKey = `${chainId}:${nativeCurrency}`;
++        const updateKey = `${chainId}:${nativeCurrency}:${tokenAddresses.length}`;
+         if (updateKey in __classPrivateFieldGet(this, _TokenRatesController_inProcessExchangeRateUpdates, "f")) {
+             // This prevents redundant updates
+             // This promise is resolved after the in-progress update has finished,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

After some debugging, we saw that when we detect new tokens and perform a balance update, if there is a rates request that is in-flight, we will abort other requests. This meant that we abort the newly detected tokens so will show the error seen in the bug.

This doesn't happen that often, but is apparent during onboarding.

We hypothesis that our recent performance improvements have reduced the number of times we stop/start polling services (including token rates polling), this uncovered this bug.

This patch is similar to this core fix: https://github.com/MetaMask/core/pull/5531

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13788

## **Manual testing steps**

See bug repro steps

1. Have a fresh install of the app
2. Onboard
3. switch to polygon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
