### PR TITLE
fix: cp-7.44.0 Fix header styling for redesigned staking confirmations

### DIFF
--- a/app/components/Views/confirmations/components/Confirm/Info/StakingClaim/StakingClaim.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingClaim/StakingClaim.test.tsx
@@ -81,6 +81,7 @@ describe('StakingClaim', () => {
       title: 'Claim',
       onReject: mockOnReject,
       addBackButton: false,
+      theme: expect.any(Object),
     });
   });
 });

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingDeposit/StakingDeposit.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingDeposit/StakingDeposit.test.tsx
@@ -93,6 +93,7 @@ describe('StakingDeposit', () => {
       title: 'Stake',
       onReject: mockOnReject,
       addBackButton: true,
+      theme: expect.any(Object),
     });
   });
 

--- a/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Info/StakingWithdrawal/StakingWithdrawal.test.tsx
@@ -102,6 +102,7 @@ describe('StakingWithdrawal', () => {
       title: 'Unstake',
       onReject: mockOnReject,
       addBackButton: true,
+      theme: expect.any(Object),
     });
   });
 

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { getNavbar } from './Navbar';
 import { Theme } from '../../../../../../util/theme/models';
+
 describe('getStakingDepositNavbar', () => {
   it('renders the header title correctly', () => {
     const title = 'Test Title';

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { getNavbar } from './Navbar';
-
+import { Theme } from '../../../../../../util/theme/models';
 describe('getStakingDepositNavbar', () => {
   it('renders the header title correctly', () => {
     const title = 'Test Title';
     const { getByText } = render(
       <>
-        {getNavbar({ title, onReject: jest.fn() }).headerTitle()}
+        {getNavbar({
+          onReject: jest.fn(),
+          theme: {} as Theme,
+          title,
+        }).headerTitle()}
       </>,
     );
 
@@ -19,8 +23,9 @@ describe('getStakingDepositNavbar', () => {
     const { getByTestId } = render(
       <>
         {getNavbar({
-          title: 'Test Title',
           onReject: onRejectMock,
+          theme: {} as Theme,
+          title: 'Test Title',
         }).headerLeft()}
       </>,
     );

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.test.tsx
@@ -10,7 +10,13 @@ describe('getStakingDepositNavbar', () => {
       <>
         {getNavbar({
           onReject: jest.fn(),
-          theme: {} as Theme,
+          theme: {
+            colors: {
+              background: {
+                alternative: 'red',
+              },
+            },
+          } as Theme,
           title,
         }).headerTitle()}
       </>,
@@ -25,7 +31,13 @@ describe('getStakingDepositNavbar', () => {
       <>
         {getNavbar({
           onReject: onRejectMock,
-          theme: {} as Theme,
+          theme: {
+            colors: {
+              background: {
+                alternative: 'red',
+              },
+            },
+          } as Theme,
           title: 'Test Title',
         }).headerLeft()}
       </>,

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
@@ -33,7 +33,7 @@ export function getNavbar({
     },
     headerStyle: {
       backgroundColor: theme.colors.background.alternative,
-      // @ts-ignore - null is the only way to remove the shadow but it's not typed
+      // @ts-expect-error - null is the only way to remove the shadow but it's not typed
       shadowOffset: null,
     },
   });

--- a/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
+++ b/app/components/Views/confirmations/components/Confirm/Navbar/Navbar.tsx
@@ -9,15 +9,18 @@ import {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import Device from '../../../../../../util/device';
+import { Theme } from '../../../../../../util/theme/models';
 
 export function getNavbar({
   title,
   onReject,
   addBackButton = true,
+  theme,
 }: {
   title: string;
   onReject: () => void;
   addBackButton?: boolean;
+  theme: Theme;
 }) {
   const innerStyles = StyleSheet.create({
     headerLeft: {
@@ -27,6 +30,11 @@ export function getNavbar({
     headerTitle: {
       alignItems: 'center',
       marginRight: Device.isAndroid() ? 60 : undefined,
+    },
+    headerStyle: {
+      backgroundColor: theme.colors.background.alternative,
+      // @ts-ignore - null is the only way to remove the shadow but it's not typed
+      shadowOffset: null,
     },
   });
 
@@ -51,5 +59,6 @@ export function getNavbar({
         testID={`${title}-navbar-back-button`}
       />
     ),
+    headerStyle: innerStyles.headerStyle,
   };
 }

--- a/app/components/Views/confirmations/hooks/useNavbar.test.ts
+++ b/app/components/Views/confirmations/hooks/useNavbar.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
+import { Theme } from '../../../../util/theme/models';
 import { getNavbar } from '../components/Confirm/Navbar/Navbar';
 import { useConfirmActions } from './useConfirmActions';
 import useNavbar from './useNavbar';
@@ -54,6 +55,7 @@ describe('useNavbar', () => {
         title: mockTitle,
         onReject: mockOnReject,
         addBackButton: true,
+        theme: {} as Theme,
       }),
     );
   });

--- a/app/components/Views/confirmations/hooks/useNavbar.test.ts
+++ b/app/components/Views/confirmations/hooks/useNavbar.test.ts
@@ -49,6 +49,7 @@ describe('useNavbar', () => {
       title: mockTitle,
       onReject: mockOnReject,
       addBackButton: true,
+      theme: expect.any(Object),
     });
     expect(mockSetOptions).toHaveBeenCalledWith(
       getNavbar({
@@ -74,6 +75,7 @@ describe('useNavbar', () => {
       title: 'Updated Title',
       onReject: mockOnReject,
       addBackButton: true,
+      theme: expect.any(Object),
     });
   });
 
@@ -89,6 +91,7 @@ describe('useNavbar', () => {
       title: mockTitle,
       onReject: newOnReject,
       addBackButton: true,
+      theme: expect.any(Object),
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/useNavbar.ts
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useEffect } from 'react';
+import { useTheme } from '../../../../util/theme';
 import { StakeNavigationParamsList } from '../../../UI/Stake/types';
 import { getNavbar } from '../components/Confirm/Navbar/Navbar';
 import { useConfirmActions } from './useConfirmActions';
@@ -8,6 +9,7 @@ import { useConfirmActions } from './useConfirmActions';
 const useNavbar = (title: string, addBackButton = true) => {
   const navigation = useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
   const { onReject } = useConfirmActions();
+  const theme = useTheme();
 
   useEffect(() => {
     navigation.setOptions(
@@ -15,6 +17,7 @@ const useNavbar = (title: string, addBackButton = true) => {
         title,
         onReject,
         addBackButton,
+        theme,
       }),
     );
   }, [navigation, onReject, title, addBackButton]);

--- a/app/components/Views/confirmations/hooks/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/useNavbar.ts
@@ -7,7 +7,8 @@ import { getNavbar } from '../components/Confirm/Navbar/Navbar';
 import { useConfirmActions } from './useConfirmActions';
 
 const useNavbar = (title: string, addBackButton = true) => {
-  const navigation = useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation =
+    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
   const { onReject } = useConfirmActions();
   const theme = useTheme();
 
@@ -20,7 +21,7 @@ const useNavbar = (title: string, addBackButton = true) => {
         theme,
       }),
     );
-  }, [navigation, onReject, title, addBackButton]);
+  }, [navigation, onReject, theme, title, addBackButton]);
 };
 
 export default useNavbar;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix background of staking confirmations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4580

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-04-07 at 11 08 44](https://github.com/user-attachments/assets/6bc1c161-3bcb-492d-ad61-bd0034a43082)


### **After**

![Screenshot 2025-04-07 at 11 08 20](https://github.com/user-attachments/assets/dc6352b7-f2b1-465c-9074-74c5fc4a11a3)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
