### PR TITLE
feat: track snap account metrics

### DIFF
--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -381,6 +381,9 @@ enum EVENT_NAME {
 
   // Remove an account
   ACCOUNT_REMOVED = 'Account removed',
+  ACCOUNT_REMOVE_FAILED = 'Account remove failed',
+  // Account added
+  ACCOUNT_ADDED = 'Account Added',
 
   //Notifications
   ALL_NOTIFICATIONS = 'All Notifications',
@@ -493,11 +496,11 @@ const events = {
     EVENT_NAME.CONNECT_REQUEST_OTPFAILURE,
   ),
   CONNECT_REQUEST_CANCELLED: generateOpt(EVENT_NAME.CONNECT_REQUEST_CANCELLED),
-  
+
   // Phishing events
   PHISHING_PAGE_DISPLAYED: generateOpt(EVENT_NAME.PHISHING_PAGE_DISPLAYED),
   PROCEED_ANYWAY_CLICKED: generateOpt(EVENT_NAME.PROCEED_ANYWAY_CLICKED),
-  
+
   WALLET_OPENED: generateOpt(EVENT_NAME.WALLET_OPENED),
   TOKEN_ADDED: generateOpt(EVENT_NAME.TOKEN_ADDED),
   COLLECTIBLE_ADDED: generateOpt(EVENT_NAME.COLLECTIBLE_ADDED),
@@ -863,6 +866,8 @@ const events = {
 
   // Remove an account
   ACCOUNT_REMOVED: generateOpt(EVENT_NAME.ACCOUNT_REMOVED),
+  ACCOUNT_REMOVE_FAILED: generateOpt(EVENT_NAME.ACCOUNT_REMOVE_FAILED),
+  ACCOUNT_ADDED: generateOpt(EVENT_NAME.ACCOUNT_ADDED),
 
   // Smart transactions
   SMART_TRANSACTION_OPT_IN: generateOpt(EVENT_NAME.SMART_TRANSACTION_OPT_IN),

--- a/app/core/Analytics/helpers/SnapKeyring/trackSnapAccountEvent.test.ts
+++ b/app/core/Analytics/helpers/SnapKeyring/trackSnapAccountEvent.test.ts
@@ -1,0 +1,60 @@
+import { IMetaMetricsEvent, MetaMetrics } from '../..';
+import { trackSnapAccountEvent } from './trackSnapAccountEvent';
+import { MetricsEventBuilder } from '../../MetricsEventBuilder';
+import { IMetaMetrics } from '../../MetaMetrics.types';
+
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn().mockReturnThis();
+const mockBuild = jest.fn().mockReturnValue({ mockBuiltEvent: true });
+const mockCreateEventBuilder = jest.fn().mockReturnValue({
+  addProperties: mockAddProperties,
+  build: mockBuild,
+});
+
+jest
+  .spyOn(MetricsEventBuilder, 'createEventBuilder')
+  .mockImplementation(mockCreateEventBuilder);
+
+jest.spyOn(MetaMetrics, 'getInstance').mockReturnValue({
+  trackEvent: mockTrackEvent,
+  isEnabled: jest.fn(),
+  enable: jest.fn(),
+  addTraitsToUser: jest.fn(),
+  group: jest.fn(),
+  reset: jest.fn(),
+  flush: jest.fn(),
+  createDataDeletionTask: jest.fn(),
+  checkDataDeleteStatus: jest.fn(),
+  getDeleteRegulationCreationDate: jest.fn(),
+  getDeleteRegulationId: jest.fn(),
+  isDataRecorded: jest.fn(),
+  configure: jest.fn(),
+  getMetaMetricsId: jest.fn(),
+} as IMetaMetrics);
+
+describe('trackSnapAccountEvent', () => {
+  const mockMetricEvent: IMetaMetricsEvent = {
+    category: 'testCategory',
+    properties: { name: 'testEvent' },
+  };
+  const mockSnapId = 'npm:@metamask/test-snap';
+  const mockSnapName = 'Test Snap';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create and track an event with the correct properties', () => {
+    trackSnapAccountEvent(mockMetricEvent, mockSnapId, mockSnapName);
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(mockMetricEvent);
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      account_type: 'Snap',
+      snap_id: mockSnapId,
+      snap_name: mockSnapName,
+    });
+
+    expect(mockBuild).toHaveBeenCalled();
+    // Verify MetaMetrics trackEvent was called with the built event
+    expect(mockTrackEvent).toHaveBeenCalledWith({ mockBuiltEvent: true });
+  });
+});

