### PR TITLE
fix: create Solana account in beta builds (cherry pick from #14460)

### DIFF
--- a/app/components/Views/AddAccountActions/AddAccountActions.tsx
+++ b/app/components/Views/AddAccountActions/AddAccountActions.tsx
@@ -33,6 +33,8 @@ import Text, {
 import { CaipChainId } from '@metamask/utils';
 import { KeyringClient } from '@metamask/keyring-snap-client';
 import { SolanaWalletSnapSender } from '../../../core/SnapKeyring/SolanaWalletSnap';
+// eslint-disable-next-line import/no-duplicates
+import { SolScope } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import {
@@ -40,8 +42,9 @@ import {
   hasCreatedBtcTestnetAccount,
 } from '../../../selectors/accountsController';
 import { BitcoinWalletSnapSender } from '../../../core/SnapKeyring/BitcoinWalletSnap';
-import { BtcScope, SolScope } from '@metamask/keyring-api';
 import { useSelector } from 'react-redux';
+// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
+import { BtcScope } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF
 
 const AddAccountActions = ({ onBack }: AddAccountActionsProps) => {

--- a/app/core/SnapKeyring/BitcoinWalletSnap.ts
+++ b/app/core/SnapKeyring/BitcoinWalletSnap.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import { SnapId } from '@metamask/snaps-sdk';
 import { Sender } from '@metamask/keyring-snap-client';
 import { HandlerType } from '@metamask/snaps-utils';


### PR DESCRIPTION
## Description

When this [PR was merged](https://github.com/MetaMask/metamask-mobile/pull/14406), it broke the beta builds when creating a solana account. A user would press the create solana account button and nothing would happen. This was due to an issue with the code fences. This PR addresses this issue by moving the appropriate type imports inside the appropriate code fence.

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14459

1. ensure that you are building metamask-beta by changing the value of METAMASK_BUILD_TYPE in the .js.env file to "beta"
2. yarn setup && yarn start:ios
3. import a wallet
4. click on the selected account at the top of the screen
5. click on "add new account or hardware wallet"
6. click solana
7. A solana account should be created and the network should be switched.

https://github.com/user-attachments/assets/c6186d79-2335-45e3-948c-39e9182f3873

https://github.com/user-attachments/assets/e3b0c6ac-8dcd-494d-9cb1-f91fc9f1863e

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->