### PR TITLE
fix: SDK Connection when multichain account is selected

### DIFF
--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -168,7 +168,7 @@ describe('AccountConnect', () => {
     );
 
     // Create a new snapshot since the component UI has changed
-    expect(toJSON()).toMatchSnapshot({ mode: 'shallow' });
+    expect(toJSON()).toMatchSnapshot();
   });
 
   describe('Renders different screens based on SDK URL status', () => {

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -8,6 +8,11 @@ import { RootState } from '../../../reducers';
 import { fireEvent } from '@testing-library/react-native';
 import AccountConnectMultiSelector from './AccountConnectMultiSelector/AccountConnectMultiSelector';
 import Engine from '../../../core/Engine';
+import {
+  createMockAccountsControllerState as createMockAccountsControllerStateUtil,
+  MOCK_ADDRESS_1 as mockAddress1,
+  MOCK_ADDRESS_2 as mockAddress2,
+} from '../../../util/test/accountsControllerTestUtils';
 
 const mockedNavigate = jest.fn();
 const mockedGoBack = jest.fn();
@@ -49,20 +54,36 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
-jest.mock('../../../core/Engine', () => ({
-  context: {
-    PhishingController: {
-      maybeUpdateState: jest.fn(),
-      test: jest.fn((url: string) => {
-        if (url === 'phishing.com') return { result: true };
-        return { result: false };
-      }),
+jest.mock('../../../core/Engine', () => {
+  const {
+    createMockAccountsControllerState,
+    MOCK_ADDRESS_1,
+    MOCK_ADDRESS_2,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  } = require('../../../util/test/accountsControllerTestUtils');
+  const mockAccountsState = createMockAccountsControllerState(
+    [MOCK_ADDRESS_1, MOCK_ADDRESS_2],
+    MOCK_ADDRESS_1,
+  );
+
+  return {
+    context: {
+      PhishingController: {
+        maybeUpdateState: jest.fn(),
+        test: jest.fn((url: string) => {
+          if (url === 'phishing.com') return { result: true };
+          return { result: false };
+        }),
+      },
+      PermissionController: {
+        rejectPermissionsRequest: jest.fn(),
+      },
+      AccountsController: {
+        state: mockAccountsState,
+      },
     },
-    PermissionController: {
-      rejectPermissionsRequest: jest.fn(),
-    },
-  },
-}));
+  };
+});
 
 const mockRemoveChannel = jest.fn();
 
@@ -79,11 +100,45 @@ jest.mock('../../../core/SDKConnect/utils/isUUID', () => ({
   isUUID: () => false,
 }));
 
+// Mock useAccounts to return test accounts
+jest.mock('../../hooks/useAccounts', () => ({
+  useAccounts: jest.fn(() => ({
+    evmAccounts: [
+      {
+        address: mockAddress1,
+        name: 'Account 1',
+      },
+      {
+        address: mockAddress2,
+        name: 'Account 2',
+      },
+    ],
+    ensByAccountAddress: {},
+  })),
+}));
+
+// Setup test state with proper account data
 const mockInitialState: DeepPartial<RootState> = {
   settings: {},
   engine: {
     backgroundState: {
       ...backgroundState,
+      AccountsController: createMockAccountsControllerStateUtil(
+        [mockAddress2, mockAddress2],
+        mockAddress1,
+      ),
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum',
+            rpcEndpoints: [{ url: 'https://mainnet.infura.io/v3/test' }],
+            blockExplorerUrls: ['https://etherscan.io'],
+            nativeCurrency: 'ETH',
+          },
+        },
+        selectedNetworkClientId: '1',
+      },
     },
   },
 };
