### PR TITLE
fix: cp-7.46.0 navigate to activity page before solana originating swap/bridge…

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -34,6 +34,7 @@ import {
   selectIsEvmSolanaBridge,
   selectIsSolanaSwap,
   setSlippage,
+  selectIsSolanaToEvm,
 } from '../../../../../core/redux/slices/bridge';
 import { ethers } from 'ethers';
 import {
@@ -107,7 +108,7 @@ const BridgeView = () => {
 
   const isEvmSolanaBridge = useSelector(selectIsEvmSolanaBridge);
   const isSolanaSwap = useSelector(selectIsSolanaSwap);
-
+  const isSolanaToEvm = useSelector(selectIsSolanaToEvm);
   // inputRef is used to programmatically blur the input field after a delay
   // This gives users time to type before the keyboard disappears
   // The ref is typed to only expose the blur method we need
@@ -251,6 +252,11 @@ const BridgeView = () => {
   const handleContinue = async () => {
     if (activeQuote) {
       setIsSubmittingTx(true);
+      // TEMPORARY: If tx originates from Solana, navigate to transactions view BEFORE submitting the tx
+      // Necessary because snaps prevents navigation after tx is submitted
+      if (isSolanaSwap || isSolanaToEvm) {
+        navigation.navigate(Routes.TRANSACTIONS_VIEW);
+      }
       await submitBridgeTx({
         quoteResponse: activeQuote,
       });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Because snaps prevent navigation after tx submission, it's necessary to navigate to the activity page BEFORE the tx is submitted.

This is terrible UX and absolutely a temporary fix until a better solution is found, hopefully within the next few days.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMS-2305

## **Manual testing steps**

1. Go to this solana swap/bridge
2. Click "continue" button
3. Get navigated to activity page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
