### PR TITLE
fix: pass correct disabled prop in `SnapUInput`

### DIFF
--- a/app/components/Snaps/SnapUIInput/SnapUIInput.test.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { SnapUIInput } from './SnapUIInput';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
+import { INPUT_TEST_ID } from '../../../component-library/components/Form/TextField/foundation/Input/Input.constants';
 
 // Mock the entire module
 jest.mock('../SnapInterfaceContext');
@@ -76,6 +77,13 @@ describe('SnapUIInput', () => {
     fireEvent(input, 'blur');
 
     expect(mockSetCurrentFocusedInput).toHaveBeenCalledWith(null);
+  });
+
+  it('handles disabled input', () => {
+    const { getByTestId } = render(<SnapUIInput name="testInput" disabled />);
+
+    const input = getByTestId(INPUT_TEST_ID);
+    expect(input.props.editable).toBe(false);
   });
 
   it('updates value when initialValue changes', () => {

--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -17,6 +17,7 @@ export interface SnapUIInputProps {
   label?: string;
   error?: string;
   style?: ViewStyle;
+  disabled?: boolean;
 }
 
 export const SnapUIInput = ({
@@ -25,6 +26,7 @@ export const SnapUIInput = ({
   label,
   error,
   style,
+  disabled,
   ...props
 }: SnapUIInputProps) => {
   const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
@@ -66,6 +68,7 @@ export const SnapUIInput = ({
       <TextField
         {...props}
         size={TextFieldSize.Lg}
+        isDisabled={disabled}
         ref={inputRef}
         onFocus={handleFocus}
         onBlur={handleBlur}


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? The correct prop was not being passed to `TextField` in `SnapUIInput`.
2. What is the improvement/solution? Use the correct `isDisabled` prop. Add test for disabled scenario.

## **Related issues**

Fixes: #14532 

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
