### PR TITLE
fix: ledger singing on re-designed signature pages

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/LedgerSignModal/LedgerSignModal.tsx
+++ b/app/components/Views/confirmations/components/Confirm/LedgerSignModal/LedgerSignModal.tsx
@@ -40,8 +40,12 @@ const LedgerSignModal = () => {
   }, [signingEvent.eventStage, completeRequest]);
 
   const onConfirmation = useCallback(async () => {
-    onConfirm();
-  }, [onConfirm]);
+    try {
+      await onConfirm();
+    } catch (err) {
+      onReject();
+    }
+  }, [onConfirm, onReject]);
 
   const onRejection = useCallback(() => {
     onReject();

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
@@ -3,10 +3,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { merge, cloneDeep } from 'lodash';
 
 // eslint-disable-next-line import/no-namespace
-import {
-  isExternalHardwareAccount,
-  isHardwareAccount,
-} from '../../../../util/address';
+import { isHardwareAccount } from '../../../../util/address';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import {
   personalSignatureConfirmationState,
@@ -46,18 +43,6 @@ describe('useConfirmationRedesignEnabled', () => {
       );
 
       expect(result.current.isRedesignedEnabled).toBe(true);
-    });
-
-    it('returns false for external accounts', async () => {
-      (isExternalHardwareAccount as jest.Mock).mockReturnValue(true);
-      const { result } = renderHookWithProvider(
-        useConfirmationRedesignEnabled,
-        {
-          state: personalSignatureConfirmationState,
-        },
-      );
-
-      expect(result.current.isRedesignedEnabled).toBe(false);
     });
 
     it('returns false when remote flag is disabled', async () => {

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -9,10 +9,7 @@ import {
   type ConfirmationRedesignRemoteFlags,
   selectConfirmationRedesignFlags,
 } from '../../../../selectors/featureFlagController';
-import {
-  isExternalHardwareAccount,
-  isHardwareAccount,
-} from '../../../../util/address';
+import { isHardwareAccount } from '../../../../util/address';
 import { isStakingConfirmation } from '../utils/confirm';
 import useApprovalRequest from './useApprovalRequest';
 import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
@@ -31,17 +28,14 @@ const REDESIGNED_TRANSACTION_TYPES = [
 function isRedesignedSignature({
   approvalRequestType,
   confirmationRedesignFlags,
-  fromAddress,
 }: {
   approvalRequestType: ApprovalType;
   confirmationRedesignFlags: ConfirmationRedesignRemoteFlags;
-  fromAddress: string;
 }) {
   return (
     confirmationRedesignFlags?.signatures &&
     approvalRequestType &&
-    REDESIGNED_SIGNATURE_TYPES.includes(approvalRequestType as ApprovalType) &&
-    !isExternalHardwareAccount(fromAddress)
+    REDESIGNED_SIGNATURE_TYPES.includes(approvalRequestType as ApprovalType)
   );
 }
 
@@ -91,7 +85,6 @@ export const useConfirmationRedesignEnabled = () => {
       isRedesignedSignature({
         approvalRequestType,
         confirmationRedesignFlags,
-        fromAddress,
       }) ||
       isRedesignedTransaction({
         approvalRequestType,


### PR DESCRIPTION
## **Description**

In new designs app was hanged after any error in ledger signing. The PR fixes this issue.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4482

## **Manual testing steps**

1. Connect to ledger
2. On test dapp submit signatures
3. Ensure they works as expected

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
