### PR TITLE
chore: bridge keep keyboard on screen even during quote fetching cp-7.46.0

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -36,7 +36,6 @@ import {
   setSlippage,
   selectIsSolanaToEvm,
 } from '../../../../../core/redux/slices/bridge';
-import { ethers } from 'ethers';
 import {
   useNavigation,
   useRoute,

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -140,10 +140,7 @@ const BridgeView = () => {
   });
 
   const isValidSourceAmount =
-    !!sourceAmount &&
-    sourceAmount !== '.' &&
-    sourceToken?.decimals &&
-    !ethers.utils.parseUnits(sourceAmount, sourceToken.decimals).isZero();
+    sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
 
   const hasValidBridgeInputs =
     isValidSourceAmount && !!sourceToken && !!destToken;

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -151,7 +151,8 @@ const BridgeView = () => {
   const hasInsufficientBalance = quoteRequest?.insufficientBal;
 
   // Primary condition for keypad visibility - when input is focused or we don't have valid inputs
-  const shouldDisplayKeypad = isInputFocused || !hasValidBridgeInputs;
+  const shouldDisplayKeypad =
+    isInputFocused || !hasValidBridgeInputs || !activeQuote;
   const shouldDisplayQuoteDetails = hasQuoteDetails && !isInputFocused;
 
   // Compute error state directly from dependencies

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -85,5 +85,5 @@ export const useBridgeQuoteRequest = () => {
   ]);
 
   // Create a stable debounced function that persists across renders
-  return useMemo(() => debounce(updateQuoteParams, 300), [updateQuoteParams]);
+  return useMemo(() => debounce(updateQuoteParams, 500), [updateQuoteParams]);
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -40,7 +40,7 @@ export const useBridgeQuoteRequest = () => {
     if (
       !sourceToken ||
       !destToken ||
-      !sourceAmount ||
+      sourceAmount === undefined ||
       !destChainId ||
       !walletAddress
     ) {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -85,5 +85,5 @@ export const useBridgeQuoteRequest = () => {
   ]);
 
   // Create a stable debounced function that persists across renders
-  return useMemo(() => debounce(updateQuoteParams, 500), [updateQuoteParams]);
+  return useMemo(() => debounce(updateQuoteParams, 700), [updateQuoteParams]);
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -18,6 +18,8 @@ import { calcTokenValue } from '../../../../../util/transactions';
 import { debounce } from 'lodash';
 import { useUnifiedSwapBridgeContext } from '../useUnifiedSwapBridgeContext';
 
+export const DEBOUNCE_WAIT = 700;
+
 /**
  * Hook for handling bridge quote request updates
  * @returns {Function} A debounced function to update quote parameters
@@ -85,5 +87,8 @@ export const useBridgeQuoteRequest = () => {
   ]);
 
   // Create a stable debounced function that persists across renders
-  return useMemo(() => debounce(updateQuoteParams, 700), [updateQuoteParams]);
+  return useMemo(
+    () => debounce(updateQuoteParams, DEBOUNCE_WAIT),
+    [updateQuoteParams],
+  );
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -1,4 +1,4 @@
-import { useBridgeQuoteRequest } from './';
+import { DEBOUNCE_WAIT, useBridgeQuoteRequest } from './';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { createBridgeTestState } from '../../testUtils';
 import Engine from '../../../../../core/Engine';
@@ -58,7 +58,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalled();
   });
@@ -76,7 +76,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     spyUpdateBridgeQuoteRequestParams.mockClear();
@@ -96,7 +96,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     spyUpdateBridgeQuoteRequestParams.mockClear();
@@ -116,7 +116,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     spyUpdateBridgeQuoteRequestParams.mockClear();
@@ -136,7 +136,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     spyUpdateBridgeQuoteRequestParams.mockClear();
@@ -156,7 +156,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
@@ -180,7 +180,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
@@ -215,7 +215,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
@@ -239,13 +239,13 @@ describe('useBridgeQuoteRequest', () => {
       result.current();
 
       // Advance timer by less than debounce time
-      jest.advanceTimersByTime(200);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT - 100);
 
       // Should not have been called yet
       expect(spyUpdateBridgeQuoteRequestParams).not.toHaveBeenCalled();
 
       // Advance timer past debounce time
-      jest.advanceTimersByTime(100);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT + 100);
 
       // Should have been called exactly once
       expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledTimes(1);
@@ -289,7 +289,7 @@ describe('useBridgeQuoteRequest', () => {
 
     await act(async () => {
       await result.current();
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
     });
 
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This pull request focuses on improving the handling of `sourceAmount` validations and updating the debounce timing for better performance in the bridge feature. Key changes include refining input validation logic, enhancing conditional rendering, and adjusting debounce timing.

It also fixes an issue where if you entered a valid source amount, got a quote, then entered in 0 as the source amount, the app would continue to poll for the previously valid quoteRequest. Now the destTokenAmount will immediately show 0 and no further fetching happens.

### Input Validation Improvements:
* [`app/components/UI/Bridge/Views/BridgeView/index.tsx`](diffhunk://#diff-a13ca1ff567c225cd7ee3408c45ca95763a7148d80a56148704a232641efd245L143-R152): Updated the `isValidSourceAmount` logic to simplify the validation by removing the unnecessary check for zero values.
* [`app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts`](diffhunk://#diff-f2bfcce39464acfd7db4f7548e4fc907eae7ed1368e9f59d7ba379b8fc45e3e5L43-R43): Adjusted the `useBridgeQuoteRequest` hook to treat `sourceAmount` explicitly as `undefined` instead of relying on falsy checks, improving clarity and robustness.

### Conditional Rendering Enhancements:
* [`app/components/UI/Bridge/Views/BridgeView/index.tsx`](diffhunk://#diff-a13ca1ff567c225cd7ee3408c45ca95763a7148d80a56148704a232641efd245L143-R152): Modified the `shouldDisplayKeypad` condition to include a check for `activeQuote`, ensuring the keypad is displayed when no active quote is available.

### Performance Optimization:
* [`app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts`](diffhunk://#diff-f2bfcce39464acfd7db4f7548e4fc907eae7ed1368e9f59d7ba379b8fc45e3e5L88-R88): Increased the debounce timing for the `updateQuoteParams` function from 300ms to 500ms, reducing the frequency of updates and improving performance.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Bridge
2. Enter in a valid quote request 
3. Observe keyboard stays on screen during quote fetching
4. You can change numbers during fetching
5. Also notice if you change the source amount to 0, you immediately get 0 dest tokens and no quote is fetched

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6a3597a0-2343-4a78-bfa4-ce20dd1fb936




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