--- a/app/core/Analytics/helpers/SnapKeyring/trackSnapAccountEvent.ts
+++ b/app/core/Analytics/helpers/SnapKeyring/trackSnapAccountEvent.ts
@@ -1,0 +1,33 @@
+import { IMetaMetricsEvent, MetaMetrics } from '../..';
+import Logger from '../../../../util/Logger';
+import { MetricsEventBuilder } from '../../MetricsEventBuilder';
+
+/**
+ * Track a Snap account-related event.
+ *
+ * @param metricEvent - The name of the event to track.
+ * @param snapId - The ID of the Snap.
+ * @param snapName - The name of the Snap.
+ */
+export function trackSnapAccountEvent(
+  metricEvent: IMetaMetricsEvent,
+  snapId: string,
+  snapName: string,
+): void {
+  try {
+    const event = MetricsEventBuilder.createEventBuilder(metricEvent)
+      .addProperties({
+        account_type: 'Snap',
+        snap_id: snapId,
+        snap_name: snapName,
+      })
+      .build();
+
+    MetaMetrics.getInstance().trackEvent(event);
+  } catch (error) {
+    Logger.error(
+      error as Error,
+      `Error tracking snap account event: ${JSON.stringify(metricEvent)}`,
+    );
+  }
+}

--- a/app/core/SnapKeyring/SnapKeyring.test.ts
+++ b/app/core/SnapKeyring/SnapKeyring.test.ts
@@ -149,7 +149,7 @@ jest.mock('./utils/snaps', () => ({
 }));
 
 // Mock the trackSnapAccountEvent function
