### PR TITLE
perf: Debounce and group state updates being flushed to Redux

### DIFF
--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -106,11 +106,6 @@ export class EngineService {
 
     const updatedControllers = new Set<string>()
 
-    const updateReduxStateDebounced = (controllerName: string) => {
-      updatedControllers.add(controllerName);
-      flushStateDebounced();
-    }
-
     const flushStateDebounced = debounce(() => {
       if (!engine.context.KeyringController.metadata.vault) {
         Logger.log('keyringController vault missing for UPDATE_BG_STATE_KEY');
@@ -121,6 +116,11 @@ export class EngineService {
       });
       updatedControllers.clear();
     }, 200);
+
+    const updateReduxStateDebounced = (controllerName: string) => {
+      updatedControllers.add(controllerName);
+      flushStateDebounced();
+    }
 
     BACKGROUND_STATE_CHANGE_EVENT_NAMES.forEach((eventName) => {
       engine.controllerMessenger.subscribe(eventName, () =>

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -9,13 +9,13 @@ import {
 import { getTraceTags } from '../../util/sentry/tags';
 import { trace, endTrace, TraceName, TraceOperation } from '../../util/trace';
 import getUIStartupSpan from '../Performance/UIStartup';
+import { BACKGROUND_STATE_CHANGE_EVENT_NAMES } from '../Engine/constants';
 import ReduxService from '../redux';
 import NavigationService from '../NavigationService';
 import Routes from '../../constants/navigation/Routes';
 import { KeyringControllerState } from '@metamask/keyring-controller';
 import { MetaMetrics } from '../Analytics';
 import { debounce } from 'lodash';
-import { BACKGROUND_STATE_CHANGE_EVENT_NAMES } from '../Engine/constants';
 
 const LOG_TAG = 'EngineService';
 

--- a/app/core/redux/slices/engine/engineReducer.test.tsx
+++ b/app/core/redux/slices/engine/engineReducer.test.tsx
@@ -45,7 +45,7 @@ describe('engineReducer', () => {
     };
     const { backgroundState } = engineReducer(
       reduxInitialState,
-      updateBgState({ key }),
+      updateBgState({ updatedControllers: [key] }),
     );
     expect(backgroundState).toEqual({
       ...reduxInitialState.backgroundState,

--- a/app/core/redux/slices/engine/index.ts
+++ b/app/core/redux/slices/engine/index.ts
@@ -30,16 +30,7 @@ const engineReducer = (
       return { backgroundState: Engine.state };
     }
     case updateBgState.type: {
-      const newState = { ...state };
-
-      if (action.payload) {
-        const newControllerState =
-          Engine.state[action.payload.key as keyof typeof Engine.state];
-
-        newState.backgroundState[action.payload.key] = newControllerState;
-      }
-
-      return newState;
+      return { backgroundState: Engine.state };
     }
     default:
       return state;

--- a/app/core/redux/slices/engine/index.ts
+++ b/app/core/redux/slices/engine/index.ts
@@ -11,8 +11,8 @@ const initialState = {
 export const initBgState = createAction('INIT_BG_STATE');
 
 // Create an action to update the background state
-export const updateBgState = createAction('UPDATE_BG_STATE', (key) => ({
-  payload: key,
+export const updateBgState = createAction('UPDATE_BG_STATE', (payload) => ({
+  payload,
 }));
 
 // TODO: Replace "any" with type

--- a/app/core/redux/slices/engine/index.ts
+++ b/app/core/redux/slices/engine/index.ts
@@ -21,16 +21,25 @@ export const counter: any = {};
 const engineReducer = (
   // eslint-disable-next-line @typescript-eslint/default-param-last
   state = initialState,
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  action: PayloadAction<{ key: any } | undefined>,
+  action: PayloadAction<{ updatedControllers: string[] } | undefined>,
 ) => {
   switch (action.type) {
     case initBgState.type: {
       return { backgroundState: Engine.state };
     }
     case updateBgState.type: {
-      return { backgroundState: Engine.state };
+      const newState = { ...state };
+
+      if (action.payload) {
+        for (const controllerName of action.payload.updatedControllers) {
+          const newControllerState =
+            Engine.state[controllerName as keyof typeof Engine.state];
+
+          newState.backgroundState[controllerName] = newControllerState;
+        }
+      }
+
+      return newState;
     }
     default:
       return state;

--- a/app/selectors/accountTrackerControllerReRenders.test.tsx
+++ b/app/selectors/accountTrackerControllerReRenders.test.tsx
@@ -349,7 +349,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'NetworkController',
+            updatedControllers: ['NetworkController'],
           },
         });
       });
@@ -375,7 +375,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'AccountTrackerController',
+            updatedControllers: ['AccountTrackerController'],
           },
         });
       });
@@ -403,7 +403,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'AccountsController',
+            updatedControllers: ['AccountsController'],
           },
         });
       });
@@ -438,7 +438,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'NetworkController',
+            updatedControllers: ['NetworkController'],
           },
         });
       });
@@ -464,7 +464,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'AccountTrackerController',
+            updatedControllers: ['AccountTrackerController'],
           },
         });
       });
@@ -487,7 +487,7 @@ describe('selectAccountBalanceByChainId', () => {
         store.dispatch({
           type: 'UPDATE_BG_STATE',
           payload: {
-            key: 'AccountsController',
+            updatedControllers: ['AccountsController'],
           },
         });
       });

--- a/app/selectors/multichain/evm.test.tsx
+++ b/app/selectors/multichain/evm.test.tsx
@@ -1037,7 +1037,7 @@ describe('re-renders', () => {
       store.dispatch({
         type: 'UPDATE_BG_STATE',
         payload: {
-          key: 'TokensController',
+          updatedControllers: ['TokensController'],
         },
       });
     });
@@ -1057,7 +1057,7 @@ describe('re-renders', () => {
       store.dispatch({
         type: 'UPDATE_BG_STATE',
         payload: {
-          key: 'TokensController',
+          updatedControllers: ['TokensController'],
         },
       });
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Debounce and group state updates being flushed to Redux since dispatching the Redux actions has proved to be slow and often tied directly to the UI being rendered at the time. It is less than ideal for a controller state update to be waiting for this to happen. By grouping and debouncing, the Redux dispatch is deferred and simultaneous state updates get grouped into one dispatch.
