### PR TITLE
feat: solana opt-in changes cp-7.46.0

### DIFF
--- a/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.styles.ts
+++ b/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.styles.ts
@@ -34,6 +34,11 @@ const createStyles = (colors: {
     cancelButton: {
       marginTop: 12,
     },
+    learnMore: {
+      ...fontStyles.normal,
+      color: colors.text.default,
+      marginBottom: 12,
+    },
   });
 
 export default createStyles;

--- a/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.test.tsx
+++ b/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.test.tsx
@@ -101,12 +101,14 @@ describe('SolanaNewFeatureContent', () => {
     });
   });
 
-  it('shows the "got it" button for existing users', async () => {
+  it('shows the "view solana account" button for existing users', async () => {
     (useSelector as jest.Mock).mockReturnValue(true);
     const { getByText } = renderWithProviders(<SolanaNewFeatureContent />);
 
     await waitFor(() => {
-      expect(getByText('solana_new_feature_content.got_it')).toBeTruthy();
+      expect(
+        getByText('solana_new_feature_content.view_solana_account'),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.tsx
+++ b/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { View } from 'react-native';
+import { Linking, View } from 'react-native';
 import { KeyringClient } from '@metamask/keyring-snap-client';
 import { SolScope } from '@metamask/keyring-api';
 import Text from '../../../component-library/components/Texts/Text';
@@ -17,10 +17,15 @@ import FeatureItem from './FeatureItem';
 import { useTheme } from '../../../util/theme';
 import SolanaLogo from '../../../images/solana-logo-transparent.svg';
 import { strings } from '../../../../locales/i18n';
-import { selectHasCreatedSolanaMainnetAccount } from '../../../selectors/accountsController';
+import {
+  selectHasCreatedSolanaMainnetAccount,
+  selectLastSelectedSolanaAccount,
+} from '../../../selectors/accountsController';
 import createStyles from './SolanaNewFeatureContent.styles';
 import StorageWrapper from '../../../store/storage-wrapper';
 import { SOLANA_FEATURE_MODAL_SHOWN } from '../../../constants/storage';
+import Engine from '../../../core/Engine';
+import { SOLANA_NEW_FEATURE_CONTENT_LEARN_MORE } from '../../../constants/urls';
 
 const SolanaNewFeatureContent = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -30,6 +35,9 @@ const SolanaNewFeatureContent = () => {
   const styles = createStyles(colors);
   const hasExistingSolanaAccount = useSelector(
     selectHasCreatedSolanaMainnetAccount,
+  );
+  const lastSelectedSolanaAccount = useSelector(
+    selectLastSelectedSolanaAccount,
   );
 
   useEffect(() => {
@@ -56,6 +64,17 @@ const SolanaNewFeatureContent = () => {
   const handleClose = async () => {
     await handleSheetClose();
     sheetRef.current?.onCloseBottomSheet();
+  };
+
+  const viewSolanaAccount = async () => {
+    if (lastSelectedSolanaAccount) {
+      await Engine.setSelectedAddress(lastSelectedSolanaAccount.address);
+    }
+    await handleClose();
+  };
+
+  const onLearnMoreClicked = () => {
+    Linking.openURL(SOLANA_NEW_FEATURE_CONTENT_LEARN_MORE);
   };
 
   const createSolanaAccount = async () => {
@@ -112,13 +131,21 @@ const SolanaNewFeatureContent = () => {
         </View>
 
         <Button
+          style={styles.learnMore}
+          variant={ButtonVariants.Link}
+          label={strings('solana_new_feature_content.learn_more')}
+          onPress={onLearnMoreClicked}
+        />
+        <Button
           variant={ButtonVariants.Primary}
           label={strings(
             hasExistingSolanaAccount
-              ? 'solana_new_feature_content.got_it'
+              ? 'solana_new_feature_content.view_solana_account'
               : 'solana_new_feature_content.create_solana_account',
           )}
-          onPress={hasExistingSolanaAccount ? handleClose : createSolanaAccount}
+          onPress={
+            hasExistingSolanaAccount ? viewSolanaAccount : createSolanaAccount
+          }
           width={ButtonWidthTypes.Full}
         />
 

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -104,3 +104,6 @@ export const ETHEREUM_LOGO =
 
 export const HOW_TO_MANAGE_METRAMETRICS_SETTINGS =
   'https://support.metamask.io/privacy-and-security/how-to-manage-your-metametrics-settings';
+
+export const SOLANA_NEW_FEATURE_CONTENT_LEARN_MORE =
+  'https://support.metamask.io/configure/accounts/how-to-add-accounts-in-your-wallet/#solana-accounts';

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3537,13 +3537,14 @@
     "title": "Solana on MetaMask",
     "create_solana_account": "Create Solana account",
     "not_now": "Not now",
-    "got_it": "Got it",
+    "view_solana_account": "View Solana account",
     "feature_1_title": "Send, receive, and swap tokens",
     "feature_1_description": "Transfer and transact with tokens such as SOL, USDC, and more.",
     "feature_2_title": "Import Solana accounts",
     "feature_2_description": "Import a Secret Recovery Phrase to migrate your Solana account from an other wallet.",
     "feature_3_title": "More features coming soon",
-    "feature_3_description": "Solana dapps, NFTs, hardware wallet support, and more coming soon."
+    "feature_3_description": "Solana dapps, NFTs, hardware wallet support, and more coming soon.",
+    "learn_more": "Learn more about Solana accounts"
   },
   "ipfs_gateway_banner": {
     "ipfs_gateway_banner_title": "IPFS gateway",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

* Added `Learn more` link
* Changed call to action when the use has a solana account

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

![Simulator Screenshot - iPhone 16 Pro - 2025-04-25 at 13 46 17](https://github.com/user-attachments/assets/74b77ebd-cd68-4539-82cb-d73076450d54)


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
