### PR TITLE
chore: removing unused icons and types

### DIFF
--- a/app/components/UI/Ramp/components/PaymentMethodIcon.tsx
+++ b/app/components/UI/Ramp/components/PaymentMethodIcon.tsx
@@ -4,19 +4,16 @@ import { Payment, PaymentType } from '@consensys/on-ramp-sdk';
 import { PaymentIcon, PaymentIconType } from '@consensys/on-ramp-sdk/dist/API';
 
 import AntDesignIcon from 'react-native-vector-icons/AntDesign';
-import EntypoIcon from 'react-native-vector-icons/Entypo';
+
 import EvilIconsIcon from 'react-native-vector-icons/EvilIcons';
 import FeatherIcon from 'react-native-vector-icons/Feather';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import FontAwesome5Icon from 'react-native-vector-icons/FontAwesome5';
-// import FontistoIcon from 'react-native-vector-icons/Fontisto';
-import FoundationIcon from 'react-native-vector-icons/Foundation';
 import IoniconsIcon from 'react-native-vector-icons/Ionicons';
 import MaterialsIconsIcon from 'react-native-vector-icons/MaterialIcons';
 import MaterialsCommunityIconsIcon from 'react-native-vector-icons/MaterialCommunityIcons';
-import OcticonsIcon from 'react-native-vector-icons/Octicons';
+
 import SimpleLineIconsIcon from 'react-native-vector-icons/SimpleLineIcons';
-import ZocialIcon from 'react-native-vector-icons/Zocial';
 
 interface iconParams {
   paymentMethodIcons?: Payment['icons'];
@@ -39,9 +36,6 @@ function getIconComponent(icon: PaymentIcon) {
     case PaymentIconType.AntDesign: {
       return AntDesignIcon;
     }
-    case PaymentIconType.Entypo: {
-      return EntypoIcon;
-    }
     case PaymentIconType.EvilIcons: {
       return EvilIconsIcon;
     }
@@ -57,9 +51,6 @@ function getIconComponent(icon: PaymentIcon) {
     case PaymentIconType.Fontisto: {
       return null;
     }
-    case PaymentIconType.Foundation: {
-      return FoundationIcon;
-    }
     case PaymentIconType.Ionicons: {
       return IoniconsIcon;
     }
@@ -69,14 +60,8 @@ function getIconComponent(icon: PaymentIcon) {
     case PaymentIconType.MaterialCommunityIcons: {
       return MaterialsCommunityIconsIcon;
     }
-    case PaymentIconType.Octicons: {
-      return OcticonsIcon;
-    }
     case PaymentIconType.SimpleLineIcons: {
       return SimpleLineIconsIcon;
-    }
-    case PaymentIconType.Zocial: {
-      return ZocialIcon;
     }
     default: {
       return null;
@@ -85,12 +70,18 @@ function getIconComponent(icon: PaymentIcon) {
 }
 
 /*
-* With the integration of Expo, it introduced a compatibility layer (https://github.com/expo/vector-icons)
-* around react-native-vector-icons which doesn't expose hasIcon anymore so we need to build our own based on
-* the implementation https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js#L158
-*/
-function hasIcon(IconComponent: { glyphMap: { [key: string]: number } }, name: string) {
-  return IconComponent?.glyphMap && Object.prototype.hasOwnProperty.call(IconComponent.glyphMap, name);
+ * With the integration of Expo, it introduced a compatibility layer (https://github.com/expo/vector-icons)
+ * around react-native-vector-icons which doesn't expose hasIcon anymore so we need to build our own based on
+ * the implementation https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js#L158
+ */
+function hasIcon(
+  IconComponent: { glyphMap: { [key: string]: number } },
+  name: string,
+) {
+  return (
+    IconComponent?.glyphMap &&
+    Object.prototype.hasOwnProperty.call(IconComponent.glyphMap, name)
+  );
 }
 
 function getIcon(icon: PaymentIcon) {

--- a/app/declarations/index.d.ts
+++ b/app/declarations/index.d.ts
@@ -194,22 +194,6 @@ declare module 'react-native-vector-icons/FontAwesome5' {
   export default FontAwesome5;
 }
 
-declare module 'react-native-vector-icons/Octicons' {
-  import { IconProps } from 'react-native-vector-icons/Octicons';
-
-  const Octicons: ComponentType<IconProps>;
-
-  /**
-   * @deprecated The `<OcticonsIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
-   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
-   * You can find documentation for the new Icon component in the README:
-   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
-   * If you would like to help with the replacement of the usage of the Octicons component, please submit a pull request against this GitHub issue:
-   * {@link https://github.com/MetaMask/metamask-mobile/issues/8119}
-   */
-  export default Octicons;
-}
-
 declare module 'react-native-vector-icons/Entypo' {
   import { IconProps } from 'react-native-vector-icons/Entypo';
 
@@ -224,54 +208,6 @@ declare module 'react-native-vector-icons/Entypo' {
    * {@link https://github.com/MetaMask/metamask-mobile/issues/8120}
    */
   export default Entypo;
-}
-
-declare module 'react-native-vector-icons/Foundation' {
-  import { IconProps } from 'react-native-vector-icons/Foundation';
-
-  const Foundation: ComponentType<IconProps>;
-
-  /**
-   * @deprecated The `<FoundationIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
-   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
-   * You can find documentation for the new Icon component in the README:
-   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
-   * If you would like to help with the replacement of the usage of the Foundation component, please submit a pull request against this GitHub issue:
-   * {@link https://github.com/MetaMask/metamask-mobile/issues/8121}
-   */
-  export default Foundation;
-}
-
-declare module 'react-native-vector-icons/Fontisto' {
-  import { IconProps } from 'react-native-vector-icons/Fontisto';
-
-  const Fontisto: ComponentType<IconProps>;
-
-  /**
-   * @deprecated The `<FontistoIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
-   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
-   * You can find documentation for the new Icon component in the README:
-   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
-   * If you would like to help with the replacement of the usage of the Fontisto component, please submit a pull request against this GitHub issue:
-   * {@link https://github.com/MetaMask/metamask-mobile/issues/8122}
-   */
-  export default Fontisto;
-}
-
-declare module 'react-native-vector-icons/Zocial' {
-  import { IconProps } from 'react-native-vector-icons/Zocial';
-
-  const Zocial: ComponentType<IconProps>;
-
-  /**
-   * @deprecated The `<ZocialIcon />` component has been deprecated in favor of the new `<Icon>` component from the component-library.
-   * Please update your code to use the new `<Icon>` component instead, which can be found at app/component-library/components/Icons/Icon/Icon.tsx.
-   * You can find documentation for the new Icon component in the README:
-   * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/Icons/Icon/README.md}
-   * If you would like to help with the replacement of the usage of the Zocial component, please submit a pull request against this GitHub issue:
-   * {@link https://github.com/MetaMask/metamask-mobile/issues/8123}
-   */
-  export default Zocial;
 }
 
 declare module '@metamask/contract-metadata' {


### PR DESCRIPTION
## **Description**
This PR removes several deprecated vector icon libraries and their type declarations are no longer being used in the codebase
 - Remove unused icon imports from PaymentMethodIcon.tsx
 - Remove corresponding type declarations from index.d.ts

## **Related issues**

Closes these good first issues

Fixes: #8119 #8121 #8122 #8123

## **Manual testing steps**

1. Ensure none of the remove types are used in the codebase
2. Ensure none of the removed icon libraries are used in the codebase

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - Code removal only, no visual changes

### **After**

N/A - Code removal only, no visual changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.