### PR TITLE
fix: not switching networks when selecting source token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(bridge): Handle Solana vs EVM swap and bridge routing ([#14614](https://github.com/MetaMask/metamask-mobile/pull/14614))
 
+### Fixed
+
+- fix(bridge): fix not switching networks when selecting source token ([#14712](https://github.com/MetaMask/metamask-mobile/pull/14712))
+
 ## [7.44.0]
 
 ### Added

--- a/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
@@ -1,7 +1,7 @@
 import { useRoute, RouteProp } from '@react-navigation/native';
 import { setSourceToken } from '../../../../../core/redux/slices/bridge';
 import { useDispatch, useSelector } from 'react-redux';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { BridgeToken, BridgeViewMode } from '../../types';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
@@ -40,6 +40,7 @@ export const useInitialSourceToken = () => {
   const evmNetworkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
+  const hasSetInitialSourceToken = useRef(false);
 
   const {
     chainId: selectedChainId,
@@ -60,6 +61,8 @@ export const useInitialSourceToken = () => {
   const initialSourceToken = route.params?.token;
 
   useEffect(() => {
+    if (hasSetInitialSourceToken.current) return;
+
     // Will default to the native token of the current chain if no token is provided
     if (!initialSourceToken) {
       dispatch(setSourceToken(getNativeSourceToken(selectedChainId)));
@@ -90,6 +93,8 @@ export const useInitialSourceToken = () => {
         evmNetworkConfigurations[initialSourceToken.chainId as Hex],
       );
     }
+
+    hasSetInitialSourceToken.current = true;
   }, [
     dispatch,
     initialSourceToken,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes an issue where Bridge would not switch networks when selecting a source token with a different network properly.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Bridge
2. Select a source token from a different chain than your current chain
3. Should switch networks and set source token properly.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
