### PR TITLE
fix: cp-7.45.0 fix block explorer link for default networks on trx detail modal.

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
@@ -1569,6 +1569,55 @@ exports[`TransactionDetails should render correctly 1`] = `
                           </View>
                         </View>
                       </View>
+                      <TouchableOpacity
+                        onPress={[Function]}
+                        style={
+                          {
+                            "marginBottom": 24,
+                            "marginTop": 12,
+                          }
+                        }
+                      >
+                        <Text
+                          style={
+                            [
+                              false,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              {
+                                "color": "#4459ff",
+                                "fontFamily": "CentraNo1-Book",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                        >
+                          VIEW ON Etherscan
+                        </Text>
+                      </TouchableOpacity>
                     </View>
                   </View>
                 </View>

--- a/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
@@ -497,44 +497,18 @@ exports[`TransactionDetails should render correctly 1`] = `
                             Date
                           </Text>
                           <Text
+                            accessibilityRole="text"
+                            primary={true}
+                            small={true}
                             style={
-                              [
-                                {
-                                  "color": "#121314",
-                                  "fontFamily": "CentraNo1-Book",
-                                  "fontSize": 30,
-                                  "fontWeight": "400",
-                                  "marginVertical": 2,
-                                },
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                {
-                                  "color": "#121314",
-                                },
-                                undefined,
-                                undefined,
-                                {
-                                  "fontSize": 12,
-                                },
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                                undefined,
-                              ]
+                              {
+                                "color": "#121314",
+                                "fontFamily": "CentraNo1-Book",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                              }
                             }
                           >
                             [missing "en.date.months.NaN" translation] NaN at 12:NaN am
@@ -778,44 +752,18 @@ exports[`TransactionDetails should render correctly 1`] = `
                                   </View>
                                 </View>
                                 <Text
+                                  accessibilityRole="text"
+                                  primary={true}
+                                  small={true}
                                   style={
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#121314",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "fontSize": 12,
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                    ]
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Book",
+                                      "fontSize": 16,
+                                      "fontWeight": "400",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                   testID="account-label"
                                 >
@@ -1058,44 +1006,18 @@ exports[`TransactionDetails should render correctly 1`] = `
                                   </View>
                                 </View>
                                 <Text
+                                  accessibilityRole="text"
+                                  primary={true}
+                                  small={true}
                                   style={
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#121314",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "fontSize": 12,
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                    ]
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Book",
+                                      "fontSize": 16,
+                                      "fontWeight": "400",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
                                   }
                                   testID="account-label"
                                 >
