### PR TITLE
fix: stop pv polling when non evm account is selected

### DIFF
--- a/app/components/hooks/AssetPolling/useAccountTrackerPolling.test.ts
+++ b/app/components/hooks/AssetPolling/useAccountTrackerPolling.test.ts
@@ -212,4 +212,29 @@ describe('useAccountTrackerPolling', () => {
       mockedAccountTrackerController.stopPollingByPollingToken,
     ).toHaveBeenCalledTimes(1);
   });
+
+  it('Should not poll when evm is not selected', async () => {
+    renderHookWithProvider(() => useAccountTrackerPolling(), {
+      state: {
+        ...state,
+        engine: {
+          ...state.engine,
+          backgroundState: {
+            ...state.engine.backgroundState,
+            MultichainNetworkController: {
+              ...state.engine.backgroundState.MultichainNetworkController,
+              isEvmSelected: false,
+            },
+          },
+        },
+      },
+    });
+
+    const mockedAccountTrackerController = jest.mocked(
+      Engine.context.AccountTrackerController,
+    );
+    expect(mockedAccountTrackerController.startPolling).toHaveBeenCalledTimes(
+      0,
+    );
+  });
 });

--- a/app/components/hooks/AssetPolling/useAccountTrackerPolling.ts
+++ b/app/components/hooks/AssetPolling/useAccountTrackerPolling.ts
@@ -9,6 +9,7 @@ import {
 import Engine from '../../../core/Engine';
 import { selectAccountsByChainId } from '../../../selectors/accountTrackerController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 // Polls native currency prices across networks.
 const useAccountTrackerPolling = ({
@@ -20,6 +21,7 @@ const useAccountTrackerPolling = ({
   );
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
 
@@ -50,7 +52,7 @@ const useAccountTrackerPolling = ({
       AccountTrackerController.stopPollingByPollingToken.bind(
         AccountTrackerController,
       ),
-    input: chainIdsToPoll,
+    input: isEvmSelected ? chainIdsToPoll : [],
   });
 
   return {

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
@@ -14,6 +14,10 @@ jest.mock('../../../core/Engine', () => ({
 }));
 
 describe('useCurrencyRatePolling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('Should poll by the native currencies in network state', async () => {
     const state = {
       engine: {

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.test.ts
@@ -113,4 +113,55 @@ describe('useCurrencyRatePolling', () => {
       jest.mocked(Engine.context.CurrencyRateController.startPolling),
     ).toHaveBeenCalledWith({ nativeCurrencies: ['SCROLL'] });
   });
+
+  it('Should not poll when evm is not selected', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          MultichainNetworkController: {
+            isEvmSelected: false,
+            selectedMultichainNetworkChainId: SolScope.Mainnet,
+
+            multichainNetworkConfigurationsByChainId: {},
+          },
+          NetworkController: {
+            selectedNetworkClientId: 'selectedNetworkClientId',
+            networkConfigurationsByChainId: {
+              '0x82750': {
+                nativeCurrency: 'SCROLL',
+                chainId: '0x82750',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'selectedNetworkClientId',
+                  },
+                ],
+              },
+              '0x89': {
+                chainId: '0x89',
+                nativeCurrency: 'POL',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'selectedNetworkClientId2',
+                  },
+                ],
+              },
+            },
+          },
+          PreferencesController: {
+            tokenNetworkFilter: {
+              '0x82750': true,
+              '0x89': true,
+            },
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    renderHookWithProvider(() => useCurrencyRatePolling(), { state });
+
+    const mockedCurrencyRateController = jest.mocked(
+      Engine.context.CurrencyRateController,
+    );
+    expect(mockedCurrencyRateController.startPolling).toHaveBeenCalledTimes(0);
+  });
 });

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
@@ -13,6 +13,7 @@ import {
   selectCurrencyRates,
 } from '../../../selectors/currencyRateController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 // Polls native currency prices across networks.
 const useCurrencyRatePolling = () => {
@@ -26,6 +27,7 @@ const useCurrencyRatePolling = () => {
   const currentChainId = useSelector(selectEvmChainId);
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   // Selectors returning state updated by the polling
   const conversionRate = useSelector(selectConversionRate);
@@ -59,7 +61,7 @@ const useCurrencyRatePolling = () => {
       CurrencyRateController.stopPollingByPollingToken.bind(
         CurrencyRateController,
       ),
-    input: [{ nativeCurrencies }],
+    input: isEvmSelected ? [{ nativeCurrencies }] : [],
   });
 
   return {

--- a/app/components/hooks/AssetPolling/useTokenBalancesPolling.test.ts
+++ b/app/components/hooks/AssetPolling/useTokenBalancesPolling.test.ts
@@ -201,4 +201,27 @@ describe('useTokenBalancesPolling', () => {
       mockedTokenBalancesController.stopPollingByPollingToken,
     ).toHaveBeenCalledTimes(1);
   });
+
+  it('Should not poll when evm is not selected', async () => {
+    renderHookWithProvider(() => useTokenBalancesPolling(), {
+      state: {
+        ...state,
+        engine: {
+          ...state.engine,
+          backgroundState: {
+            ...state.engine.backgroundState,
+            MultichainNetworkController: {
+              ...state.engine.backgroundState.MultichainNetworkController,
+              isEvmSelected: false,
+            },
+          },
+        },
+      },
+    });
+
+    const mockedTokenBalancesController = jest.mocked(
+      Engine.context.TokenBalancesController,
+    );
+    expect(mockedTokenBalancesController.startPolling).toHaveBeenCalledTimes(0);
+  });
 });

