### PR TITLE
fix: Hide account list selector balance for non evm accounts

### DIFF
--- a/app/components/hooks/useAccounts/useAccounts.ts
+++ b/app/components/hooks/useAccounts/useAccounts.ts
@@ -40,6 +40,7 @@ import {
   isNonEvmAddress,
 } from '../../../core/Multichain/utils';
 import { getAccountBalances } from './utils';
+import { isEvmAccountType } from '@metamask/keyring-api';
 
 /**
  * Hook that returns both wallet accounts and ens name information.
@@ -175,6 +176,7 @@ const useAccounts = ({
           const balanceTicker = getTicker(ticker);
           const balanceLabel = `${balanceFiat}\n${balanceETH} ${balanceTicker}`;
           const balanceError = checkBalanceError?.(balanceWeiHex);
+          const isEvmAccount = isEvmAccountType(internalAccount.type);
           const isBalanceAvailable =
             isMultiAccountBalancesEnabled || isSelected;
           const mappedAccount: Account = {
@@ -185,9 +187,11 @@ const useAccounts = ({
             isSelected,
             // TODO - Also fetch assets. Reference AccountList component.
             // assets
-            assets: isBalanceAvailable
-              ? { fiatBalance: balanceLabel }
-              : undefined,
+            assets:
+              // TODO = Render non evm assets. This is a temporary fix.
+              isBalanceAvailable && isEvmAccount
+                ? { fiatBalance: balanceLabel }
+                : undefined,
             balanceError,
           };
           // Calculate height of the account item.


### PR DESCRIPTION
## **Description**

This PR provides a temporary fix for an issue where the Solana account balances appear as "0 ETH" in the account selector list. A proper fix that renders the correct Soalana fiat/token balance in this list is being worked on [here](https://github.com/MetaMask/metamask-mobile/pull/14278) but for the sake of speed and to unblock the RC 7.44.0, we are going to simply hide this incorrect value. This approach was disussed and confirmed with Rizivi this morning.

The plan for this change to be cherry picked into rc 7.44.0 once it merges.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14332

## **Manual testing steps**

1. ensure you are building flask by verifying that your `.js.env` file contains `export METAMASK_BUILD_TYPE="flask"`
2. yarn setup && yarn start:ios
3. create or import a wallet
4. click on the account selector list
5. click on add account of hardware wallet
6. click on solana account
7. notice that there is no data at all in the right section of the account selector list
8. if you select the solana account, it should still render your balance in the main wallet page. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/3b3b31bb-19e9-40b6-8fe2-8e0e1fda4599)


### **After**

<image src="https://github.com/user-attachments/assets/e6214357-c1a0-4087-b051-ca7224b8d444" height="700" width="350" />


https://github.com/user-attachments/assets/513bd567-8473-47b3-9cdc-3f29ddd6d496



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
