### PR TITLE
fix: cp-7.44.0 Disable auto correct on Snaps UI inputs

### DIFF
--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -72,6 +72,8 @@ export const SnapUIInput = ({
         id={name}
         value={value}
         onChangeText={handleChange}
+        autoCapitalize="none"
+        autoCorrect={false}
       />
       {error && (
         // eslint-disable-next-line react-native/no-inline-styles

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -239,6 +239,8 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input"
@@ -360,6 +362,8 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input"
@@ -420,6 +424,8 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input2"
@@ -542,6 +548,8 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input"
@@ -601,6 +609,8 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input2"
@@ -1646,6 +1656,8 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                   }
                 >
                   <TextInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
                     autoFocus={false}
                     editable={true}
                     id="input"
@@ -1832,6 +1844,8 @@ exports[`SnapUIRenderer supports forms with fields 1`] = `
                   }
                 >
                   <TextInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
                     autoFocus={false}
                     editable={true}
                     id="input"
@@ -2851,6 +2865,8 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                 }
               >
                 <TextInput
+                  autoCapitalize="none"
+                  autoCorrect={false}
                   autoFocus={false}
                   editable={true}
                   id="input"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Disable auto correct and auto capitalization in the Snaps UI inputs.

## **Related Issues**

Progresses https://github.com/MetaMask/metamask-mobile/issues/14367