### PR TITLE
fix: Remove `Transaction Finalized` event tied to STX

### DIFF
--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -393,10 +393,6 @@ enum EVENT_NAME {
   // Smart transactions
   SMART_TRANSACTION_OPT_IN = 'Smart Transaction Opt In',
 
-  // Transactions
-  // Fired when the transaction reaches a final state (e.g., CONFIRMED, FAILED, DROPPED).
-  TRANSACTION_FINALIZED = 'Transaction Finalized',
-
   // Simulations
   INCOMPLETE_ASSET_DISPLAYED = 'Incomplete Asset Displayed',
 
@@ -889,8 +885,6 @@ const events = {
   INCOMPLETE_ASSET_DISPLAYED: generateOpt(
     EVENT_NAME.INCOMPLETE_ASSET_DISPLAYED,
   ),
-  // Transactions
-  TRANSACTION_FINALIZED: generateOpt(EVENT_NAME.TRANSACTION_FINALIZED),
   // Nft auto detection modal
   NFT_AUTO_DETECTION_MODAL_ENABLE: generateOpt(
     EVENT_NAME.NFT_AUTO_DETECTION_ENABLED_MODAL,

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -1,6 +1,6 @@
 import { MarketDataDetails } from '@metamask/assets-controllers';
 import Engine, { Engine as EngineClass } from './Engine';
-import { EngineState, TransactionEventPayload } from './types';
+import { EngineState } from './types';
 import { backgroundState } from '../../util/test/initial-root-state';
 import { zeroAddress } from 'ethereumjs-util';
 import {
@@ -9,13 +9,7 @@ import {
   MOCK_ADDRESS_1,
 } from '../../util/test/accountsControllerTestUtils';
 import { mockNetworkState } from '../../util/test/network';
-import MetaMetrics from '../Analytics/MetaMetrics';
-import { store } from '../../store';
-import { MetaMetricsEvents } from '../Analytics';
 import { Hex } from '@metamask/utils';
-import { TransactionMeta } from '@metamask/transaction-controller';
-import { RootState } from '../../reducers';
-import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
 import { KeyringControllerState } from '@metamask/keyring-controller';
 import { backupVault } from '../BackupVault';
 
@@ -525,140 +519,6 @@ describe('Engine', () => {
         tokenFiat,
         tokenFiat1dAgo,
       });
-    });
-  });
-});
-
-describe('Transaction event handlers', () => {
-  let engine: EngineClass;
-
-  beforeEach(() => {
-    engine = Engine.init({});
-    jest.spyOn(MetaMetrics.getInstance(), 'trackEvent').mockImplementation();
-    jest.spyOn(store, 'getState').mockReturnValue({} as RootState);
-  });
-
-  afterEach(() => {
-    engine?.destroyEngineInstance();
-    jest.clearAllMocks();
-  });
-
-  describe('_handleTransactionFinalizedEvent', () => {
-    it('tracks event with basic properties when smart transactions are disabled', async () => {
-      const properties = { status: 'confirmed' };
-      const transactionEventPayload: TransactionEventPayload = {
-        transactionMeta: { hash: '0x123' } as TransactionMeta,
-      };
-
-      await engine._handleTransactionFinalizedEvent(
-        transactionEventPayload,
-        properties,
-      );
-
-      const expectedEvent = MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties(properties)
-        .build();
-
-      expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-        expectedEvent,
-      );
-    });
-
-    it('does not process smart transaction metrics if transactionMeta is missing', async () => {
-      const properties = { status: 'failed' };
-      const transactionEventPayload = {} as TransactionEventPayload;
-
-      await engine._handleTransactionFinalizedEvent(
-        transactionEventPayload,
-        properties,
-      );
-
-      const expectedEvent = MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties(properties)
-        .build();
-
-      expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-        expectedEvent,
-      );
-    });
-  });
-
-  describe('Transaction status handlers', () => {
-    it('tracks dropped transactions', async () => {
-      const transactionEventPayload: TransactionEventPayload = {
-        transactionMeta: { hash: '0x123' } as TransactionMeta,
-      };
-
-      await engine._handleTransactionDropped(transactionEventPayload);
-
-      const expectedEvent = MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties({ status: 'dropped' })
-        .build();
-
-      expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-        expectedEvent,
-      );
-    });
-
-    it('tracks confirmed transactions', async () => {
-      const transactionMeta = { hash: '0x123' } as TransactionMeta;
-
-      await engine._handleTransactionConfirmed(transactionMeta);
-
-      const expectedEvent = MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties({ status: 'confirmed' })
-        .build();
-
-      expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-        expectedEvent,
-      );
-    });
-
-    it('tracks failed transactions', async () => {
-      const transactionEventPayload: TransactionEventPayload = {
-        transactionMeta: { hash: '0x123' } as TransactionMeta,
-      };
-
-      await engine._handleTransactionFailed(transactionEventPayload);
-
-      const expectedEvent = MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties({ status: 'failed' })
-        .build();
-
-      expect(MetaMetrics.getInstance().trackEvent).toHaveBeenCalledWith(
-        expectedEvent,
-      );
-    });
-  });
-
-  describe('_addTransactionControllerListeners', () => {
-    it('subscribes to transaction events', () => {
-      jest.spyOn(engine.controllerMessenger, 'subscribe');
-
-      engine._addTransactionControllerListeners();
-
-      expect(engine.controllerMessenger.subscribe).toHaveBeenCalledWith(
-        'TransactionController:transactionDropped',
-        engine._handleTransactionDropped,
-      );
-      expect(engine.controllerMessenger.subscribe).toHaveBeenCalledWith(
-        'TransactionController:transactionConfirmed',
-        engine._handleTransactionConfirmed,
-      );
-      expect(engine.controllerMessenger.subscribe).toHaveBeenCalledWith(
-        'TransactionController:transactionFailed',
-        engine._handleTransactionFailed,
-      );
     });
   });
 });

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -130,7 +130,6 @@ import {
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 import { getAllowedSmartTransactionsChainIds } from '../../../app/constants/smartTransactions';
 import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
-import { selectShouldUseSmartTransaction } from '../../selectors/smartTransactionsController';
 import { selectSwapsChainFeatureFlags } from '../../reducers/swaps';
 import { ClientId } from '@metamask/smart-transactions-controller/dist/types';
 import { zeroAddress } from 'ethereumjs-util';
@@ -176,15 +175,12 @@ import {
   SnapControllerUpdateSnapStateAction,
 } from './controllers/snaps';
 ///: END:ONLY_INCLUDE_IF
-import { getSmartTransactionMetricsProperties } from '../../util/smart-transactions';
 import { trace } from '../../util/trace';
 import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
-import { JsonMap } from '../Analytics/MetaMetrics.types';
 import {
   BaseControllerMessenger,
   EngineState,
   EngineContext,
-  TransactionEventPayload,
   StatefulControllers,
 } from './types';
 import {
@@ -1489,95 +1485,8 @@ export class Engine {
     this.configureControllersOnNetworkChange();
     this.startPolling();
     this.handleVaultBackup();
-    this._addTransactionControllerListeners();
 
     Engine.instance = this;
-  }
-
-  // Logs the "Transaction Finalized" event after a transaction was either confirmed, dropped or failed.
-  _handleTransactionFinalizedEvent = async (
-    transactionEventPayload: TransactionEventPayload,
-    properties: JsonMap,
-  ) => {
-    const shouldUseSmartTransaction = selectShouldUseSmartTransaction(
-      store.getState(),
-    );
-    if (
-      !shouldUseSmartTransaction ||
-      !transactionEventPayload.transactionMeta
-    ) {
-      MetaMetrics.getInstance().trackEvent(
-        MetricsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.TRANSACTION_FINALIZED,
-        )
-          .addProperties(properties)
-          .build(),
-      );
-      return;
-    }
-    const { transactionMeta } = transactionEventPayload;
-    const { SmartTransactionsController } = this.context;
-    const waitForSmartTransaction = true;
-    const smartTransactionMetricsProperties =
-      await getSmartTransactionMetricsProperties(
-        SmartTransactionsController,
-        transactionMeta,
-        waitForSmartTransaction,
-        this.controllerMessenger,
-      );
-    MetaMetrics.getInstance().trackEvent(
-      MetricsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.TRANSACTION_FINALIZED,
-      )
-        .addProperties(smartTransactionMetricsProperties)
-        .addProperties(properties)
-        .build(),
-    );
-  };
-
-  _handleTransactionDropped = async (
-    transactionEventPayload: TransactionEventPayload,
-  ) => {
-    const properties = { status: 'dropped' };
-    await this._handleTransactionFinalizedEvent(
-      transactionEventPayload,
-      properties,
-    );
-  };
-
-  _handleTransactionConfirmed = async (transactionMeta: TransactionMeta) => {
-    const properties = { status: 'confirmed' };
-    await this._handleTransactionFinalizedEvent(
-      { transactionMeta },
-      properties,
-    );
-  };
-
-  _handleTransactionFailed = async (
-    transactionEventPayload: TransactionEventPayload,
-  ) => {
-    const properties = { status: 'failed' };
-    await this._handleTransactionFinalizedEvent(
-      transactionEventPayload,
-      properties,
-    );
-  };
-
-  _addTransactionControllerListeners() {
-    this.controllerMessenger.subscribe(
-      'TransactionController:transactionDropped',
-      this._handleTransactionDropped,
-    );
-
-    this.controllerMessenger.subscribe(
-      'TransactionController:transactionConfirmed',
-      this._handleTransactionConfirmed,
-    );
-
-    this.controllerMessenger.subscribe(
-      'TransactionController:transactionFailed',
-      this._handleTransactionFailed,
-    );
   }
 
   handleVaultBackup() {

--- a/app/core/Engine/controllers/transaction-controller/data-helpers.ts
+++ b/app/core/Engine/controllers/transaction-controller/data-helpers.ts
@@ -1,0 +1,71 @@
+import { merge } from 'lodash';
+
+export const enabledSmartTransactionsState = {
+  engine: {
+    backgroundState: {
+      SmartTransactionsController: {
+        enabled: true,
+        smartTransactionsState: {
+          liveness: true,
+        },
+      },
+      AccountsController: {
+        internalAccounts: {
+          selectedAccount: 'account1',
+          accounts: {
+            account1: {
+              address: '0x123',
+            },
+          },
+        },
+      },
+      NetworkController: {
+        selectedNetworkClientId: 'mainnet',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                type: 'infura',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            nativeCurrency: 'ETH',
+          },
+        },
+      },
+      PreferencesController: {
+        smartTransactionsOptInStatus: true,
+      },
+    },
+  },
+  swaps: {
+    featureFlags: {
+      smart_transactions: {
+        mobile_active: true,
+      },
+      smartTransactions: {
+        mobileActive: true,
+      },
+    },
+  },
+  selectedAccount: {
+    address: '0x1234567890123456789012345678901234567890',
+  },
+};
+
+export const disabledSmartTransactionsState = merge(
+  {},
+  enabledSmartTransactionsState,
+  {
+    engine: {
+      backgroundState: {
+        PreferencesController: {
+          smartTransactionsOptInStatus: false,
+        },
+      },
+    },
+  },
+);

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -21,9 +21,7 @@ import {
 import {
   handleTransactionAdded,
   handleTransactionApproved,
-  handleTransactionConfirmed,
-  handleTransactionDropped,
-  handleTransactionFailed,
+  handleTransactionFinalized,
   handleTransactionRejected,
   handleTransactionSubmitted,
 } from './transaction-event-handlers';
@@ -33,7 +31,7 @@ import type {
   ControllerInitFunction,
   ControllerInitRequest,
 } from '../../types';
-import type { TransactionMetrics } from './types';
+import type { TransactionEventHandlerRequest } from './types';
 
 export const TransactionControllerInit: ControllerInitFunction<
   TransactionController,
@@ -112,6 +110,7 @@ export const TransactionControllerInit: ControllerInitFunction<
     addTransactionControllerListeners({
       initMessenger,
       getState,
+      smartTransactionsController,
     });
 
     return { controller: transactionController };
@@ -188,71 +187,75 @@ function getControllers(
   };
 }
 
