### PR TITLE
fix: fix dark mode for trx history network selector

### DIFF
--- a/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
@@ -422,6 +422,7 @@ exports[`ActivityView should render correctly 1`] = `
                       <Text
                         style={
                           {
+                            "color": "#121314",
                             "fontSize": 20,
                             "marginTop": 20,
                           }
@@ -477,6 +478,11 @@ exports[`ActivityView should render correctly 1`] = `
                         >
                           <Text
                             numberOfLines={1}
+                            style={
+                              {
+                                "color": "#121314",
+                              }
+                            }
                           >
                             Ethereum Main Network
                           </Text>

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -74,7 +74,15 @@ const createStyles = (params) => {
       flexDirection: 'row',
       paddingHorizontal: 16,
     },
-    title: { marginTop: 20, fontSize: 20, ...typography.headingMd },
+    title: {
+      marginTop: 20,
+      fontSize: 20,
+      color: colors.text.default,
+      ...typography.headingMd,
+    },
+    titleText: {
+      color: colors.text.default,
+    },
   });
 };
 
@@ -174,7 +182,7 @@ const ActivityView = () => {
           <ButtonBase
             testID={WalletViewSelectorsIDs.TOKEN_NETWORK_FILTER}
             label={
-              <Text numberOfLines={1}>
+              <Text numberOfLines={1} style={styles.titleText}>
                 {isAllNetworks && isPopularNetwork && isEvmSelected
                   ? `${strings('app_settings.popular')} ${strings(
                       'app_settings.networks',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
fix dark mode issue on transaction history

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to transactions history
2. enable dark mode
3. check the header and network filter

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="439" alt="Screenshot 2025-04-03 at 23 59 39" src="https://github.com/user-attachments/assets/c70acf2b-d034-4d60-bf37-cad6e7b63328" />


### **After**

<!-- [screenshots/recordings] -->

<img width="443" alt="Screenshot 2025-04-04 at 00 11 45" src="https://github.com/user-attachments/assets/17e538f6-8daf-4c4e-ab4a-5d4b110097eb" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
