### PR TITLE
feat: Support input types on `SnapUIInput`

### DIFF
--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
@@ -19,6 +19,7 @@ const styleSheet = (params: { theme: Theme }) => {
       borderTopRightRadius: 24,
       minHeight: 200,
       paddingBottom: Device.isIphoneX() ? 20 : 0,
+      maxHeight: "80%",
     },
     actionContainer: {
       flex: 0,

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
@@ -19,7 +19,7 @@ const styleSheet = (params: { theme: Theme }) => {
       borderTopRightRadius: 24,
       minHeight: 200,
       paddingBottom: Device.isIphoneX() ? 20 : 0,
-      maxHeight: "80%",
+      maxHeight: '80%',
     },
     actionContainer: {
       flex: 0,

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -297,13 +297,20 @@ describe('SnapUIRenderer', () => {
 
   it('re-renders when the interface changes', () => {
     const { toJSON, getAllByTestId, updateInterface, getRenderCount } =
-      renderInterface(Box({ children: Input({ name: 'input' }) }));
+      renderInterface(
+        Box({ children: Input({ name: 'input', type: 'number' }) }),
+      );
 
     const inputs = getAllByTestId('input');
     expect(inputs).toHaveLength(1);
 
     updateInterface(
-      Box({ children: [Input({ name: 'input' }), Input({ name: 'input2' })] }),
+      Box({
+        children: [
+          Input({ name: 'input', type: 'number' }),
+          Input({ name: 'input2', type: 'password' }),
+        ],
+      }),
     );
 
     const inputsAfterRerender = getAllByTestId('input');

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -2243,6 +2243,7 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
                       "backgroundColor": "#ffffff",
                       "borderTopLeftRadius": 24,
                       "borderTopRightRadius": 24,
+                      "maxHeight": "80%",
                       "minHeight": 300,
                       "overflow": "hidden",
                       "paddingBottom": 20,

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -353,6 +353,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                   autoFocus={false}
                   editable={true}
                   id="input"
+                  keyboardType="numeric"
                   onBlur={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}
@@ -415,6 +416,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                   onBlur={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}
+                  secureTextEntry={true}
                   style={
                     {
                       "backgroundColor": "#ffffff",

--- a/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.test.ts
@@ -104,4 +104,48 @@ describe('banner component', () => {
       },
     });
   });
+
+  it('removes empty title', () => {
+    const el: BannerElement = {
+      type: 'Banner',
+      props: {
+        title: '',
+        severity: 'info',
+        children: createTextElement('Test content'),
+      },
+      key: null,
+    };
+
+    const result = banner({ element: el, ...defaultParams });
+
+    expect(result).toEqual({
+      element: 'SnapUIBanner',
+      children: [
+        {
+          element: 'Text',
+          key: 'mock-key',
+          children: [
+            {
+              key: '4322bc9dfc78dd5fac77c48bc64efc877ae6265f8cc50c12a63fe3a62674e402_3',
+              element: 'RNText',
+              props: {
+                color: 'inherit',
+              },
+              children: 'Test content',
+            },
+          ],
+          props: {
+            color: 'inherit',
+            fontWeight: 'normal',
+            textAlign: 'left',
+            variant: 'sBodyMD',
+          },
+        },
+      ],
+      props: {
+        severity: 'Info',
+        title: null,
+      },
+    });
+  });
 });

--- a/app/components/Snaps/SnapUIRenderer/components/banner.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/banner.ts
@@ -22,7 +22,8 @@ export const banner: UIComponentFactory<BannerElement> = ({
     mapToTemplate({ element: children as JSXElement, ...params }),
   ),
   props: {
-    title: e.props.title,
+    // The Banner component shows an empty title if we dont do this.
+    title: e.props.title.length > 0 ? e.props.title : null,
     severity: transformSeverity(e.props.severity),
   },
 });

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -10,6 +10,7 @@ import { getPrimaryChildElementIndex, mapToTemplate } from '../utils';
 import { checkbox as checkboxFn } from './checkbox';
 import { selector as selectorFn } from './selector';
 import { UIComponentFactory, UIComponentParams } from './types';
+import { constructInputProps } from './input';
 
 export const field: UIComponentFactory<FieldElement> = ({
   element: e,
@@ -62,6 +63,7 @@ export const field: UIComponentFactory<FieldElement> = ({
       return {
         element: 'SnapUIInput',
         props: {
+          ...constructInputProps(input.props),
           id: input.props.name,
           placeholder: input.props.placeholder,
           label: e.props.label,

--- a/app/components/Snaps/SnapUIRenderer/components/input.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/input.ts
@@ -1,14 +1,40 @@
-import { InputElement } from '@metamask/snaps-sdk/jsx';
+import { InputElement, NumberInputProps } from '@metamask/snaps-sdk/jsx';
+import { hasProperty } from '@metamask/utils';
 
 import { UIComponentFactory } from './types';
 
-// TODO: Support min, max, type etc.
+// For now the types only change what the input looks like.
+// There is no special behavior for min, max, step etc.
+export const constructInputProps = (props: InputElement['props']) => {
+  if (!hasProperty(props, 'type')) {
+    return {};
+  }
+
+  switch (props.type) {
+    case 'password': {
+      return {
+        secureTextEntry: true,
+      };
+    }
+
+    case 'number': {
+      return {
+        keyboardType: 'numeric',
+      };
+    }
+
+    default:
+      return {};
+  }
+};
+
 export const input: UIComponentFactory<InputElement> = ({
   element: e,
   form,
 }) => ({
   element: 'SnapUIInput',
   props: {
+    ...constructInputProps(e.props),
     id: e.props.name,
     placeholder: e.props.placeholder,
     disabled: e.props.disabled,

--- a/app/components/Snaps/SnapUIRenderer/components/input.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/input.ts
@@ -1,4 +1,4 @@
-import { InputElement, NumberInputProps } from '@metamask/snaps-sdk/jsx';
+import { InputElement } from '@metamask/snaps-sdk/jsx';
 import { hasProperty } from '@metamask/utils';
 
 import { UIComponentFactory } from './types';

--- a/app/components/Snaps/SnapUISelector/SnapUISelector.styles.ts
+++ b/app/components/Snaps/SnapUISelector/SnapUISelector.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: { theme: Theme }) => {
       minHeight: 300,
       paddingBottom: Device.isIphoneX() ? 20 : 0,
       overflow: 'hidden',
-      maxHeight: "80%",
+      maxHeight: '80%',
     },
     content: {
       paddingLeft: 16,

--- a/app/components/Snaps/SnapUISelector/SnapUISelector.styles.ts
+++ b/app/components/Snaps/SnapUISelector/SnapUISelector.styles.ts
@@ -20,6 +20,7 @@ const styleSheet = (params: { theme: Theme }) => {
       minHeight: 300,
       paddingBottom: Device.isIphoneX() ? 20 : 0,
       overflow: 'hidden',
+      maxHeight: "80%",
     },
     content: {
       paddingLeft: 16,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Support input types on the `SnapUIInput` component. For mobile, this means changing the keyboard type and potentially hiding characters in a password input. This PR does not implement `min`, `max` or `step` as there doesn't seem to be any direct equivalents on mobile at this time.

This PR also fixes a number of small issues like the sheets not having a max height and the banner sometimes showing an empty title.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3181