### PR TITLE
fix: hide show private key in non-evm accounts

### DIFF
--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -420,12 +420,14 @@ const AccountActions = () => {
           onPress={onShare}
           testID={AccountActionsBottomSheetSelectorsIDs.SHARE_ADDRESS}
         />
-        <AccountAction
-          actionTitle={strings('account_details.show_private_key')}
-          iconName={IconName.Key}
-          onPress={goToExportPrivateKey}
-          testID={AccountActionsBottomSheetSelectorsIDs.SHOW_PRIVATE_KEY}
-        />
+        {selectedAddress && isEvmAccountType(selectedAccount.type) && (
+          <AccountAction
+            actionTitle={strings('account_details.show_private_key')}
+            iconName={IconName.Key}
+            onPress={goToExportPrivateKey}
+            testID={AccountActionsBottomSheetSelectorsIDs.SHOW_PRIVATE_KEY}
+          />
+        )}
         {selectedAddress && isHardwareAccount(selectedAddress) && (
           <AccountAction
             actionTitle={strings('accounts.remove_hardware_account')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Hides `Show private key` option for non-evm accounts.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14338

## **Manual testing steps**

1. Click on the account selector
2. Click on the 3 dots menu on an EVM account
3. `Show private key` should show
4. Click on the 3 dots menu on an non-EVM account 
5. `Show private key` should not be there

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/05502614-78d8-4782-9aaf-8c85144a2cf8

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
