### PR TITLE
fix: snaps text input does not trim whitespace

### DIFF
--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -58,7 +58,15 @@ export const SnapUIInput = ({
   };
 
   const handleFocus = () => setCurrentFocusedInput(name);
-  const handleBlur = () => setCurrentFocusedInput(null);
+
+  const handleBlur = () => {
+    const trimmedText = value.trim();
+    if (trimmedText !== value) {
+      setValue(trimmedText);
+      handleInputChange(name, trimmedText, form);
+    }
+    setCurrentFocusedInput(null);
+  };
 
   return (
     <Box style={style}>


### PR DESCRIPTION
## **Description**

When a user copy and pastes a wallet address, they may occasionally copy and paste whitespace in the process. The Text Input will then give a warning to the user stating the "Solana address is invalid", when in reality it's just a whitespace issue.

This PR addresses the issue by trimming the whitespace on blur so the user most likely won't see the error as it will disappear once they press outside of the text input.

## **Related issues**

Fixes: https://github.com/orgs/MetaMask/projects/149/views/1?filterQuery=&pane=issue&itemId=2946522697&issue=MetaMask%7Csnaps%7C3257

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

![Simulator Screenshot - iPhone 16 Pro - 2025-03-25 at 14 19 16](https://github.com/user-attachments/assets/50c464e3-c85a-413e-98a8-9e109dded056)

### **After**

https://github.com/user-attachments/assets/82660aeb-665d-4372-8eac-17b55e510dcd

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
