### PR TITLE
fix: Do not initialize RemoteFeatureFlagController with state

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -277,6 +277,20 @@ describe('Engine', () => {
     });
   });
 
+  it('does not pass initial RemoteFeatureFlagController state to the controller', () => {
+    const state = {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {},
+        cacheTimestamp: 20000000000000,
+      },
+    };
+    const engine = Engine.init(state);
+    expect(engine.datamodel.state.RemoteFeatureFlagController).toStrictEqual({
+      remoteFeatureFlags: {},
+      cacheTimestamp: 0,
+    });
+  });
+
   describe('getTotalEvmFiatAccountBalance', () => {
     let engine: EngineClass;
     afterEach(() => engine?.destroyEngineInstance());

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -445,7 +445,6 @@ export class Engine {
       }),
     });
     const remoteFeatureFlagController = createRemoteFeatureFlagController({
-      state: initialState.RemoteFeatureFlagController,
       messenger: this.controllerMessenger.getRestricted({
         name: 'RemoteFeatureFlagController',
         allowedActions: [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently, the state kept by RemoteFeatureFlagController is persisted and passed back into the controller on a reload. This creates a problem if we want to place another controller in a certain mode based on a feature flag. For instance, if we want to call `NetworkController.enableRpcFailover` when the `walletFrameworkRpcFailoverEnabled` flag is true, we might think to use a `RemoteFeatureFlagController:stateChange` subscription handler to wait until RemoteFeatureFlagController knows about this flag. However, if this flag is already true then the RemoteFeatureFlagController state will never change, and so `NetworkController.enableRpcFailover` will never be called.

To fix this, this commit effectively ignores the RemoteFeatureFlagController persisted state, allowing the controller to start fresh each time the app is loaded. This behavior solves the problem mentioned above, and it is also consistent with the way extension works.

## **Related issues**

This bug was discovered while working on another feature and is a prerequisite to https://github.com/MetaMask/metamask-mobile/issues/14120.

## **Manual testing steps**

The changes in this PR should not be user-visible.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
