### PR TITLE
fix: cp-7.45.0 WC  automatically update network permissions when switching chains

### DIFF
--- a/app/core/Permissions/index.test.ts
+++ b/app/core/Permissions/index.test.ts
@@ -2,6 +2,7 @@ import {
   getPermittedAccounts,
   getPermittedChains,
   switchActiveAccounts,
+  addPermittedChain,
 } from './index';
 import { errorCodes as rpcErrorCodes } from '@metamask/rpc-errors';
 import { RestrictedMethods, CaveatTypes } from './constants';
@@ -15,6 +16,7 @@ jest.mock('../Engine', () => ({
       executeRestrictedMethod: jest.fn(),
       getCaveat: jest.fn(),
       updateCaveat: jest.fn(),
+      grantPermissions: jest.fn(),
     },
     AccountsController: {
       getSelectedAccount: jest.fn(),
@@ -162,6 +164,79 @@ describe('Permission Management Functions', () => {
         CaveatTypes.restrictReturnedAccounts,
         ['0xdef', '0xabc'],
       );
+    });
+  });
+
+  describe('addPermittedChain', () => {
+    it('adds a new chain to permitted chains', async () => {
+      const hostname = 'example.com';
+      const chainId = '0x1';
+      Engine.context.PermissionController.getCaveat.mockReturnValue({
+        value: ['0xa'],
+      });
+      Engine.context.PermissionController.grantPermissions.mockResolvedValue(undefined);
+
+      await addPermittedChain(hostname, chainId);
+
+      expect(Engine.context.PermissionController.getCaveat).toHaveBeenCalledWith(
+        hostname,
+        PermissionKeys.permittedChains,
+        CaveatTypes.restrictNetworkSwitching,
+      );
+      expect(Engine.context.PermissionController.grantPermissions).toHaveBeenCalledWith({
+        approvedPermissions: {
+          [PermissionKeys.permittedChains]: {
+            caveats: [
+              { type: CaveatTypes.restrictNetworkSwitching, value: ['0xa', '0x1'] },
+            ],
+          },
+        },
+        subject: {
+          origin: hostname,
+        },
+        preserveExistingPermissions: true,
+      });
+    });
+
+    it('does not add chain if already permitted', async () => {
+      const hostname = 'example.com';
+      const chainId = '0x1';
+      Engine.context.PermissionController.getCaveat.mockReturnValue({
+        value: ['0xa', '0x1'],
+      });
+
+      await addPermittedChain(hostname, chainId);
+
+      expect(Engine.context.PermissionController.getCaveat).toHaveBeenCalledWith(
+        hostname,
+        PermissionKeys.permittedChains,
+        CaveatTypes.restrictNetworkSwitching,
+      );
+      expect(Engine.context.PermissionController.grantPermissions).not.toHaveBeenCalled();
+    });
+
+    it('handles empty initial permitted chains', async () => {
+      const hostname = 'example.com';
+      const chainId = '0x1';
+      Engine.context.PermissionController.getCaveat.mockReturnValue({
+        value: [],
+      });
+
+      await addPermittedChain(hostname, chainId);
+
+      expect(Engine.context.PermissionController.grantPermissions).toHaveBeenCalledWith({
+        approvedPermissions: {
+          [PermissionKeys.permittedChains]: {
+            caveats: [
+              { type: CaveatTypes.restrictNetworkSwitching, value: ['0x1'] },
+            ],
+          },
+        },
+        subject: {
+          origin: hostname,
+        },
+        preserveExistingPermissions: true,
+      });
     });
   });
 });