@@ -112,7 +167,8 @@ describe('AccountConnect', () => {
       { state: mockInitialState },
     );
 
-    expect(toJSON()).toMatchSnapshot();
+    // Create a new snapshot since the component UI has changed
+    expect(toJSON()).toMatchSnapshot({ mode: 'shallow' });
   });
 
   describe('Renders different screens based on SDK URL status', () => {

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -28,6 +28,7 @@ import Engine from '../../../core/Engine';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
 import {
   selectInternalAccounts,
+  selectPreviouslySelectedEvmAccount,
   selectSelectedInternalAccountFormattedAddress,
 } from '../../../selectors/accountsController';
 import { isDefaultAccountName } from '../../../util/ENSUtils';
@@ -83,6 +84,7 @@ import { isUUID } from '../../../core/SDKConnect/utils/isUUID';
 import useOriginSource from '../../hooks/useOriginSource';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { getPhishingTestResult } from '../../../util/phishingDetection';
+import { getFormattedAddressFromInternalAccount } from '../../../core/Multichain/utils';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -105,10 +107,21 @@ const AccountConnect = (props: AccountConnectProps) => {
     selectSelectedInternalAccountFormattedAddress,
   );
 
-  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
+  const previouslySelectedEvmAccount = useSelector(
+    selectPreviouslySelectedEvmAccount,
+  );
 
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const [selectedAddresses, setSelectedAddresses] = useState<string[]>(
-    selectedWalletAddress && isEvmSelected ? [selectedWalletAddress] : [],
+    selectedWalletAddress && isEvmSelected
+      ? [selectedWalletAddress]
+      : [
+          previouslySelectedEvmAccount
+            ? getFormattedAddressFromInternalAccount(
+                previouslySelectedEvmAccount,
+              )
+            : '',
+        ],
   );
   const [confirmedAddresses, setConfirmedAddresses] =
     useState<string[]>(selectedAddresses);

--- a/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
+++ b/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`AccountConnect renders correctly 1`] = `
                             }
                           }
                         >
-                          Connect an account
+                          Requesting for Account 2
                         </Text>
                       </Text>
                     </View>
@@ -373,7 +373,169 @@ exports[`AccountConnect renders correctly 1`] = `
                           "minWidth": "25%",
                         }
                       }
