### PR TITLE
feat(ramps): adds performance tracing for initial ramp experience load

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -368,14 +368,14 @@ describe('BuildQuote View', () => {
 
   it('calls setOptions when rendering', async () => {
     render(BuildQuote);
-    expect(mockSetOptions).toBeCalledTimes(1);
+    expect(mockSetOptions).toHaveBeenCalled();
 
     mockSetOptions.mockReset();
 
     mockUseRampSDKValues.isBuy = false;
     mockUseRampSDKValues.isSell = true;
     render(BuildQuote);
-    expect(mockSetOptions).toBeCalledTimes(1);
+    expect(mockSetOptions).toHaveBeenCalled();
   });
 
   it('navigates and tracks event on cancel button press', async () => {

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -279,6 +279,7 @@ describe('BuildQuote View', () => {
     mockPop.mockClear();
     mockTrackEvent.mockClear();
     (mockUseRampSDKInitialValues.setSelectedRegion as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
   beforeEach(() => {

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -25,6 +25,7 @@ import { toTokenMinimalUnit } from '../../../../../util/number';
 import { RampType } from '../../../../../reducers/fiatOrders/types';
 import { NATIVE_ADDRESS } from '../../../../../constants/on-ramp';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../../util/test/accountsControllerTestUtils';
+import { endTrace, TraceName } from '../../../../../util/trace';
 
 const getByRoleButton = (name?: string | RegExp) =>
   screen.getByRole('button', { name });
@@ -262,6 +263,13 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
 
 jest.mock('../../hooks/useAnalytics', () => () => mockTrackEvent);
 
+jest.mock('../../../../../util/trace', () => ({
+  endTrace: jest.fn(),
+  TraceName: {
+    LoadRampExperience: 'Load Ramp Experience',
+  },
+}));
+
 describe('BuildQuote View', () => {
   afterEach(() => {
     mockNavigate.mockClear();
@@ -391,6 +399,33 @@ describe('BuildQuote View', () => {
       chain_id_source: '1',
       location: 'Amount to Sell Screen',
     });
+  });
+
+  it('calls endTrace when the conditions are met', () => {
+    render(BuildQuote);
+    expect(endTrace).toHaveBeenCalledWith({
+      name: TraceName.LoadRampExperience,
+    });
+  });
+
+  it('does not call endTrace if conditions are not met', () => {
+    mockUseRampSDKValues = {
+      ...mockUseRampSDKInitialValues,
+      sdkError: new Error('sdkError'),
+    };
+    render(BuildQuote);
+    expect(endTrace).not.toHaveBeenCalled();
+  });
+
+  it('only calls endTrace once', () => {
+    render(BuildQuote);
+    act(() => {
+      mockUseRegionsValues = {
+        ...mockUseRegionsInitialValues,
+        isFetching: true,
+      };
+    });
+    expect(endTrace).toHaveBeenCalledTimes(1);
   });
 
   describe('Regions data', () => {

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Pressable, View, BackHandler } from 'react-native';
+import { BackHandler, Pressable, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -66,8 +66,8 @@ import { selectTicker } from '../../../../../selectors/networkController';
 
 import styleSheet from './BuildQuote.styles';
 import {
-  toTokenMinimalUnit,
   fromTokenMinimalUnitString,
+  toTokenMinimalUnit,
 } from '../../../../../util/number';
 import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
 import useIntentAmount from '../../hooks/useIntentAmount';
@@ -83,6 +83,7 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import ListItemColumnEnd from '../../components/ListItemColumnEnd';
 import { BuildQuoteSelectors } from '../../../../../../e2e/selectors/Ramps/BuildQuote.selectors';
+import { endTrace, TraceName } from '../../../../../util/trace';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -634,6 +635,23 @@ const BuildQuote = () => {
     errorPaymentMethods,
     errorCryptoCurrencies,
   ]);
+
+  const [shouldEndTrace, setShouldEndTrace] = useState(true);
+  useEffect(() => {
+    if (
+      shouldEndTrace &&
+      !sdkError &&
+      !error &&
+      !isFetching &&
+      cryptoCurrencies &&
+      cryptoCurrencies.length > 0
+    ) {
+      endTrace({
+        name: TraceName.LoadRampExperience,
+      });
+      setShouldEndTrace(false);
+    }
+  }, [cryptoCurrencies, error, isFetching, rampType, sdkError, shouldEndTrace]);
 
   if (sdkError) {
     return (

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { BackHandler, Pressable, View } from 'react-native';
+import { Pressable, View, BackHandler } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -66,8 +66,8 @@ import { selectTicker } from '../../../../../selectors/networkController';
 
 import styleSheet from './BuildQuote.styles';
 import {
-  fromTokenMinimalUnitString,
   toTokenMinimalUnit,
+  fromTokenMinimalUnitString,
 } from '../../../../../util/number';
 import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
 import useIntentAmount from '../../hooks/useIntentAmount';

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -206,7 +206,6 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
-// mock trace util
 jest.mock('../../../util/trace', () => ({
   trace: jest.fn(),
   TraceName: {

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -31,6 +31,7 @@ import Engine from '../../../core/Engine';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 import { trace, TraceName } from '../../../util/trace';
+import { RampType } from '../../../reducers/fiatOrders/types';
 
 jest.mock('../../../core/SnapKeyring/utils/sendMultichainTransaction', () => ({
   sendMultichainTransaction: jest.fn(),
@@ -327,7 +328,27 @@ describe('WalletActions', () => {
     expect(trace).toHaveBeenCalledWith({
       name: TraceName.LoadRampExperience,
       tags: {
-        rampType: 'BUY',
+        rampType: RampType.BUY,
+      },
+    });
+  });
+
+  it('should call the onSell function when the Sell button is pressed', () => {
+    jest
+      .requireMock('../../UI/Ramp/hooks/useRampNetwork')
+      .default.mockReturnValue([true]);
+    const { getByTestId } = renderWithProvider(<WalletActions />, {
+      state: mockInitialState,
+    });
+
+    fireEvent.press(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.SELL_BUTTON),
+    );
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledWith({
+      name: TraceName.LoadRampExperience,
+      tags: {
+        rampType: RampType.SELL,
       },
     });
   });
@@ -342,12 +363,6 @@ describe('WalletActions', () => {
     );
 
     expect(mockNavigate).toHaveBeenCalled();
-    expect(trace).toHaveBeenCalledWith({
-      name: TraceName.LoadRampExperience,
-      tags: {
-        rampType: 'SELL',
-      },
-    });
   });
 
   it('should call the goToSwaps function when the Swap button is pressed', () => {

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -30,6 +30,7 @@ import {
 import Engine from '../../../core/Engine';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
+import { trace, TraceName } from '../../../util/trace';
 
 jest.mock('../../../core/SnapKeyring/utils/sendMultichainTransaction', () => ({
   sendMultichainTransaction: jest.fn(),
@@ -56,7 +57,9 @@ jest.mock('@metamask/bridge-controller', () => {
     ...actual,
     getNativeAssetForChainId: jest.fn((chainId) => {
       if (chainId === 'solana:mainnet') {
-        return actual.getNativeAssetForChainId('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp');
+        return actual.getNativeAssetForChainId(
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        );
       }
       return actual.getNativeAssetForChainId(chainId);
     }),
@@ -203,6 +206,14 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+// mock trace util
+jest.mock('../../../util/trace', () => ({
+  trace: jest.fn(),
+  TraceName: {
+    LoadRampExperience: 'LoadRampExperience',
+  },
+}));
+
 describe('WalletActions', () => {
   afterEach(() => {
     mockNavigate.mockClear();
@@ -314,6 +325,12 @@ describe('WalletActions', () => {
       getByTestId(WalletActionsBottomSheetSelectorsIDs.BUY_BUTTON),
     );
     expect(mockNavigate).toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledWith({
+      name: TraceName.LoadRampExperience,
+      tags: {
+        rampType: 'BUY',
+      },
+    });
   });
 
   it('should call the onSend function when the Send button is pressed', () => {
@@ -326,6 +343,12 @@ describe('WalletActions', () => {
     );
 
     expect(mockNavigate).toHaveBeenCalled();
+    expect(trace).toHaveBeenCalledWith({
+      name: TraceName.LoadRampExperience,
+      tags: {
+        rampType: 'SELL',
+      },
+    });
   });
 
   it('should call the goToSwaps function when the Swap button is pressed', () => {

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -54,6 +54,7 @@ import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
 } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
+import { RampType } from '../../../reducers/fiatOrders/types';
 
 const WalletActions = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -151,7 +152,7 @@ const WalletActions = () => {
     trace({
       name: TraceName.LoadRampExperience,
       tags: {
-        rampType: 'BUY',
+        rampType: RampType.BUY,
       },
     });
   }, [
@@ -180,7 +181,7 @@ const WalletActions = () => {
     trace({
       name: TraceName.LoadRampExperience,
       tags: {
-        rampType: 'SELL',
+        rampType: RampType.SELL,
       },
     });
   }, [

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -38,11 +38,7 @@ import {
 } from '../../UI/Ramp/routes/utils';
 import { trace, TraceName } from '../../../util/trace';
 // eslint-disable-next-line no-duplicate-imports, import/no-duplicates
-// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
-import {
-  selectCanSignTransactions,
-  selectSelectedInternalAccount,
-} from '../../../selectors/accountsController';
+import { selectCanSignTransactions } from '../../../selectors/accountsController';
 import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
@@ -50,11 +46,13 @@ import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constan
 import { CaipChainId, SnapId } from '@metamask/snaps-sdk';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { isMultichainWalletSnap } from '../../../core/SnapKeyring/utils/snaps';
+// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 ///: END:ONLY_INCLUDE_IF
 import {
-  SwapBridgeNavigationLocation,
   useSwapBridgeNavigation,
+  SwapBridgeNavigationLocation,
 } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
 
 const WalletActions = () => {

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -36,8 +36,13 @@ import {
   createBuyNavigationDetails,
   createSellNavigationDetails,
 } from '../../UI/Ramp/routes/utils';
+import { trace, TraceName } from '../../../util/trace';
 // eslint-disable-next-line no-duplicate-imports, import/no-duplicates
-import { selectCanSignTransactions } from '../../../selectors/accountsController';
+// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
+import {
+  selectCanSignTransactions,
+  selectSelectedInternalAccount,
+} from '../../../selectors/accountsController';
 import { WalletActionType } from '../../UI/WalletAction/WalletAction.types';
 import { isStablecoinLendingFeatureEnabled } from '../../UI/Stake/constants';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
@@ -45,11 +50,12 @@ import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constan
 import { CaipChainId, SnapId } from '@metamask/snaps-sdk';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { isMultichainWalletSnap } from '../../../core/SnapKeyring/utils/snaps';
-// eslint-disable-next-line no-duplicate-imports, import/no-duplicates
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { sendMultichainTransaction } from '../../../core/SnapKeyring/utils/sendMultichainTransaction';
 ///: END:ONLY_INCLUDE_IF
-import { useSwapBridgeNavigation, SwapBridgeNavigationLocation } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
+import {
+  SwapBridgeNavigationLocation,
+  useSwapBridgeNavigation,
+} from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
 
 const WalletActions = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -67,10 +73,11 @@ const WalletActions = () => {
   ///: END:ONLY_INCLUDE_IF
 
   const canSignTransactions = useSelector(selectCanSignTransactions);
-  const { goToBridge: goToBridgeBase, goToSwaps: goToSwapsBase } = useSwapBridgeNavigation({
-    location: SwapBridgeNavigationLocation.TabBar,
-    sourcePage: 'MainView',
-  });
+  const { goToBridge: goToBridgeBase, goToSwaps: goToSwapsBase } =
+    useSwapBridgeNavigation({
+      location: SwapBridgeNavigationLocation.TabBar,
+      sourcePage: 'MainView',
+    });
 
   const closeBottomSheetAndNavigate = useCallback(
     (navigateFunc: () => void) => {
@@ -142,6 +149,13 @@ const WalletActions = () => {
         })
         .build(),
     );
+
+    trace({
+      name: TraceName.LoadRampExperience,
+      tags: {
+        rampType: 'BUY',
+      },
+    });
   }, [
     closeBottomSheetAndNavigate,
     navigate,
@@ -164,6 +178,13 @@ const WalletActions = () => {
         })
         .build(),
     );
+
+    trace({
+      name: TraceName.LoadRampExperience,
+      tags: {
+        rampType: 'SELL',
+      },
+    });
   }, [
     closeBottomSheetAndNavigate,
     navigate,

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -47,6 +47,7 @@ export enum TraceName {
   AssetDetails = 'Asset Details',
   ImportNfts = 'Import Nfts',
   ImportTokens = 'Import Tokens',
+  LoadRampExperience = 'Load Ramp Experience',
 }
 
 export enum TraceOperation {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds performance tracing for the buy and sell experiences. Trace starts when user clicks the buy or sell button, and ends when the build quote page is displayed. This requires all ramps data to be available such as the regions, payment methods, fiats and cryptoCurrencies.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/c42c2fda-0674-439d-bf07-ca64daaba740

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
