### PR TITLE
feat: Use chainId when checking if it's a smart transaction

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -590,7 +590,7 @@ const mapStateToProps = (state) => ({
   providerType: selectProviderType(state),
   shouldUseSmartTransaction: selectShouldUseSmartTransaction(
     state,
-    state.transaction?.chainId, // TODO: Verify if this is correct.
+    selectEvmChainId(state),
   ),
 });
 

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -588,7 +588,10 @@ const mapStateToProps = (state) => ({
   chainId: selectEvmChainId(state),
   tokens: selectTokens(state),
   providerType: selectProviderType(state),
-  shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+  shouldUseSmartTransaction: selectShouldUseSmartTransaction(
+    state,
+    state.transaction?.chainId, // TODO: Verify if this is correct.
+  ),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -2650,7 +2650,10 @@ const mapStateToProps = (state) => ({
   usedCustomGas: selectSwapsUsedCustomGas(state),
   primaryCurrency: state.settings.primaryCurrency,
   swapsTokens: swapsTokensSelector(state),
-  shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+  shouldUseSmartTransaction: selectShouldUseSmartTransaction(
+    state,
+    selectEvmChainId(state),
+  ),
   isEIP1559Network: selectIsEIP1559Network(state),
 });
 

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -1040,7 +1040,10 @@ const mapStateToProps = (state) => ({
   selectedNetworkClientId: selectSelectedNetworkClientId(state),
   tokensWithBalance: swapsTokensWithBalanceSelector(state),
   tokensTopAssets: swapsTopAssetsSelector(state),
-  shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+  shouldUseSmartTransaction: selectShouldUseSmartTransaction(
+    state,
+    selectEvmChainId(state),
+  ),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -522,7 +522,10 @@ const mapStateToProps = (state) => ({
   primaryCurrency: selectPrimaryCurrency(state),
   swapsTransactions: selectSwapsTransactions(state),
   swapsTokens: swapsControllerTokens(state),
-  shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+  shouldUseSmartTransaction: selectShouldUseSmartTransaction(
+    state,
+    ownProps.transactionObject.chainId,
+  ),
 });
 
 TransactionDetails.contextType = ThemeContext;

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -509,7 +509,7 @@ class TransactionDetails extends PureComponent {
   };
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   chainId: selectChainId(state),
   networkConfigurations: selectNetworkConfigurations(state),
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -102,7 +102,6 @@ const renderComponent = ({
       <Stack.Screen name="Amount" options={{}}>
         {() => (
           <TransactionDetails
-            // @ts-expect-error - TransactionDetails needs to be converted to typescript
             transactionObject={{
               networkID: '1',
               status,
@@ -112,7 +111,6 @@ const renderComponent = ({
               chainId: networkId,
               ...(txParams ? { txParams } : {}),
             }}
-            //@ts-expect-error - TransactionDetails needs to be converted to typescript
             transactionDetails={{
               renderFrom: '0x0',
               renderTo: networkId,
@@ -126,9 +124,7 @@ const renderComponent = ({
               hash: '0x3',
               ...(hash ? { hash } : {}),
             }}
-            //@ts-expect-error - navigation is not typed
             navigation={navigationMock}
-            // @ts-expect-error - chainId is not typed
             chainId={networkId}
           />
         )}

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -515,7 +515,10 @@ const mapStateToProps = (state) => ({
   isTokenDetectionEnabled: selectUseTokenDetection(state),
   chainId: selectChainId(state),
   smartTransactionsOptInStatus: selectSmartTransactionsOptInStatus(state),
-  smartTransactionsEnabled: selectSmartTransactionsEnabled(state, chainId),
+  smartTransactionsEnabled: selectSmartTransactionsEnabled(
+    state,
+    selectChainId(state),
+  ),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -515,7 +515,7 @@ const mapStateToProps = (state) => ({
   isTokenDetectionEnabled: selectUseTokenDetection(state),
   chainId: selectChainId(state),
   smartTransactionsOptInStatus: selectSmartTransactionsOptInStatus(state),
-  smartTransactionsEnabled: selectSmartTransactionsEnabled(state),
+  smartTransactionsEnabled: selectSmartTransactionsEnabled(state, chainId),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -12,6 +12,7 @@ import { useSignatureMetrics } from './signatures/useSignatureMetrics';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
 import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import { useSelector } from 'react-redux';
+import { RootState } from '../../../../reducers';
 
 export const useConfirmActions = () => {
   const {
@@ -29,7 +30,7 @@ export const useConfirmActions = () => {
   const navigation = useNavigation();
   const transactionMetadata = useTransactionMetadataRequest();
   const shouldUseSmartTransaction = useSelector(
-    selectShouldUseSmartTransaction,
+    (state: RootState) => selectShouldUseSmartTransaction(state, transactionMetadata?.chainId)
   );
   const isOneOfTheStakingConfirmations = isStakingConfirmation(
     transactionMetadata?.type as string,

--- a/app/components/Views/confirmations/legacy/Approval/index.js
+++ b/app/components/Views/confirmations/legacy/Approval/index.js
@@ -379,8 +379,8 @@ class Approval extends PureComponent {
       request_source: this.originIsMMSDKRemoteConn
         ? AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN
         : this.originIsWalletConnect
-          ? AppConstants.REQUEST_SOURCES.WC
-          : AppConstants.REQUEST_SOURCES.IN_APP_BROWSER,
+        ? AppConstants.REQUEST_SOURCES.WC
+        : AppConstants.REQUEST_SOURCES.IN_APP_BROWSER,
     };
 
     try {
@@ -760,7 +760,7 @@ const mapStateToProps = (state) => {
     showCustomNonce: selectShowCustomNonce(state),
     chainId,
     activeTabUrl: getActiveTabUrl(state),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     confirmationMetricsById: selectConfirmationMetrics(state),
     securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
   };

--- a/app/components/Views/confirmations/legacy/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/Approve/index.js
@@ -983,7 +983,7 @@ const mapStateToProps = (state) => {
     providerType: selectProviderTypeByChainId(state, chainId),
     providerRpcTarget: selectRpcUrlByChainId(state, chainId),
     networkConfigurations: selectEvmNetworkConfigurationsByChainId(state),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     simulationData: selectCurrentTransactionMetadata(state)?.simulationData,
   };
 };

--- a/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
@@ -984,7 +984,7 @@ const mapStateToProps = (state) => {
     providerType: selectProviderTypeByChainId(state, chainId),
     providerRpcTarget: selectRpcUrlByChainId(state, chainId),
     networkConfigurations: selectEvmNetworkConfigurationsByChainId(state),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     simulationData: selectCurrentTransactionMetadata(state)?.simulationData,
   };
 };

--- a/app/components/Views/confirmations/legacy/Send/index.js
+++ b/app/components/Views/confirmations/legacy/Send/index.js
@@ -820,7 +820,10 @@ const mapStateToProps = (state) => {
     selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
     dappTransactionModalVisible: state.modals.dappTransactionModalVisible,
     tokenList: selectTokenList(state),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(
+      state,
+      state.transaction?.chainId, // TODO: Verify if this is correct.
+    ),
   };
 };
 

--- a/app/components/Views/confirmations/legacy/Send/index.js
+++ b/app/components/Views/confirmations/legacy/Send/index.js
@@ -822,7 +822,7 @@ const mapStateToProps = (state) => {
     tokenList: selectTokenList(state),
     shouldUseSmartTransaction: selectShouldUseSmartTransaction(
       state,
-      state.transaction?.chainId, // TODO: Verify if this is correct.
+      state.transaction?.chainId,
     ),
   };
 };

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -136,7 +136,6 @@ import {
   // eslint-disable-next-line no-restricted-syntax
   selectNetworkClientId,
   selectProviderTypeByChainId,
-  selectEvmChainId,
 } from '../../../../../../selectors/networkController';
 import { selectContractExchangeRatesByChainId } from '../../../../../../selectors/tokenRatesController';
 import { updateTransactionToMaxValue } from './utils';

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -136,6 +136,7 @@ import {
   // eslint-disable-next-line no-restricted-syntax
   selectNetworkClientId,
   selectProviderTypeByChainId,
+  selectEvmChainId,
 } from '../../../../../../selectors/networkController';
 import { selectContractExchangeRatesByChainId } from '../../../../../../selectors/tokenRatesController';
 import { updateTransactionToMaxValue } from './utils';
@@ -1612,7 +1613,8 @@ Confirm.contextType = ThemeContext;
 
 const mapStateToProps = (state) => {
   const transaction = getNormalizedTxState(state);
-  const chainId = selectEvmChainId(state);
+  const chainId = transaction?.chainId || selectEvmChainId(state);
+
   const networkClientId =
     transaction?.networkClientId || selectNetworkClientId(state);
 

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -1640,7 +1640,7 @@ const mapStateToProps = (state) => {
       chainId,
       getRampNetworks(state),
     ),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     confirmationMetricsById: selectConfirmationMetrics(state),
     transactionMetadata: selectCurrentTransactionMetadata(state),
     useTransactionSimulations: selectUseTransactionSimulations(state),

--- a/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/index.js
@@ -1369,7 +1369,7 @@ const mapStateToProps = (state) => {
       chainId,
       getRampNetworks(state),
     ),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
   };
 };

--- a/app/components/Views/confirmations/legacy/components/SmartTransactionsMigrationBanner/SmartTransactionsMigrationBanner.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/SmartTransactionsMigrationBanner/SmartTransactionsMigrationBanner.test.tsx
@@ -4,6 +4,12 @@ import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import SmartTransactionsMigrationBanner from './SmartTransactionsMigrationBanner';
 import Engine from '../../../../../../core/Engine';
+import { Linking } from 'react-native';
+import AppConstants from '../../../../../../core/AppConstants';
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(() => Promise.resolve()),
+}));
 
 jest.mock('../../../../../../core/Engine', () => ({
  context: {
@@ -32,6 +38,7 @@ describe('SmartTransactionsMigrationBanner', () => {
  const mockSetFeatureFlag = jest.mocked(Engine.context.PreferencesController.setFeatureFlag);
  const mockedPreferences = jest.requireMock('../../../../../../selectors/preferencesController');
  const mockedSmartTransactions = jest.requireMock('../../../../../../selectors/smartTransactionsController');
+ const mockOpenURL = jest.mocked(Linking.openURL);
 
  beforeEach(() => {
    jest.clearAllMocks();
@@ -102,6 +109,25 @@ describe('SmartTransactionsMigrationBanner', () => {
      );
 
      fireEvent.press(getByTestId('banner-close-button-icon'));
+     expect(mockSetFeatureFlag).toHaveBeenCalledWith(
+       'smartTransactionsBannerDismissed',
+       true,
+     );
+   });
+
+   it('opens URL and dismisses banner when learn more link is pressed', () => {
+     const store = mockStore({});
+     
+     const { getByText } = render(
+       <Provider store={store}>
+         <SmartTransactionsMigrationBanner />
+       </Provider>
+     );
+
+     fireEvent.press(getByText('smart_transactions_migration.link'));
+     
+     expect(mockOpenURL).toHaveBeenCalledTimes(1);
+     expect(mockOpenURL).toHaveBeenCalledWith(AppConstants.URLS.SMART_TXS);
      expect(mockSetFeatureFlag).toHaveBeenCalledWith(
        'smartTransactionsBannerDismissed',
        true,

--- a/app/components/Views/confirmations/legacy/components/SmartTransactionsMigrationBanner/SmartTransactionsMigrationBanner.tsx
+++ b/app/components/Views/confirmations/legacy/components/SmartTransactionsMigrationBanner/SmartTransactionsMigrationBanner.tsx
@@ -12,6 +12,7 @@ import { SmartTransactionsMigrationBannerProps } from './SmartTransactionsMigrat
 import {
   selectShouldUseSmartTransaction,
 } from '../../../../../../selectors/smartTransactionsController';
+import { selectEvmChainId } from '../../../../../../selectors/networkController';
 import Engine from '../../../../../../core/Engine';
 import Logger from '../../../../../../util/Logger';
 import {
@@ -25,8 +26,11 @@ const SmartTransactionsMigrationBanner = ({
   const { styles } = useStyles(styleSheet, { style });
   const isMigrationApplied = useSelector(selectSmartTransactionsMigrationApplied);
   const isBannerDismissed = useSelector(selectSmartTransactionsBannerDismissed);
+  const chainId = useSelector(selectEvmChainId);
 
-  const shouldUseSmartTransaction = useSelector(selectShouldUseSmartTransaction);
+  const shouldUseSmartTransaction = useSelector((state) => 
+    selectShouldUseSmartTransaction(state, chainId)
+  );
 
   const dismissBanner = useCallback(async () => {
     try {

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/TransactionReviewInformation/index.js
@@ -257,7 +257,8 @@ class TransactionReviewInformation extends PureComponent {
   };
 
   setNetworkNonce = async () => {
-    const { networkClientId, setNonce, setProposedNonce, transaction } = this.props;
+    const { networkClientId, setNonce, setProposedNonce, transaction } =
+      this.props;
     const proposedNonce = await getNetworkNonce(transaction, networkClientId);
     setNonce(proposedNonce);
     setProposedNonce(proposedNonce);
@@ -358,14 +359,16 @@ class TransactionReviewInformation extends PureComponent {
           currentCurrency,
           amountToken,
         );
-        const totalValue = `${amountToken + ' ' + selectedAsset.symbol
-          } + ${renderFromWei(totalGas)} ${getTicker(ticker)}`;
+        const totalValue = `${
+          amountToken + ' ' + selectedAsset.symbol
+        } + ${renderFromWei(totalGas)} ${getTicker(ticker)}`;
         return [totalFiat, totalValue];
       },
       ERC721: () => {
         const totalFiat = totalGasFiat;
-        const totalValue = `${selectedAsset.name}  (#${selectedAsset.tokenId
-          }) + ${renderFromWei(totalGas)} ${getTicker(ticker)}`;
+        const totalValue = `${selectedAsset.name}  (#${
+          selectedAsset.tokenId
+        }) + ${renderFromWei(totalGas)} ${getTicker(ticker)}`;
         return [totalFiat, totalValue];
       },
       default: () => [undefined, undefined],
@@ -515,11 +518,13 @@ class TransactionReviewInformation extends PureComponent {
           totalMaxConversion,
         });
 
-        renderableTotalMinNative = `${selectedAsset.name} ${' (#' + selectedAsset.tokenId + ')'
-          } + ${renderableTotalMinNative}`;
+        renderableTotalMinNative = `${selectedAsset.name} ${
+          ' (#' + selectedAsset.tokenId + ')'
+        } + ${renderableTotalMinNative}`;
 
-        renderableTotalMaxNative = `${selectedAsset.name} ${' (#' + selectedAsset.tokenId + ')'
-          } + ${renderableTotalMaxNative}`;
+        renderableTotalMaxNative = `${selectedAsset.name} ${
+          ' (#' + selectedAsset.tokenId + ')'
+        } + ${renderableTotalMaxNative}`;
 
         return [
           renderableTotalMinNative,
@@ -761,7 +766,7 @@ const mapStateToProps = (state) => {
       chainId,
       getRampNetworks(state),
     ),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
   };
 };
 

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/index.js
@@ -734,7 +734,7 @@ const mapStateToProps = (state) => {
     browser: state.browser,
     primaryCurrency: state.settings.primaryCurrency,
     tokenList: selectTokenList(state),
-    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
+    shouldUseSmartTransaction: selectShouldUseSmartTransaction(state, chainId),
     useTransactionSimulations: selectUseTransactionSimulations(state),
     securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
     transactionMetadata,

--- a/app/constants/smartTransactions.test.ts
+++ b/app/constants/smartTransactions.test.ts
@@ -21,8 +21,8 @@ describe('smartTransactions', () => {
       expect(allowedChainIds).toStrictEqual([
         NETWORKS_CHAIN_ID.MAINNET,
         NETWORKS_CHAIN_ID.SEPOLIA,
-        NETWORKS_CHAIN_ID.BASE,
-        NETWORKS_CHAIN_ID.LINEA_MAINNET,
+        // NETWORKS_CHAIN_ID.BASE, // TODO: Add base to development when ready
+        // NETWORKS_CHAIN_ID.LINEA_MAINNET, // TODO: Add linea mainnet to development when ready
         NETWORKS_CHAIN_ID.BSC,
       ]);
     });

--- a/app/constants/smartTransactions.ts
+++ b/app/constants/smartTransactions.ts
@@ -6,8 +6,8 @@ import { NETWORKS_CHAIN_ID } from './network';
 const ALLOWED_SMART_TRANSACTIONS_CHAIN_IDS_DEVELOPMENT: string[] = [
   NETWORKS_CHAIN_ID.MAINNET,
   NETWORKS_CHAIN_ID.SEPOLIA,
-  NETWORKS_CHAIN_ID.BASE,
-  NETWORKS_CHAIN_ID.LINEA_MAINNET,
+  // NETWORKS_CHAIN_ID.BASE, // TODO: Add base to development when ready
+  // NETWORKS_CHAIN_ID.LINEA_MAINNET, // TODO: Add linea mainnet to development when ready
   NETWORKS_CHAIN_ID.BSC,
 ];
 

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -21,8 +21,8 @@ import {
 jest.mock('../../../../../util/smart-transactions', () => {
   const actual = jest.requireActual('../../../../../util/smart-transactions');
   return {
-    ...actual, // Use real implementations for all utility functions
-    getSmartTransactionMetricsProperties: jest.fn(), // Only mock the specific function used in tests
+    ...actual,
+    getSmartTransactionMetricsProperties: jest.fn(),
   };
 });
 

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -18,7 +18,13 @@ import {
   enabledSmartTransactionsState,
 } from '../data-helpers';
 
-jest.mock('../../../../../util/smart-transactions');
+jest.mock('../../../../../util/smart-transactions', () => {
+  const actual = jest.requireActual('../../../../../util/smart-transactions');
+  return {
+    ...actual, // Use real implementations for all utility functions
+    getSmartTransactionMetricsProperties: jest.fn(), // Only mock the specific function used in tests
+  };
+});
 
 // Mock dependencies
 jest.mock('../../../../Analytics', () => ({

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
@@ -59,7 +59,7 @@ export async function handleTransactionFinalizedEventForMetrics(
 
   let stxMetricsProperties = {};
 
-  const shouldUseSmartTransaction = selectShouldUseSmartTransaction(getState());
+  const shouldUseSmartTransaction = selectShouldUseSmartTransaction(getState(), transactionMeta.chainId);
   if (shouldUseSmartTransaction) {
     stxMetricsProperties = await getSmartTransactionMetricsProperties(
       smartTransactionsController,

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -245,6 +245,7 @@ describe('Transaction Controller Init', () => {
   it('publish hook calls submitSmartTransactionHook', () => {
     const MOCK_TRANSACTION_META = {
       id: '123',
+      chainId: '0x1',
     } as TransactionMeta;
 
     const hooks = testConstructorOption('hooks');
@@ -253,6 +254,7 @@ describe('Transaction Controller Init', () => {
 
     expect(submitSmartTransactionHookMock).toHaveBeenCalledTimes(1);
     expect(selectShouldUseSmartTransactionMock).toHaveBeenCalledTimes(1);
+    expect(selectShouldUseSmartTransactionMock).toHaveBeenCalledWith(expect.anything(), MOCK_TRANSACTION_META.chainId);
     expect(selectSwapsChainFeatureFlagsMock).toHaveBeenCalledTimes(1);
     expect(submitSmartTransactionHookMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -260,7 +260,7 @@ describe('Transaction Controller Init', () => {
 
     expect(submitSmartTransactionHookMock).toHaveBeenCalledTimes(1);
     expect(selectShouldUseSmartTransactionMock).toHaveBeenCalledTimes(1);
-    expect(selectShouldUseSmartTransactionMock).toHaveBeenCalledWith(expect.anything(), MOCK_TRANSACTION_META.chainId);
+    expect(selectShouldUseSmartTransactionMock).toHaveBeenCalledWith(undefined, MOCK_TRANSACTION_META.chainId);
     expect(selectSwapsChainFeatureFlagsMock).toHaveBeenCalledTimes(1);
     expect(submitSmartTransactionHookMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -246,6 +246,12 @@ describe('Transaction Controller Init', () => {
     const MOCK_TRANSACTION_META = {
       id: '123',
       chainId: '0x1',
+      status: 'approved',
+      time: 123,
+      txParams: {
+        from: '0x123',
+      },
+      networkClientId: 'selectedNetworkClientId',
     } as TransactionMeta;
 
     const hooks = testConstructorOption('hooks');

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -140,7 +140,7 @@ function publishHook({
   initMessenger: TransactionControllerInitMessenger;
 }): Promise<{ transactionHash: string }> {
   const state = getState();
-  const shouldUseSmartTransaction = selectShouldUseSmartTransaction(state);
+  const shouldUseSmartTransaction = selectShouldUseSmartTransaction(state, transactionMeta.chainId);
 
   // @ts-expect-error - TransactionController expects transactionHash to be defined but submitSmartTransactionHook could return undefined
   return submitSmartTransactionHook({

--- a/app/reducers/swaps/index.js
+++ b/app/reducers/swaps/index.js
@@ -74,17 +74,11 @@ export const swapsLivenessMultichainSelector = createSelector(
 /**
  * Returns if smart transactions are enabled in feature flags
  */
-const DEVICE_KEY = 'mobileActive';
 export const swapsSmartTxFlagEnabled = createSelector(
   swapsStateSelector,
   (swapsState) => {
     const globalFlags = swapsState.featureFlags;
-
-    const isEnabled = Boolean(
-      globalFlags?.smart_transactions?.mobile_active &&
-        globalFlags?.smartTransactions?.[DEVICE_KEY],
-    );
-
+    const isEnabled = Boolean(globalFlags?.smartTransactions?.mobileActive);
     return isEnabled;
   },
 );

--- a/app/selectors/smartTransactionsController.test.ts
+++ b/app/selectors/smartTransactionsController.test.ts
@@ -154,6 +154,13 @@ describe('SmartTransactionsController Selectors', () => {
       const shouldUseSmartTransaction = selectShouldUseSmartTransaction(state);
       expect(shouldUseSmartTransaction).toEqual(true);
     });
+    it('should accept an optional chainId parameter', () => {
+      const state = getDefaultState();
+      state.swaps.featureFlags.smart_transactions.mobile_active = true;
+      state.swaps.featureFlags.smartTransactions.mobileActive = true;
+      const shouldUseSmartTransaction = selectShouldUseSmartTransaction(state, '0x1');
+      expect(shouldUseSmartTransaction).toEqual(true);
+    });
   });
 
   describe('getSmartTransactionsForCurrentChain', () => {

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -50,16 +50,18 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
     smartTransactionsLiveness,
   ) => {
     const effectiveChainId = transactionChainId || globalChainId;
-    const addrIshardwareAccount = selectedAddress
+    const addressIsHardwareAccount = selectedAddress
       ? isHardwareAccount(selectedAddress)
       : false;
     const isAllowedNetwork =
       getAllowedSmartTransactionsChainIds().includes(effectiveChainId);
     return Boolean(
       isAllowedNetwork &&
+        !addressIsHardwareAccount &&
         getIsAllowedRpcUrlForSmartTransactions(providerConfigRpcUrl) &&
-        !addrIshardwareAccount, // && TODO: Make sure the functions below use the right chainId..
-      // smartTransactionsFeatureFlagEnabled &&
+        smartTransactionsFeatureFlagEnabled,
+      // TODO: "fetchLiveness" fn from the STX controller has to be called with the right networkClientId,
+      // and then the smartTransactionsState?.liveness will return the correct value.
       // smartTransactionsLiveness,
     );
   },

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -32,7 +32,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
     smartTransactionsFeatureFlagEnabled,
     smartTransactionsLiveness,
   ) => {
-    const effectiveChainId = transactionChainId ?? globalChainId;
+    const effectiveChainId = transactionChainId || globalChainId;
     const addrIshardwareAccount = selectedAddress
       ? isHardwareAccount(selectedAddress)
       : false;

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -17,7 +17,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
   [
     selectSelectedInternalAccountFormattedAddress,
     selectEvmChainId,
-    (state: RootState, chainId: Hex) => chainId,
+    (state: RootState, chainId?: Hex) => chainId,
     (state: RootState) => selectProviderConfig(state).rpcUrl,
     swapsSmartTxFlagEnabled,
     (state: RootState) =>
@@ -44,9 +44,11 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
         ? providerConfigRpcUrl === undefined
         : true;
     return Boolean(
-      isAllowedNetwork && canBypassRpc && !addrIshardwareAccount, // &&
-      // smartTransactionsFeatureFlagEnabled &&
-      // smartTransactionsLiveness,
+      isAllowedNetwork &&
+        canBypassRpc &&
+        !addrIshardwareAccount // && TODO: Make sure the functions below use the right chainId..
+        // smartTransactionsFeatureFlagEnabled &&
+        // smartTransactionsLiveness,
     );
   },
 );

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -1,4 +1,3 @@
-import { NETWORKS_CHAIN_ID } from '../constants/network';
 import { selectSmartTransactionsOptInStatus } from './preferencesController';
 import { RootState } from '../reducers';
 import { swapsSmartTxFlagEnabled } from '../reducers/swaps';
@@ -47,7 +46,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
     transactionChainId,
     providerConfigRpcUrl,
     smartTransactionsFeatureFlagEnabled,
-    smartTransactionsLiveness,
+    _smartTransactionsLiveness,
   ) => {
     const effectiveChainId = transactionChainId || globalChainId;
     const addressIsHardwareAccount = selectedAddress

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -46,7 +46,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
     transactionChainId,
     providerConfigRpcUrl,
     smartTransactionsFeatureFlagEnabled,
-    _smartTransactionsLiveness,
+    smartTransactionsLiveness,
   ) => {
     const effectiveChainId = transactionChainId || globalChainId;
     const addressIsHardwareAccount = selectedAddress
@@ -58,10 +58,8 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
       isAllowedNetwork &&
         !addressIsHardwareAccount &&
         getIsAllowedRpcUrlForSmartTransactions(providerConfigRpcUrl) &&
-        smartTransactionsFeatureFlagEnabled,
-      // TODO: "fetchLiveness" fn from the STX controller has to be called with the right networkClientId,
-      // and then the smartTransactionsState?.liveness will return the correct value.
-      // smartTransactionsLiveness,
+        smartTransactionsFeatureFlagEnabled &&
+        smartTransactionsLiveness,
     );
   },
 );

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -10,23 +10,8 @@ import {
 import { selectSelectedInternalAccountFormattedAddress } from './accountsController';
 import { getAllowedSmartTransactionsChainIds } from '../../app/constants/smartTransactions';
 import { createDeepEqualSelector } from './util';
-import { isProduction } from '../util/environment';
 import { Hex } from '@metamask/utils';
-
-const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
-  // Allow in non-production environments.
-  if (!isProduction()) {
-    return true;
-  }
-
-  const hostname = rpcUrl && new URL(rpcUrl).hostname;
-
-  return (
-    hostname?.endsWith('.infura.io') ||
-    hostname?.endsWith('.binance.org') ||
-    false
-  );
-};
+import { getIsAllowedRpcUrlForSmartTransactions } from '../util/smart-transactions';
 
 export const selectSmartTransactionsEnabled = createDeepEqualSelector(
   [

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -10,6 +10,7 @@ import {
   getIsAllowedRpcUrlForSmartTransactions,
 } from './index';
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
+// eslint-disable-next-line import/no-namespace
 import * as environment from '../environment';
 import type { BaseControllerMessenger } from '../../core/Engine';
 

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -7,8 +7,10 @@ import {
   getTradeTxTokenFee,
   getGasIncludedTransactionFees,
   type GasIncludedQuote,
+  getIsAllowedRpcUrlForSmartTransactions,
 } from './index';
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
+import * as environment from '../environment';
 import type { BaseControllerMessenger } from '../../core/Engine';
 
 describe('Smart Transactions utils', () => {
@@ -642,6 +644,55 @@ describe('Smart Transactions utils', () => {
 
       const result = getGasIncludedTransactionFees(mockQuote);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getIsAllowedRpcUrlForSmartTransactions', () => {
+    let isProductionMock: jest.SpyInstance;
+    
+    beforeEach(() => {
+      // Mock isProduction function before each test
+      isProductionMock = jest.spyOn(environment, 'isProduction');
+    });
+    
+    afterEach(() => {
+      isProductionMock.mockRestore();
+    });
+
+    it('returns true for Infura URLs in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions('https://mainnet.infura.io/v3/abc123');
+      expect(result).toBe(true);
+    });
+
+    it('returns true for Binance URLs in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions('https://bsc-dataseed.binance.org/');
+      expect(result).toBe(true);
+    });
+
+    it('returns false for other URLs in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions('https://example.com/rpc');
+      expect(result).toBe(false);
+    });
+
+    it('returns false for undefined URL in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions(undefined);
+      expect(result).toBe(false);
+    });
+
+    it('returns true for any URL in non-production environments', () => {
+      isProductionMock.mockReturnValue(false);
+      const result = getIsAllowedRpcUrlForSmartTransactions('https://example.com/rpc');
+      expect(result).toBe(true);
+    });
+
+    it('returns true for undefined URL in non-production environments', () => {
+      isProductionMock.mockReturnValue(false);
+      const result = getIsAllowedRpcUrlForSmartTransactions(undefined);
+      expect(result).toBe(true);
     });
   });
 });

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -13,6 +13,7 @@ import {
   Fees,
 } from '@metamask/smart-transactions-controller/dist/types';
 import type { BaseControllerMessenger } from '../../core/Engine';
+import { isProduction } from '../environment';
 
 const TIMEOUT_FOR_SMART_TRANSACTION_CONFIRMATION_DONE_EVENT = 10000;
 
@@ -149,4 +150,19 @@ export const getGasIncludedTransactionFees = (quote: GasIncludedQuote) => {
     };
   }
   return transactionFees;
+};
+
+export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
+  // Allow in non-production environments.
+  if (!isProduction()) {
+    return true;
+  }
+
+  const hostname = rpcUrl && new URL(rpcUrl).hostname;
+
+  return (
+    hostname?.endsWith('.infura.io') ||
+    hostname?.endsWith('.binance.org') ||
+    false
+  );
 };


### PR DESCRIPTION
## **Description**

We should be using a chainId param from a transaction (if available) to better support multichain efforts. This PR also disables unused STX networks in the dev environment and is similar to the PR in the extension: https://github.com/MetaMask/metamask-extension/pull/32201

## **Related issues**

Fixes:

## **Manual testing steps**

1. Make sure that smart transactions still work (Send, Swap, dapp transactions)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
