### PR TITLE
chore: allow fixtures to be used with appium and BrowserStack

### DIFF
--- a/app/util/test/network-store.js
+++ b/app/util/test/network-store.js
@@ -22,6 +22,7 @@ const fetchWithTimeout = (url) =>
   });
 
 const FIXTURE_SERVER_HOST = 'localhost';
+const BROWSERSTACK_LOCALHOST = 'bs-local.com';
 const FIXTURE_SERVER_URL = `http://${FIXTURE_SERVER_HOST}:${getFixturesServerPortInApp()}/state.json`;
 
 class ReadOnlyNetworkStore {
@@ -74,11 +75,27 @@ class ReadOnlyNetworkStore {
   }
 
   async _init() {
+    // List of URLs to check for Fixture Server availability.
+    // Browserstack requires that the HOST is bs-local.com instead of localhost.
+    const urls = [
+      FIXTURE_SERVER_URL,
+      FIXTURE_SERVER_URL.replace(FIXTURE_SERVER_HOST, BROWSERSTACK_LOCALHOST)
+    ];
+
     try {
-      const response = await fetchWithTimeout(FIXTURE_SERVER_URL);
-      if (response.status === 200) {
-        this._state = response.data?.state;
-        this._asyncState = response.data?.asyncState;
+      for (const url of urls) {
+        try {
+          const response = await fetchWithTimeout(url);
+          if (response.status === 200) {
+            this._state = response.data?.state;
+            this._asyncState = response.data?.asyncState;
+            return;
+          }
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.debug(`Error loading network state from ${url}: '${error}'`);
+          // Continue to next URL if this one failed
+        }
       }
     } catch (error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Allows the use of fixtures with Appium by providing a fallback to load the state from the BrowserStack localhost equivalent.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

Tested with both Android and iOS manually through BrowserStack app automate.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/27a82753-c03e-40fa-a771-d65f53ab9507



### **Before**

Fixtures would not load when using appium.

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
