### PR TITLE
fix: prevent multiple banner display tracking events

### DIFF
--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, FC, useMemo } from 'react';
+import React, { useState, useCallback, FC, useMemo, useEffect } from 'react';
 import {
   View,
   TouchableOpacity,
@@ -108,7 +108,64 @@ export const Carousel: FC<CarouselProps> = ({ style }) => {
   );
 
   const renderBannerSlides = useCallback(
-    ({ item: slide }: { item: CarouselSlide }) => {
+    ({ item: slide }: { item: CarouselSlide }) => (
+      <Pressable
+        key={slide.id}
+        testID={slide.testID}
+        style={[
+          styles.slideContainer,
+          pressedSlideId === slide.id && styles.slideContainerPressed,
+        ]}
+        onPress={() => handleSlideClick(slide.id, slide.navigation)}
+        onPressIn={() => setPressedSlideId(slide.id)}
+        onPressOut={() => setPressedSlideId(null)}
+      >
+        <View style={styles.slideContent}>
+          <View style={styles.imageContainer}>
+            <Image
+              source={BANNER_IMAGES[slide.id]}
+              style={styles.bannerImage}
+              resizeMode="contain"
+            />
+          </View>
+          <View style={styles.textContainer}>
+            <View style={styles.textWrapper}>
+              <Text
+                variant={TextVariant.BodyMD}
+                style={styles.title}
+                testID={slide.testIDTitle}
+              >
+                {slide.title}
+              </Text>
+              <Text variant={TextVariant.BodySM} style={styles.description}>
+                {slide.description}
+              </Text>
+            </View>
+          </View>
+          {!slide.undismissable && (
+            <TouchableOpacity
+              testID={slide.testIDCloseButton}
+              style={styles.closeButton}
+              onPress={() => handleClose(slide.id)}
+            >
+              <Icon name="close" size={18} color={colors.icon.default} />
+            </TouchableOpacity>
+          )}
+        </View>
+      </Pressable>
+    ),
+    [
+      styles,
+      handleSlideClick,
+      handleClose,
+      colors.icon.default,
+      pressedSlideId,
+    ],
+  );
+
+  // Track banner display events when visible slides change
+  useEffect(() => {
+    visibleSlides.forEach((slide) => {
       trackEvent(
         createEventBuilder({
           category: 'Banner Display',
@@ -117,64 +174,8 @@ export const Carousel: FC<CarouselProps> = ({ style }) => {
           },
         }).build(),
       );
-
-      return (
-        <Pressable
-          key={slide.id}
-          testID={slide.testID}
-          style={[
-            styles.slideContainer,
-            pressedSlideId === slide.id && styles.slideContainerPressed,
-          ]}
-          onPress={() => handleSlideClick(slide.id, slide.navigation)}
-          onPressIn={() => setPressedSlideId(slide.id)}
-          onPressOut={() => setPressedSlideId(null)}
-        >
-          <View style={styles.slideContent}>
-            <View style={styles.imageContainer}>
-              <Image
-                source={BANNER_IMAGES[slide.id]}
-                style={styles.bannerImage}
-                resizeMode="contain"
-              />
-            </View>
-            <View style={styles.textContainer}>
-              <View style={styles.textWrapper}>
-                <Text
-                  variant={TextVariant.BodyMD}
-                  style={styles.title}
-                  testID={slide.testIDTitle}
-                >
-                  {slide.title}
-                </Text>
-                <Text variant={TextVariant.BodySM} style={styles.description}>
-                  {slide.description}
-                </Text>
-              </View>
-            </View>
-            {!slide.undismissable && (
-              <TouchableOpacity
-                testID={slide.testIDCloseButton}
-                style={styles.closeButton}
-                onPress={() => handleClose(slide.id)}
-              >
-                <Icon name="close" size={18} color={colors.icon.default} />
-              </TouchableOpacity>
-            )}
-          </View>
-        </Pressable>
-      );
-    },
-    [
-      styles,
-      handleSlideClick,
-      handleClose,
-      colors.icon.default,
-      pressedSlideId,
-      trackEvent,
-      createEventBuilder,
-    ],
-  );
+    });
+  }, [visibleSlides, trackEvent, createEventBuilder]);
 
   const renderProgressDots = useMemo(
     () => (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses an issue where banner display tracking events were being logged multiple times due to being placed in the `renderBannerSlides` callback. This was causing duplicate analytics events and inaccurate tracking data.


## Problem
The banner display tracking was implemented in the `renderBannerSlides` callback, which executes on every component render. This led to:
- Multiple tracking events for the same banner display
- Inflated analytics data
- Potential performance impact from unnecessary tracking calls

## Solution
Moved the banner display tracking logic to a `useEffect` hook with `visibleSlides` as a dependency. This change:
- Ensures tracking only occurs when banners are first displayed
- Logs events when the set of visible banners changes
- Prevents duplicate events from component re-renders
- Maintains proper separation of side effects from rendering logic

## **Related issues**

Fixes:

## **Manual testing steps**

- [x] Verify banner display events are logged only once per banner
- [x] Tested that no tracking events are lost during normal component updates
- [x] Ensured existing banner functionality remains intact

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
