### PR TITLE
chore: added earn team as codeowners for earn directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,8 @@ app/components/UI/Stake              @MetaMask/metamask-staking
 app/core/Engine/controllers/earn-controller @MetaMask/metamask-staking
 app/core/Engine/messengers/earn-controller-messenger @MetaMask/metamask-staking
 app/selectors/earnController         @MetaMask/metamask-staking
+**/Earn/**                           @MetaMask/metamask-staking
+**/earn/**                           @MetaMask/metamask-staking
 
 # Assets Team
 app/components/hooks/useIsOriginalNativeTokenSymbol @MetaMask/metamask-assets


### PR DESCRIPTION
Codeowners file has been updated so that earn directories are owned by @MetaMask/metamask-staking 