### PR TITLE
fix: E2E phishing test on android

### DIFF
--- a/e2e/specs/browser/browser-tests.spec.js
+++ b/e2e/specs/browser/browser-tests.spec.js
@@ -85,15 +85,24 @@ describe(SmokeCore('Browser Tests'), () => {
     await TestHelpers.delay(1500);
   });
 
-  it('should test phishing sites', async () => {
-    await Browser.tapBottomSearchBar();
-    // Clear text & Navigate to URL
-    await Browser.navigateToURL(ExternalSites.PHISHING_SITE);
-    await Browser.waitForBrowserPageToLoad();
-    await Assertions.checkIfVisible(Browser.backToSafetyButton);
+  // This is failing on android, because of the OS-level enforced
+  // ERR_CLEARTEXT_NOT_PERMITTED error
+  // We temporarily disable this test for android until we work out a solution
+  // https://consensyssoftware.atlassian.net/browse/IDENTITY-75
 
-    await Browser.tapBackToSafetyButton();
-    // Check that we are on the browser screen
-    await TestHelpers.delay(1500);
-  });
+  const itif = (condition) => (condition ? it : it.skip);
+  itif(device.getPlatform() === 'ios')(
+    'should test phishing sites',
+    async () => {
+      await Browser.tapBottomSearchBar();
+      // Clear text & Navigate to URL
+      await Browser.navigateToURL(ExternalSites.PHISHING_SITE);
+      await Browser.waitForBrowserPageToLoad();
+      await Assertions.checkIfVisible(Browser.backToSafetyButton);
+
+      await Browser.tapBackToSafetyButton();
+      // Check that we are on the browser screen
+      await TestHelpers.delay(1500);
+    },
+  );
 });


### PR DESCRIPTION
## **Description**

We are using a real malicious website to E2E test our phishing features.
This site changed yesterday (probably SSL certificate), that now falls back from https to http, and Android prevents unencrypted webviews to be displayed. This is enforced at the OS level and throws a 
 `ERR_CLEARTEXT_NOT_PERMITTED` error. 

This resulted in an E2E test timing out because the website never loaded on android.

To counter this, we are skipping this test on Android for now, and will work on finding a solution where we don't actually test this against real malicious websites as it is prone to flakyness.

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-75

## **Manual testing steps**

1. No manual testing steps as it concerns only E2E

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