--- a/app/components/hooks/AssetPolling/useTokenBalancesPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenBalancesPolling.ts
@@ -10,6 +10,7 @@ import {
 import { Hex } from '@metamask/utils';
 import { isPortfolioViewEnabled } from '../../../util/networks';
 import { selectAllTokenBalances } from '../../../selectors/tokenBalancesController';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   // Selectors to determine polling input
@@ -19,6 +20,7 @@ const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const currentChainId = useSelector(selectEvmChainId);
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   // Selectors returning state updated by the polling
   const tokenBalances = useSelector(selectAllTokenBalances);
@@ -42,7 +44,9 @@ const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
       TokenBalancesController.stopPollingByPollingToken.bind(
         TokenBalancesController,
       ),
-    input: chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex })),
+    input: isEvmSelected
+      ? chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex }))
+      : [],
   });
 
   return {

--- a/app/components/hooks/AssetPolling/useTokenListPolling.test.ts
+++ b/app/components/hooks/AssetPolling/useTokenListPolling.test.ts
@@ -168,4 +168,27 @@ describe('useTokenListPolling', () => {
       mockedTokenListController.stopPollingByPollingToken,
     ).toHaveBeenCalledTimes(1);
   });
+
+  it('Should not poll when evm is not selected', async () => {
+    renderHookWithProvider(() => useTokenListPolling(), {
+      state: {
+        ...state,
+        engine: {
+          ...state.engine,
+          backgroundState: {
+            ...state.engine.backgroundState,
+            MultichainNetworkController: {
+              ...state.engine.backgroundState.MultichainNetworkController,
+              isEvmSelected: false,
+            },
+          },
+        },
+      },
+    });
+
+    const mockedTokenListController = jest.mocked(
+      Engine.context.TokenListController,
+    );
+    expect(mockedTokenListController.startPolling).toHaveBeenCalledTimes(0);
+  });
 });

--- a/app/components/hooks/AssetPolling/useTokenListPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenListPolling.ts
@@ -13,6 +13,7 @@ import {
   selectERC20TokensByChain,
   selectTokenList,
 } from '../../../selectors/tokenListController';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   // Selectors to determine polling input
@@ -22,6 +23,7 @@ const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const currentChainId = useSelector(selectEvmChainId);
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   // Selectors returning state updated by the polling
   const tokenList = useSelector(selectTokenList);
@@ -43,7 +45,9 @@ const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
     startPolling: TokenListController.startPolling.bind(TokenListController),
     stopPollingByPollingToken:
       TokenListController.stopPollingByPollingToken.bind(TokenListController),
-    input: chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex })),
+    input: isEvmSelected
+      ? chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex }))
+      : [],
   });
 
   return {

--- a/app/components/hooks/AssetPolling/useTokenRatesPolling.test.ts
+++ b/app/components/hooks/AssetPolling/useTokenRatesPolling.test.ts
@@ -130,4 +130,27 @@ describe('useTokenRatesPolling', () => {
       mockedTokenRatesController.stopPollingByPollingToken,
     ).toHaveBeenCalledTimes(1);
   });
+
+  it('Should not poll when evm is not selected', async () => {
+    renderHookWithProvider(() => useTokenRatesPolling(), {
+      state: {
+        ...state,
+        engine: {
+          ...state.engine,
+          backgroundState: {
+            ...state.engine.backgroundState,
+            MultichainNetworkController: {
+              ...state.engine.backgroundState.MultichainNetworkController,
+              isEvmSelected: false,
+            },
+          },
+        },
+      },
+    });
+
+    const mockedTokenRatesController = jest.mocked(
+      Engine.context.TokenRatesController,
+    );
+    expect(mockedTokenRatesController.startPolling).toHaveBeenCalledTimes(0);
+  });
 });

--- a/app/components/hooks/AssetPolling/useTokenRatesPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenRatesPolling.ts
@@ -13,6 +13,7 @@ import {
   selectTokenMarketData,
 } from '../../../selectors/tokenRatesController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
+import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 const useTokenRatesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   // Selectors to determine polling input
@@ -22,6 +23,7 @@ const useTokenRatesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const currentChainId = useSelector(selectEvmChainId);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
+  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   // Selectors returning state updated by the polling
   const contractExchangeRates = useSelector(selectContractExchangeRates);
@@ -43,7 +45,9 @@ const useTokenRatesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
     startPolling: TokenRatesController.startPolling.bind(TokenRatesController),
     stopPollingByPollingToken:
       TokenRatesController.stopPollingByPollingToken.bind(TokenRatesController),
-    input: chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex })),
+    input: isEvmSelected
+      ? chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex }))
+      : [],
   });
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses an issue where the polling of portfolio values (PV) continues even when a non-EVM-compatible account is selected. This behavior can lead to unnecessary network activity and potential errors.

**Changes:**

- Added a check to detect non-EVM accounts.
- Stopped the PV polling process when such accounts are selected.
- Resumed polling only for EVM-compatible accounts.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