-                    />
+                    >
+                      <View
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "marginLeft": 0,
+                            }
+                          }
+                          testID="avatargroup-avatar-container-0"
+                        >
+                          <View
+                            style={
+                              {
+                                "backgroundColor": "#ffffff",
+                                "borderColor": "#ffffff",
+                                "borderRadius": 8,
+                                "borderWidth": 1.5,
+                                "height": 16,
+                                "overflow": "hidden",
+                                "width": 16,
+                              }
+                            }
+                            testID="avatargroup-avatar"
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "overflow": "hidden",
+                                  },
+                                  {
+                                    "backgroundColor": "#FC4800",
+                                    "borderRadius": 8,
+                                    "height": 16,
+                                    "width": 16,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <RNSVGSvgView
+                                bbHeight={16}
+                                bbWidth={16}
+                                focusable={false}
+                                height={16}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 16,
+                                      "width": 16,
+                                    },
+                                  ]
+                                }
+                                width={16}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGRect
+                                    fill={
+                                      {
+                                        "payload": 4278291575,
+                                        "type": 0,
+                                      }
+                                    }
+                                    height={16}
+                                    matrix={
+                                      [
+                                        -0.41310442982454204,
+                                        -0.910683660806177,
+                                        0.910683660806177,
+                                        -0.41310442982454204,
+                                        4.404802817153955,
+                                        20.16808402411075,
+                                      ]
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                    width={16}
+                                    x={0}
+                                    y={0}
+                                  />
+                                  <RNSVGRect
+                                    fill={
+                                      {
+                                        "payload": 4278410587,
+                                        "type": 0,
+                                      }
+                                    }
+                                    height={16}
+                                    matrix={
+                                      [
+                                        0.903335292863301,
+                                        -0.42893513340314526,
+                                        0.42893513340314526,
+                                        0.903335292863301,
+                                        -9.297010789302583,
+                                        3.362634662066926,
+                                      ]
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                    width={16}
+                                    x={0}
+                                    y={0}
+                                  />
+                                  <RNSVGRect
+                                    fill={
+                                      {
+                                        "payload": 4294382337,
+                                        "type": 0,
+                                      }
+                                    }
+                                    height={16}
+                                    matrix={
+                                      [
+                                        -0.6921431738704069,
+                                        -0.7217602280983622,
+                                        0.7217602280983622,
+                                        -0.6921431738704069,
+                                        -6.169639630140347,
+                                        15.20799235933167,
+                                      ]
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                    width={16}
+                                    x={0}
+                                    y={0}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
                   </View>
                 </View>
                 <View
@@ -515,7 +677,7 @@ exports[`AccountConnect renders correctly 1`] = `
                             }
                           }
                         >
-                          Requesting for 5 networks
+                          Requesting for Ethereum
                         </Text>
                       </Text>
                     </View>
@@ -574,137 +736,6 @@ exports[`AccountConnect renders correctly 1`] = `
                             />
                           </View>
                         </View>
-                        <View
-                          style={
-                            {
-                              "marginLeft": -6,
-                            }
-                          }
-                          testID="avatargroup-avatar-container-1"
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "backgroundColor": "#ffffff",
-                                "borderColor": "#ffffff",
-                                "borderRadius": 8,
-                                "borderWidth": 1.5,
-                                "height": 16,
-                                "justifyContent": "center",
-                                "overflow": "hidden",
-                                "width": 16,
-                              }
-                            }
-                            testID="avatargroup-avatar"
-                          >
-                            <Image
-                              onError={[Function]}
-                              resizeMode="contain"
-                              source={1}
-                              style={
-                                {
-                                  "height": 16,
-                                  "width": 16,
-                                }
-                              }
-                              testID="network-avatar-image"
-                            />
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "marginLeft": -6,
-                            }
-                          }
-                          testID="avatargroup-avatar-container-2"
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "backgroundColor": "#ffffff",
-                                "borderColor": "#ffffff",
-                                "borderRadius": 8,
-                                "borderWidth": 1.5,
-                                "height": 16,
-                                "justifyContent": "center",
-                                "overflow": "hidden",
-                                "width": 16,
-                              }
-                            }
-                            testID="avatargroup-avatar"
-                          >
-                            <Image
-                              onError={[Function]}
-                              resizeMode="contain"
-                              source={1}
-                              style={
-                                {
-                                  "height": 16,
-                                  "width": 16,
-                                }
-                              }
-                              testID="network-avatar-image"
-                            />
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "marginLeft": -6,
-                            }
-                          }
-                          testID="avatargroup-avatar-container-3"
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "backgroundColor": "#ffffff",
-                                "borderColor": "#ffffff",
-                                "borderRadius": 8,
-                                "borderWidth": 1.5,
-                                "height": 16,
-                                "justifyContent": "center",
-                                "overflow": "hidden",
-                                "width": 16,
-                              }
-                            }
-                            testID="avatargroup-avatar"
-                          >
-                            <Image
-                              onError={[Function]}
-                              resizeMode="contain"
-                              source={1}
-                              style={
-                                {
-                                  "height": 16,
-                                  "width": 16,
-                                }
-                              }
-                              testID="network-avatar-image"
-                            />
-                          </View>
-                        </View>
-                        <Text
-                          accessibilityRole="text"
-                          style={
-                            {
-                              "color": "#686e7d",
-                              "fontFamily": "CentraNo1-Medium",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0,
-                              "lineHeight": 22,
-                              "marginLeft": 2,
-                            }
-                          }
-                          testID="avatargroup-overflowcounter"
-                        >
-                          +1
-                        </Text>
                       </View>
                     </View>
                   </View>
@@ -821,8 +852,9 @@ exports[`AccountConnect renders correctly 1`] = `
               <TouchableOpacity
                 accessibilityRole="button"
                 accessible={true}
-                activeOpacity={1}
-                disabled={true}
+                activeOpacity={0.2}
+                disabled={false}
+                onPress={[Function]}
                 style={
                   [
                     [
@@ -844,9 +876,7 @@ exports[`AccountConnect renders correctly 1`] = `
                         },
                       ],
                     ],
-                    {
-                      "opacity": 0.6,
-                    },
+                    null,
                   ]
                 }
                 testID="connect-button"
