### PR TITLE
fix: Add e2e label check

### DIFF
--- a/.github/scripts/check-pr-has-required-labels.ts
+++ b/.github/scripts/check-pr-has-required-labels.ts
@@ -51,16 +51,20 @@ async function main(): Promise<void> {
   ];
   let hasTeamLabel = false;
   let hasQALabel = false;
-
+  let hasSmokeE2ELabel = false;
   // Check pull request has at least required QA label and team label
   for (const label of pullRequestLabels) {
     if (label.startsWith('team-') || label === externalContributorLabel.name) {
       console.log(`PR contains a team label as expected: ${label}`);
       hasTeamLabel = true;
     }
-    if (label.includes('Run Smoke E2E') || label.includes('No QA Needed') || label.includes('QA Passed')  ) {
+    if (label.includes('No QA Needed') || label.includes('QA Passed')  ) {
       console.log(`PR contains a QA label as expected: ${label}`);
       hasQALabel = true;
+    }
+    if (label.includes('Run Smoke E2E') || label.includes('No E2E Smoke Needed')) {
+      console.log(`PR contains a Smoke E2E label as expected: ${label}`);
+      hasSmokeE2ELabel = true;
     }
     if (preventMergeLabels.includes(label)) {
       core.setFailed(
@@ -68,7 +72,7 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
-    if (hasTeamLabel && hasQALabel) {
+    if (hasTeamLabel && hasQALabel && hasSmokeE2ELabel) {
       return;
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update `check-pr-has-required-labels` action to check for the existence of either the `Run Smoke E2E` or `No E2E Smoke Needed` label.

## **Related issues**

Fixes: Failure https://github.com/MetaMask/metamask-mobile/actions/runs/14345178356/job/40213426099?pr=14537

## **Manual testing steps**

- Apply the `No E2E Smoke Needed` label, the PR should be unblocked for the label check action. Should be able to merge via the merge queue

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
