### PR TITLE
fix: #3931 Stop loading when enabling biometrics from settings

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -332,6 +332,7 @@ const Settings: React.FC = () => {
     if (credentials && credentials.password !== '') {
       storeCredentials(credentials.password, enabled, passwordType);
     } else {
+      setLoading(false);
       navigation.navigate('EnterPasswordSimple', {
         onPasswordSet: (password: string) => {
           storeCredentials(password, enabled, passwordType);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The original issue is that the settings screen contains an infinite loader when navigating back after enabling biometrics. The fix is a one liner to resolve the loading state after navigating forward so that navigating backwards doesn't result in the infinite loader

## **Related issues**

Fixes: #3931 

## **Manual testing steps**

1. Go to settings tab
2. Tap on `Security & privacy`
3. With biometrics off, tap on the biometrics toggle
4. You will be navigated forward to a screen requesting your password
5. Navigate backwards
6. Without the fix, you will be on an infinite loader screen. With the fix, the infinite loader should've resolved and you should see the settings screen

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/111d2ea3-390c-4775-8a2a-e44b0bb2edfe


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5a382786-3b47-45d7-9607-3f47b546fc20


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