@@ -860,9 +890,7 @@ exports[`AccountConnect renders correctly 1`] = `
                         "fontWeight": "500",
                         "textAlign": "center",
                       },
-                      {
-                        "color": "#dcdcdc",
-                      },
+                      null,
                       [
                         {
                           "fontFamily": "CentraNo1-Bold",
@@ -875,9 +903,7 @@ exports[`AccountConnect renders correctly 1`] = `
                         },
                         undefined,
                       ],
-                      {
-                        "opacity": 0.6,
-                      },
+                      null,
                     ]
                   }
                 >

--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -520,7 +520,6 @@ describe('selectPreviouslySelectedEvmAccount', () => {
   };
 
   it('returns the most recently selected EVM account based on lastSelected timestamp', () => {
-    // Create multiple accounts with different lastSelected timestamps
     const accountOldest = createEvmAccountWithLastSelected(
       '0x111',
       'Oldest Account',
@@ -557,8 +556,6 @@ describe('selectPreviouslySelectedEvmAccount', () => {
         },
       },
     } as RootState;
-
-    // Should return the newest account (highest lastSelected value)
     expect(selectPreviouslySelectedEvmAccount(state)).toEqual(accountNewest);
   });
 
@@ -646,9 +643,7 @@ describe('selectPreviouslySelectedEvmAccount', () => {
 
     // The first account in the sorted list should be returned as they all have the same default timestamp (0)
     const result = selectPreviouslySelectedEvmAccount(state);
-    // We cannot assert exactly which account it will be since the sorting with equal timestamps
-    // might depend on implementation details, but we can verify it returns one of the accounts
-    expect([account1, account2, account3]).toContainEqual(result);
+    expect(result).toEqual(account1);
   });
 
   it('only returns EVM accounts when mixed with non-EVM accounts', () => {

--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -21,6 +21,7 @@ import {
   selectCanSignTransactions,
   selectSolanaAccountAddress,
   selectSolanaAccount,
+  selectPreviouslySelectedEvmAccount,
 } from './accountsController';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -491,5 +492,262 @@ describe('selectCanSignTransactions', () => {
       },
     } as RootState;
     expect(selectCanSignTransactions(state)).toBe(false);
+  });
+});
+
+describe('selectPreviouslySelectedEvmAccount', () => {
+  // Helper to create an EVM account with a lastSelected timestamp
+  const createEvmAccountWithLastSelected = (
+    address: string,
+    name: string,
+    lastSelectedTimestamp: number,
+  ): InternalAccount => {
+    const account = createMockInternalAccount(
+      address,
+      name,
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+    // Add lastSelected to metadata
+    return {
+      ...account,
+      metadata: {
+        ...account.metadata,
+        lastSelected: lastSelectedTimestamp,
+      },
+    };
+  };
+
+  it('returns the most recently selected EVM account based on lastSelected timestamp', () => {
+    // Create multiple accounts with different lastSelected timestamps
+    const accountOldest = createEvmAccountWithLastSelected(
+      '0x111',
+      'Oldest Account',
+      1000,
+    );
+
+    const accountMiddle = createEvmAccountWithLastSelected(
+      '0x222',
+      'Middle Account',
+      2000,
+    );
+
+    const accountNewest = createEvmAccountWithLastSelected(
+      '0x333',
+      'Newest Account',
+      3000,
+    );
+
+    // Test state with all accounts
+    const state = {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [accountOldest.id]: accountOldest,
+                [accountMiddle.id]: accountMiddle,
+                [accountNewest.id]: accountNewest,
+              },
+              selectedAccount: accountMiddle.id, // Currently selected doesn't affect the result
+            },
+          },
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+        },
+      },
+    } as RootState;
+
+    // Should return the newest account (highest lastSelected value)
+    expect(selectPreviouslySelectedEvmAccount(state)).toEqual(accountNewest);
+  });
+
+  it('handles EVM accounts without lastSelected timestamps', () => {
+    // Create one account with lastSelected timestamp
+    const accountWithTimestamp = createEvmAccountWithLastSelected(
+      '0x111',
+      'Account With Timestamp',
+      1000,
+    );
+
+    // Create another account without lastSelected timestamp
+    const accountWithoutTimestamp = createMockInternalAccount(
+      '0x222',
+      'Account Without Timestamp',
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+    // Test state with both accounts
+    const state = {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [accountWithTimestamp.id]: accountWithTimestamp,
+                [accountWithoutTimestamp.id]: accountWithoutTimestamp,
+              },
+              selectedAccount: accountWithoutTimestamp.id,
+            },
+          },
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+        },
+      },
+    } as RootState;
+
+    // Should return the account with timestamp as it's considered more recently selected
+    expect(selectPreviouslySelectedEvmAccount(state)).toEqual(
+      accountWithTimestamp,
+    );
+  });
+
+  it('returns the first account when multiple EVM accounts exist but none have lastSelected timestamps', () => {
+    // Create multiple accounts without lastSelected timestamps
+    const account1 = createMockInternalAccount(
+      '0x111',
+      'First Account',
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+    const account2 = createMockInternalAccount(
+      '0x222',
+      'Second Account',
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+    const account3 = createMockInternalAccount(
+      '0x333',
+      'Third Account',
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+    // Test state with all accounts
+    const state = {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [account1.id]: account1,
+                [account2.id]: account2,
+                [account3.id]: account3,
+              },
+              selectedAccount: account2.id,
+            },
+          },
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+        },
+      },
+    } as RootState;
+
+    // The first account in the sorted list should be returned as they all have the same default timestamp (0)
+    const result = selectPreviouslySelectedEvmAccount(state);
+    // We cannot assert exactly which account it will be since the sorting with equal timestamps
+    // might depend on implementation details, but we can verify it returns one of the accounts
+    expect([account1, account2, account3]).toContainEqual(result);
+  });
+
+  it('only returns EVM accounts when mixed with non-EVM accounts', () => {
+    // Create a mix of EVM and non-EVM accounts with timestamps
+    const evmAccount = createEvmAccountWithLastSelected(
+      '0x111',
+      'EVM Account',
+      1000,
+    );
+
+    // Non-EVM accounts with higher timestamps that should be ignored
+    const solAccount = {
+      ...createMockInternalAccount(
+        'solana_address_456',
+        'Solana Account',
+        KeyringTypes.snap,
+        SolAccountType.DataAccount,
+      ),
+      metadata: {
+        name: 'Solana Account',
+        importTime: 1684232000456,
+        keyring: { type: KeyringTypes.snap },
+        lastSelected: 2000, // Higher timestamp that should be ignored
+      },
+    };
+
+    const btcAccount = {
+      ...createMockInternalAccount(
+        'bc1q123xyz',
+        'Bitcoin Account',
+        KeyringTypes.snap,
+        BtcAccountType.P2wpkh,
+      ),
+      metadata: {
+        name: 'Bitcoin Account',
+        importTime: 1684232000456,
+        keyring: { type: KeyringTypes.snap },
+        lastSelected: 3000, // Highest timestamp that should be ignored
+      },
+    };
+
+    // Test state with mixed accounts
+    const state = {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [evmAccount.id]: evmAccount,
+                [solAccount.id]: solAccount,
+                [btcAccount.id]: btcAccount,
+              },
+              selectedAccount: solAccount.id, // Non-EVM account is currently selected
+            },
+          },
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+        },
+      },
+    } as RootState;
+
+    // Should return the EVM account even though non-EVM accounts have higher lastSelected timestamps
+    expect(selectPreviouslySelectedEvmAccount(state)).toEqual(evmAccount);
+  });
+
+  it('returns undefined when no EVM accounts exist', () => {
+    // Create only non-EVM accounts (Solana and Bitcoin)
+    const solAccount = createMockInternalAccount(
+      'solana_address_456',
+      'Solana Account',
+      KeyringTypes.snap,
+      SolAccountType.DataAccount,
+    );
+
+    const btcAccount = createMockInternalAccount(
+      'bc1q123xyz',
+      'Bitcoin Account',
+      KeyringTypes.snap,
+      BtcAccountType.P2wpkh,
+    );
+
+    // Test state with no EVM accounts
+    const state = {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [solAccount.id]: solAccount,
+                [btcAccount.id]: btcAccount,
+              },
+              selectedAccount: solAccount.id,
+            },
+          },
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+        },
+      },
+    } as RootState;
+
+    // Should return undefined as there are no EVM accounts
+    expect(selectPreviouslySelectedEvmAccount(state)).toBeUndefined();
   });
 });

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -4,7 +4,12 @@ import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectFlattenedKeyringAccounts } from './keyringController';
-import { BtcMethod, EthMethod, SolMethod } from '@metamask/keyring-api';
+import {
+  BtcMethod,
+  EthMethod,
+  SolMethod,
+  isEvmAccountType,
+} from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   getFormattedAddressFromInternalAccount,
@@ -72,12 +77,35 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
 /**
  * A memoized selector that returns the selected internal account address in checksum format
  */