-function addTransactionControllerListeners({
-  initMessenger,
-  getState,
-}: {
-  initMessenger: TransactionControllerInitMessenger;
-  getState: () => RootState;
-}) {
-  const getTransactionMetricProperties = (
-    transactionId: string,
-  ): TransactionMetrics => {
-    const state = getState();
-    return (state.confirmationMetrics.metricsById?.[transactionId] ||
-      {}) as unknown as TransactionMetrics;
-  };
-
-  const transactionMetricRequest = {
-    getTransactionMetricProperties,
-  };
+function addTransactionControllerListeners(
+  transactionEventHandlerRequest: TransactionEventHandlerRequest,
+) {
+  const { initMessenger } = transactionEventHandlerRequest;
 
   initMessenger.subscribe(
     'TransactionController:transactionApproved',
     ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
-      handleTransactionApproved(transactionMeta, transactionMetricRequest);
+      handleTransactionApproved(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:transactionConfirmed',
     (transactionMeta: TransactionMeta) => {
-      handleTransactionConfirmed(transactionMeta, transactionMetricRequest);
+      handleTransactionFinalized(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:transactionDropped',
     ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
-      handleTransactionDropped(transactionMeta, transactionMetricRequest);
+      handleTransactionFinalized(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:transactionFailed',
     ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
-      handleTransactionFailed(transactionMeta, transactionMetricRequest);
+      handleTransactionFinalized(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:transactionRejected',
     ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
-      handleTransactionRejected(transactionMeta, transactionMetricRequest);
+      handleTransactionRejected(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:transactionSubmitted',
     ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
-      handleTransactionSubmitted(transactionMeta, transactionMetricRequest);
+      handleTransactionSubmitted(
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
     },
   );
 
   initMessenger.subscribe(
     'TransactionController:unapprovedTransactionAdded',
     (transactionMeta: TransactionMeta) => {
-      handleTransactionAdded(transactionMeta, transactionMetricRequest);
+      handleTransactionAdded(transactionMeta, transactionEventHandlerRequest);
     },
   );
 }

--- a/app/core/Engine/controllers/transaction-controller/transaction-event-handlers.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-event-handlers.ts
@@ -71,9 +71,7 @@ export async function handleTransactionFinalized(
 
   const mergedEventProperties = merge(
     {
-      properties: {
-        ...stxMetricsProperties,
-      },
+      properties: stxMetricsProperties,
     },
     defaultTransactionMetricProperties,
   );

--- a/app/core/Engine/controllers/transaction-controller/transaction-event-handlers.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-event-handlers.ts
@@ -2,131 +2,83 @@ import { merge } from 'lodash';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TRANSACTION_EVENTS } from '../../../Analytics/events/confirmations';
 
+import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
+import { getSmartTransactionMetricsProperties } from '../../../../util/smart-transactions';
 import { MetaMetrics } from '../../../Analytics';
+import { BaseControllerMessenger } from '../../types';
 import { generateDefaultTransactionMetrics, generateEvent } from './utils';
-import type { TransactionMetricRequest } from './types';
+import type { TransactionEventHandlerRequest } from './types';
 
-export const handleTransactionAdded = (
+// Generic handler for simple transaction events
+const createTransactionEventHandler = (
+  eventType: (typeof TRANSACTION_EVENTS)[keyof typeof TRANSACTION_EVENTS],
+) => (
+    transactionMeta: TransactionMeta,
+    transactionEventHandlerRequest: TransactionEventHandlerRequest,
+  ) => {
+    const defaultTransactionMetricProperties =
+      generateDefaultTransactionMetrics(
+        eventType,
+        transactionMeta,
+        transactionEventHandlerRequest,
+      );
+
+    const event = generateEvent(defaultTransactionMetricProperties);
+    MetaMetrics.getInstance().trackEvent(event);
+  };
+
+// Simple handlers - no unique properties / actions
+export const handleTransactionAdded = createTransactionEventHandler(
+  TRANSACTION_EVENTS.TRANSACTION_ADDED,
+);
+export const handleTransactionApproved = createTransactionEventHandler(
+  TRANSACTION_EVENTS.TRANSACTION_APPROVED,
+);
+export const handleTransactionRejected = createTransactionEventHandler(
+  TRANSACTION_EVENTS.TRANSACTION_REJECTED,
+);
+export const handleTransactionSubmitted = createTransactionEventHandler(
+  TRANSACTION_EVENTS.TRANSACTION_SUBMITTED,
+);
+
+// Intentionally using TRANSACTION_FINALIZED for confirmed/failed/dropped transactions
+// as unified type for all finalized transactions.
+// Status could be derived from transactionMeta.status
+export async function handleTransactionFinalized(
   transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_ADDED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
+  transactionEventHandlerRequest: TransactionEventHandlerRequest,
+) {
+  const { getState, initMessenger, smartTransactionsController } =
+    transactionEventHandlerRequest;
 
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionApproved = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_APPROVED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
-
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionConfirmed = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  // Intentionally using TRANSACTION_FINALIZED for confirmed transactions
-  // as unified type for all finalized transactions
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_FINALIZED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
-
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionDropped = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  // Intentionally using TRANSACTION_FINALIZED for dropped transactions
-  // as unified type for all finalized transactions
   const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
     TRANSACTION_EVENTS.TRANSACTION_FINALIZED,
     transactionMeta,
-    transactionMetricRequest,
+    transactionEventHandlerRequest,
   );
 
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
+  let stxMetricsProperties = {};
+
+  const shouldUseSmartTransaction = selectShouldUseSmartTransaction(getState());
+  if (shouldUseSmartTransaction) {
+    stxMetricsProperties = await getSmartTransactionMetricsProperties(
+      smartTransactionsController,
+      transactionMeta,
+      true,
+      initMessenger as unknown as BaseControllerMessenger,
+    );
+  }
+
+  const mergedEventProperties = merge(
+    {
+      properties: {
+        ...stxMetricsProperties,
+      },
+    },
+    defaultTransactionMetricProperties,
+  );
 
   const event = generateEvent(mergedEventProperties);
 
   MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionFailed = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  // Intentionally using TRANSACTION_FINALIZED for failed transactions
-  // as unified type for all finalized transactions
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_FINALIZED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
-
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionRejected = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_REJECTED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
-
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
-
-export const handleTransactionSubmitted = (
-  transactionMeta: TransactionMeta,
-  transactionMetricRequest: TransactionMetricRequest,
-) => {
-  const defaultTransactionMetricProperties = generateDefaultTransactionMetrics(
-    TRANSACTION_EVENTS.TRANSACTION_SUBMITTED,
-    transactionMeta,
-    transactionMetricRequest,
-  );
-
-  const mergedEventProperties = merge({}, defaultTransactionMetricProperties);
-
-  const event = generateEvent(mergedEventProperties);
-
-  MetaMetrics.getInstance().trackEvent(event);
-};
+}

--- a/app/core/Engine/controllers/transaction-controller/types.ts
+++ b/app/core/Engine/controllers/transaction-controller/types.ts
@@ -1,4 +1,7 @@
 import { JsonMap } from '../../../Analytics/MetaMetrics.types';
+import SmartTransactionsController from '@metamask/smart-transactions-controller';
+import type { RootState } from '../../../../reducers';
+import { TransactionControllerInitMessenger } from '../../messengers/transaction-controller-messenger';
 
 // In order to not import from redux slice, type is defined here
 export interface TransactionMetrics {
@@ -6,6 +9,8 @@ export interface TransactionMetrics {
   sensitiveProperties: JsonMap;
 }
 
-export interface TransactionMetricRequest {
-  getTransactionMetricProperties: (id: string) => TransactionMetrics;
+export interface TransactionEventHandlerRequest {
+  getState: () => RootState;
+  initMessenger: TransactionControllerInitMessenger;
+  smartTransactionsController: SmartTransactionsController;
 }

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -3,14 +3,20 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import { merge } from 'lodash';
+import type { RootState } from '../../../../reducers';
 import { MetricsEventBuilder } from '../../../Analytics/MetricsEventBuilder';
 import {
   JsonMap,
   IMetaMetricsEvent,
 } from '../../../Analytics/MetaMetrics.types';
-import type { TransactionMetricRequest } from './types';
+import type {
+  TransactionEventHandlerRequest,
+  TransactionMetrics,
+} from './types';
 
-export function getTransactionTypeValue(transactionType: TransactionType | undefined) {
+export function getTransactionTypeValue(
+  transactionType: TransactionType | undefined,
+) {
   switch (transactionType) {
     case TransactionType.bridgeApproval:
       return 'bridge_approval';
@@ -62,10 +68,19 @@ export function getTransactionTypeValue(transactionType: TransactionType | undef
   }
 }
 
+const getConfirmationMetricProperties = (
+  getState: () => RootState,
+  transactionId: string,
+): TransactionMetrics => {
+  const state = getState();
+  return (state.confirmationMetrics.metricsById?.[transactionId] ||
+    {}) as unknown as TransactionMetrics;
+};
+
 export function generateDefaultTransactionMetrics(
   metametricsEvent: IMetaMetricsEvent,
   transactionMeta: TransactionMeta,
-  { getTransactionMetricProperties }: TransactionMetricRequest,
+  { getState }: TransactionEventHandlerRequest,
 ) {
   const { chainId, id, type, status } = transactionMeta;
 
@@ -79,7 +94,7 @@ export function generateDefaultTransactionMetrics(
         status,
       },
     },
-    getTransactionMetricProperties(id),
+    getConfirmationMetricProperties(getState, id),
   );
 
   return mergedDefaultProperties;

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -17,7 +17,10 @@ import {
   TransactionControllerTransactionSubmittedEvent,
   TransactionControllerUnapprovedTransactionAddedEvent,
 } from '@metamask/transaction-controller';
-import { SmartTransactionsControllerSmartTransactionEvent } from '@metamask/smart-transactions-controller';
+import {
+  SmartTransactionsControllerSmartTransactionEvent,
+  SmartTransactionsControllerSmartTransactionConfirmationDoneEvent,
+} from '@metamask/smart-transactions-controller';
 
 type MessengerActions =
   | ApprovalControllerActions
@@ -35,7 +38,8 @@ type MessengerEvents =
   | TransactionControllerTransactionSubmittedEvent
   | TransactionControllerUnapprovedTransactionAddedEvent
   | NetworkControllerStateChangeEvent
-  | SmartTransactionsControllerSmartTransactionEvent;
+  | SmartTransactionsControllerSmartTransactionEvent
+  | SmartTransactionsControllerSmartTransactionConfirmationDoneEvent;
 
 export type TransactionControllerInitMessenger = ReturnType<
   typeof getTransactionControllerInitMessenger
@@ -71,6 +75,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:transactionSubmitted',
       'TransactionController:unapprovedTransactionAdded',
       'SmartTransactionsController:smartTransaction',
+      'SmartTransactionsController:smartTransactionConfirmationDone',
     ],
     allowedActions: [
       'ApprovalController:addRequest',

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -97,7 +97,6 @@ import {
   TransactionControllerActions,
   TransactionControllerEvents,
   TransactionControllerState,
-  TransactionMeta,
 } from '@metamask/transaction-controller';
 import {
   GasFeeController,
@@ -391,13 +390,6 @@ type GlobalEvents =
   | BridgeControllerEvents
   | BridgeStatusControllerEvents
   | EarnControllerEvents;
-
-// TODO: Abstract this into controller utils for TransactionController
-export interface TransactionEventPayload {
-  transactionMeta: TransactionMeta;
-  actionId?: string;
-  error?: string;
-}
 
 /**
  * Type definition for the controller messenger used in the Engine.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

We recently added `TransactionController` event handlers by having flexibility of "modular initialisation". 
This means that we can get rid of existing `Transaction Finalized` events living in the Engine file. 

All STX metric properties will be added as expected as before. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4520

## **Manual testing steps**

No manual testing required - user flows are not affected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