--- a/app/core/Permissions/index.ts
+++ b/app/core/Permissions/index.ts
@@ -221,6 +221,43 @@ export const getPermittedAccounts = async (
 };
 
 /**
+ * Add a permitted chain for the given the host.
+ * 
+ * @param hostname - Subject to add permitted chain. Ex: A Dapp is a subject
+ * @param chainId - ChainId to add.
+ */
+export const addPermittedChain = async (hostname: string, chainId: string) => {
+  const { PermissionController } = Engine.context;
+
+  const caveat = PermissionController.getCaveat(
+    hostname,
+    PermissionKeys.permittedChains,
+    CaveatTypes.restrictNetworkSwitching
+  );
+
+  const currentPermittedChains = caveat.value;
+  if (currentPermittedChains.includes(chainId)) {
+    return;
+  }
+
+  const newPermittedChains = [...currentPermittedChains, chainId];
+
+  await PermissionController.grantPermissions({
+    approvedPermissions: {
+      [PermissionKeys.permittedChains]: {
+        caveats: [
+          { type: CaveatTypes.restrictNetworkSwitching, value: newPermittedChains },
+        ],
+      },
+    },
+    subject: {
+      origin: hostname,
+    },
+    preserveExistingPermissions: true,
+  });
+};
+
+/**
  * Get permitted chains for the given the host.
  *
  * @param hostname - Subject to check if permissions exists. Ex: A Dapp is a subject.

--- a/app/core/Permissions/index.ts
+++ b/app/core/Permissions/index.ts
@@ -258,6 +258,42 @@ export const addPermittedChain = async (hostname: string, chainId: string) => {
 };
 
 /**
+ * Remove a permitted chain for the given the host.
+ * 
+ * @param hostname - Subject to remove permitted chain. Ex: A Dapp is a subject
+ * @param chainId - ChainId to remove.
+ */
+export const removePermittedChain = async (hostname: string, chainId: string) => {
+  const { PermissionController } = Engine.context;
+  const caveat = PermissionController.getCaveat(
+    hostname,
+    PermissionKeys.permittedChains,
+    CaveatTypes.restrictNetworkSwitching
+  );
+
+  const currentPermittedChains = caveat.value;
+  if (!currentPermittedChains.includes(chainId)) {
+    return;
+  }
+
+  const newPermittedChains = currentPermittedChains.filter((chain: string) => chain !== chainId);
+
+  await PermissionController.grantPermissions({
+    approvedPermissions: {
+      [PermissionKeys.permittedChains]: {
+        caveats: [
+          { type: CaveatTypes.restrictNetworkSwitching, value: newPermittedChains },
+        ],
+      },
+    },
+    subject: {
+      origin: hostname,
+    },
+    preserveExistingPermissions: true,
+  });
+}
+
+/**
  * Get permitted chains for the given the host.
  *
  * @param hostname - Subject to check if permissions exists. Ex: A Dapp is a subject.

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -625,4 +625,44 @@ describe('WalletConnect2Session', () => {
       expect((session as any).requestsToRedirect['789']).toBe(true);
     });
   });
+
+  it('handles wallet_switchEthereumChain correctly', async () => {
+    // Setup spies
+    const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+    const approveRequestSpy = jest.spyOn(session, 'approveRequest');
+
+    // Create a mock switch chain request
+    const chainIdHex = '0x89'; // Polygon
+    const switchChainRequest = {
+      id: '42',
+      topic: mockSession.topic,
+      params: {
+        request: {
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: chainIdHex }],
+        },
+        chainId: 'eip155:1', // Current chain before switch
+      },
+      verifyContext: {
+        verified: {
+          origin: 'https://example.com'
+        }
+      },
+    };
+
+    // Store the request ID in the topicByRequestId map
+    (session as any).topicByRequestId[switchChainRequest.id] = switchChainRequest.topic;
+
+    // Call handleRequest with the switchChainRequest
+    await session.handleRequest(switchChainRequest as any);
+
+    // Verify handleChainChange was called with the decimal chain ID
+    expect(handleChainChangeSpy).toHaveBeenCalledWith(parseInt(chainIdHex, 16)); // 137 in decimal
+
+    // Verify approveRequest was called with the correct parameters
+    expect(approveRequestSpy).toHaveBeenCalledWith({ 
+      id: switchChainRequest.id + '', 
+      result: true 
+    });
+  });
 });

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -248,22 +248,22 @@ class WalletConnect2Session {
       const currentNamespaces = this.session.namespaces;
       const newChainId = `eip155:${chainIdDecimal}`;
       const updatedChains = [
-        ...new Set([...(currentNamespaces.eip155?.chains || []), newChainId]),
+        ...new Set([...(currentNamespaces?.eip155?.chains || []), newChainId]),
       ];
 
-      const accounts = [...new Set((currentNamespaces.eip155?.accounts || []).map((acc) => acc.split(':')[2]))].map((account) => `${newChainId}:${account}`);
+      const accounts = [...new Set((currentNamespaces?.eip155?.accounts || []).map((acc) => acc.split(':')[2]))].map((account) => `${newChainId}:${account}`);
 
       const updatedAccounts = [
-        ...new Set([...(currentNamespaces.eip155?.accounts || []), ...accounts]),
+        ...new Set([...(currentNamespaces?.eip155?.accounts || []), ...accounts]),
       ]
 
       const updatedNamespaces = {
         ...currentNamespaces,
         eip155: {
-          ...currentNamespaces.eip155,
+          ...(currentNamespaces?.eip155 || {}),
           chains: updatedChains,
-          methods: currentNamespaces.eip155.methods,
-          events: currentNamespaces.eip155.events,
+          methods: currentNamespaces?.eip155?.methods || [],
+          events: currentNamespaces?.eip155?.events || [],
           accounts: updatedAccounts,
         },
       };

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -251,6 +251,12 @@ class WalletConnect2Session {
         ...new Set([...(currentNamespaces.eip155?.chains || []), newChainId]),
       ];
 
+      const accounts = [...new Set((currentNamespaces.eip155?.accounts || []).map((acc) => acc.split(':')[2]))].map((account) => `${newChainId}:${account}`);
+
+      const updatedAccounts = [
+        ...new Set([...(currentNamespaces.eip155?.accounts || []), ...accounts]),
+      ]
+
       const updatedNamespaces = {
         ...currentNamespaces,
         eip155: {
@@ -258,7 +264,7 @@ class WalletConnect2Session {
           chains: updatedChains,
           methods: currentNamespaces.eip155.methods,
           events: currentNamespaces.eip155.events,
-          accounts: currentNamespaces.eip155.accounts,
+          accounts: updatedAccounts,
         },
       };
 
@@ -451,7 +457,8 @@ class WalletConnect2Session {
     const verified = requestEvent.verifyContext?.verified;
     const origin = verified?.origin ?? this.session.peer.metadata.url;
     const method = requestEvent.params.request.method;
-    const caip2ChainId = method === 'wallet_switchEthereumChain' ? `eip155:${parseInt(requestEvent.params.request.params[0].chainId, 16)}` : requestEvent.params.chainId;
+    const isSwitchingChain = method === 'wallet_switchEthereumChain';
+    const caip2ChainId = isSwitchingChain ? `eip155:${parseInt(requestEvent.params.request.params[0].chainId, 16)}` : requestEvent.params.chainId;
     const methodParams = requestEvent.params.request.params;
 
     DevLogger.log(
@@ -459,7 +466,7 @@ class WalletConnect2Session {
     );
 
     try {
-      const allowed = await checkWCPermissions({ origin, caip2ChainId });
+      const allowed = await checkWCPermissions({ origin, caip2ChainId, allowSwitchingToNewChain: isSwitchingChain });
       DevLogger.log(
         `WC2::handleRequest caip2ChainId=${caip2ChainId} is allowed=${allowed}`,
       );
@@ -499,6 +506,8 @@ class WalletConnect2Session {
 
     if (method === 'wallet_switchEthereumChain') {
       this.handleChainChange(parseInt(caip2ChainId.split(':')[1], 10));
+      // respond to the request as successful
+      await this.approveRequest({ id: requestEvent.id + '', result: true });
       return;
     }
 

--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -45,6 +45,7 @@ jest.mock('../../../app/store', () => {
 jest.mock('../Permissions', () => ({
 	getPermittedAccounts: jest.fn().mockResolvedValue(['0x123']),
 	getPermittedChains: jest.fn().mockResolvedValue(['eip155:1']),
+	addPermittedChain: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../selectors/networkController', () => ({
@@ -274,6 +275,30 @@ describe('WalletConnect Utils', () => {
 				caip2ChainId: 'eip155:1',
 			});
 			expect(switchToNetwork).toHaveBeenCalled();
+		});
+
+		it('adds permitted chain when allowSwitchingToNewChain is true', async () => {
+			// Mock that the chain is not permitted
+			const mockPermittedChains = jest.requireMock('../Permissions').getPermittedChains;
+			mockPermittedChains.mockResolvedValueOnce([]);
+			
+			// Mock the addPermittedChain function
+			const mockAddPermittedChain = jest.requireMock('../Permissions').addPermittedChain;
+			
+			// Test with allowSwitchingToNewChain set to true
+			const result = await checkWCPermissions({
+				origin: 'test-dapp.com',
+				caip2ChainId: 'eip155:3',
+				allowSwitchingToNewChain: true,
+			});
+			
+			// Verify addPermittedChain was called with the right parameters
+			expect(mockAddPermittedChain).toHaveBeenCalledWith(
+				'test-dapp.com', 
+				'0x3'
+			);
+			expect(switchToNetwork).toHaveBeenCalled();
+			expect(result).toBe(true);
 		});
 	});
 

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -291,11 +291,6 @@ export const checkWCPermissions = async ({
 
   if (caip2ChainId !== activeCaip2ChainId) {
     try {
-      if (!isAllowedChainId && allowSwitchingToNewChain) {
-        DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${origin}:`, hexChainIdString);
-        await addPermittedChain(getHostname(origin), hexChainIdString);
-      }
-
       await switchToNetwork({
         network: existingNetwork,
         chainId: hexChainIdString,
@@ -305,6 +300,11 @@ export const checkWCPermissions = async ({
         origin,
         isAddNetworkFlow: false,
       });
+      
+      if (!isAllowedChainId && allowSwitchingToNewChain) {
+        DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${origin}:`, hexChainIdString);
+        await addPermittedChain(getHostname(origin), hexChainIdString);
+      }
 
     } catch (error) {
       DevLogger.log(

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -291,6 +291,11 @@ export const checkWCPermissions = async ({
 
   if (caip2ChainId !== activeCaip2ChainId) {
     try {
+      if (!isAllowedChainId && allowSwitchingToNewChain) {
+        DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${origin}:`, hexChainIdString);
+        await addPermittedChain(getHostname(origin), hexChainIdString);
+      }
+
       await switchToNetwork({
         network: existingNetwork,
         chainId: hexChainIdString,
@@ -300,11 +305,6 @@ export const checkWCPermissions = async ({
         origin,
         isAddNetworkFlow: false,
       });
-      
-      if (!isAllowedChainId && allowSwitchingToNewChain) {
-        DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${origin}:`, hexChainIdString);
-        await addPermittedChain(getHostname(origin), hexChainIdString);
-      }
 
     } catch (error) {
       DevLogger.log(

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -10,7 +10,7 @@ import {
   selectProviderConfig,
 } from '../../selectors/networkController';
 import Engine from '../Engine';
-import { addPermittedChain, getPermittedAccounts, getPermittedChains } from '../Permissions';
+import { addPermittedChain, getPermittedAccounts, getPermittedChains, removePermittedChain } from '../Permissions';
 import {
   findExistingNetwork,
   switchToNetwork,
@@ -292,6 +292,8 @@ export const checkWCPermissions = async ({
   if (caip2ChainId !== activeCaip2ChainId) {
     try {
       if (!isAllowedChainId && allowSwitchingToNewChain) {
+        // Preemptively add the chain to the permitted chains
+        // This is to prevent a race condition where WalletConnect is told about the chain switch before permissions are updated
         DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${origin}:`, hexChainIdString);
         await addPermittedChain(getHostname(origin), hexChainIdString);
       }
@@ -311,6 +313,14 @@ export const checkWCPermissions = async ({
         `WC::checkWCPermissions error switching to network:`,
         error,
       );
+
+      if (!isAllowedChainId && allowSwitchingToNewChain) {
+        // If we failed to switch to the network, remove the chain from the permitted chains
+        // This is so we don't leave any dangling permissions if the user rejects the switch
+        DevLogger.log(`WC::checkWCPermissions removing permitted chain for ${origin}:`, hexChainIdString);
+        await removePermittedChain(getHostname(origin), hexChainIdString);
+      }
+
       return false;
     }
   }


### PR DESCRIPTION
## **Description**

When using `wallet_switchEthereumChain` via WalletConnect on a chain that wasn't previously permitted, the chain is granted permissions in the PermissionComtroller. It seems currently switching to a non-permitted chain via `switchToNetwork` will ask the user for permission, so granting permissions when we successfully switch seems to be fix issues with mismatching WalletConnect namespaces vs what the Wallet is currently allowing

## **Related issues**

Fixes: #14757

## **Manual testing steps**

1. Go to https://appkit-lab.reown.com/library/wagmi/ on your desktop browser
2. Click connect ont he dapp
3. Scan the QRCode and edit the permitted networks for Mainnet only
4. Switch to Polygon (or any other chain) from the dapp -> see error on the dapp and the dapp gets disconnected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/bd938a98-97ef-4b63-af02-f879612d7bec

### **After**


https://github.com/user-attachments/assets/3d31a6a9-8443-4a00-a1ce-0e6caeb1336a


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
