### PR TITLE
fix: Prevent Snap footer buttons from being pushed out of the modal

### DIFF
--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.styles.ts
@@ -21,10 +21,12 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingBottom: Device.isIphoneX() ? 20 : 0,
       maxHeight: '80%',
     },
-    actionContainer: {
-      flex: 0,
+    footer: {
+      position: 'absolute',
+      bottom: 20,
+      width: '100%',
       paddingVertical: 16,
-      justifyContent: 'center',
+      height: 80,
     },
   });
 };

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
@@ -126,7 +126,9 @@ const SnapDialogApproval = () => {
           onCancel={onCancel}
           useFooter={approvalRequest?.type === DIALOG_APPROVAL_TYPES.default}
           style={{
-            marginBottom: approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default ? 80 : 0,
+            // eslint-disable-next-line react-native/no-inline-styles
+            marginBottom:
+              approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default ? 80 : 0,
           }}
         />
         {approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default && (

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
@@ -125,14 +125,16 @@ const SnapDialogApproval = () => {
           isLoading={isLoading}
           onCancel={onCancel}
           useFooter={approvalRequest?.type === DIALOG_APPROVAL_TYPES.default}
+          style={{
+            marginBottom: approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default ? 80 : 0,
+          }}
         />
         {approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default && (
-          <View style={styles.actionContainer}>
-            <BottomSheetFooter
-              buttonsAlignment={ButtonsAlignment.Horizontal}
-              buttonPropsArray={buttons}
-            />
-          </View>
+          <BottomSheetFooter
+            style={styles.footer}
+            buttonsAlignment={ButtonsAlignment.Horizontal}
+            buttonPropsArray={buttons}
+          />
         )}
       </View>
     </ApprovalModal>

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
@@ -125,8 +125,8 @@ const SnapDialogApproval = () => {
           isLoading={isLoading}
           onCancel={onCancel}
           useFooter={approvalRequest?.type === DIALOG_APPROVAL_TYPES.default}
+          // eslint-disable-next-line react-native/no-inline-styles
           style={{
-            // eslint-disable-next-line react-native/no-inline-styles
             marginBottom:
               approvalRequest?.type !== DIALOG_APPROVAL_TYPES.default ? 80 : 0,
           }}

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx
@@ -1,12 +1,11 @@
 import React, { memo, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { Box } from '../../UI/Box/Box';
 import { isEqual } from 'lodash';
 import { getMemoizedInterface } from '../../../selectors/snaps/interfaceController';
 import { SnapInterfaceContextProvider } from '../SnapInterfaceContext';
 import { mapToTemplate } from './utils';
 import TemplateRenderer from '../../UI/TemplateRenderer';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, View, ViewStyle } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import { Container } from '@metamask/snaps-sdk/jsx';
 import { strings } from '../../../../locales/i18n';
@@ -21,6 +20,7 @@ interface SnapUIRendererProps {
   interfaceId: string;
   onCancel?: () => void;
   useFooter: boolean;
+  style?: ViewStyle;
   PERF_DEBUG?: boolean; // DO NOT USE IN PRODUCTION
 }
 
@@ -39,6 +39,7 @@ const SnapUIRendererComponent = ({
   interfaceId,
   onCancel,
   useFooter,
+  style,
   PERF_DEBUG,
 }: SnapUIRendererProps) => {
   const theme = useTheme();
@@ -75,7 +76,7 @@ const SnapUIRendererComponent = ({
 
   const { state: initialState, context } = interfaceState;
   return (
-    <Box style={styles.root}>
+    <View style={[styles.root, style]}>
       <SnapInterfaceContextProvider
         snapId={snapId}
         interfaceId={interfaceId}
@@ -85,7 +86,7 @@ const SnapUIRendererComponent = ({
         <TemplateRenderer sections={sections} />
         {PERF_DEBUG && <PerformanceTracker />}
       </SnapInterfaceContextProvider>
-    </Box>
+    </View>
   );
 };
 

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`SnapUIRenderer adds a footer if required 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -160,11 +160,11 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -281,11 +281,11 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -463,11 +463,11 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -643,11 +643,11 @@ exports[`SnapUIRenderer renders basic UI 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -736,11 +736,11 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -1232,11 +1232,11 @@ exports[`SnapUIRenderer renders footers 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -1488,11 +1488,11 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -1720,11 +1720,11 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -2772,11 +2772,11 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >
@@ -2893,11 +2893,11 @@ exports[`SnapUIRenderer supports the onCancel prop 1`] = `
 <View
   style={
     [
-      {},
       {
         "flexGrow": 1,
         "minHeight": 667,
       },
+      undefined,
     ]
   }
 >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent Snap footer buttons from being pushed out of the modal by re-using a similar approach to how the new footer buttons are positioned.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3294

## Screenshots

<img src="https://github.com/user-attachments/assets/cc76cf62-86cd-4a71-9ffd-6d2f174bfcd5" width="400" />
