### PR TITLE
fix: cp-7.44.0 Prevent re-renders of Field component in Snaps UI

### DIFF
--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -33,6 +33,9 @@ export interface MapToTemplateParams {
   textAlignment?: string;
 }
 
+// For some components we wish to ignore the JSX children as they are implemented using props in the client.
+const IGNORE_CHILDREN_COMPONENTS = ['Field'];
+
 /**
  * Get a truncated version of component children to use in a hash.
  *
@@ -40,7 +43,10 @@ export interface MapToTemplateParams {
  * @returns A truncated version of component children to use in a hash.
  */
 function getChildrenForHash(component: JSXElement) {
-  if (!hasChildren(component)) {
+  if (
+    !hasChildren(component) ||
+    IGNORE_CHILDREN_COMPONENTS.includes(component.type)
+  ) {
     return null;
   }
 

--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -39,6 +39,27 @@ export interface MapToTemplateParams {
 }
 
 /**
+ * Registry of element types that are used within Field element.
+ */
+export const FIELD_ELEMENT_TYPES = [
+  'FileInput',
+  'Input',
+  'Dropdown',
+  'RadioGroup',
+  'Checkbox',
+  'Selector',
+];
+
+/**
+ * Search for the element that is considered to be primary child element of a Field.
+ *
+ * @param children - Children elements specified within Field element.
+ * @returns Number, representing index of a primary field in the array of children elements.
+ */
+export const getPrimaryChildElementIndex = (children: JSXElement[]) =>
+  children.findIndex((c) => FIELD_ELEMENT_TYPES.includes(c.type));
+
+/**
  * Get a truncated version of component children to use in a hash.
  *
  * @param component - The component.
@@ -53,9 +74,9 @@ function getChildrenForHash(component: JSXElement) {
 
   // Field has special handling to determine the primary child to use for the key
   if (component.type === 'Field') {
-    const children = getJsxChildren(component) as JSXElement[];
-    const primaryChildIndex = getPrimaryChildElementIndex(children);
-    const primaryChild = children[primaryChildIndex] as InputElement;
+    const fieldChildren = getJsxChildren(component) as JSXElement[];
+    const primaryChildIndex = getPrimaryChildElementIndex(fieldChildren);
+    const primaryChild = fieldChildren[primaryChildIndex] as InputElement;
     return { type: primaryChild?.type, name: primaryChild?.props?.name };
   }
 
@@ -210,27 +231,6 @@ export const mergeValue = <Type extends State>(
   }
   return { ...state, [name]: value };
 };
-
-/**
- * Registry of element types that are used within Field element.
- */
-export const FIELD_ELEMENT_TYPES = [
-  'FileInput',
-  'Input',
-  'Dropdown',
-  'RadioGroup',
-  'Checkbox',
-  'Selector',
-];
-
-/**
- * Search for the element that is considered to be primary child element of a Field.
- *
- * @param children - Children elements specified within Field element.
- * @returns Number, representing index of a primary field in the array of children elements.
- */
-export const getPrimaryChildElementIndex = (children: JSXElement[]) =>
-  children.findIndex((c) => FIELD_ELEMENT_TYPES.includes(c.type));
 
 /**
  * Map Snap custom size for border radius to mobile compatible size.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent re-renders of the Field component in Snaps UI which would make the keyboard briefly disappear. Since `Field` does not actually map to have any children (as it instead passes some components as props), we do not want the default key generation behavior. Instead, this PR introduces specific logic for fields.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3308