### PR TITLE
fix(bridge): cp-7.46.0 keyboard not appearing when error banner is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat(bridge): use dynamic slippage for single-chain Solana swaps ([#14805](https://github.com/MetaMask/metamask-mobile/pull/14805))
-
 ### Added
 
+- feat(bridge): use dynamic slippage for single-chain Solana swaps ([#14805](https://github.com/MetaMask/metamask-mobile/pull/14805))
 - feat(bridge): enhance bridging with network fee estimation and UI improvements ([#14786](https://github.com/MetaMask/metamask-mobile/pull/14786))
 - feat(ramp): auto-select region ([#14780](https://github.com/MetaMask/metamask-mobile/pull/14780))
 - feat(bridge): add solana chain support and improve bridge state management ([#14713](https://github.com/MetaMask/metamask-mobile/pull/14713))
@@ -38,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(bridge): keyboard not appearing when error banner is displayed ([#14862](https://github.com/MetaMask/metamask-mobile/pull/14862))
 - fix(bridge): fix not switching networks when selecting source token ([#14712](https://github.com/MetaMask/metamask-mobile/pull/14712))
 - fix: updates a padding style specifically for Android devices ([#14725](https://github.com/MetaMask/metamask-mobile/pull/14725))
 - fix(bridge): enhance UI/UX with improved input handling and layout adjustments ([#14781](https://github.com/MetaMask/metamask-mobile/pull/14781))

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -374,6 +374,7 @@ describe('BridgeView', () => {
           },
           quotesLoadingStatus: RequestStatus.FETCHED,
           quotes: [mockQuotes[0] as unknown as QuoteResponse],
+          quotesLastFetched: 12,
         },
       });
 
@@ -415,6 +416,7 @@ describe('BridgeView', () => {
           },
           quotesLoadingStatus: RequestStatus.FETCHED,
           quotes: [mockQuotes[0] as unknown as QuoteResponse],
+          quotesLastFetched: 12,
         },
         bridgeReducerOverrides: {
           sourceAmount: '1.0', // Less than balance of 2.0 ETH
@@ -441,6 +443,7 @@ describe('BridgeView', () => {
           },
           quotesLoadingStatus: RequestStatus.FETCHED,
           quotes: [mockQuotes[0] as unknown as QuoteResponse],
+          quotesLastFetched: 12,
         },
         bridgeReducerOverrides: {
           sourceAmount: '1.0', // Less than balance of 2.0 ETH
@@ -472,6 +475,7 @@ describe('BridgeView', () => {
           },
           quotesLoadingStatus: RequestStatus.FETCHED,
           quotes: [mockQuotes[0] as unknown as QuoteResponse],
+          quotesLastFetched: 12,
         },
         bridgeReducerOverrides: {
           sourceAmount: '1.0', // Less than balance of 2.0 ETH

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -1679,6 +1679,38 @@ exports[`BridgeView renders 1`] = `
                                 </View>
                               </View>
                             </View>
+                            <View
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#ffffff",
+                                    "gap": 12,
+                                    "justifyContent": "center",
+                                    "paddingBottom": 24,
+                                    "paddingHorizontal": 16,
+                                    "width": "100%",
+                                  },
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#4459ff",
+                                    "fontFamily": "CentraNo1-Book",
+                                    "fontSize": 16,
+                                    "fontWeight": "400",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                              >
+                                Select amount
+                              </Text>
+                            </View>
                           </View>
                         </View>
                       </RCTScrollView>

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -1679,38 +1679,6 @@ exports[`BridgeView renders 1`] = `
                                 </View>
                               </View>
                             </View>
-                            <View
-                              style={
-                                [
-                                  {},
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#ffffff",
-                                    "gap": 12,
-                                    "justifyContent": "center",
-                                    "paddingBottom": 24,
-                                    "paddingHorizontal": 16,
-                                    "width": "100%",
-                                  },
-                                ]
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#4459ff",
-                                    "fontFamily": "CentraNo1-Book",
-                                    "fontSize": 16,
-                                    "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                              >
-                                Select amount
-                              </Text>
-                            </View>
                           </View>
                         </View>
                       </RCTScrollView>

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -285,17 +285,9 @@ const BridgeView = () => {
   };
 
   const renderBottomContent = () => {
-    if (isError) {
-      return (
-        <Box style={styles.buttonContainer}>
-          <BannerAlert
-            severity={BannerAlertSeverity.Error}
-            description={strings('bridge.error_banner_description')}
-          />
-        </Box>
-      );
+    if (!activeQuote && !quotesLastFetched) {
+      return;
     }
-
     if (!hasValidBridgeInputs || isInputFocused) {
       return (
         <Box style={styles.buttonContainer}>
@@ -316,8 +308,15 @@ const BridgeView = () => {
       );
     }
 
-    if (!activeQuote && !quotesLastFetched) {
-      return;
+    if (isError) {
+      return (
+        <Box style={styles.buttonContainer}>
+          <BannerAlert
+            severity={BannerAlertSeverity.Error}
+            description={strings('bridge.error_banner_description')}
+          />
+        </Box>
+      );
     }
 
     return (

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -285,9 +285,6 @@ const BridgeView = () => {
   };
 
   const renderBottomContent = () => {
-    if (!activeQuote && !quotesLastFetched) {
-      return;
-    }
     if (!hasValidBridgeInputs || isInputFocused) {
       return (
         <Box style={styles.buttonContainer}>
@@ -320,24 +317,27 @@ const BridgeView = () => {
     }
 
     return (
-      <Box style={styles.buttonContainer}>
-        <Button
-          variant={ButtonVariants.Primary}
-          label={getButtonLabel()}
-          onPress={handleContinue}
-          style={styles.button}
-          isDisabled={hasInsufficientBalance || isSubmittingTx}
-        />
-        <Button
-          variant={ButtonVariants.Link}
-          label={
-            <Text color={TextColor.Alternative}>
-              {strings('bridge.terms_and_conditions')}
-            </Text>
-          }
-          onPress={handleTermsPress}
-        />
-      </Box>
+      activeQuote &&
+      quotesLastFetched && (
+        <Box style={styles.buttonContainer}>
+          <Button
+            variant={ButtonVariants.Primary}
+            label={getButtonLabel()}
+            onPress={handleContinue}
+            style={styles.button}
+            isDisabled={hasInsufficientBalance || isSubmittingTx}
+          />
+          <Button
+            variant={ButtonVariants.Link}
+            label={
+              <Text color={TextColor.Alternative}>
+                {strings('bridge.terms_and_conditions')}
+              </Text>
+            }
+            onPress={handleTermsPress}
+          />
+        </Box>
+      )
     );
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR addresses an issue where the keyboard would not appear when an error banner is displayed in the BridgeView component. The changes reorder the error handling logic to ensure proper keyboard behavior while maintaining error visibility.

1. Reason for change: The keyboard was being dismissed when error banner appeared, preventing user input
2. Solution: Reordered error handling conditions to maintain keyboard visibility while showing error banner

## **Related issues**

Fixes: [MMS-2306](https://consensyssoftware.atlassian.net/browse/MMS-2306)

## **Manual testing steps**

1. Go to the Bridge screen
2. Enter an invalid amount that triggers an error
3. Verify the keyboard remains visible when the error banner appears
4. Verify you can still edit the input field while error banner is shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



[MMS-2306]: https://consensyssoftware.atlassian.net/browse/MMS-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