### PR TITLE
ci: address lockfile issue with detox

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1239,7 +1239,7 @@ workflows:
             - content: |-
                 #!/usr/bin/env bash
                 xcrun simctl boot "iPhone 15 Pro" || true
-                simulator_id=$(xcrun simctl list devices | grep "iPhone 15 Pro" | awk '{print $1}')
+                xcrun simctl list | grep Booted
       - script@1:
           title: Run detox test
           timeout: 1200

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1234,6 +1234,13 @@ workflows:
                 brew tap wix/brew
           title: Set Env Path for caching deps
       - script@1:
+          title: Boot up simulator
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                xcrun simctl boot "iPhone 15 Pro" || true
+                simulator_id=$(xcrun simctl list devices | grep "iPhone 15 Pro" | awk '{print $1}')
+      - script@1:
           title: Run detox test
           timeout: 1200
           is_always_run: false


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is an existing detox issue where the tests would fail with the following error:


```

Error: Unable to update lock within the stale threshold
    at /Users/vagrant/git/node_modules/proper-lockfile/lib/lockfile.js:[REDACTED]09:2[REDACTED]
    at newFs.<computed> [as utimes] (/Users/vagrant/git/node_modules/proper-lockfile/lib/adapter.js:20:[REDACTED]3)
    at Timeout._onTimeout (/Users/vagrant/git/node_modules/proper-lockfile/lib/lockfile.js:[REDACTED]00:20)
    at listOnTimeout (node:internal/timers:58[REDACTED]:[REDACTED]7)
    at process.processTimers (node:internal/timers:5[REDACTED]9:7) {
  code: 'ECOMPROMISED'
}

```


The issue is stemming from Detox itself and was reported [here](https://github.com/wix/Detox/issues/4210). Unfortunately there is no fix available. One of the commenters suggested booting the simulator prior to running the test rather than letting Detox handle it during test execution.


The purpose of this PR is to add a bitrise step in the `ios_e2e_test` workflow that boots the simulator before executing the tests.  

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-411

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
