### PR TITLE
test: reduce flakiness with notification e2e mocks

### DIFF
--- a/e2e/specs/notifications/enable-notifications-after-onboarding.spec.js
+++ b/e2e/specs/notifications/enable-notifications-after-onboarding.spec.js
@@ -18,14 +18,18 @@ import {
   mockNotificationServices,
 } from './utils/mocks';
 
-/** @type {import('detox/detox').DeviceLaunchAppConfig} */
-const launchAppSettings = {
+/**
+ * @param {number} port
+ * @returns {import('detox/detox').DeviceLaunchAppConfig}
+ */
+const launchAppSettings = (port) => ({
   newInstance: true,
   delete: true,
   permissions: {
     notifications: 'YES',
   },
-};
+  launchArgs: { mockServerPort: port },
+});
 
 describe(SmokeNotifications('Notification Onboarding'), () => {
   /** @type {import('mockttp').Mockttp} */
@@ -40,7 +44,7 @@ describe(SmokeNotifications('Notification Onboarding'), () => {
     await mockNotificationServices(mockServer);
 
     // Launch App
-    await TestHelpers.launchApp(launchAppSettings);
+    await TestHelpers.launchApp(launchAppSettings(mockServer.port));
   });
 
   afterAll(async () => {

--- a/e2e/specs/notifications/notification-settings-flow.spec.js
+++ b/e2e/specs/notifications/notification-settings-flow.spec.js
@@ -14,14 +14,18 @@ import {
 } from './utils/constants';
 import { mockNotificationServices } from './utils/mocks';
 
-/** @type {import('detox/detox').DeviceLaunchAppConfig} */
-const launchAppSettings = {
+/**
+ * @param {number} port
+ * @returns {import('detox/detox').DeviceLaunchAppConfig}
+ */
+const launchAppSettings = (port) => ({
   newInstance: true,
   delete: true,
   permissions: {
     notifications: 'YES',
   },
-};
+  launchArgs: { mockServerPort: port },
+});
 
 describe(SmokeNotifications('Notification Settings Flow'), () => {
   /** @type {import('mockttp').Mockttp} */
@@ -36,7 +40,7 @@ describe(SmokeNotifications('Notification Settings Flow'), () => {
     await mockNotificationServices(mockServer);
 
     // Launch App
-    await TestHelpers.launchApp(launchAppSettings);
+    await TestHelpers.launchApp(launchAppSettings(mockServer.port));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## **Description**

Ensures that we setup our detox launch settings to recognise our mock server port. This should help reduce flakiness in CI where E2E tests are run in parallel and the port is randomly allocated..

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
