### PR TITLE
fix: Receive page shows 0x prefix for Solana account

### DIFF
--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.test.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent } from '@testing-library/react-native';
 import { renderScreen } from '../../../util/test/renderWithProvider';
 import backgroundState from '../../../util/test/initial-background-state.json';
 import ClipboardManager from '../../../core/ClipboardManager';
+import { MOCK_SOLANA_ACCOUNT } from '../../../util/test/accountsControllerTestUtils';
 
 const initialState = {
   engine: {
@@ -26,7 +27,9 @@ jest.mock('../../../core/ClipboardManager', () => {
   };
 });
 
-const TestWrapper = () => <QRAccountDisplay accountAddress={ACCOUNT} />;
+const TestWrapper = ({ accountAddress }: { accountAddress: string }) => (
+  <QRAccountDisplay accountAddress={accountAddress} />
+);
 
 describe('QRAccountDisplay', () => {
   beforeEach(() => {
@@ -35,7 +38,7 @@ describe('QRAccountDisplay', () => {
 
   it('render matches snapshot', () => {
     const { toJSON } = renderScreen(
-      TestWrapper,
+      () => <TestWrapper accountAddress={ACCOUNT} />,
       { name: 'QRAccountDisplay' },
       // @ts-expect-error initialBackgroundState throws error
       { state: initialState },
@@ -45,7 +48,7 @@ describe('QRAccountDisplay', () => {
 
   it('copies address to clipboard and checks clipboard content', async () => {
     const { getByTestId } = renderScreen(
-      TestWrapper,
+      () => <TestWrapper accountAddress={ACCOUNT} />,
       { name: 'QRAccountDisplay' },
       // @ts-expect-error initialBackgroundState throws error
       { state: initialState },
@@ -57,5 +60,42 @@ describe('QRAccountDisplay', () => {
     expect(ClipboardManager.setString).toHaveBeenCalledWith(ACCOUNT);
     expect(ClipboardManager.getString()).toBe(ACCOUNT);
     expect(copyButton).toBeTruthy();
+  });
+
+  it('correctly renders Solana account address without 0x prefix', () => {
+    const stateWithSolanaAccount = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                [MOCK_SOLANA_ACCOUNT.id]: MOCK_SOLANA_ACCOUNT,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getByText, queryByText } = renderScreen(
+      () => <TestWrapper accountAddress={MOCK_SOLANA_ACCOUNT.address} />,
+      { name: 'QRAccountDisplay' },
+      // @ts-expect-error initialBackgroundState throws error
+      { state: stateWithSolanaAccount },
+    );
+
+    // Verify the component shows the account name
+    expect(getByText('Solana Account')).toBeTruthy();
+
+    // Checking that the address doesn't contain 0x prefix by verifying the starting characters
+    expect(queryByText(/^0x/)).toBeNull();
+
+    // Check the component shows the correct Solana address
+    // We're looking for a text node that contains the starting characters of the Solana address
+    expect(getByText(/7EcDhS/)).toBeTruthy();
+
+    // Verify the end of the address is also present
+    expect(getByText(/CFLtV$/)).toBeTruthy();
   });
 });

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
@@ -28,8 +28,8 @@ const ADDRESS_SUFFIX_LENGTH = 5;
 const QRAccountDisplay = (props: { accountAddress: string }) => {
   const { styles } = useStyles(styleSheet, {});
   const addr = props.accountAddress;
-  const identities = useSelector(selectInternalAccounts);
-  const accountLabel = renderAccountName(addr, identities);
+  const accounts = useSelector(selectInternalAccounts);
+  const accountLabel = renderAccountName(addr, accounts);
   const { toastRef } = useContext(ToastContext);
   const addressStart = addr.substring(0, ADDRESS_PREFIX_LENGTH);
   const addressMiddle: string = addr.substring(

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -136,7 +136,7 @@ export function renderAccountName(
   internalAccounts: InternalAccount[],
 ) {
   const chainId = selectChainId(store.getState());
-  address = toChecksumHexAddress(address);
+  address = toFormattedAddress(address);
   const account = internalAccounts.find((acc) =>
     toLowerCaseEquals(acc.address, address),
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a bug where the receive page would add a `0x` prefix to Solana addresses. This is invalid for Solana accounts. To fix this I simply swapped out a call from `toChecksumHexAddress` to `toFormattedAddress` which checks if the account is an EVM account before checksumming the address. This function is already widely used in the app, this section was just missed when we made this change. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14771

## **Manual testing steps**

1. Ensure you are building beta by editing the value of `METAMASK_BUILD_TYPE` to be `beta` in your `.js.env` file
2. yarn setup && yarn watch:clean
3. this needs to be tested with a Physical device in order to use the camera permissions. 
4. Build the app on a physical device with expo (see readme for details)
5. create a wallet
6. click on the selected account and then click on add new account or hardware wallet
7. click on solana
8. create a solana account
9. then at the top of the home page, click on the scanner icon

![Screenshot_20250424-164821](https://github.com/user-attachments/assets/16de19d1-00cf-4dbc-9dba-c08ca1ee827f)

10. Allow camera permissions
11. then click on the receive tab
12. a QR code should be rendered, along with your full address and the account name which will likely be a shortened version of your address `WITHOUT A 0x PREFIX`

## **Screenshots/Recordings**


### **Before**

<image src="https://github.com/user-attachments/assets/3f38db9d-8338-4dbd-8d81-fb055ec336db" width="250" height="500">


### **After**

#### Receive page with Sol account

<image src="https://github.com/user-attachments/assets/73863805-2014-43bf-98d3-683a14373121" width="250" height="500">

#### Address copy is working 

<image src="https://github.com/user-attachments/assets/b2ee2cf3-8a14-45aa-9f0e-3822ea7ae000" width="250" height="500">

#### ETH accounts are still working as expected

<image src="https://github.com/user-attachments/assets/defba664-8552-49a9-85d2-2e565ba97688" width="250" height="500">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
