### PR TITLE
fix: cp-7.44.0 Correct `SnapUIImage` border radius and sizing logic

### DIFF
--- a/app/components/Snaps/SnapUICard/SnapUICard.tsx
+++ b/app/components/Snaps/SnapUICard/SnapUICard.tsx
@@ -41,7 +41,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       alignItems={AlignItems.center}
     >
       {image && (
-        <SnapUIImage width={32} height={32} borderRadius="full" value={image} />
+        <SnapUIImage width={32} height={32} borderRadius={999} value={image} />
       )}
       <Box flexDirection={FlexDirection.Column}>
         <Text variant={TextVariant.BodyMDMedium} ellipsizeMode="tail">

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,6 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { useState } from 'react';
-import { ImageStyle, StyleProp } from 'react-native';
+import { ImageStyle, StyleProp, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
 export interface SnapUIImageProps {
@@ -8,7 +8,51 @@ export interface SnapUIImageProps {
   style?: StyleProp<ImageStyle>;
   width?: number;
   height?: number;
-  borderRadius?: number | 'full';
+  borderRadius?: number;
+}
+
+function getViewBox(svg: string) {
+  const viewBoxMatch = svg.match(/viewBox="([^"]+)"/);
+
+  if (viewBoxMatch?.[1]) {
+    return viewBoxMatch?.[1];
+  }
+
+  const widthMatch = svg.match(/width="([^"]+)"/);
+  const heightMatch = svg.match(/height="([^"]+)"/);
+
+  if (widthMatch?.[1] && heightMatch?.[1]) {
+    const width = widthMatch[1];
+    const height = heightMatch[1];
+    return `0 0 ${width} ${height}`;
+  }
+
+  return undefined;
+}
+
+function getAspectRatio(viewBox?: string) {
+  if (!viewBox) {
+    return null;
+  }
+
+  const viewBoxElements = viewBox.split(' ');
+  const originalHeight = viewBoxElements[2];
+  const originalWidth = viewBoxElements[3];
+
+  if (!originalHeight || !originalHeight) {
+    return null;
+  }
+
+  const parsedWidth = parseInt(originalWidth, 10);
+  const parsedHeight = parseInt(originalHeight, 10);
+
+  const aspectRatio = parsedWidth / parsedHeight;
+
+  if (!Number.isFinite(aspectRatio)) {
+    return null;
+  }
+
+  return aspectRatio;
 }
 
 export const SnapUIImage: React.FC<SnapUIImageProps> = ({
@@ -18,37 +62,35 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
   style,
   borderRadius,
 }) => {
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const viewBox = getViewBox(value);
+  const aspectRatio = getAspectRatio(viewBox) ?? 1;
 
   return (
-    <SvgXml
-      testID="snaps-ui-image"
+    <View
       style={[
         // eslint-disable-next-line react-native/no-inline-styles
         {
-          borderRadius:
-            borderRadius === 'full'
-              ? Math.min(dimensions.width, dimensions.height) / 2
-              : borderRadius,
+          width,
+          height,
+          borderRadius,
           overflow: 'hidden',
+          aspectRatio,
         },
         style,
       ]}
-      xml={value}
-      {...(width ? { width } : {})}
-      {...(height ? { height } : {})}
-      onLayout={(layoutChangeEvent) => {
-        if (!dimensions.width || !dimensions.height) {
-          const { width: layoutWidth, height: layoutHeight } =
-            layoutChangeEvent.nativeEvent.layout;
-
-          setDimensions({
-            width: layoutWidth,
-            height: layoutHeight,
-          });
-        }
-      }}
-    />
+    >
+      <SvgXml
+        testID="snaps-ui-image"
+        xml={value}
+        // eslint-disable-next-line react-native/no-inline-styles
+        style={{
+          flex: 1,
+        }}
+        height="100%"
+        width="100%"
+        viewBox={viewBox}
+      />
+    </View>
   );
 };
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -30,7 +30,7 @@ function getViewBox(svg: string) {
   return undefined;
 }
 
