### PR TITLE
chore: Improve `mock-server`

### DIFF
--- a/e2e/api-mocking/mock-server.js
+++ b/e2e/api-mocking/mock-server.js
@@ -1,6 +1,39 @@
 /* eslint-disable no-console */
 import { getLocal } from 'mockttp';
 import portfinder from 'portfinder';
+import _ from 'lodash';
+import { device } from 'detox';
+
+/**
+ * Utility function to handle direct fetch requests
+ * @param {string} url - The URL to fetch from
+ * @param {string} method - The HTTP method
+ * @param {Headers} headers - Request headers
+ * @param {Object} requestBody - The request body object
+ * @returns {Promise<{statusCode: number, body: string}>} Response object
+ */
+const handleDirectFetch = async (url, method, headers, requestBody) => {
+  try {
+    const response = await global.fetch(url, {
+      method,
+      headers,
+      body: ['POST', 'PUT', 'PATCH'].includes(method) ? requestBody : undefined,
+    });
+
+    const responseBody = await response.text();
+    return {
+      statusCode: response.status,
+      body: responseBody,
+    };
+  } catch (error) {
+    console.error('Error forwarding request:', url);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to forward request' }),
+    };
+  }
+};
+
 /**
  * Starts the mock server and sets up mock events.
  *
@@ -19,53 +52,99 @@ export const startMockServer = async (events, port) => {
     .forGet('/health-check')
     .thenReply(200, 'Mock server is running');
 
-  for (const method in events) {
-    const methodEvents = events[method];
+  // Handle all /proxy requests
+  await mockServer
+    .forAnyRequest()
+    .matching((request) => request.path.startsWith('/proxy'))
+    .thenCallback(async (request) => {
+      const urlEndpoint = new URL(request.url).searchParams.get('url');
+      const method = request.method;
 
-    console.log(`Setting up mock events for ${method} requests...`);
+      // Find matching mock event
+      const methodEvents = events[method] || [];
+      const matchingEvent = methodEvents.find(
+        (event) => event.urlEndpoint === urlEndpoint,
+      );
 
-    for (const {
-      urlEndpoint,
-      response,
-      requestBody,
-      responseCode,
-    } of methodEvents) {
-      console.log(`Mocking ${method} request to: ${urlEndpoint}`);
-      console.log(`Response status: ${responseCode}`);
-      console.log('Response:', response);
-      if (requestBody) {
-        console.log(`POST request body:`, requestBody);
+      if (matchingEvent) {
+        console.log(`Mocking ${method} request to: ${urlEndpoint}`);
+        console.log(`Response status: ${matchingEvent.responseCode}`);
+        console.log('Response:', matchingEvent.response);
+
+        // For POST requests, verify the request body if specified
+        if (method === 'POST' && matchingEvent.requestBody) {
+          const requestBodyJson = await request.body.getJson();
+
+          // Ensure both objects exist before comparison
+          if (!requestBodyJson || !matchingEvent.requestBody) {
+            console.log('Request body validation failed: Missing request body');
+            return {
+              statusCode: 400,
+              body: JSON.stringify({ error: 'Missing request body' }),
+            };
+          }
+
+          // We don't use _.isEqual because we want to ignore extra fields in the request body
+          const matches = _.isMatch(requestBodyJson, matchingEvent.requestBody);
+
+          if (!matches) {
+            console.log('Request body validation failed:');
+            console.log(
+              'Expected:',
+              JSON.stringify(matchingEvent.requestBody, null, 2),
+            );
+            console.log('Received:', JSON.stringify(requestBodyJson, null, 2));
+            console.log(
+              'Differences:',
+              JSON.stringify(
+                _.differenceWith(
+                  [requestBodyJson],
+                  [matchingEvent.requestBody],
+                  _.isEqual,
+                ),
+                null,
+                2,
+              ),
+            );
+
+            return {
+              statusCode: 404,
+              body: JSON.stringify({
+                error: 'Request body validation failed',
+                expected: matchingEvent.requestBody,
+                received: requestBodyJson,
+              }),
+            };
+          }
+        }
+
+        return {
+          statusCode: matchingEvent.responseCode,
+          body: JSON.stringify(matchingEvent.response),
+        };
       }
 
-      if (method === 'GET') {
-        await mockServer
-          .forGet('/proxy')
-          .withQuery({ url: urlEndpoint })
-          .thenReply(responseCode, JSON.stringify(response));
-      }
-
-      if (method === 'POST') {
-        await mockServer
-          .forPost('/proxy')
-          .withQuery({ url: urlEndpoint })
-          .withJsonBodyIncluding(requestBody || {})
-          .thenReply(responseCode, JSON.stringify(response));
-      }
-    }
-  }
-
-  await mockServer.forUnmatchedRequest().thenPassThrough({
-    beforeRequest: async ({ url, method }) => {
-      const returnUrl = new URL(url).searchParams.get('url') || url;
+      // If no matching mock found, pass through to actual endpoint
       const updatedUrl =
         device.getPlatform() === 'android'
-          ? returnUrl.replace('localhost', '127.0.0.1')
-          : returnUrl;
-      console.log(`Mock proxy forwarding request to: ${updatedUrl}`);
-      return { url: updatedUrl };
-    },
-  });
+          ? urlEndpoint.replace('localhost', '127.0.0.1')
+          : urlEndpoint;
 
+      return handleDirectFetch(
+        updatedUrl,
+        method,
+        request.headers,
+        method === 'POST' ? await request.body.getText() : undefined
+      );
+    });
+
+  // In case any other requests are made, pass them through to the actual endpoint
+  await mockServer.forUnmatchedRequest().thenCallback(async (request) => handleDirectFetch(
+      request.url,
+      request.method,
+      request.headers,
+      await request.body.getText()
+    ));
 
   return mockServer;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

For some developers we noticed local issues of `mockServer.forUnmatchedRequest().thenPassThrough` approach. 

This PR aims to process better on unhandled proxy API calls. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4753

## **Manual testing steps**

No user flow affected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
