### PR TITLE
fix: refresh pooled staking data on tx confirm

### DIFF
--- a/app/components/UI/Stake/Views/StakeInputView/StakeInputView.test.tsx
+++ b/app/components/UI/Stake/Views/StakeInputView/StakeInputView.test.tsx
@@ -33,9 +33,14 @@ import {
 } from '../../../../../selectors/featureFlagController';
 import { flushPromises } from '../../../../../util/test/utils';
 import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
+import usePooledStakes from '../../hooks/usePooledStakes';
 import { MetricsEventBuilder } from '../../../../../core/Analytics/MetricsEventBuilder';
 import useMetrics from '../../../../hooks/useMetrics/useMetrics';
 import { EVENT_PROVIDERS } from '../../constants/events';
+import {
+  MOCK_EXCHANGE_RATE,
+  MOCK_POOLED_STAKES_DATA,
+} from '../../__mocks__/earnControllerMockData';
 
 const MOCK_SELECTED_INTERNAL_ACCOUNT = {
   address: '0x123',
@@ -187,6 +192,11 @@ jest.mock('../../hooks/usePoolStakedDeposit', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../../hooks/usePooledStakes', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockInitialState: DeepPartial<RootState> = {
   settings: {},
   engine: {
@@ -199,6 +209,8 @@ const mockInitialState: DeepPartial<RootState> = {
 
 describe('StakeInputView', () => {
   const usePoolStakedDepositMock = jest.mocked(usePoolStakedDeposit);
+  const usePooledStakesMock = jest.mocked(usePooledStakes);
+
   const selectConfirmationRedesignFlagsMock = jest.mocked(
     selectConfirmationRedesignFlags,
   );
@@ -232,6 +244,19 @@ describe('StakeInputView', () => {
     usePoolStakedDepositMock.mockReturnValue({
       attemptDepositTransaction: jest.fn(),
     });
+    usePooledStakesMock.mockReturnValue({
+      pooledStakesData: MOCK_POOLED_STAKES_DATA,
+      exchangeRate: MOCK_EXCHANGE_RATE,
+      isLoadingPooledStakesData: false,
+      error: '',
+      refreshPooledStakes: jest.fn(),
+      refreshPooledStakesOnTxConfirmation: jest.fn(),
+      hasStakedPositions: false,
+      hasRewards: true,
+      hasRewardsOnly: false,
+      hasNeverStaked: false,
+      hasEthToUnstake: true,
+    });
     useMetricsMock.mockReturnValue({
       trackEvent: mockTrackEvent,
       createEventBuilder: MetricsEventBuilder.createEventBuilder,
@@ -247,7 +272,7 @@ describe('StakeInputView', () => {
       {
         state: mockInitialState,
       },
-      baseProps.route.params
+      baseProps.route.params,
     );
   }
 

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -14,8 +14,13 @@ import {
   type ConfirmationRedesignRemoteFlags,
 } from '../../../../../selectors/featureFlagController';
 import usePoolStakedDeposit from '../../hooks/usePoolStakedDeposit';
+import usePooledStakes from '../../hooks/usePooledStakes';
 import { GasImpactModalProps } from './GasImpactModal.types';
 import GasImpactModal from './index';
+import {
+  MOCK_POOLED_STAKES_DATA,
+  MOCK_EXCHANGE_RATE,
+} from '../../__mocks__/earnControllerMockData';
 
 const MOCK_SELECTED_INTERNAL_ACCOUNT = {
   address: '0x123',
@@ -44,6 +49,11 @@ jest.mock('../../../../../selectors/featureFlagController', () => ({
 }));
 
 jest.mock('../../hooks/usePoolStakedDeposit', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../hooks/usePooledStakes', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
@@ -78,6 +88,8 @@ const renderGasImpactModal = () =>
 
 describe('GasImpactModal', () => {
   const usePoolStakedDepositMock = jest.mocked(usePoolStakedDeposit);
+  const usePooledStakesMock = jest.mocked(usePooledStakes);
+
   const selectConfirmationRedesignFlagsMock = jest.mocked(
     selectConfirmationRedesignFlags,
   );
@@ -93,6 +105,20 @@ describe('GasImpactModal', () => {
 
     usePoolStakedDepositMock.mockReturnValue({
       attemptDepositTransaction: jest.fn(),
+    });
+
+    usePooledStakesMock.mockReturnValue({
+      pooledStakesData: MOCK_POOLED_STAKES_DATA,
+      exchangeRate: MOCK_EXCHANGE_RATE,
+      isLoadingPooledStakesData: false,
+      error: '',
+      refreshPooledStakes: jest.fn(),
+      refreshPooledStakesOnTxConfirmation: jest.fn(),
+      hasStakedPositions: false,
+      hasRewards: true,
+      hasRewardsOnly: false,
+      hasNeverStaked: false,
+      hasEthToUnstake: true,
     });
 
     selectSelectedInternalAccountMock.mockReturnValue(

--- a/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
@@ -49,7 +49,8 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
   const { stakingContract } = useStakeContext();
   const {
     pooledStakesData,
-    refreshPooledStakes
+    refreshPooledStakes,
+    refreshPooledStakesOnTxConfirmation,
   } = usePooledStakes();
 
   const chainId = useSelector(selectEvmChainId);
@@ -86,7 +87,7 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
         // redesigned confirmations architecture relies on the transaction
         // metadata object being defined by the time the confirmation is displayed
         // to the user.
-        await attemptPoolStakedClaimTransaction(
+        const txRes = await attemptPoolStakedClaimTransaction(
           activeAccount?.address,
           pooledStakesData,
         );
@@ -96,6 +97,11 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
             amountWei: claimableAmount,
           },
         });
+
+        const transactionId = txRes?.transactionMeta?.id;
+
+        refreshPooledStakesOnTxConfirmation(transactionId);
+
         return;
       }
 
@@ -134,15 +140,16 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
       setIsSubmittingClaimTransaction(false);
     }
   }, [
-    activeAccount,
-    pooledStakesData,
-    attemptPoolStakedClaimTransaction,
-    createEventBuilder,
+    activeAccount?.address,
     trackEvent,
-    refreshPooledStakes,
-    claimableAmount,
+    createEventBuilder,
     isStakingDepositRedesignedEnabled,
+    attemptPoolStakedClaimTransaction,
+    pooledStakesData,
     navigation,
+    claimableAmount,
+    refreshPooledStakesOnTxConfirmation,
+    refreshPooledStakes,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR fixes a regression in the redesigned confirmation screens where pool-staking data isn't refreshed when a transaction confirms.

The regression behaviour was impacting the redesigned screens.