-function getAspectRatio(viewBox?: string) {
+function getDimensions(viewBox?: string) {
   if (!viewBox) {
     return null;
   }
@@ -52,18 +52,21 @@ function getAspectRatio(viewBox?: string) {
     return null;
   }
 
-  return aspectRatio;
+  return { aspectRatio, height: parsedHeight, width: parsedWidth };
 }
 
 export const SnapUIImage: React.FC<SnapUIImageProps> = ({
   value,
-  width,
-  height,
+  width: propWidth,
+  height: propHeight,
   style,
   borderRadius,
 }) => {
   const viewBox = getViewBox(value);
-  const aspectRatio = getAspectRatio(viewBox) ?? 1;
+  const dimensions = getDimensions(viewBox);
+  const aspectRatio = dimensions?.aspectRatio ?? 1;
+  const width = propWidth ?? dimensions?.width;
+  const height = propHeight ?? dimensions?.height;
 
   return (
     <View

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -39,7 +39,7 @@ function getAspectRatio(viewBox?: string) {
   const originalHeight = viewBoxElements[2];
   const originalWidth = viewBoxElements[3];
 
-  if (!originalHeight || !originalHeight) {
+  if (!originalHeight || !originalWidth) {
     return null;
   }
 

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -78,6 +78,8 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
           borderRadius,
           overflow: 'hidden',
           aspectRatio,
+          maxHeight: '100%',
+          maxWidth: '100%',
         },
         style,
       ]}

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,5 +1,5 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import React, { useState } from 'react';
+import React from 'react';
 import { ImageStyle, StyleProp, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -36,8 +36,8 @@ function getAspectRatio(viewBox?: string) {
   }
 
   const viewBoxElements = viewBox.split(' ');
-  const originalHeight = viewBoxElements[2];
-  const originalWidth = viewBoxElements[3];
+  const originalWidth = viewBoxElements[2];
+  const originalHeight = viewBoxElements[3];
 
   if (!originalHeight || !originalWidth) {
     return null;

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -540,7 +540,11 @@ describe('SnapUIRenderer', () => {
             Field({
               label: 'My Input',
               children: [
-                Box({ children: [ImageComponent({ src: '<svg height="32" width="32" />' })]}),
+                Box({
+                  children: [
+                    ImageComponent({ src: '<svg height="32" width="32" />' }),
+                  ],
+                }),
                 Input({ name: 'input' }),
                 Button({ type: 'submit', name: 'submit', children: 'Submit' }),
               ],

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -540,7 +540,7 @@ describe('SnapUIRenderer', () => {
             Field({
               label: 'My Input',
               children: [
-                ImageComponent({ src: '<svg />' }),
+                Box({ children: [ImageComponent({ src: '<svg viewBox="0 0 32 32" />' })]}),
                 Input({ name: 'input' }),
                 Button({ type: 'submit', name: 'submit', children: 'Submit' }),
               ],

--- a/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/SnapUIRenderer.test.tsx
@@ -540,7 +540,7 @@ describe('SnapUIRenderer', () => {
             Field({
               label: 'My Input',
               children: [
-                Box({ children: [ImageComponent({ src: '<svg viewBox="0 0 32 32" />' })]}),
+                Box({ children: [ImageComponent({ src: '<svg height="32" width="32" />' })]}),
                 Input({ name: 'input' }),
                 Button({ type: 'submit', name: 'submit', children: 'Submit' }),
               ],

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1682,7 +1682,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                         vbHeight={32}
                         vbWidth={32}
                         width="100%"
-                        xml="<svg viewBox="0 0 32 32" />"
+                        xml="<svg height="32" width="32" />"
                       >
                         <RNSVGGroup
                           fill={

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1621,14 +1621,17 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                   testID="textfield-startacccessory"
                 >
                   <View
+                    color="Default"
+                    flexDirection="column"
+                    gap={8}
+                    justifyContent="flex-start"
                     style={
                       [
                         {
-                          "aspectRatio": 1,
-                          "borderRadius": 0,
-                          "height": undefined,
-                          "overflow": "hidden",
-                          "width": undefined,
+                          "color": "Default",
+                          "flexDirection": "column",
+                          "gap": 8,
+                          "justifyContent": "flex-start",
                         },
                         {
                           "padding": 0,
@@ -1636,40 +1639,61 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                       ]
                     }
                   >
-                    <RNSVGSvgView
-                      bbHeight="100%"
-                      bbWidth="100%"
-                      focusable={false}
-                      height="100%"
+                    <View
                       style={
                         [
                           {
-                            "backgroundColor": "transparent",
-                            "borderWidth": 0,
+                            "aspectRatio": 1,
+                            "borderRadius": 0,
+                            "height": undefined,
+                            "overflow": "hidden",
+                            "width": undefined,
                           },
-                          {
-                            "flex": 1,
-                          },
-                          {
-                            "flex": 0,
-                            "height": "100%",
-                            "width": "100%",
-                          },
+                          undefined,
                         ]
                       }
-                      testID="snaps-ui-image"
-                      width="100%"
-                      xml="<svg />"
                     >
-                      <RNSVGGroup
-                        fill={
-                          {
-                            "payload": 4278190080,
-                            "type": 0,
-                          }
+                      <RNSVGSvgView
+                        align="xMidYMid"
+                        bbHeight="100%"
+                        bbWidth="100%"
+                        focusable={false}
+                        height="100%"
+                        meetOrSlice={0}
+                        minX={0}
+                        minY={0}
+                        style={
+                          [
+                            {
+                              "backgroundColor": "transparent",
+                              "borderWidth": 0,
+                            },
+                            {
+                              "flex": 1,
+                            },
+                            {
+                              "flex": 0,
+                              "height": "100%",
+                              "width": "100%",
+                            },
+                          ]
                         }
-                      />
-                    </RNSVGSvgView>
+                        testID="snaps-ui-image"
+                        vbHeight={32}
+                        vbWidth={32}
+                        width="100%"
+                        xml="<svg viewBox="0 0 32 32" />"
+                      >
+                        <RNSVGGroup
+                          fill={
+                            {
+                              "payload": 4278190080,
+                              "type": 0,
+                            }
+                          }
+                        />
+                      </RNSVGSvgView>
+                    </View>
                   </View>
                 </View>
                 <View

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -946,6 +946,8 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
                         "aspectRatio": 1,
                         "borderRadius": 999,
                         "height": 32,
+                        "maxHeight": "100%",
+                        "maxWidth": "100%",
                         "overflow": "hidden",
                         "width": 32,
                       },
@@ -1634,6 +1636,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           "justifyContent": "flex-start",
                         },
                         {
+                          "height": "100%",
                           "padding": 0,
                         },
                       ]
@@ -1646,6 +1649,8 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                             "aspectRatio": 1,
                             "borderRadius": 0,
                             "height": 32,
+                            "maxHeight": "100%",
+                            "maxWidth": "100%",
                             "overflow": "hidden",
                             "width": 32,
                           },

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -939,45 +939,55 @@ exports[`SnapUIRenderer renders complex nested components 1`] = `
                   ]
                 }
               >
-                <RNSVGSvgView
-                  bbHeight={32}
-                  bbWidth={32}
-                  focusable={false}
-                  height={32}
-                  onLayout={[Function]}
+                <View
                   style={
                     [
                       {
-                        "backgroundColor": "transparent",
-                        "borderWidth": 0,
-                      },
-                      [
-                        {
-                          "borderRadius": 0,
-                          "overflow": "hidden",
-                        },
-                        undefined,
-                      ],
-                      {
-                        "flex": 0,
+                        "aspectRatio": 1,
+                        "borderRadius": 999,
                         "height": 32,
+                        "overflow": "hidden",
                         "width": 32,
                       },
+                      undefined,
                     ]
                   }
-                  testID="snaps-ui-image"
-                  width={32}
-                  xml="<svg />"
                 >
-                  <RNSVGGroup
-                    fill={
-                      {
-                        "payload": 4278190080,
-                        "type": 0,
-                      }
+                  <RNSVGSvgView
+                    bbHeight="100%"
+                    bbWidth="100%"
+                    focusable={false}
+                    height="100%"
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        {
+                          "flex": 1,
+                        },
+                        {
+                          "flex": 0,
+                          "height": "100%",
+                          "width": "100%",
+                        },
+                      ]
                     }
-                  />
-                </RNSVGSvgView>
+                    testID="snaps-ui-image"
+                    width="100%"
+                    xml="<svg />"
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4278190080,
+                          "type": 0,
+                        }
+                      }
+                    />
+                  </RNSVGSvgView>
+                </View>
                 <View
                   flexDirection="column"
                   style={
@@ -1610,43 +1620,57 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                   }
                   testID="textfield-startacccessory"
                 >
-                  <RNSVGSvgView
-                    bbHeight="100%"
-                    bbWidth="100%"
-                    focusable={false}
-                    onLayout={[Function]}
+                  <View
                     style={
                       [
                         {
-                          "backgroundColor": "transparent",
-                          "borderWidth": 0,
+                          "aspectRatio": 1,
+                          "borderRadius": 0,
+                          "height": undefined,
+                          "overflow": "hidden",
+                          "width": undefined,
                         },
-                        [
-                          {
-                            "borderRadius": 0,
-                            "overflow": "hidden",
-                          },
-                          undefined,
-                        ],
                         {
-                          "flex": 0,
-                          "height": "100%",
-                          "width": "100%",
+                          "padding": 0,
                         },
                       ]
                     }
-                    testID="snaps-ui-image"
-                    xml="<svg />"
                   >
-                    <RNSVGGroup
-                      fill={
-                        {
-                          "payload": 4278190080,
-                          "type": 0,
-                        }
+                    <RNSVGSvgView
+                      bbHeight="100%"
+                      bbWidth="100%"
+                      focusable={false}
+                      height="100%"
+                      style={
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "borderWidth": 0,
+                          },
+                          {
+                            "flex": 1,
+                          },
+                          {
+                            "flex": 0,
+                            "height": "100%",
+                            "width": "100%",
+                          },
+                        ]
                       }
-                    />
-                  </RNSVGSvgView>
+                      testID="snaps-ui-image"
+                      width="100%"
+                      xml="<svg />"
+                    >
+                      <RNSVGGroup
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                    </RNSVGSvgView>
+                  </View>
                 </View>
                 <View
                   style={

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1637,6 +1637,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                         },
                         {
                           "height": "100%",
+                          "justifyContent": "center",
                           "padding": 0,
                         },
                       ]

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.tsx.snap
@@ -1645,9 +1645,9 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           {
                             "aspectRatio": 1,
                             "borderRadius": 0,
-                            "height": undefined,
+                            "height": 32,
                             "overflow": "hidden",
-                            "width": undefined,
+                            "width": 32,
                           },
                           undefined,
                         ]

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -81,6 +81,7 @@ export const field: UIComponentFactory<FieldElement> = ({
               style: {
                 padding: 0,
                 height: '100%',
+                justifyContent: 'center',
               },
             },
           },
@@ -91,6 +92,7 @@ export const field: UIComponentFactory<FieldElement> = ({
               style: {
                 padding: 0,
                 height: '100%',
+                justifyContent: 'center',
               },
             },
           },

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -80,6 +80,7 @@ export const field: UIComponentFactory<FieldElement> = ({
               ...leftAccessoryMapped.props,
               style: {
                 padding: 0,
+                height: '100%',
               },
             },
           },
@@ -89,6 +90,7 @@ export const field: UIComponentFactory<FieldElement> = ({
               ...rightAccessoryMapped.props,
               style: {
                 padding: 0,
+                height: '100%',
               },
             },
           },

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -31,7 +31,7 @@ export const field: UIComponentFactory<FieldElement> = ({
     flexBasis: '50%',
   };
 
-  switch (child.type) {
+  switch (child?.type) {
     case 'Input': {
       const getLeftAccessory = () =>
         mapToTemplate({
@@ -78,14 +78,18 @@ export const field: UIComponentFactory<FieldElement> = ({
             ...leftAccessoryMapped,
             props: {
               ...leftAccessoryMapped.props,
-              padding: 0,
+              style: {
+                padding: 0,
+              },
             },
           },
           endAccessory: rightAccessoryMapped && {
             ...rightAccessoryMapped,
             props: {
               ...rightAccessoryMapped.props,
-              padding: 0,
+              style: {
+                padding: 0,
+              },
             },
           },
         },

--- a/app/components/Snaps/SnapUIRenderer/components/image.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.test.ts
@@ -24,7 +24,7 @@ describe('image component', () => {
     expect(result).toEqual({
       element: 'SnapUIImage',
       props: {
-        borderRadius: 'full',
+        borderRadius: 999,
         value: '<svg />',
       },
     });

--- a/app/components/Snaps/SnapUIRenderer/components/image.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/image.ts
@@ -13,7 +13,7 @@ function generateBorderRadius(
       return 6;
 
     case 'full':
-      return 'full';
+      return 999;
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add a container for the SnapUIImage component and apply the border radius directly to that hiding the overflow. Additionally adds logic to deal with `viewBox` and other problems that would prevent SVGs from rendering or overflow outside of the container with border radius.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3243
Fixes https://github.com/MetaMask/metamask-mobile/issues/14288

## **Screenshots/Recordings**

<img src="https://github.com/user-attachments/assets/61309ef8-d020-45ba-b8a1-7349d8aaba2d" width="200" />

