### PR TITLE
fix: cp-7.44.0 STAKE-1005 refresh staking data when staking txs are confirmed

### DIFF
--- a/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
@@ -47,10 +47,7 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
   const [shouldAttemptClaim, setShouldAttemptClaim] = useState(false);
   const { attemptPoolStakedClaimTransaction } = usePoolStakedClaim();
   const { stakingContract } = useStakeContext();
-  const {
-    pooledStakesData,
-    refreshPooledStakes
-  } = usePooledStakes();
+  const { pooledStakesData } = usePooledStakes();
 
   const chainId = useSelector(selectEvmChainId);
   const { isStakingSupportedChain } = useStakingChain();
@@ -64,7 +61,7 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
   useFocusEffect(
     useCallback(() => {
       setIsSubmittingClaimTransaction(false);
-    }, [])
+    }, []),
   );
 
   const attemptClaim = useCallback(async () => {
@@ -109,7 +106,6 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
       Engine.controllerMessenger.subscribeOnceIf(
         'TransactionController:transactionConfirmed',
         () => {
-          refreshPooledStakes();
           setIsSubmittingClaimTransaction(false);
         },
         (transactionMeta) => transactionMeta.id === transactionId,
@@ -139,7 +135,6 @@ const ClaimBanner = ({ claimableAmount, style }: StakeBannerProps) => {
     attemptPoolStakedClaimTransaction,
     createEventBuilder,
     trackEvent,
-    refreshPooledStakes,
     claimableAmount,
     isStakingDepositRedesignedEnabled,
     navigation,

--- a/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/FooterButtonGroup/FooterButtonGroup.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/FooterButtonGroup/FooterButtonGroup.tsx
@@ -23,7 +23,6 @@ import {
 } from './FooterButtonGroup.types';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import usePoolStakedUnstake from '../../../../hooks/usePoolStakedUnstake';
-import usePooledStakes from '../../../../hooks/usePooledStakes';
 import {
   MetaMetricsEvents,
   useMetrics,
@@ -66,7 +65,6 @@ const FooterButtonGroup = ({ valueWei, action }: FooterButtonGroupProps) => {
   const activeAccount = useSelector(selectSelectedInternalAccount);
 
   const { attemptDepositTransaction } = usePoolStakedDeposit();
-  const { refreshPooledStakes } = usePooledStakes();
 
   const { attemptUnstakeTransaction } = usePoolStakedUnstake();
 
@@ -143,12 +141,11 @@ const FooterButtonGroup = ({ valueWei, action }: FooterButtonGroupProps) => {
         'TransactionController:transactionConfirmed',
         () => {
           submitTxMetaMetric(STAKING_TX_METRIC_EVENTS[action].CONFIRMED);
-          refreshPooledStakes();
         },
         (transactionMeta) => transactionMeta.id === transactionId,
       );
     },
-    [action, navigate, refreshPooledStakes, submitTxMetaMetric],
+    [action, navigate, submitTxMetaMetric],
   );
 
   const handleConfirmation = async () => {

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1147,6 +1147,7 @@ export class Engine {
         allowedEvents: [
           'AccountsController:selectedAccountChange',
           'NetworkController:stateChange',
+          'TransactionController:transactionConfirmed',
         ],
         allowedActions: [
           'AccountsController:getSelectedAccount',

--- a/app/core/Engine/messengers/earn-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/earn-controller-messenger/index.ts
@@ -15,6 +15,7 @@ export function getEarnControllerMessenger(
     allowedEvents: [
       'AccountsController:selectedAccountChange',
       'NetworkController:stateChange',
+      'TransactionController:transactionConfirmed',
     ],
     allowedActions: [
       'AccountsController:getSelectedAccount',

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@metamask/composable-controller": "^11.0.0",
     "@metamask/controller-utils": "^11.7.0",
     "@metamask/design-tokens": "^7.0.0",
-    "@metamask/earn-controller": "^0.10.0",
+    "@metamask/earn-controller": "^0.11.0",
     "@metamask/eth-hd-keyring": "^12.1.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4581,14 +4581,14 @@
   resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-7.0.0.tgz#3434c19fb52a0cba15242085867236c3ec1c2aea"
   integrity sha512-M92BTgygZ4zteKL0tlWnXMpeWUY2cyraP1g+f6xIH67litdSu5iUyp2nhzVIlzHwGR+ycQAaicSscKyKm3aUVQ==
 
-"@metamask/earn-controller@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.npmjs.org/@metamask/earn-controller/-/earn-controller-0.10.0.tgz#890587d9e51e4fbaa8e85f09077c040e85a99462"
-  integrity sha512-vhywGCsaQphYyDwYksjk7+DZMQAeeC94lpDs6xUEV3xr0l1rG3NR5Ubqhl29oFwYsPV/0HGAbiGW9i3UYOBvkQ==
+"@metamask/earn-controller@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@metamask/earn-controller/-/earn-controller-0.11.0.tgz#47da160db26efd4b6b3e75dfd3c430541fe4b9b0"
+  integrity sha512-uxiuMYPd1pntHV3s4fq7At4fFSVlJ5LyRjKMVy4ySj+brsLpi8uAaD21ci4AEpvx3mB3NPCyxzCdKYwVRurtIw==
   dependencies:
     "@ethersproject/providers" "^5.7.0"
     "@metamask/base-controller" "^8.0.0"
-    "@metamask/controller-utils" "^11.6.0"
+    "@metamask/controller-utils" "^11.7.0"
     "@metamask/stake-sdk" "^1.0.0"
 
 "@metamask/eslint-config-typescript@^9.0.0":


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR aims to fix missing pooled-staking data refreshing when a transaction is confirmed using the redesigned confirmation screens.

#### Changes:
- Bumped the `@metamask/earn-controller` dependency to `^11.0.0`
- Removed existing calls to `refreshPooledStakes` in transaction subscription handlers
- Added new `TransactionController:transactionConfirmed` event to `EarnController` messengers

## **Related issues**

Fixes:
- https://github.com/MetaMask/metamask-mobile/issues/14440
- https://github.com/MetaMask/metamask-mobile/issues/14444

## **Manual testing steps**

Prerequisite: 
- Ensure you have ETH to stake.
- Update your local `.js.env` file to include the following variables
```ts
export FEATURE_FLAG_REDESIGNED_STAKING_TRANSACTIONS=true
export FEATURE_FLAG_REDESIGNED_SIGNATURES=true
```

To test the unstaking flow, we must first stake some ETH. You can skip this part if you have Staked Ethereum already.
1. From the token list home screen, click on Ethereum or Staked Ethereum
2. On the Ethereum token details screen, click "stake" or "stake more"
3. Stake a valid amount of ETH and continue to the confirmation screen
4. Review and confirm your stake

1. To unstake, click on Ethereum or Staked Ethereum from the token list screen
2. Click "unstake" (only visible if you have Staked ETH already)
3. Enter a valid amount to unstake and continue to the confirmation screen
4. Review and confirm your unstake transaction
5. Wait for smart transaction success
6. After your transaction is confirmed, return to the Ethereum token details screen and you should see a new blue unstaking banner.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

https://github.com/user-attachments/assets/7d121837-1d32-4d9a-a464-ab6c0b0f8df0

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
