### PR TITLE
fix: notification switch loading flicker

### DIFF
--- a/app/components/Views/Notifications/OptIn/index.tsx
+++ b/app/components/Views/Notifications/OptIn/index.tsx
@@ -25,15 +25,14 @@ const OptIn = () => {
   const styles = createStyles(theme);
   const navigation = useNavigation();
 
-  const { enableNotifications, isEnablingNotifications } =
-    useEnableNotifications({
-      nudgeEnablePush: true,
-    });
+  const { enableNotifications, loading } = useEnableNotifications({
+    nudgeEnablePush: true,
+  });
 
   const handleOptInCancel = useHandleOptInCancel({
     navigation,
     metrics,
-    isCreatingNotifications: isEnablingNotifications,
+    isCreatingNotifications: loading,
   });
 
   const handleOptInClick = useHandleOptInClick({
@@ -108,7 +107,7 @@ const OptIn = () => {
         </View>
       </View>
       <SwitchLoadingModal
-        loading={isEnablingNotifications}
+        loading={loading}
         loadingText={strings('app_settings.enabling_notifications')}
       />
     </Fragment>

--- a/app/util/notifications/hooks/useNotifications.test.tsx
+++ b/app/util/notifications/hooks/useNotifications.test.tsx
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
 
 // eslint-disable-next-line import/no-namespace
@@ -11,6 +11,7 @@ import {
 import * as Selectors from '../../../selectors/notifications';
 import { renderHookWithProvider } from '../../test/renderWithProvider';
 import {
+  useContiguousLoading,
   useDisableNotifications,
   useEnableNotifications,
   useListNotifications,
@@ -317,5 +318,70 @@ describe('useNotifications - useResetNotifications()', () => {
     });
 
     expect(hook.result.current.error).toBeDefined();
+  });
+});
+
+describe('useNotifications - useContiguousLoading()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  const arrangeHook = (loading1: boolean, loading2: boolean) =>
+    renderHook(
+      ({ loadingParam1, loadingParam2 }) =>
+        useContiguousLoading(loadingParam1, loadingParam2),
+      {
+        initialProps: { loadingParam1: loading1, loadingParam2: loading2 },
+      },
+    );
+
+  const assertResultAfterMs = (
+    ms: number,
+    result: ReturnType<typeof arrangeHook>['result'],
+    expectedValue: boolean,
+  ) => {
+    act(() => {
+      jest.advanceTimersByTime(ms);
+    });
+    expect(result.current).toBe(expectedValue);
+  };
+
+  it('returns true when either loadingParam1 or loadingParam2 is true', () => {
+    const { result, rerender } = arrangeHook(true, false);
+    expect(result.current).toBe(true);
+
+    rerender({ loadingParam1: false, loadingParam2: true });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false after both loadingParam1 and loadingParam2 are false and delay has passed', () => {
+    const { result, rerender } = arrangeHook(true, false);
+    expect(result.current).toBe(true);
+
+    // Toggle both loading states off
+    rerender({ loadingParam1: false, loadingParam2: false });
+    expect(result.current).toBe(true);
+
+    // Wait for contiguous loading to expire
+    assertResultAfterMs(100, result, false);
+  });
+
+  it('remains true if loadingParam1 or loadingParam2 becomes true again before delay expires', () => {
+    const { result, rerender } = arrangeHook(true, false);
+    expect(result.current).toBe(true);
+
+    // Toggle both loading states off
+    rerender({ loadingParam1: false, loadingParam2: false });
+    expect(result.current).toBe(true);
+
+    // Wait a little, but not long enough to contiguous loading to expire
+    assertResultAfterMs(50, result, true);
+
+    // Rerender with loading set to true
+    rerender({ loadingParam1: false, loadingParam2: true });
+    expect(result.current).toBe(true);
+
+    // Now if we we wait, it should still remain true since loading params are enabled
+    assertResultAfterMs(200, result, true);
   });
 });

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -80,6 +80,49 @@ export function useListNotificationsEffect() {
 }
 
 /**
+ * Adds a tiny delay between 2 loading states to ensure that we have a smooth loading experience.
+ * It prevents any flickers while we are transitioning between the 2 loading params
+ * E.g.
+ * ```
+ * loadingParam1: true, loadingParam2: false // 1st loading
+ * loadingParam1: false, loadingParam2: false // False positive (causes UI flicker)
+ * loadingParam1: false, loadingParam2: true // 2nd loading
+ * loadingParam1: false, loadingParam2: false // Finished loading
+ * ```
+ * @param loadingParam1 boolean
+ * @param loadingParam2 boolean
+ */
+export function useContiguousLoading(
+  loadingParam1: boolean,
+  loadingParam2: boolean,
+) {
+  const [contiguousLoading, setContiguousLoading] = useState(false);
+
+  useEffect(() => {
+    const isLoading = loadingParam1 || loadingParam2;
+
+    // If loading is true, we set it immediately
+    if (isLoading) {
+      setContiguousLoading(isLoading);
+      return;
+    }
+
+    // Otherwise if loading has stopped, we will continue to be loading for a little bit
+    // In case the boolean params update again
+    if (!isLoading) {
+      const timeout = setTimeout(() => {
+        setContiguousLoading(false);
+      }, 100);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [loadingParam1, loadingParam2]);
+
+  return contiguousLoading;
+}
+
+/**
  * Custom hook to enable MetaMask notifications.
  * This hook encapsulates the logic for enabling notifications, handling loading and error states.
  * It uses Redux to dispatch actions related to notifications.
@@ -104,11 +147,13 @@ export function useEnableNotifications(props = { nudgeEnablePush: true }) {
     await enableNotificationsHelper().catch((e) => setError(e));
   }, [togglePushNotification]);
 
+  const contiguousLoading = useContiguousLoading(loading, pushLoading);
+
   return {
     enableNotifications,
     isEnablingNotifications: loading,
     isEnablingPushNotifications: pushLoading,
-    loading: loading && pushLoading,
+    loading: loading || pushLoading || contiguousLoading,
     error,
     data,
   };

--- a/app/util/notifications/hooks/useSwitchNotifications.ts
+++ b/app/util/notifications/hooks/useSwitchNotifications.ts
@@ -20,6 +20,7 @@ import {
   useListNotifications,
   useEnableNotifications,
   useDisableNotifications,
+  useContiguousLoading,
 } from './useNotifications';
 import { isNotificationsFeatureEnabled } from '../constants';
 import { strings } from '../../../../locales/i18n';
@@ -179,11 +180,16 @@ export function useSwitchNotificationLoadingText(): string | undefined {
     selectIsUpdatingMetamaskNotificationsAccount,
   );
 
+  const loading = useContiguousLoading(
+    notificationsLoading,
+    pushNotificationsLoading,
+  );
+
   if (accountsLoading.length > 0) {
     return strings('app_settings.updating_account_settings');
   }
 
-  if (notificationsLoading || pushNotificationsLoading) {
+  if (notificationsLoading || pushNotificationsLoading || loading) {
     return strings('app_settings.updating_notifications');
   }
 


### PR DESCRIPTION
## **Description**

The loading banner flickers and was delayed because we have 2 loading states from 2 different controllers.
We now combine them into a contiguous loading state, and ensure we check both controllers are loading to show the loading banner.

## **Related issues**

Fixes:

## **Manual testing steps**

Test notification enable flow
1. Onboard
2. Click Bell
3. Enable Notifications

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://www.loom.com/share/8a7f4dc67c1b46f0b3fd3be8b3766108?sid=e45d1f5f-ecb0-4ede-8608-ac1376be51cd

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/84dc07aa17524cf19baee592006b5099?sid=dbbb9340-a02b-46eb-8015-cf21d61caa09

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
