### PR TITLE
fix: update error logic for address input

### DIFF
--- a/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.test.tsx
+++ b/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.test.tsx
@@ -195,21 +195,17 @@ describe('SnapUIAddressInput', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('does not render the matched address info if there is an error', () => {
+  it('renders the matched address info with an error', () => {
     mockGetValue.mockReturnValue(`${testChainId}:${testAddress}`);
     const displayName = 'Vitalik.eth';
     (useDisplayName as jest.Mock).mockReturnValue(displayName);
 
-    const { queryByText, queryByTestId, getByText, toJSON } = renderWithProvider(
+    const { queryByText, getByText, toJSON } = renderWithProvider(
       <SnapUIAddressInput name="testAddress" chainId={testChainId} error="Error" />,
       { state: mockInitialState },
     );
 
-    expect(queryByText(displayName)).toBeFalsy();
-
-    const input = queryByTestId(INPUT_TEST_ID);
-
-    expect(input.props.value).toBe(testAddress);
+    expect(queryByText(displayName)).toBeTruthy();
     expect(getByText('Error')).toBeTruthy();
 
     const tree = JSON.stringify(toJSON());

--- a/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.tsx
+++ b/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.tsx
@@ -51,6 +51,7 @@ interface MatchedAccountInfoProps {
   displayName: string;
   handleClear: () => void;
   disabled?: boolean;
+  error?: string;
 }
 
 const MatchedAccountInfo = ({
@@ -61,6 +62,7 @@ const MatchedAccountInfo = ({
   displayName,
   handleClear,
   disabled,
+  error,
 }: MatchedAccountInfoProps) => {
   const { colors } = useTheme();
   const styles = StyleSheet.create({
@@ -115,6 +117,12 @@ const MatchedAccountInfo = ({
           testID="snap-ui-address-input__clear-button"
         />
       </Box>
+      {error && (
+        // eslint-disable-next-line react-native/no-inline-styles
+        <HelpText severity={HelpTextSeverity.Error} style={{ marginTop: 4 }}>
+          {error}
+        </HelpText>
+      )}
     </Box>
   );
 };
@@ -204,7 +212,7 @@ export const SnapUIAddressInput = ({
     handleInputChange(name, '', form);
   };
 
-  if (displayName && !error) {
+  if (displayName) {
     return (
       <MatchedAccountInfo
         label={label}
@@ -214,6 +222,7 @@ export const SnapUIAddressInput = ({
         displayName={displayName}
         handleClear={handleClear}
         disabled={disabled}
+        error={error}
       />
     );
   }


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? Brings the component into parity with the extension
2. What is the improvement/solution? Display matched account info regardless of error.

## **Manual testing steps**

1. Update send-flow snap in `SendForm.tsx` locally with the following snippets:

**Error**
```ts
    <Field label="To account" error="Invalid address">
      <AddressInput
        name="to"
        chainId="eip155:0"
        placeholder="Enter receiving address"
        disabled={true}
        displayAvatar={true}
        value="oneofyouraccountaddresses"
      />
    </Field>
```

**No Error**
```ts
    <Field label="To account">
      <AddressInput
        name="to"
        chainId="eip155:0"
        placeholder="Enter receiving address"
        disabled={true}
        displayAvatar={true}
        value="oneofyouraccountaddresses"
      />
    </Field>
```

3. Navigate to test-snaps and run `yarn start`.
4. Open the simulator and navigate to the local instance of test-snaps.
5. Trigger the send-flow snap's dialog.
6. Observe the results.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/0174d334-f381-4c9e-a2b1-854a7734e867

### **After**

https://github.com/user-attachments/assets/064c2a0a-ccda-413d-a66f-25f65e3aaf3b

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
