### PR TITLE
cp: PR 14718 to release 7.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.45.0]
 
-### Fixed
+### Changed
 
-- fix: updates a padding style specifically for Android devices ([#14725](https://github.com/MetaMask/metamask-mobile/pull/14725))
+- fix(multi-srp): display errors only after all the words are have been entered ([#14607](https://github.com/MetaMask/metamask-mobile/pull/14607))
+- fix(multi-srp): display alternative text color when in dark mode([#14718](https://github.com/MetaMask/metamask-mobile/pull/14718))
 
 ### Added
 
@@ -103,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: reduce tests worker for only performance tests ([#14051](https://github.com/MetaMask/metamask-mobile/pull/14051))
 - fix: scroll for the confirmation screen ([#14269](https://github.com/MetaMask/metamask-mobile/pull/14269))
 - fix: STAKE-964: bumped @metamask/earn-controller dependency to resolve pooled-staking geo-block for fresh installs ([#14257](https://github.com/MetaMask/metamask-mobile/pull/14257))
+- fix: updates a padding style specifically for Android devices ([#14725](https://github.com/MetaMask/metamask-mobile/pull/14725))
+- fix(swaps): set default slippage when source or destination token is not stablecoin ([#14730](https://github.com/MetaMask/metamask-mobile/pull/14730))
 
 ## [7.44.0]
 
@@ -176,11 +179,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: inherit icon size from text component parent ([#14024](https://github.com/MetaMask/metamask-mobile/pull/14024))
 - fix: animation added for loading state on SnapUILink button ([#13973](https://github.com/MetaMask/metamask-mobile/pull/13973))
 - fix: Revert "chore: upgrade Xcode 16 on bitrise.yml" ([#14012](https://github.com/MetaMask/metamask-mobile/pull/14012))
-<<<<<<< HEAD
-=======
 - fix(bridge): hide staked native assets from token selectors ([#14457](https://github.com/MetaMask/metamask-mobile/pull/14457))
 
->>>>>>> 14fd5f227f (fix: not setting default slippage for non stablecoin pairs (#14730))
 
 ## [7.43.0]
 

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
@@ -33,7 +33,6 @@ import Icon, {
 } from '../../../component-library/components/Icons/Icon';
 import ButtonLink from '../../../component-library/components/Buttons/Button/variants/ButtonLink';
 import { ButtonSize } from '../../../component-library/components/Buttons/Button';
-import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { isValidMnemonic } from '../../../util/validators';
 import useCopyClipboard from '../Notifications/Details/hooks/useCopyClipboard';
 import ClipboardManager from '../../../core/ClipboardManager';
@@ -46,6 +45,14 @@ import {
 } from '../../../component-library/components/Toast';
 import { useSelector } from 'react-redux';
 import { selectHDKeyrings } from '../../../selectors/keyringController';
+import {
+  validateSRP,
+  validateCompleteness,
+  validateCase,
+  validateWords,
+  validateMnemonic,
+} from './validation';
+import { AppThemeKey } from '../../../util/theme/models';
 
 const defaultNumberOfWords = 12;
 
@@ -105,9 +112,6 @@ const ImportNewSecretRecoveryPhrase = () => {
     }
   }, [inputWidth]);
 
-  const hasUpperCase = (draftSrp: string) =>
-    draftSrp !== draftSrp.toLowerCase();
-
   const hasEmptySrp = useMemo(
     () => secretRecoveryPhrase.every((word) => word === ''),
     [secretRecoveryPhrase],
@@ -135,110 +139,6 @@ const ImportNewSecretRecoveryPhrase = () => {
 
   const onSrpChange = useCallback(
     (newDraftSrp: string[]) => {
-      const validateSRP = (phrase: string[], words: boolean[]) => {
-        if (!phrase.some((word) => word !== '')) {
-          return { error: '', words };
-        }
-
-        const state = {
-          error: '',
-          words: phrase.map((word) => !wordlist.includes(word)),
-        };
-
-        return state;
-      };
-
-      const validateCompleteness = (
-        state: { error: string; words: boolean[] },
-        phrase: string[],
-      ) => {
-        if (state.error) {
-          return state;
-        }
-        if (phrase.some((word) => word === '')) {
-          return {
-            ...state,
-            error: strings(
-              'import_new_secret_recovery_phrase.error_number_of_words_error_message',
-            ),
-          };
-        }
-        return state;
-      };
-
-      const validateCase = (
-        state: { error: string; words: boolean[] },
-        phrase: string,
-      ) => {
-        if (state.error) {
-          return state;
-        }
-        if (hasUpperCase(phrase)) {
-          return {
-            ...state,
-            error: strings(
-              'import_new_secret_recovery_phrase.error_srp_is_case_sensitive',
-            ),
-          };
-        }
-        return state;
-      };
-
-      const validateWords = (state: { error: string; words: boolean[] }) => {
-        if (state.error) {
-          return state;
-        }
-
-        const invalidWordIndices = state.words
-          .map((invalid, index) => (invalid ? index + 1 : 0))
-          .filter((index) => index !== 0);
-
-        if (invalidWordIndices.length === 0) {
-          return state;
-        }
-        if (invalidWordIndices.length === 1) {
-          return {
-            ...state,
-            error: `${strings(
-              'import_new_secret_recovery_phrase.error_srp_word_error_1',
-            )}${invalidWordIndices[0]}${strings(
-              'import_new_secret_recovery_phrase.error_srp_word_error_2',
-            )}`,
-          };
-        }
-
-        const lastIndex = invalidWordIndices.pop();
-        const firstPart = invalidWordIndices.join(', ');
-        return {
-          ...state,
-          error: `${strings(
-            'import_new_secret_recovery_phrase.error_multiple_srp_word_error_1',
-          )}${firstPart}${strings(
-            'import_new_secret_recovery_phrase.error_multiple_srp_word_error_2',
-          )}${lastIndex}${strings(
-            'import_new_secret_recovery_phrase.error_multiple_srp_word_error_3',
-          )}`,
-        };
-      };
-
-      const validateMnemonic = (
-        state: { error: string; words: boolean[] },
-        phrase: string,
-      ) => {
-        if (state.error) {
-          return state;
-        }
-        if (!isValidMnemonic(phrase)) {
-          return {
-            ...state,
-            error: strings(
-              'import_new_secret_recovery_phrase.error_invalid_srp',
-            ),
-          };
-        }
-        return state;
-      };
-
       const hideErrorIfSrpIsEmpty = (
         state: { error: string; words: boolean[] },
         phrase: string[],
@@ -401,6 +301,10 @@ const ImportNewSecretRecoveryPhrase = () => {
                     borderColor: invalidSRPWords[index]
                       ? colors.error.default
                       : colors.border.muted,
+                    color:
+                      themeAppearance === AppThemeKey.light
+                        ? colors.text.default
+                        : colors.text.alternative,
                   }}
                   autoCapitalize="none"
                   keyboardAppearance={themeAppearance}

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/validation.ts
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/validation.ts
@@ -1,0 +1,107 @@
+import { isValidMnemonic } from 'ethers/lib/utils';
+import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+import { strings } from '../../../../locales/i18n';
+
+const hasUpperCase = (draftSrp: string) => draftSrp !== draftSrp.toLowerCase();
+
+export const validateSRP = (phrase: string[], words: boolean[]) => {
+  if (!phrase.some((word) => word !== '')) {
+    return { error: '', words };
+  }
+
+  const state = {
+    error: '',
+    words: phrase.map((word) => !wordlist.includes(word)),
+  };
+
+  return state;
+};
+
+export const validateCompleteness = (
+  state: { error: string; words: boolean[] },
+  phrase: string[],
+) => {
+  if (state.error) {
+    return state;
+  }
+  if (phrase.some((word) => word === '')) {
+    return {
+      ...state,
+      error: strings(
+        'import_new_secret_recovery_phrase.error_number_of_words_error_message',
+      ),
+    };
+  }
+  return state;
+};
+
+export const validateCase = (
+  state: { error: string; words: boolean[] },
+  phrase: string,
+) => {
+  if (state.error) {
+    return state;
+  }
+  if (hasUpperCase(phrase)) {
+    return {
+      ...state,
+      error: strings(
+        'import_new_secret_recovery_phrase.error_srp_is_case_sensitive',
+      ),
+    };
+  }
+  return state;
+};
+
+export const validateWords = (state: { error: string; words: boolean[] }) => {
+  if (state.error) {
+    return state;
+  }
+
+  const invalidWordIndices = state.words
+    .map((invalid, index) => (invalid ? index + 1 : 0))
+    .filter((index) => index !== 0);
+
+  if (invalidWordIndices.length === 0) {
+    return state;
+  }
+  if (invalidWordIndices.length === 1) {
+    return {
+      ...state,
+      error: `${strings(
+        'import_new_secret_recovery_phrase.error_srp_word_error_1',
+      )}${invalidWordIndices[0]}${strings(
+        'import_new_secret_recovery_phrase.error_srp_word_error_2',
+      )}`,
+    };
+  }
+
+  const lastIndex = invalidWordIndices.pop();
+  const firstPart = invalidWordIndices.join(', ');
+  return {
+    ...state,
+    error: `${strings(
+      'import_new_secret_recovery_phrase.error_multiple_srp_word_error_1',
+    )}${firstPart}${strings(
+      'import_new_secret_recovery_phrase.error_multiple_srp_word_error_2',
+    )}${lastIndex}${strings(
+      'import_new_secret_recovery_phrase.error_multiple_srp_word_error_3',
+    )}`,
+  };
+};
+
+export const validateMnemonic = (
+  state: { error: string; words: boolean[] },
+  phrase: string,
+) => {
+  if (state.error) {
+    return state;
+  }
+  if (!isValidMnemonic(phrase)) {
+    return {
+      ...state,
+      error: strings('import_new_secret_recovery_phrase.error_invalid_srp'),
+    };
+  }
+  return state;
+};


### PR DESCRIPTION
## **Description**
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

This pr fixes the input text color to show the alternative text color in dark mode and moves validation logic into a validation file.

Changes:
1. ImportNewSecretRecoveryPhrase dark mode text color.
2. Moved logic into a new validation file

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution? -->

Fixes:
https://consensyssoftware.atlassian.net/browse/MMMULTISRP-172?atlOrigin=eyJpIjoiODc2NzY1Y2RjMGExNDBiMzlkODY2OWFkOWNkYjIxMTUiLCJwIjoiaiJ9

1. Go to account actions
2. Click on `Secret Recovery Phrase`
4. Enter a word
5. Switch to dark mode and see that the text color is visible.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- [screenshots/recordings] -->

![Screenshot 2025-04-17 at 19 13
05](https://github.com/user-attachments/assets/8dc35491-b45f-4eb5-8ceb-02ece09208f0)

<!-- [screenshots/recordings] -->

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
