### PR TITLE
chore: codeowner snapshots updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 # Design System Team
 app/component-library/               @MetaMask/design-system-engineers
+# Allows the design system and mobile platform team to review and approve all snapshot changes. This allows for system wide design token changes to color, typography, etc.
 **/*.snap                            @MetaMask/design-system-engineers @MetaMask/mobile-devs
 
 # Platform Team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 # Design System Team
 app/component-library/               @MetaMask/design-system-engineers
+**/*.snap                          @MetaMask/design-system-engineers
 
 # Platform Team
 .github/CODEOWNERS                                          @MetaMask/mobile-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 
 # Design System Team
 app/component-library/               @MetaMask/design-system-engineers
-**/*.snap                          @MetaMask/design-system-engineers
+**/*.snap                            @MetaMask/design-system-engineers @MetaMask/mobile-devs
 
 # Platform Team
 .github/CODEOWNERS                                          @MetaMask/mobile-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # Design System Team
 app/component-library/               @MetaMask/design-system-engineers
 # Allows the design system and mobile platform team to review and approve all snapshot changes. This allows for system wide design token changes to color, typography, etc.
-**/*.snap                            @MetaMask/design-system-engineers @MetaMask/mobile-devs
+**/*.snap                            @MetaMask/design-system-engineers @MetaMask/mobile-platform
 
 # Platform Team
 .github/CODEOWNERS                                          @MetaMask/mobile-platform


### PR DESCRIPTION
## **Description**
This PR adds the @MetaMask/mobile-platform and @MetaMask/design-system-engineers as owners of all snapshot files across the codebase. This is necessary to allow the design system team to efficiently manage and approve changes when design token updates affect multiple snapshot tests across different team areas.

This ensures that:
- Design system team can approve any snapshot changes across the codebase
- Design token updates that affect multiple snapshots can be reviewed efficiently
- Teams maintain their existing ownership of files in their directories
- No team is blocked by requiring multiple approvals for snapshot changes

## **Related issues**
N/A

## **Manual testing steps**
1. Merge this PR
2. Rebase and try to merge [this PR](https://github.com/MetaMask/metamask-mobile/pull/14218) without requiring every engineering teams review
2. Verify that snapshot changes across multiple team directories can be approved by design system engineers
3. Verify that teams can still approve snapshot changes in their owned directories

## **Screenshots/Recordings**
N/A - CODEOWNERS file change only

## **Pre-merge author checklist**
- [x] This PR has been tested and follows the [Coding Guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] This PR follows the [Contributing Guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CONTRIBUTING.md)
- [x] This PR has appropriate labels added

## **Pre-merge reviewer checklist**
- [ ] This code has been reviewed for security
- [ ] This code follows our coding guidelines and documentation requirements
