### PR TITLE
fix: fix remove nft multichain

### DIFF
--- a/app/components/UI/CollectibleMedia/CollectibleMedia.types.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.types.ts
@@ -17,6 +17,7 @@ export interface Collectible {
   description?: string;
   rarityRank?: number;
   isCurrentlyOwned?: boolean;
+  chainId: number;
 }
 
 type NFTData = Omit<Nft, 'image'> & {

--- a/app/components/Views/NftOptions/NftOptions.tsx
+++ b/app/components/Views/NftOptions/NftOptions.tsx
@@ -8,7 +8,10 @@ import { strings } from '../../../../locales/i18n';
 import Icon, {
   IconName,
 } from '../../../component-library/components/Icons/Icon';
-import { selectChainId } from '../../../selectors/networkController';
+import {
+  selectChainId,
+  selectEvmNetworkConfigurationsByChainId,
+} from '../../../selectors/networkController';
 import ReusableModal, { ReusableModalRef } from '../../UI/ReusableModal';
 import styleSheet from './NftOptions.styles';
 import Text, {
@@ -26,6 +29,7 @@ import {
   MetaMetricsEvents,
 } from '../../../components/hooks/useMetrics';
 import { getDecimalChainId } from '../../../util/networks';
+import { toHex } from '@metamask/controller-utils';
 
 interface Props {
   route: {
@@ -45,6 +49,9 @@ const NftOptions = (props: Props) => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
+  );
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
   );
 
   const goToWalletPage = () => {
@@ -91,10 +98,17 @@ const NftOptions = (props: Props) => {
 
   const removeNft = () => {
     const { NftController } = Engine.context;
+    const nftChainNetwork = networkConfigurations[toHex(collectible.chainId)];
+    const nftNetworkClientId =
+      nftChainNetwork?.rpcEndpoints?.[nftChainNetwork?.defaultRpcEndpointIndex]
+        .networkClientId;
     removeFavoriteCollectible(selectedAddress, chainId, collectible);
     NftController.removeAndIgnoreNft(
       collectible.address,
       collectible.tokenId.toString(),
+      {
+        networkClientId: nftNetworkClientId,
+      },
     );
     trackEvent(
       createEventBuilder(MetaMetricsEvents.COLLECTIBLE_REMOVED)


### PR DESCRIPTION
## **Description**

PR to fix allowing a user to remove an NFT while on popular networks.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Select a network different than the NFT network that you want to remove
2. Select popular networks
3. Go to NFT tab
4. Click on your NFT that you want to remove
5. Select options button and remove the NFT
6. You should be able to remove the NFT


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
