### PR TITLE
fix: not showing fiat value of inputted Solana assets in bridge token…

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -4,6 +4,9 @@ import { Hex } from '@metamask/utils';
 describe('getDisplayFiatValue', () => {
   const mockChainId = '0x1' as Hex;
   const mockTokenAddress = '0x0000000000000000000000000000000000000001' as Hex;
+  const mockSolanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as const;
+  const mockSolanaTokenAddress = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as const;
+  const mockSplTokenAddress = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as const;
 
   const mockToken = {
     address: mockTokenAddress,
@@ -15,6 +18,26 @@ describe('getDisplayFiatValue', () => {
     balance: '1',
     balanceFiat: '$20000',
     tokenFiatAmount: 20000,
+  };
+
+  const mockSolanaToken = {
+    address: mockSolanaTokenAddress,
+    chainId: mockSolanaChainId,
+    symbol: 'SOL',
+    decimals: 9,
+    image: 'https://solana.com/logo.png',
+    name: 'Solana',
+    balance: '1',
+  };
+
+  const mockSplToken = {
+    address: mockSplTokenAddress,
+    chainId: mockSolanaChainId,
+    symbol: 'USDC',
+    decimals: 6,
+    image: 'https://usdc.com/logo.png',
+    name: 'USD Coin',
+    balance: '1',
   };
 
   const mockNetworkConfigurations = {
@@ -39,6 +62,37 @@ describe('getDisplayFiatValue', () => {
     },
   };
 
+  const mockNonEvmMultichainAssetRates = {
+    [mockSolanaTokenAddress]: {
+      conversionTime: 1745436145391,
+      currency: 'swift:0/iso4217:USD',
+      expirationTime: 1745439745391,
+      marketData: {
+        allTimeHigh: '293.31',
+        allTimeLow: '0.500801',
+        circulatingSupply: '517313513.4593564',
+        marketCap: '78479310083',
+        pricePercentChange: {},
+        totalVolume: '6225869757',
+      },
+      rate: '151.7',
+    },
+    [mockSplTokenAddress]: {
+      conversionTime: 1745436145392,
+      currency: 'swift:0/iso4217:USD',
+      expirationTime: 1745439745392,
+      marketData: {
+        allTimeHigh: '1.17',
+        allTimeLow: '0.877647',
+        circulatingSupply: '61517136784.14079',
+        marketCap: '61511872061',
+        pricePercentChange: {},
+        totalVolume: '13352880710',
+      },
+      rate: '0.999915',
+    },
+  };
+
   it('should return zero when token is undefined', () => {
     const result = getDisplayFiatValue({
       token: undefined,
@@ -47,6 +101,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     expect(result).toBe('$0');
@@ -60,6 +115,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     expect(result).toBe('$0');
@@ -73,6 +129,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     // 1 TOKEN1 = 10 ETH, 1 ETH = $2000, so 1 TOKEN1 = $20000
@@ -87,6 +144,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     expect(result).toBe('< $0.01');
@@ -100,6 +158,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'EUR',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     // Currency symbol should be included
@@ -114,6 +173,7 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     expect(result).toBe('$0');
@@ -136,8 +196,104 @@ describe('getDisplayFiatValue', () => {
       networkConfigurationsByChainId: mockNetworkConfigurations,
       multiChainCurrencyRates: mockMultiChainCurrencyRates,
       currentCurrency: 'USD',
+      nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
     });
 
     expect(result).toBe('$0');
+  });
+
+  describe('Solana token tests', () => {
+    it('should calculate correct fiat value for SOL amount', () => {
+      const result = getDisplayFiatValue({
+        token: mockSolanaToken,
+        amount: '1',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'USD',
+        nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+      });
+
+      // 1 SOL = $151.7
+      expect(result).toBe('$151.69999');
+    });
+
+    it('should calculate correct fiat value for SPL token amount', () => {
+      const result = getDisplayFiatValue({
+        token: mockSplToken,
+        amount: '1',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'USD',
+        nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+      });
+
+      // 1 USDC = $0.999915
+      expect(result).toBe('$0.99991');
+    });
+
+    it('should handle different currencies for Solana tokens', () => {
+      const result = getDisplayFiatValue({
+        token: mockSolanaToken,
+        amount: '1',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'EUR',
+        nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+      });
+
+      expect(result).toBe('€151.69999');
+    });
+
+    it('should handle very small amounts for Solana tokens', () => {
+      const result = getDisplayFiatValue({
+        token: mockSolanaToken,
+        amount: '0.0000001',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'USD',
+        nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+      });
+
+      expect(result).toBe('< $0.01');
+    });
+
+    it('should handle undefined rates for Solana tokens', () => {
+      const result = getDisplayFiatValue({
+        token: mockSolanaToken,
+        amount: '1',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'USD',
+        nonEvmMultichainAssetRates: {},
+      });
+
+      expect(result).toBe('$0');
+    });
+
+    it('should handle zero rate for Solana tokens', () => {
+      const zeroRateNonEvmMultichainAssetRates = {
+        [mockSolanaTokenAddress]: {
+          ...mockNonEvmMultichainAssetRates[mockSolanaTokenAddress],
+          rate: '0',
+        },
+      };
+
+      const result = getDisplayFiatValue({
+        token: mockSolanaToken,
+        amount: '1',
+        multiChainMarketData: mockMultiChainMarketData,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        multiChainCurrencyRates: mockMultiChainCurrencyRates,
+        currentCurrency: 'USD',
+        nonEvmMultichainAssetRates: zeroRateNonEvmMultichainAssetRates,
+      });
+
+      expect(result).toBe('$0');
+    });
   });
 });

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../../../util/number';
 import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-import { Hex } from '@metamask/utils';
+import { CaipAssetType, Hex } from '@metamask/utils';
 import { ethers } from 'ethers';
 import { BridgeToken } from '../../types';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
@@ -31,6 +31,8 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
 import { BridgeDestNetworkSelectorRouteParams } from '../BridgeDestNetworkSelector';
 import { selectBridgeControllerState } from '../../../../../core/redux/slices/bridge';
+import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
+import { isSolanaChainId } from '@metamask/bridge-controller';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -67,36 +69,51 @@ interface GetDisplayFiatValueParams {
     | Record<string, { conversionRate: number | null }>
     | undefined;
   currentCurrency: string;
+  nonEvmMultichainAssetRates: ReturnType<typeof selectMultichainAssetsRates>;
 }
 
 export const getDisplayFiatValue = ({
   token,
   amount,
-  multiChainMarketData,
+  multiChainMarketData, // EVM
   networkConfigurationsByChainId,
-  multiChainCurrencyRates,
+  multiChainCurrencyRates, // EVM
   currentCurrency,
+  nonEvmMultichainAssetRates, // Non-EVM
 }: GetDisplayFiatValueParams): string => {
   if (!token || !amount) {
     return addCurrencySymbol('0', currentCurrency);
   }
 
-  const chainId = token.chainId as Hex;
-  const multiChainExchangeRates = multiChainMarketData?.[chainId];
-  const tokenMarketData = multiChainExchangeRates?.[token.address as Hex];
+  let balanceFiatCalculation = 0;
 
-  const nativeCurrency =
-    networkConfigurationsByChainId[chainId]?.nativeCurrency;
-  const multiChainConversionRate =
-    multiChainCurrencyRates?.[nativeCurrency]?.conversionRate ?? 0;
+  if (isSolanaChainId(token.chainId)) {
+    const assetId = token.address as CaipAssetType;
+    // This rate is asset to fiat. Whatever the user selected display fiat currency is.
+    // We don't need to have an additional conversion from native token to fiat.
+    const rate = nonEvmMultichainAssetRates?.[assetId]?.rate || '0';
+    balanceFiatCalculation = Number(
+      balanceToFiatNumber(amount, Number(rate), 1),
+    );
+  } else {
+    // EVM
+    const evmChainId = token.chainId as Hex;
+    const multiChainExchangeRates = multiChainMarketData?.[evmChainId];
+    const tokenMarketData = multiChainExchangeRates?.[token.address as Hex];
 
-  const balanceFiatCalculation = Number(
-    balanceToFiatNumber(
-      amount,
-      multiChainConversionRate,
-      tokenMarketData?.price ?? 0,
-    ),
-  );
+    const nativeCurrency =
+      networkConfigurationsByChainId[evmChainId]?.nativeCurrency;
+    const multiChainConversionRate =
+      multiChainCurrencyRates?.[nativeCurrency]?.conversionRate ?? 0;
+
+    balanceFiatCalculation = Number(
+      balanceToFiatNumber(
+        amount,
+        multiChainConversionRate,
+        tokenMarketData?.price ?? 0,
+      ),
+    );
+  }
 
   if (balanceFiatCalculation >= 0.01 || balanceFiatCalculation === 0) {
     return addCurrencySymbol(balanceFiatCalculation, currentCurrency);
@@ -183,6 +200,8 @@ export const TokenInputArea = forwardRef<
     const { quoteRequest } = useSelector(selectBridgeControllerState);
     const isInsufficientBalance = quoteRequest?.insufficientBal;
 
+    const nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
+
     const fiatValue = getDisplayFiatValue({
       token,
       amount,
@@ -190,6 +209,7 @@ export const TokenInputArea = forwardRef<
       networkConfigurationsByChainId,
       multiChainCurrencyRates,
       currentCurrency,
+      nonEvmMultichainAssetRates,
     });
 
     // Convert non-atomic balance to atomic form and then format it with renderFromTokenMinimalUnit


### PR DESCRIPTION
… input area

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue with Solana assets in the Bridge input area.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Solana bridge
2. Input an amount
3. You should see the fiat value change accordingly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/6909dfcf-9065-4e0a-8ae6-306e7a267aae



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