-export const selectSelectedInternalAccountFormattedAddress = createSelector(
-  selectSelectedInternalAccount,
-  (account) =>
+export const selectSelectedInternalAccountFormattedAddress =
+  createDeepEqualSelector(selectSelectedInternalAccount, (account) =>
     account?.address
       ? getFormattedAddressFromInternalAccount(account)
       : undefined,
+  );
+
+/**
+ * A memoized selector that returns the previously selected EVM account
+ */
+export const selectPreviouslySelectedEvmAccount = createDeepEqualSelector(
+  selectInternalAccounts,
+  (accounts) => {
+    const evmAccounts = accounts.filter((account) =>
+      isEvmAccountType(account.type),
+    );
+
+    if (evmAccounts.length === 0) {
+      return undefined;
+    }
+
+    const previouslySelectedEvmAccount = [...evmAccounts].sort((a, b) => {
+      const aTimestamp = a?.metadata?.lastSelected || 0;
+      const bTimestamp = b?.metadata?.lastSelected || 0;
+      return bTimestamp - aTimestamp;
+    })[0];
+
+    return previouslySelectedEvmAccount;
+  },
 );
 
 /**


### PR DESCRIPTION
## **Description**

This PR addresses an issue reported by @christopherferreira9. When connecting to the MetaMask SDK while your current selected account is a multichain account (solana, bitcoin etc), the AccountConnect component would not provide an account to be connected. The connect button was not disabled so when a user would press connect, it would fail since no account was selected. My solution is...

1. create a new selector called `selectPreviouslySelectedEvmAccount` which returns the previously selected EVM account
2. in the AccountConnect component, if the current chainId is non evm, set the initial selected account to the previously selected EVM account. 
3. The result is, when the user tries to connect to the SDK while their currently selected account is a Solana account, the user would still be prompted to connect their EVM account.
4. Users can connect multi non evm accounts by clicking the "connect multiple accounts" button which will only show their EVM accounts.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14426
Fixes https://github.com/MetaMask/metamask-mobile/issues/14427

## **Manual testing steps**

1. edit the `.js.env` file such that the METAMASK_BUILD_TYPE is set to `beta`
2. `yarn setup`
3. Build the branch on a real Physical device. Easiest option is to build the app using expo via runway. docs on this can be found here: https://github.com/MetaMask/metamask-mobile?tab=readme-ov-file#for-internal-developers
5. Select Solana in the wallet
6. Open [this dapp](https://metamask.github.io/metamask-sdk/release-110.0.0/packages/examples/react-demo/build/index.html) on your desktop browser
7. Click connect on the dapp
8. Scan the QR Code with MetaMask -> The connection modal presents no accounts
9. Accepting on this modal rejects the connection (see dapp console)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="339" alt="Screenshot 2025-04-07 at 7 11 29 PM" src="https://github.com/user-attachments/assets/13e69ca9-1950-46bd-a3ed-9bac1410f90e" />


https://github.com/user-attachments/assets/7a1f1c8d-fee2-4a66-960d-ece10f2adae2


### **After**

<image src="https://github.com/user-attachments/assets/a659e4c5-6772-4bb4-979e-4d1347c5d01a" height="500" width="250" />


#### Phone cam


https://github.com/user-attachments/assets/36135b80-60f7-4299-9d56-0d113f24bdc7


#### Laptop cam


https://github.com/user-attachments/assets/cf246473-d70b-4fca-b533-3049f35358e4




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
