### PR TITLE
fix: cp-7.45.0 use correct default etherscan link on tx details

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -7,6 +7,7 @@ import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsCo
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { createStackNavigator } from '@react-navigation/stack';
 import { mockNetworkState } from '../../../../util/test/network';
+import type { NetworkState } from '@metamask/network-controller';
 
 const Stack = createStackNavigator();
 const mockEthQuery = {
@@ -55,13 +56,6 @@ const initialState = {
       ...backgroundState,
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
     },
-    // NetworkController: {
-    //   ...mockNetworkState({
-    //     chainId: '0x89',
-    //     id: 'Polygon',
-    //     nickname: 'Polygon',
-    //   }),
-    // },
     SmartTransactionsController: {
       smartTransactionsState: {
         liveness: 'live',
@@ -219,112 +213,140 @@ describe('TransactionDetails', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should view transaction details on etherscan', () => {
+  const arrangeBlockExplorerTest = () => {
     jest.mocked(query).mockResolvedValueOnce(123).mockResolvedValueOnce({
       timestamp: 1234,
       l1Fee: '0x1',
     });
 
-    const { getByText } = renderComponent({
-      state: {
-        ...initialState,
-        engine: {
-          ...initialState.engine,
-          backgroundState: {
-            ...initialState.engine.backgroundState,
-            NetworkController: {
-              '0x1': {
-                chainId: '0x1',
-                blockExplorerUrls: [],
-                rpcEndpoints: [
-                  {
-                    rpcUrl: 'https://mainnet.infura.io/v3/123',
-                    chainId: '0x1',
-                    nickname: 'Mainnet',
-                    ticker: 'ETH',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                name: 'Mainnet',
-                nativeCurrency: 'ETH',
-              },
+    const mockState = {
+      ...initialState,
+      engine: {
+        ...initialState.engine,
+        backgroundState: {
+          ...initialState.engine.backgroundState,
+          NetworkController: {
+            '0x1': {
+              chainId: '0x1',
+              blockExplorerUrls: [],
+              rpcEndpoints: [
+                {
+                  rpcUrl: 'https://mainnet.infura.io/v3/123',
+                  chainId: '0x1',
+                  nickname: 'Mainnet',
+                  ticker: 'ETH',
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              name: 'Mainnet',
+              nativeCurrency: 'ETH',
             },
-          },
+          } as unknown as NetworkState,
         },
       },
-      hash: '0x3',
-      txParams: {
-        multiLayerL1FeeTotal: '0x1',
-      },
+    };
+
+    const mockProps = {
+      networkId: '0x1',
+    };
+
+    return {
+      mockState,
+      mockProps,
+    };
+  };
+
+  const arrangeActAssertBlockExplorerTest = (props: {
+    buttonText: string;
+    expectedUrl: string;
+    overrideMocks?: (
+      mocks: ReturnType<typeof arrangeBlockExplorerTest>,
+    ) => void;
+  }) => {
+    // Arrange
+    const mocks = arrangeBlockExplorerTest();
+    props.overrideMocks?.(mocks);
+
+    const { getByText } = renderComponent({
+      state: mocks.mockState,
+      networkId: mocks.mockProps.networkId,
     });
-    const etherscanButton = getByText('VIEW ON Etherscan');
-    expect(etherscanButton).toBeDefined();
-    fireEvent.press(etherscanButton);
-    expect(navigationMock.push).toHaveBeenCalled();
+
+    fireEvent.press(getByText(props.buttonText));
+
+    expect(navigationMock.push).toHaveBeenCalledWith('Webview', {
+      params: expect.objectContaining({ url: props.expectedUrl }),
+      screen: 'SimpleWebview',
+    });
+  };
+
+  it('should view transaction details on etherscan', () => {
+    arrangeActAssertBlockExplorerTest({
+      overrideMocks: (mocks) => {
+        mocks.mockState.engine.backgroundState.NetworkController =
+          mockNetworkState({
+            chainId: '0x1',
+            id: 'mainnet',
+            nickname: 'Ethereum Mainnet',
+            ticker: 'ETH',
+          });
+        mocks.mockProps.networkId = '0x1';
+      },
+      buttonText: 'VIEW ON Etherscan',
+      expectedUrl: 'https://etherscan.io/tx/0x3',
+    });
   });
 
   it('should display explorer link for linea mainnet', () => {
-    jest.mocked(query).mockResolvedValueOnce(123).mockResolvedValueOnce({
-      timestamp: 1234,
-      l1Fee: '0x1',
-    });
-
-    const { getByText } = renderComponent({
-      state: {
-        ...initialState,
-        engine: {
-          ...initialState.engine,
-          backgroundState: {
-            ...initialState.engine.backgroundState,
-            NetworkController: {
-              ...mockNetworkState({
-                chainId: '0xe708',
-                id: 'linea',
-                nickname: 'Linea Mainnet',
-                ticker: 'ETH',
-              }),
-            },
-          },
-        },
+    arrangeActAssertBlockExplorerTest({
+      overrideMocks: (mocks) => {
+        mocks.mockState.engine.backgroundState.NetworkController =
+          mockNetworkState({
+            chainId: '0xe708',
+            id: 'linea',
+            nickname: 'Linea Mainnet',
+            ticker: 'ETH',
+          });
+        mocks.mockProps.networkId = '0xe708';
       },
-      networkId: '0xe708',
+      buttonText: 'VIEW ON Lineascan',
+      expectedUrl: 'https://lineascan.build/tx/0x3',
     });
-    const etherscanButton = getByText('VIEW ON Lineascan');
-    expect(etherscanButton).toBeDefined();
-    fireEvent.press(etherscanButton);
-    expect(navigationMock.push).toHaveBeenCalled();
   });
 
   it('should display explorer link for sepolia mainnet', () => {
-    jest.mocked(query).mockResolvedValueOnce(123).mockResolvedValueOnce({
-      timestamp: 1234,
-      l1Fee: '0x1',
-    });
-
-    const { getByText } = renderComponent({
-      state: {
-        ...initialState,
-        engine: {
-          ...initialState.engine,
-          backgroundState: {
-            ...initialState.engine.backgroundState,
-            NetworkController: {
-              ...mockNetworkState({
-                chainId: '0xaa36a7',
-                id: 'sepolia',
-                nickname: 'Sepolia Mainnet',
-                ticker: 'ETH',
-              }),
-            },
-          },
-        },
+    arrangeActAssertBlockExplorerTest({
+      overrideMocks: (mocks) => {
+        mocks.mockState.engine.backgroundState.NetworkController =
+          mockNetworkState({
+            chainId: '0xaa36a7',
+            id: 'sepolia',
+            nickname: 'Sepolia Mainnet',
+            ticker: 'ETH',
+          });
+        mocks.mockProps.networkId = '0xaa36a7';
       },
-      networkId: '0xaa36a7',
+      buttonText: 'VIEW ON Sepolia',
+      expectedUrl: 'https://sepolia.etherscan.io/tx/0x3',
     });
-    const etherscanButton = getByText('VIEW ON Sepolia');
-    expect(etherscanButton).toBeDefined();
-    fireEvent.press(etherscanButton);
-    expect(navigationMock.push).toHaveBeenCalled();
+  });
+
+  it('should display explorer link for custom network', () => {
+    arrangeActAssertBlockExplorerTest({
+      overrideMocks: (mocks) => {
+        mocks.mockState.engine.backgroundState.NetworkController =
+          mockNetworkState({
+            chainId: '0x1337',
+            id: '123-123-123',
+            nickname: 'My Custom Network',
+            ticker: 'FOO',
+            blockExplorerUrl: 'https://custom-block-explorer.net',
+          });
+        mocks.mockProps.networkId = '0x1337';
+      },
+      buttonText: 'VIEW ON Custom-block-explorer',
+      expectedUrl: 'https://custom-block-explorer.net/tx/0x3',
+    });
   });
 
   it('should render speed up and cancel buttons', async () => {

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -50,7 +50,7 @@ export const MM_ETHERSCAN_URL = 'https://etherscamdb.info/domain/meta-mask.com';
 export const LINEA_GOERLI_BLOCK_EXPLORER = 'https://goerli.lineascan.build';
 export const LINEA_SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.lineascan.build';
 export const LINEA_MAINNET_BLOCK_EXPLORER = 'https://lineascan.build';
-export const MAINNET_BLOCK_EXPLORER = 'https://etherscan.com';
+export const MAINNET_BLOCK_EXPLORER = 'https://etherscan.io';
 export const SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.etherscan.io';
 
 // Rpcs


### PR DESCRIPTION
## **Description**

This updates the default etherscan link to be `etherscan.io`

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14767

## **Manual testing steps**

See repro steps in issue .

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
