### PR TITLE
feat: add quote info modal component 

### DIFF
--- a/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+
+const createStyles = () =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: 16,
+      gap: 16,
+    },
+    footer: {
+      paddingVertical: 0,
+      paddingHorizontal: 0,
+      paddingBottom: 16,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.test.tsx
@@ -8,12 +8,16 @@ import QuoteInfoModal from './QuoteInfoModal';
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({
-    navigate: mockNavigate,
-    goBack: mockGoBack,
-  }),
-}));
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: jest.fn(() => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+    })),
+  };
+});
 
 const initialMetrics = {
   frame: { x: 0, y: 0, width: 320, height: 640 },
@@ -48,15 +52,6 @@ describe('QuoteInfoModal', () => {
     const { getByText } = renderQuoteInfoModal();
 
     const closeButton = getByText(strings('bridge.see_other_quotes'));
-    fireEvent.press(closeButton);
-
-    expect(mockGoBack).toHaveBeenCalled();
-  });
-
-  it('closes modal when header close button is pressed', () => {
-    const { getByLabelText } = renderQuoteInfoModal();
-
-    const closeButton = getByLabelText('Close');
     fireEvent.press(closeButton);
 
     expect(mockGoBack).toHaveBeenCalled();

--- a/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { strings } from '../../../../../../locales/i18n';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import QuoteInfoModal from './QuoteInfoModal';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+  }),
+}));
+
+const initialMetrics = {
+  frame: { x: 0, y: 0, width: 320, height: 640 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+const renderQuoteInfoModal = () =>
+  renderWithProvider(
+    <SafeAreaProvider initialMetrics={initialMetrics}>
+      <QuoteInfoModal />
+    </SafeAreaProvider>,
+  );
+
+describe('QuoteInfoModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { toJSON } = renderQuoteInfoModal();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('displays the correct title and content', () => {
+    const { getByText } = renderQuoteInfoModal();
+
+    expect(getByText(strings('bridge.quote_info_title'))).toBeDefined();
+    expect(getByText(strings('bridge.quote_info_content'))).toBeDefined();
+  });
+
+  it('closes modal when footer button is pressed', () => {
+    const { getByText } = renderQuoteInfoModal();
+
+    const closeButton = getByText(strings('bridge.see_other_quotes'));
+    fireEvent.press(closeButton);
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('closes modal when header close button is pressed', () => {
+    const { getByLabelText } = renderQuoteInfoModal();
+
+    const closeButton = getByLabelText('Close');
+    fireEvent.press(closeButton);
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.tsx
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/QuoteInfoModal.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { strings } from '../../../../../../locales/i18n';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
+import { View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
+import createStyles from './QuoteInfoModal.styles';
+
+const QuoteInfoModal = () => {
+  const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const { styles } = useStyles(createStyles, {});
+
+  const handleClose = () => {
+    navigation.goBack();
+  };
+
+  const footerButtonProps = [
+    {
+      label: strings('bridge.see_other_quotes'),
+      variant: ButtonVariants.Secondary,
+      size: ButtonSize.Lg,
+      onPress: handleClose,
+    },
+  ];
+
+  return (
+    <BottomSheet ref={sheetRef}>
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingMD}>
+          {strings('bridge.quote_info_title')}
+        </Text>
+      </BottomSheetHeader>
+      <View style={styles.container}>
+        <Text variant={TextVariant.BodyMD}>
+          {strings('bridge.quote_info_content')}
+        </Text>
+        <BottomSheetFooter
+          buttonPropsArray={footerButtonProps}
+          style={styles.footer}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default QuoteInfoModal;

--- a/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuoteInfoModal renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+/>
+`;

--- a/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
@@ -11,5 +11,293 @@ exports[`QuoteInfoModal renders correctly 1`] = `
       undefined,
     ]
   }
-/>
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#00000099",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#BBC0C566",
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderWidth": 1,
+              "maxHeight": 1334,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001A",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 1334,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#BBC0C566",
+                "borderRadius": 2,
+                "height": 4,
+                "width": 40,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            />
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "marginHorizontal": 16,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#141618",
+                  "fontFamily": "EuclidCircularB-Bold",
+                  "fontSize": 18,
+                  "fontWeight": "700",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Why we recommend this quote
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <TouchableOpacity
+                accessible={true}
+                activeOpacity={1}
+                disabled={false}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "borderRadius": 8,
+                    "height": 24,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 24,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#141618"
+                  height={16}
+                  name="Close"
+                  style={
+                    {
+                      "height": 16,
+                      "width": 16,
+                    }
+                  }
+                  width={16}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "gap": 16,
+              "paddingHorizontal": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#141618",
+                "fontFamily": "EuclidCircularB-Regular",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            This quote offers the best return from our search. It’s based on the swap rate, including bridging fees and a 0.875% MetaMask fee, but not gas fees. Gas fees vary with network activity and transaction complexity.
+          </Text>
+          <View
+            style={
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "paddingBottom": 16,
+                "paddingHorizontal": 0,
+                "paddingVertical": 0,
+              }
+            }
+            testID="bottomsheetfooter"
+          >
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessible={true}
+              activeOpacity={1}
+              onPress={[Function]}
+              onPressIn={[Function]}
+              onPressOut={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "transparent",
+                  "borderColor": "#0376c9",
+                  "borderRadius": 24,
+                  "borderWidth": 1,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "height": 48,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 16,
+                }
+              }
+              testID="bottomsheetfooter-button"
+            >
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#0376c9",
+                    "fontFamily": "EuclidCircularB-Medium",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                See other quotes
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
 `;

--- a/app/components/UI/Bridge/components/QuoteInfoModal/index.ts
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './QuoteInfoModal';

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -7,6 +7,7 @@ import SlippageModal from './components/SlippageModal';
 import { BridgeSourceNetworkSelector } from './BridgeSourceNetworkSelector';
 import { BridgeDestNetworkSelector } from './BridgeDestNetworkSelector';
 import BridgeView from '.';
+import QuoteInfoModal from './components/QuoteInfoModal';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -19,10 +20,7 @@ const clearStackNavigatorOptions = {
 const Stack = createStackNavigator();
 export const BridgeScreenStack = () => (
   <Stack.Navigator>
-    <Stack.Screen
-      name="BridgeView"
-      component={BridgeView}
-    />
+    <Stack.Screen name="BridgeView" component={BridgeView} />
   </Stack.Navigator>
 );
 
@@ -51,6 +49,10 @@ export const BridgeModalStack = () => (
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.SLIPPAGE_MODAL}
       component={SlippageModal}
+    />
+    <ModalStack.Screen
+      name={Routes.BRIDGE.MODALS.QUOTE_INFO_MODAL}
+      component={QuoteInfoModal}
     />
   </ModalStack.Navigator>
 );

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -147,6 +147,7 @@ const Routes = {
       SLIPPAGE_MODAL: 'SlippageModal',
       DEST_TOKEN_SELECTOR: 'BridgeDestTokenSelector',
       DEST_NETWORK_SELECTOR: 'BridgeDestNetworkSelector',
+      QUOTE_INFO_MODAL: 'QuoteInfoModal',
     },
   },
   LOCK_SCREEN: 'LockScreen',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -417,7 +417,7 @@
       "subtitle": "Available in select regions"
     },
     "fund": {
-      "title": "Fund your wallet", 
+      "title": "Fund your wallet",
       "subtitle": "Add or transfer tokens to get started"
     },
     "cashout": {
@@ -2047,7 +2047,7 @@
     "error_empty_message":"You need to enter your secret recovery phrase.",
     "error_number_of_words_error_message": "Secret Recovery Phrases contain 12, or 24 words",
     "error_srp_is_case_sensitive":"Invalid input! Secret Recovery Phrase is case sensitive.",
-    "error_srp_word_error_1": "Word ", 
+    "error_srp_word_error_1": "Word ",
     "error_srp_word_error_2": " is incorrect or misspelled.",
     "error_multiple_srp_word_error_1": "Word ",
     "error_multiple_srp_word_error_2": " and ",
@@ -3817,6 +3817,15 @@
     "see_all": "See all",
     "apply": "Apply",
     "slippage": "Slippage",
-    "slippage_info": "If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here."
+    "slippage_info": "If the price changes between the time your order is placed and confirmed it’s called “slippage.” Your swap will automatically cancel if slippage exceeds the tolerance you set here.",
+    "network_fee": "Network Fee",
+    "estimated_time": "Estimated Time",
+    "quote": "Quote",
+    "quote_details": "Quote Details",
+    "price_impact": "Price Impact",
+    "time": "Time",
+    "quote_info_content": "This quote offers the best return from our search. It’s based on the swap rate, including bridging fees and a 0.875% MetaMask fee, but not gas fees. Gas fees vary with network activity and transaction complexity.",
+    "quote_info_title": "Why we recommend this quote",
+    "see_other_quotes": "See other quotes"
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This commit introduces the QuoteInfoModal component, which includes its styles and test cases. The modal displays quote information and allows users to navigate back when the footer or header close button is pressed.
## **Related issues**

Fixes: [MMS-2155](https://consensyssoftware.atlassian.net/browse/MMS-2155)

## **Manual testing steps**

### 1. Route Verification
1. Check that the new route is added in Routes.ts:
   ```typescript
   BRIDGE: {
     MODALS: {
       QUOTE_INFO_MODAL: 'QuoteInfoModal',
       // ... other routes
     }
   }
   ```

### 2. Component Rendering
1. Navigate to the QuoteInfoModal route directly (for testing)
2. Verify the modal renders with:
   - Title: "Why we recommend this quote"
   - Content text explaining the quote selection
   - "See other quotes" button in footer
   - Close button in header

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/248615de-25a6-4538-a52a-359d8c6e0698)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMS-2155]: https://consensyssoftware.atlassian.net/browse/MMS-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