@@ -1579,40 +1501,17 @@ exports[`TransactionDetails should render correctly 1`] = `
                         }
                       >
                         <Text
+                          accessibilityRole="text"
                           style={
-                            [
-                              false,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              undefined,
-                              {
-                                "color": "#4459ff",
-                                "fontFamily": "CentraNo1-Book",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "textAlign": "center",
-                              },
-                            ]
+                            {
+                              "color": "#4459ff",
+                              "fontFamily": "CentraNo1-Book",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                              "textAlign": "center",
+                            }
                           }
                         >
                           VIEW ON Etherscan

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -20,7 +20,7 @@ import TransactionSummary from '../../../Views/TransactionSummary';
 import { toDateFormat } from '../../../../util/date';
 import StyledButton from '../../StyledButton';
 import StatusText from '../../../Base/StatusText';
-import Text from '../../../Base/Text';
+import Text from '../../../../component-library/components/Texts/Text';
 import DetailsModal from '../../../Base/DetailsModal';
 import { RPC, NO_RPC_BLOCK_EXPLORER } from '../../../../constants/network';
 import { withNavigation } from '@react-navigation/compat';
@@ -491,18 +491,17 @@ class TransactionDetails extends PureComponent {
         </View>
         {updatedTransactionDetails.hash &&
           status !== 'cancelled' &&
+          rpcBlockExplorer &&
           rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER && (
             <TouchableOpacity
               onPress={this.viewOnEtherscan}
               style={styles.touchableViewOnEtherscan}
             >
-              {rpcBlockExplorer ? (
-                <Text reset style={styles.viewOnEtherscan}>
-                  {`${strings('transactions.view_on')} ${getBlockExplorerName(
-                    rpcBlockExplorer,
-                  )}`}
-                </Text>
-              ) : null}
+              <Text style={styles.viewOnEtherscan}>
+                {`${strings('transactions.view_on')} ${getBlockExplorerName(
+                  rpcBlockExplorer,
+                )}`}
+              </Text>
             </TouchableOpacity>
           )}
       </DetailsModal.Body>

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -12,6 +12,7 @@ import {
   isMultiLayerFeeNetwork,
   getBlockExplorerTxUrl,
   findBlockExplorerForNonEvmChainId,
+  isLineaMainnet,
 } from '../../../../util/networks';
 import Logger from '../../../../util/Logger';
 import EthereumAddress from '../../EthereumAddress';
@@ -53,6 +54,13 @@ import Avatar, {
 } from '../../../../component-library/components/Avatars/Avatar';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { WalletViewSelectorsIDs } from '../../../../../e2e/selectors/wallet/WalletView.selectors';
+import {
+  LINEA_MAINNET_BLOCK_EXPLORER,
+  LINEA_SEPOLIA_BLOCK_EXPLORER,
+  MAINNET_BLOCK_EXPLORER,
+  SEPOLIA_BLOCK_EXPLORER,
+} from '../../../../constants/urls';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -167,6 +175,39 @@ class TransactionDetails extends PureComponent {
   };
 
   /**
+   * Returns the appropriate block explorer URL for a given chain
+   * @param {string} chainId - The chain ID to get the block explorer for
+   * @param {string} txChainId - The transaction chain ID
+   * @param {Object} networkConfigurations - The network configurations object
+   * @returns {string} The block explorer URL
+   */
+  getBlockExplorerForChain = (chainId, txChainId, networkConfigurations) => {
+    // First check for network configuration block explorer
+    let blockExplorer =
+      networkConfigurations?.[txChainId]?.blockExplorerUrls[
+        networkConfigurations[txChainId]?.defaultBlockExplorerUrlIndex
+      ] || NO_RPC_BLOCK_EXPLORER;
+
+    // Check for default block explorers based on chain ID
+    if (isMainNet(chainId)) {
+      blockExplorer = MAINNET_BLOCK_EXPLORER;
+    } else if (isLineaMainnet(chainId)) {
+      blockExplorer = LINEA_MAINNET_BLOCK_EXPLORER;
+    } else if (chainId === CHAIN_IDS.LINEA_SEPOLIA) {
+      blockExplorer = LINEA_SEPOLIA_BLOCK_EXPLORER;
+    } else if (chainId === CHAIN_IDS.SEPOLIA) {
+      blockExplorer = SEPOLIA_BLOCK_EXPLORER;
+    }
+
+    // Check for non-EVM chain block explorer
+    if (isNonEvmChainId(chainId)) {
+      blockExplorer = findBlockExplorerForNonEvmChainId(chainId);
+    }
+
+    return blockExplorer;
+  };
+
+  /**
    * Updates transactionDetails for multilayer fee networks (e.g. for Optimism).
    */
   updateTransactionDetails = async () => {
@@ -231,14 +272,11 @@ class TransactionDetails extends PureComponent {
       networkConfigurations,
     } = this.props;
 
-    let blockExplorer =
-      networkConfigurations?.[txChainId]?.blockExplorerUrls[
-        networkConfigurations[txChainId]?.defaultBlockExplorerUrlIndex
-      ] || NO_RPC_BLOCK_EXPLORER;
-
-    if (isNonEvmChainId(chainId)) {
-      blockExplorer = findBlockExplorerForNonEvmChainId(chainId);
-    }
+    const blockExplorer = this.getBlockExplorerForChain(
+      chainId,
+      txChainId,
+      networkConfigurations,
+    );
     this.setState({ rpcBlockExplorer: blockExplorer });
     this.updateTransactionDetails();
   };

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -12,7 +12,7 @@ import {
   isMultiLayerFeeNetwork,
   getBlockExplorerTxUrl,
   findBlockExplorerForNonEvmChainId,
-  isLineaMainnet,
+  isLineaMainnetChainId,
 } from '../../../../util/networks';
 import Logger from '../../../../util/Logger';
 import EthereumAddress from '../../EthereumAddress';
@@ -189,13 +189,13 @@ class TransactionDetails extends PureComponent {
       ] || NO_RPC_BLOCK_EXPLORER;
 
     // Check for default block explorers based on chain ID
-    if (isMainNet(chainId)) {
+    if (isMainNet(txChainId)) {
       blockExplorer = MAINNET_BLOCK_EXPLORER;
-    } else if (isLineaMainnet(chainId)) {
+    } else if (isLineaMainnetChainId(txChainId)) {
       blockExplorer = LINEA_MAINNET_BLOCK_EXPLORER;
-    } else if (chainId === CHAIN_IDS.LINEA_SEPOLIA) {
+    } else if (txChainId === CHAIN_IDS.LINEA_SEPOLIA) {
       blockExplorer = LINEA_SEPOLIA_BLOCK_EXPLORER;
-    } else if (chainId === CHAIN_IDS.SEPOLIA) {
+    } else if (txChainId === CHAIN_IDS.SEPOLIA) {
       blockExplorer = SEPOLIA_BLOCK_EXPLORER;
     }
 
@@ -489,7 +489,6 @@ class TransactionDetails extends PureComponent {
             chainId={chainId}
           />
         </View>
-
         {updatedTransactionDetails.hash &&
           status !== 'cancelled' &&
           rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER && (

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -55,6 +55,13 @@ const initialState = {
       ...backgroundState,
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
     },
+    // NetworkController: {
+    //   ...mockNetworkState({
+    //     chainId: '0x89',
+    //     id: 'Polygon',
+    //     nickname: 'Polygon',
+    //   }),
+    // },
     SmartTransactionsController: {
       smartTransactionsState: {
         liveness: 'live',

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -211,13 +211,21 @@ describe('TransactionDetails', () => {
           backgroundState: {
             ...initialState.engine.backgroundState,
             NetworkController: {
-              ...mockNetworkState({
+              '0x1': {
                 chainId: '0x1',
-                id: 'mainnet',
-                nickname: 'Mainnet',
-                ticker: 'ETH',
-                blockExplorerUrl: 'https://etherscan.io/',
-              }),
+                blockExplorerUrls: [],
+                rpcEndpoints: [
+                  {
+                    rpcUrl: 'https://mainnet.infura.io/v3/123',
+                    chainId: '0x1',
+                    nickname: 'Mainnet',
+                    ticker: 'ETH',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                name: 'Mainnet',
+                nativeCurrency: 'ETH',
+              },
             },
           },
         },

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -39,6 +39,16 @@ const initialState = {
         },
       },
     },
+    '0xe708': {
+      isLive: true,
+      featureFlags: {
+        smartTransactions: {
+          expectedDeadline: 45,
+          maxDeadline: 160,
+          mobileReturnTxHashAsap: false,
+        },
+      },
+    },
   },
   engine: {
     backgroundState: {
@@ -75,6 +85,7 @@ const renderComponent = ({
   hash,
   txParams,
   status = 'confirmed',
+  networkId = '0x1',
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   state?: any;
@@ -83,6 +94,7 @@ const renderComponent = ({
   txParams?: any;
   status?: string;
   shouldUseSmartTransaction?: boolean;
+  networkId?: string;
 }) =>
   renderWithProvider(
     <Stack.Navigator>
@@ -96,24 +108,27 @@ const renderComponent = ({
               transaction: {
                 nonce: '',
               },
-              chainId: '0x1',
+              chainId: networkId,
               ...(txParams ? { txParams } : {}),
             }}
             //@ts-expect-error - TransactionDetails needs to be converted to typescript
             transactionDetails={{
               renderFrom: '0x0',
-              renderTo: '0x1',
+              renderTo: networkId,
               transactionHash: '0x2',
               renderValue: '2 TKN',
               renderGas: '21000',
               renderGasPrice: '2',
               renderTotalValue: '2 TKN / 0.001 ETH',
               renderTotalValueFiat: '',
-              txChainId: '0x1',
+              txChainId: networkId,
+              hash: '0x3',
               ...(hash ? { hash } : {}),
             }}
             //@ts-expect-error - navigation is not typed
             navigation={navigationMock}
+            // @ts-expect-error - chainId is not typed
+            chainId={networkId}
           />
         )}
       </Stack.Screen>
@@ -236,6 +251,70 @@ describe('TransactionDetails', () => {
       },
     });
     const etherscanButton = getByText('VIEW ON Etherscan');
+    expect(etherscanButton).toBeDefined();
+    fireEvent.press(etherscanButton);
+    expect(navigationMock.push).toHaveBeenCalled();
+  });
+
+  it('should display explorer link for linea mainnet', () => {
+    jest.mocked(query).mockResolvedValueOnce(123).mockResolvedValueOnce({
+      timestamp: 1234,
+      l1Fee: '0x1',
+    });
+
+    const { getByText } = renderComponent({
+      state: {
+        ...initialState,
+        engine: {
+          ...initialState.engine,
+          backgroundState: {
+            ...initialState.engine.backgroundState,
+            NetworkController: {
+              ...mockNetworkState({
+                chainId: '0xe708',
+                id: 'linea',
+                nickname: 'Linea Mainnet',
+                ticker: 'ETH',
+              }),
+            },
+          },
+        },
+      },
+      networkId: '0xe708',
+    });
+    const etherscanButton = getByText('VIEW ON Lineascan');
+    expect(etherscanButton).toBeDefined();
+    fireEvent.press(etherscanButton);
+    expect(navigationMock.push).toHaveBeenCalled();
+  });
+
+  it('should display explorer link for sepolia mainnet', () => {
+    jest.mocked(query).mockResolvedValueOnce(123).mockResolvedValueOnce({
+      timestamp: 1234,
+      l1Fee: '0x1',
+    });
+
+    const { getByText } = renderComponent({
+      state: {
+        ...initialState,
+        engine: {
+          ...initialState.engine,
+          backgroundState: {
+            ...initialState.engine.backgroundState,
+            NetworkController: {
+              ...mockNetworkState({
+                chainId: '0xaa36a7',
+                id: 'sepolia',
+                nickname: 'Sepolia Mainnet',
+                ticker: 'ETH',
+              }),
+            },
+          },
+        },
+      },
+      networkId: '0xaa36a7',
+    });
+    const etherscanButton = getByText('VIEW ON Sepolia');
     expect(etherscanButton).toBeDefined();
     fireEvent.press(etherscanButton);
     expect(navigationMock.push).toHaveBeenCalled();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Block explorer link should be displayed for default networks

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #14497 

## **Manual testing steps**

1. Install MM
2. Recover from SRP
3. Select Linea Sepolia network
4. Send a transaction
5. Click on Transaction tab
6. Verify the 'Click on Explorer' button is displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/80c5f382-1a57-44ff-bd64-f4a4f1d87d1d



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
