### PR TITLE
cp: cherry-pick adfb8a1

### DIFF
--- a/app/components/Views/confirmations/hooks/useSignatureMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureMetrics.test.ts
@@ -5,8 +5,8 @@ import {
   typedSignV4SignatureRequest,
 } from '../../../../util/test/confirm-data-helpers';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { Reason, ResultType, SecurityAlertSource } from '../legacy/components/BlockaidBanner/BlockaidBanner.types';
 import { useSignatureMetrics } from './useSignatureMetrics';
-import { ResultType, Reason, SecurityAlertSource } from '../../../../../components/Views/confirmations/legacy/components/BlockaidBanner/BlockaidBanner.types';
 
 const mockTypedSignV4SignatureRequest = typedSignV4SignatureRequest;
 jest.mock('./useSignatureRequest', () => ({

--- a/app/components/Views/confirmations/hooks/useSignatureMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureMetrics.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../util/test/confirm-data-helpers';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import { useSignatureMetrics } from './useSignatureMetrics';
+import { ResultType, Reason, SecurityAlertSource } from '../../../../../components/Views/confirmations/legacy/components/BlockaidBanner/BlockaidBanner.types';
 
 const mockTypedSignV4SignatureRequest = typedSignV4SignatureRequest;
 jest.mock('./useSignatureRequest', () => ({
@@ -44,7 +45,47 @@ const SignatureMetrics = {
   security_alert_response: 'Malicious',
   security_alert_source: 'api',
   signature_type: 'eth_signTypedData',
-  ui_customizations: ['flagged_as_malicious'],
+  ui_customizations: ['redesigned_confirmation', 'flagged_as_malicious'],
+  version: 'V4',
+};
+
+const securityAlertResponseLoading = {
+  result_type: ResultType.RequestInProgress,
+  reason: Reason.notApplicable,
+  source: SecurityAlertSource.API,
+  providerRequestsCount: {
+    eth_call: 5,
+    eth_getCode: 3,
+  },
+  features: [],
+};
+
+const SignatureMetricsLoading = {
+  account_type: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+  chain_id: '1',
+  dapp_host_name: 'metamask.github.io',
+  eip712_primary_type: 'Permit',
+  request_source: 'In-App-Browser',
+  security_alert_reason: 'not_applicable',
+  security_alert_response: 'loading',
+  security_alert_source: 'api',
+  signature_type: 'eth_signTypedData',
+  ui_customizations: ['redesigned_confirmation', 'security_alert_loading'],
+  version: 'V4',
+  ppom_eth_call_count: 5,
+  ppom_eth_getCode_count: 3,
+};
+
+const securityAlertResponseUndefined = undefined;
+
+const SignatureMetricsUndefined = {
+  account_type: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+  chain_id: '1',
+  dapp_host_name: 'metamask.github.io',
+  eip712_primary_type: 'Permit',
+  request_source: 'In-App-Browser',
+  signature_type: 'eth_signTypedData',
+  ui_customizations: ['redesigned_confirmation'],
   version: 'V4',
 };
 
@@ -52,6 +93,7 @@ describe('useSignatureMetrics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it('should capture metrics events correctly', async () => {
     const { result } = renderHookWithProvider(() => useSignatureMetrics(), {
       state: {
@@ -72,5 +114,49 @@ describe('useSignatureMetrics', () => {
     );
     expect(mockTrackEvent).toHaveBeenCalledTimes(3);
     expect(mockAddProperties).toHaveBeenLastCalledWith(SignatureMetrics);
+  });
+
+  it('captures metrics events correctly with loading security alert response', async () => {
+    const { result } = renderHookWithProvider(() => useSignatureMetrics(), {
+      state: {
+        ...typedSignV4ConfirmationState,
+        signatureRequest: { securityAlertResponse: securityAlertResponseLoading },
+      },
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockAddProperties).toHaveBeenCalledWith(SignatureMetricsLoading);
+    result?.current?.captureSignatureMetrics(
+      MetaMetricsEvents.SIGNATURE_APPROVED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(mockAddProperties).toHaveBeenLastCalledWith(SignatureMetricsLoading);
+    result?.current?.captureSignatureMetrics(
+      MetaMetricsEvents.SIGNATURE_REJECTED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(3);
+    expect(mockAddProperties).toHaveBeenLastCalledWith(SignatureMetricsLoading);
+  });
+
+  it('captures metrics events correctly with undefined security alert response', async () => {
+    const { result } = renderHookWithProvider(() => useSignatureMetrics(), {
+      state: {
+        ...typedSignV4ConfirmationState,
+        signatureRequest: { securityAlertResponse: securityAlertResponseUndefined },
+      },
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockAddProperties).toHaveBeenCalledWith(SignatureMetricsUndefined);
+    result?.current?.captureSignatureMetrics(
+      MetaMetricsEvents.SIGNATURE_APPROVED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(mockAddProperties).toHaveBeenLastCalledWith(SignatureMetricsUndefined);
+    result?.current?.captureSignatureMetrics(
+      MetaMetricsEvents.SIGNATURE_REJECTED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(3);
+    expect(mockAddProperties).toHaveBeenLastCalledWith(SignatureMetricsUndefined);
   });
 });

--- a/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
+++ b/app/components/Views/confirmations/hooks/useSignatureMetrics.ts
@@ -38,6 +38,7 @@ const getAnalyticsParams = (
   confirmationMetrics: Record<string, unknown>,
 ) => {
   const { meta = {}, from, version } = messageParams;
+  const { ui_customizations = [], ...blockaidProperties } = securityAlertResponse ? getBlockaidMetricsParams(securityAlertResponse) : {};
 
   return {
     account_type: getAddressAccountType(from as string),
@@ -45,17 +46,15 @@ const getAnalyticsParams = (
     signature_type: type,
     version: version || 'N/A',
     chain_id: chainId ? getDecimalChainId(chainId) : '',
-    ui_customizations: ['redesigned_confirmation'],
+    ui_customizations: ['redesigned_confirmation', ...ui_customizations as string[]],
     ...(primaryType ? { eip712_primary_type: primaryType } : {}),
     ...(meta.analytics as Record<string, string>),
-    ...(securityAlertResponse
-      ? getBlockaidMetricsParams(securityAlertResponse)
-      : {}),
     ...getSignatureDecodingEventProps(
       decodingData,
       decodingLoading,
       isSimulationEnabled,
     ),
+    ...blockaidProperties,
     ...confirmationMetrics,
   };
 };

--- a/app/util/blockaid/index.test.ts
+++ b/app/util/blockaid/index.test.ts
@@ -188,6 +188,30 @@ describe('Blockaid util', () => {
         security_alert_reason: Reason.notApplicable,
       });
     });
+
+    it('should return additionalParams object when result_type is RequestInProgress', async () => {
+      const securityAlertResponse: SecurityAlertResponse & { source: string } =
+        {
+          result_type: ResultType.RequestInProgress,
+          reason: Reason.notApplicable,
+          source: SecurityAlertSource.API,
+          providerRequestsCount: {
+            eth_call: 5,
+            eth_getCode: 3,
+          },
+          features: [],
+        };
+
+      const result = getBlockaidMetricsParams(securityAlertResponse);
+      expect(result).toEqual({
+        ui_customizations: ['security_alert_loading'],
+        security_alert_response: 'loading',
+        security_alert_reason: Reason.notApplicable,
+        security_alert_source: SecurityAlertSource.API,
+        ppom_eth_call_count: 5,
+        ppom_eth_getCode_count: 3,
+      });
+    });
   });
 
   describe('isBlockaidFeatureEnabled', () => {


### PR DESCRIPTION
- fix: blockaid metrics to properly merge into the ui_customizations (#14764)

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**
This PR aims to void overriding the `ui_customizations` coming from the blockaid properties in the `getBlockaidMetricsParams`, which previously overrode the redesign metrics.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4627

## **Manual testing steps**

1. Go to test dapp
2. Click on PermitSingle

To test blockaid
1. Click on Malicious Permit

## **Screenshots/Recordings**

[Screencast from 2025-04-22
09-26-54.webm](https://github.com/user-attachments/assets/07e11438-e668-4487-8683-549b7b2347eb)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---------

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
