### PR TITLE
fix(14025): call keyring cancel sync when closing QR scan modal to resolve pending promise

### DIFF
--- a/app/components/Views/ConnectQRHardware/index.tsx
+++ b/app/components/Views/ConnectQRHardware/index.tsx
@@ -160,6 +160,14 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
 
   const [existingAccounts, setExistingAccounts] = useState<string[]>([]);
 
+  const qrInteractionsRef =
+    useRef<
+      Pick<
+        QRKeyring,
+        'cancelSync' | 'submitCryptoAccount' | 'submitCryptoHDKey'
+      >
+    >();
+
   const showScanner = useCallback(() => {
     setScannerVisible(true);
   }, []);
@@ -167,6 +175,11 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
   const hideScanner = useCallback(() => {
     setScannerVisible(false);
   }, []);
+
+  const hideModal = useCallback(() => {
+    qrInteractionsRef.current?.cancelSync();
+    hideScanner();
+  }, [hideScanner]);
 
   useEffect(() => {
     KeyringController.getAccounts().then((value: string[]) => {
@@ -205,14 +218,6 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
       hideScanner();
     }
   }, [QRState.sync, hideScanner, showScanner]);
-
-  const qrInteractionsRef =
-    useRef<
-      Pick<
-        QRKeyring,
-        'cancelSync' | 'submitCryptoAccount' | 'submitCryptoHDKey'
-      >
-    >();
 
   const onConnectHardware = useCallback(async () => {
     trackEvent(
@@ -379,7 +384,7 @@ const ConnectQRHardware = ({ navigation }: IConnectQRHardwareProps) => {
         purpose={'sync'}
         onScanSuccess={onScanSuccess}
         onScanError={onScanError}
-        hideModal={hideScanner}
+        hideModal={hideModal}
       />
       <BlockingActionModal modalVisible={blockingModalVisible} isLoadingAction>
         <Text style={styles.text}>{strings('common.please_wait')}</Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When user wants to import a QR hardware account, he needs to:
- select QR hardware on the device selection
- then he lands on a page where he needs to click on "Continue" button to open camera to scan the QR code.
If the user closes scanner modal (by clicking on the cross icon), and then click again on the continue button, the scanner modal doesn't open again.

What happens is that KeyringController mutex stays in a locked state, and this locked state will only be released if the user scans the QR code. To fix that we can call `cancelSync` function from keyring when user closes the scanner modal.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14025

## **Manual testing steps**

1. Go to this device selection page
2. Choose QR hardware and click on continue button
3. Close Scanner modal
4. Click again on Continue button
5. Scanner modal should open again.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/4ebfacf5-8651-4ef1-8f03-cddaa2afeb0d



### **After**



https://github.com/user-attachments/assets/da5b5b11-621e-4eac-a35d-36d6b2f0d9ce




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