-jest.mock('../Analytics/helpers/snaps/trackSnapAccountEvent', () => ({
+jest.mock('../Analytics/helpers/SnapKeyring/trackSnapAccountEvent', () => ({
   trackSnapAccountEvent: jest.fn(),
 }));
 

--- a/app/core/SnapKeyring/SnapKeyring.ts
+++ b/app/core/SnapKeyring/SnapKeyring.ts
@@ -10,10 +10,12 @@ import { SnapKeyringBuilderMessenger } from './types';
 import { SnapId } from '@metamask/snaps-sdk';
 import { assertIsValidSnapId } from '@metamask/snaps-utils';
 import { getUniqueAccountName } from './utils/getUniqueAccountName';
-import { isSnapPreinstalled } from './utils/snaps';
+import { getSnapName, isSnapPreinstalled } from './utils/snaps';
 import { endTrace, trace, TraceName, TraceOperation } from '../../util/trace';
 import { getTraceTags } from '../../util/sentry/tags';
 import { store } from '../../store';
+import { MetaMetricsEvents } from '../../core/Analytics/MetaMetrics.events';
+import { trackSnapAccountEvent } from '../Analytics/helpers/SnapKeyring/trackSnapAccountEvent';
 
 /**
  * Builder type for the Snap keyring.
@@ -140,6 +142,8 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
   }
 
   private async addAccountFinalize({
+    address: _address,
+    snapId,
     accountName,
     onceSaved,
   }: {
@@ -176,6 +180,15 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
             accountName,
           );
         }
+
+        // Track successful account addition
+        const snapName = getSnapName(snapId as SnapId, this.#messenger);
+        trackSnapAccountEvent(
+          MetaMetricsEvents.ACCOUNT_ADDED,
+          snapId,
+          snapName,
+        );
+
         endTrace({
           name: TraceName.AddSnapAccount,
         });
@@ -231,6 +244,7 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
     handleUserInput: (accepted: boolean) => Promise<void>,
   ) {
     assertIsValidSnapId(snapId);
+
     // TODO: Implement proper snap account confirmations. Currently, we are approving everything for testing purposes.
     Logger.log(
       `SnapKeyring: removeAccount called with \n
@@ -238,10 +252,31 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
           - handleUserInput: ${handleUserInput} \n
           - snapId: ${snapId} \n`,
     );
+
     // Approve everything for now because we have not implemented snap account confirmations yet
     await handleUserInput(true);
-    await this.#removeAccountHelper(address);
-    await this.#persistKeyringHelper();
+
+    try {
+      await this.#removeAccountHelper(address);
+      await this.#persistKeyringHelper();
+
+      // Track successful account removal
+      const snapName = getSnapName(snapId as SnapId, this.#messenger);
+      trackSnapAccountEvent(
+        MetaMetricsEvents.ACCOUNT_REMOVED,
+        snapId,
+        snapName,
+      );
+    } catch (error) {
+      Logger.error(error as Error, `Error removing snap account: ${address}`);
+      const snapName = getSnapName(snapId as SnapId, this.#messenger);
+      trackSnapAccountEvent(
+        MetaMetricsEvents.ACCOUNT_REMOVED,
+        snapId,
+        snapName,
+      );
+      throw error;
+    }
   }
 
   async redirectUser(snapId: string, url: string, message: string) {

--- a/app/core/SnapKeyring/utils/snaps.test.ts
+++ b/app/core/SnapKeyring/utils/snaps.test.ts
@@ -1,0 +1,152 @@
+import { SnapId } from '@metamask/snaps-sdk';
+import { SnapKeyringBuilderMessenger } from '../types';
+import {
+  isSnapPreinstalled,
+  isMultichainWalletSnap,
+  getSnapName,
+} from './snaps';
+import {
+  stripSnapPrefix,
+  getLocalizedSnapManifest,
+} from '@metamask/snaps-utils';
+
+// Mock the Bitcoin and Solana wallet snap IDs
+const MOCK_BITCOIN_WALLET_SNAP_ID =
+  'npm:@metamask/bitcoin-wallet-snap' as SnapId;
+const MOCK_SOLANA_WALLET_SNAP_ID = 'npm:@metamask/solana-wallet-snap' as SnapId;
+
+// Mock dependencies
+jest.mock('../../../lib/snaps/preinstalled-snaps', () => ({
+  __esModule: true,
+  default: [
+    { snapId: 'npm:@metamask/test-snap-1' },
+    { snapId: 'npm:@metamask/test-snap-2' },
+  ],
+}));
+
+// Mock the Engine
+jest.mock('../../../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+}));
+
+// Mock the BitcoinWalletSnap module
+jest.mock('../BitcoinWalletSnap', () => ({
+  BITCOIN_WALLET_SNAP_ID: 'npm:@metamask/bitcoin-wallet-snap',
+}));
+
+// Mock the SolanaWalletSnap module
+jest.mock('../SolanaWalletSnap', () => ({
+  SOLANA_WALLET_SNAP_ID: 'npm:@metamask/solana-wallet-snap',
+}));
+
+jest.mock('@metamask/snaps-utils', () => ({
+  stripSnapPrefix: jest.fn((snapId) => snapId.replace('npm:', '')),
+  getLocalizedSnapManifest: jest.fn(),
+}));
+
+jest.mock('../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: {
+    locale: 'en-US',
+  },
+}));
+
+describe('snaps utility functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isSnapPreinstalled', () => {
+    it('should return true for preinstalled snap', () => {
+      const snapId = 'npm:@metamask/test-snap-1' as SnapId;
+      expect(isSnapPreinstalled(snapId)).toBe(true);
+    });
+
+    it('should return false for non-preinstalled snap', () => {
+      const snapId = 'npm:@metamask/non-preinstalled-snap' as SnapId;
+      expect(isSnapPreinstalled(snapId)).toBe(false);
+    });
+  });
+
+  describe('isMultichainWalletSnap', () => {
+    it('should return true for Bitcoin wallet snap', () => {
+      expect(isMultichainWalletSnap(MOCK_BITCOIN_WALLET_SNAP_ID)).toBe(true);
+    });
+
+    it('should return true for Solana wallet snap', () => {
+      expect(isMultichainWalletSnap(MOCK_SOLANA_WALLET_SNAP_ID)).toBe(true);
+    });
+
+    it('should return false for non-multichain wallet snap', () => {
+      const snapId = 'npm:@metamask/other-snap' as SnapId;
+      expect(isMultichainWalletSnap(snapId)).toBe(false);
+    });
+  });
+
+  describe('getSnapName', () => {
+    // Create a proper mock for the messenger
+    const mockCall = jest.fn();
+    const mockMessenger = {
+      call: mockCall,
+    } as unknown as SnapKeyringBuilderMessenger;
+
+    beforeEach(() => {
+      mockCall.mockReset();
+    });
+
+    it('should return stripped snap id when snap is not found', () => {
+      const snapId = 'npm:@metamask/not-found-snap' as SnapId;
+      mockCall.mockReturnValue(null);
+
+      const result = getSnapName(snapId, mockMessenger);
+
+      expect(mockCall).toHaveBeenCalledWith('SnapController:get', snapId);
+      expect(stripSnapPrefix).toHaveBeenCalledWith(snapId);
+      expect(result).toBe('@metamask/not-found-snap');
+    });
+
+    it('should return proposedName when snap has no localization files', () => {
+      const snapId = 'npm:@metamask/test-snap' as SnapId;
+      const mockSnap = {
+        manifest: {
+          proposedName: 'Test Snap',
+        },
+      };
+      mockCall.mockReturnValue(mockSnap);
+
+      const result = getSnapName(snapId, mockMessenger);
+
+      expect(mockCall).toHaveBeenCalledWith('SnapController:get', snapId);
+      expect(result).toBe('Test Snap');
+    });
+
+    it('should return localized proposedName when snap has localization files', () => {
+      const snapId = 'npm:@metamask/localized-snap' as SnapId;
+      const mockSnap = {
+        manifest: {
+          proposedName: 'Original Name',
+        },
+        localizationFiles: {
+          'en-US': { content: { proposedName: 'Localized Name' } },
+        },
+      };
+      mockCall.mockReturnValue(mockSnap);
+
+      (getLocalizedSnapManifest as jest.Mock).mockReturnValue({
+        proposedName: 'Localized Name',
+      });
+
+      const result = getSnapName(snapId, mockMessenger);
+
+      expect(mockCall).toHaveBeenCalledWith('SnapController:get', snapId);
+      expect(getLocalizedSnapManifest).toHaveBeenCalledWith(
+        mockSnap.manifest,
+        'en-US',
+        mockSnap.localizationFiles,
+      );
+      expect(result).toBe('Localized Name');
+    });
+  });
+});

--- a/app/core/SnapKeyring/utils/snaps.ts
+++ b/app/core/SnapKeyring/utils/snaps.ts
@@ -2,6 +2,12 @@ import { SnapId } from '@metamask/snaps-sdk';
 import PREINSTALLED_SNAPS from '../../../lib/snaps/preinstalled-snaps';
 import { BITCOIN_WALLET_SNAP_ID } from '../BitcoinWalletSnap';
 import { SOLANA_WALLET_SNAP_ID } from '../SolanaWalletSnap';
+import {
+  getLocalizedSnapManifest,
+  stripSnapPrefix,
+} from '@metamask/snaps-utils';
+import { SnapKeyringBuilderMessenger } from '../types';
+import I18n from '../../../../locales/i18n';
 
 /**
  * Check if a Snap is a preinstalled Snap.
@@ -31,4 +37,34 @@ const ALLOW_LISTED_SNAPS = [BITCOIN_WALLET_SNAP_ID, SOLANA_WALLET_SNAP_ID];
  */
 export function isMultichainWalletSnap(id: SnapId): boolean {
   return ALLOW_LISTED_SNAPS.includes(id);
+}
+
+/**
+ * Get the localized Snap name or some fallback name otherwise.
+ *
+ * @param snapId - Snap ID.
+ * @param messenger - Snap keyring messenger.
+ * @returns The Snap name.
+ */
+export function getSnapName(
+  snapId: SnapId,
+  messenger: SnapKeyringBuilderMessenger,
+) {
+  const snap = messenger.call('SnapController:get', snapId);
+  const currentLocale = I18n.locale;
+
+  if (!snap) {
+    return stripSnapPrefix(snapId);
+  }
+
+  if (snap.localizationFiles) {
+    const localizedManifest = getLocalizedSnapManifest(
+      snap.manifest,
+      currentLocale,
+      snap.localizationFiles,
+    );
+    return localizedManifest.proposedName;
+  }
+
+  return snap.manifest.proposedName;
 }


### PR DESCRIPTION
## **Description**

This PR adds metric tracking for basic snap account actions. This brings the metric tracking more inline with the events we already track on the extension.

The main events that we are tracking are the following...
1. Snap account creation
    - [Equivalent extension event](https://github.com/MetaMask/metamask-extension/blob/5d953bf41b950eeb8358a735729c22d1e45386f6/app/scripts/lib/snap-keyring/snap-keyring.ts#L362)
    - [Extension event definition](https://github.com/MetaMask/metamask-extension/blob/478b45f3ffa7619378e43f9367e62edff6b5b810/shared/constants/metametrics.ts#L645)
2. Snap account removal
    - [Equivalent extension event ](https://github.com/MetaMask/metamask-extension/blob/5d953bf41b950eeb8358a735729c22d1e45386f6/app/scripts/lib/snap-keyring/snap-keyring.ts#L547)
    - [Extension event definition](https://github.com/MetaMask/metamask-extension/blob/478b45f3ffa7619378e43f9367e62edff6b5b810/shared/constants/metametrics.ts#L826)
3. Failed attempts at snap account removal
    - [Equivalent extension event](https://github.com/MetaMask/metamask-extension/blob/5d953bf41b950eeb8358a735729c22d1e45386f6/app/scripts/lib/snap-keyring/snap-keyring.ts#L532)
    - [Extension event definition](https://github.com/MetaMask/metamask-extension/blob/478b45f3ffa7619378e43f9367e62edff6b5b810/shared/constants/metametrics.ts#L827)

On mobile we do not have snap account confirmations so we skipped all of those events. 

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/695

## **Manual testing steps**

1. ensure you are building metamask flask by editing the `METAMASK_BUILD_TYPE` to `flask` in the `.js.env`
2. `yarn setup && yarn start:ios`
3. import/create an account
4. click on the selected account at the top of the screen
5. click `add new account or hardware wallet`
6. click on `solana`
7. the solana account should be created
8. repeat the above steps and then click on `Bitcoin` instead
9. the Bitcoin account should be created. 

## **Screenshots/Recordings**


### **Before**

<!-- [screenshots/recordings] -->

### **After**

I added a log to the trackSnapAccountEvent to verify that it is called when we create a new solana account

https://github.com/user-attachments/assets/328b95c3-0b8b-4a62-b712-4303bf1fde27


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
