### PR TITLE
feat(snaps): Add Snap export tracking hook to Snap controller init

### DIFF
--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -68,6 +68,7 @@ describe('SnapControllerInit', () => {
       getMnemonicSeed: expect.any(Function),
       maxIdleTime: expect.any(Number),
       preinstalledSnaps: expect.any(Array),
+      trackEvent: expect.any(Function),
     });
   });
 

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -21,6 +21,8 @@ import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings'
 import { store } from '../../../../store';
 import PREINSTALLED_SNAPS from '../../../../lib/snaps/preinstalled-snaps';
 import { Caip25EndowmentPermissionName } from '@metamask/chain-agnostic-permission';
+import { MetaMetrics } from '../../../Analytics';
+import { MetricsEventBuilder } from '../../../Analytics/MetricsEventBuilder';
 
 /**
  * Initialize the Snap controller.
@@ -119,6 +121,16 @@ export const snapControllerInit: ControllerInitFunction<
     clientCryptography: {
       pbkdf2Sha512: pbkdf2,
     },
+    trackEvent: (params: {
+      event: string;
+      properties?: Record<string, unknown>;
+    }) =>
+      MetaMetrics.getInstance().trackEvent(
+        MetricsEventBuilder.createEventBuilder({
+          category: params.event,
+          properties: params.properties,
+        }).build(),
+      ),
   });
 
   return {


### PR DESCRIPTION
## **Description**
This PR adds MetaMetrics tracking hook to Snap controller init. This way we delegate Snap export tracking to Snap controller.

## **Related issues**
Related PR:
https://github.com/MetaMask/snaps/pull/3281
https://github.com/MetaMask/metamask-extension/pull/31553 

## **Notes**
- Requires Snaps release.
- Snaps PR: https://github.com/MetaMask/snaps/pull/3281
- Targets Snaps release when ready.

## **Manual testing steps**
1. TBD

## **Screenshots/Recordings**
### **Before**
n/a

### **After**
n/a

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.