### PR TITLE
fix: Re-introduce bitrise ipa path

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1846,7 +1846,7 @@ workflows:
           is_always_run: false
           is_skippable: true
           inputs:
-            - deploy_path: $BINARY_DEPLOY_PATH
+            - deploy_path: $BINARY_DEPLOY_PATH:BITRISE_APP_STORE_IPA_PATH
             - is_compress: true
           title: Deploy iOS Binary
       - deploy-to-bitrise-io@2.2.3:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the failing deploy to ios step on Bitrise by reintroducing a missing bitrise ipa deploy path. It was accidentally removed here - https://github.com/MetaMask/metamask-mobile/pull/14569/files#diff-61d1ee831cb1df242161a7d23171914a1d5d628c7659b52db957d80a9394bd68R1842

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1744387408743859

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
