### PR TITLE
test: update ramps deeplink e2e test case

### DIFF
--- a/e2e/specs/ramps/deeplink-to-sell-flow.spec.js
+++ b/e2e/specs/ramps/deeplink-to-sell-flow.spec.js
@@ -91,7 +91,6 @@ describe(SmokeRamps('Sell Crypto Deeplinks'), () => {
         await NetworkAddedBottomSheet.tapCloseButton();
         await Assertions.checkIfVisible(NetworkEducationModal.container);
         await NetworkEducationModal.tapGotItButton();
-        await Assertions.checkIfTextIsDisplayed('Ether');
         await Assertions.checkIfTextIsDisplayed(
           PopularNetworksList.Optimism.providerConfig.nickname,
         );


### PR DESCRIPTION
## **Description**

Removing an assertion that was checking that a token was displayed, this would be correct, but the test is for switching networks, we can assert that directly by the network name (with an assertion that already exists).

## **Related issues**

Fixes: failures in CI, the expected token stopped being displayed and the test started to fail

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ x ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ x ] I've completed the PR template to the best of my ability
- [ x ] I’ve included tests if applicable
- [ x ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ x ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
