### PR TITLE
fix: check for empty rpc urls

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -802,7 +802,7 @@ export class NetworkSettings extends PureComponent {
     const checkCustomNetworks = Object.values(
       this.props.networkConfigurations,
     ).filter((item) =>
-      item.rpcEndpoints.some((endpoint) => endpoint.url === rpcUrl),
+      item.rpcEndpoints?.some((endpoint) => endpoint.url === rpcUrl),
     );
 
     if (checkCustomNetworks.length > 0) {

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1500,6 +1500,24 @@ describe('NetworkSettings', () => {
       expect(result).toEqual([]);
     });
 
+    it('should return an empty array if the RPC URL does not exist with no rpcEndpointUrls present', async () => {
+      const rpcUrl = 'https://random.network.io';
+      const instance = wrapper.instance();
+
+      wrapper.setProps({
+        networkConfigurations: {
+          ['0x1']: {
+            chainId: '0x1',
+            name: 'Mainnet',
+          },
+        },
+      });
+
+      const result = await instance.checkIfRpcUrlExists(rpcUrl);
+
+      expect(result).toEqual([]);
+    });
+
     it('should return multiple networks if multiple RPC URLs match', async () => {
       const instance = wrapper.instance();
 

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1506,7 +1506,7 @@ describe('NetworkSettings', () => {
 
       wrapper.setProps({
         networkConfigurations: {
-          ['0x1']: {
+          '0x1': {
             chainId: '0x1',
             name: 'Mainnet',
           },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some default network configurations (BTC and Solana) do not have a list of rpc endpoints. This ensures that those configurations don't cause an error when being validated, which was skipping rpc validation.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14508

## **Manual testing steps**

1 - Enable Flask build
2 - Add a new network
3 - Add a new RPC url
4 - Should validate fields correctly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
