### PR TITLE
fix: temporarily disable identity E2E

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -183,8 +183,8 @@ stages:
       - run_ios_api_specs: {}
       - run_tag_smoke_accounts_ios: {}
       - run_tag_smoke_accounts_android: {}
-      - run_tag_smoke_identity_ios: {}
-      - run_tag_smoke_identity_android: {}
+      # - run_tag_smoke_identity_ios: {}
+      # - run_tag_smoke_identity_android: {}
       # - run_tag_smoke_assets_ios: {}
       - run_tag_smoke_assets_android: {}
       - run_tag_smoke_confirmations_ios: {}
@@ -221,8 +221,8 @@ stages:
       - run_tag_smoke_accounts_android: {}
       - run_tag_smoke_ramps_android: {}
       - run_tag_smoke_ramps_ios: {}
-      - run_tag_smoke_identity_ios: {}
-      - run_tag_smoke_identity_android: {}
+      # - run_tag_smoke_identity_ios: {}
+      # - run_tag_smoke_identity_android: {}
       # - run_tag_smoke_assets_ios: {}
       - run_tag_smoke_assets_android: {}
       # - run_tag_smoke_swaps_ios: {}


### PR DESCRIPTION
## **Description**

This PR temporarily disables the Identity workflows in Bitrise.
While all those tests pass locally, they are flaky on Bitrise because we run into issues where multiple mock servers collide.

[Example](https://app.bitrise.io/build/d8e64f5b-aa3f-4fe3-80ee-5413f28e5aa3)
Error encountered: `address already in use :::8000`

## **Related issues**

Fixes:

## **Manual testing steps**

1. No manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
