### PR TITLE
perf: Add patch to parallelize account tracker API calls

### DIFF
--- a/patches/@metamask+assets-controllers+55.0.1.patch
+++ b/patches/@metamask+assets-controllers+55.0.1.patch
@@ -1,3 +1,71 @@
+diff --git a/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.cjs b/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.cjs
+index b654e87..7a2bde8 100644
+--- a/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.cjs
++++ b/node_modules/@metamask/assets-controllers/dist/AccountTrackerController.cjs
+@@ -136,38 +136,45 @@ class AccountTrackerController extends (0, polling_controller_1.StaticIntervalPo
+      * @param networkClientId - Optional networkClientId to fetch a network client with
+      */
+     async refresh(networkClientId) {
++        // Can be removed after @metamask/assets-controllers@59.0.0
+         const selectedAccount = this.messagingSystem.call('AccountsController:getSelectedAccount');
+         const releaseLock = await __classPrivateFieldGet(this, _AccountTrackerController_refreshMutex, "f").acquire();
+         try {
+             const { chainId, ethQuery } = __classPrivateFieldGet(this, _AccountTrackerController_instances, "m", _AccountTrackerController_getCorrectNetworkClient).call(this, networkClientId);
+             this.syncAccounts(chainId);
+-            const { accounts, accountsByChainId } = this.state;
++            const { accountsByChainId } = this.state;
+             const { isMultiAccountBalancesEnabled } = this.messagingSystem.call('PreferencesController:getState');
+             const accountsToUpdate = isMultiAccountBalancesEnabled
+-                ? Object.keys(accounts)
++                ? Object.keys(accountsByChainId[chainId])
+                 : [(0, controller_utils_1.toChecksumHexAddress)(selectedAccount.address)];
+             const accountsForChain = { ...accountsByChainId[chainId] };
+-            for (const address of accountsToUpdate) {
+-                const balance = await __classPrivateFieldGet(this, _AccountTrackerController_instances, "m", _AccountTrackerController_getBalanceFromChain).call(this, address, ethQuery);
+-                if (balance) {
++            
++            // Use Promise.allSettled to handle multiple asynchronous operations concurrently
++            const balancePromises = accountsToUpdate.map(async (address) => {
++                const balancePromise = __classPrivateFieldGet(this, _AccountTrackerController_instances, "m", _AccountTrackerController_getBalanceFromChain).call(this, address, ethQuery);
++                const stakedBalancePromise = __classPrivateFieldGet(this, _AccountTrackerController_includeStakedAssets, "f")
++                    ? __classPrivateFieldGet(this, _AccountTrackerController_getStakedBalanceForChain, "f").call(this, address, networkClientId)
++                    : Promise.resolve(null);
++                const [balanceResult, stakedBalanceResult] = await Promise.allSettled([
++                    balancePromise,
++                    stakedBalancePromise,
++                ]);
++                if (balanceResult.status === 'fulfilled' && balanceResult.value) {
+                     accountsForChain[address] = {
+-                        balance,
++                        balance: balanceResult.value,
+                     };
+                 }
+-                if (__classPrivateFieldGet(this, _AccountTrackerController_includeStakedAssets, "f")) {
+-                    const stakedBalance = await __classPrivateFieldGet(this, _AccountTrackerController_getStakedBalanceForChain, "f").call(this, address, networkClientId);
+-                    if (stakedBalance) {
+-                        accountsForChain[address] = {
+-                            ...accountsForChain[address],
+-                            stakedBalance,
+-                        };
+-                    }
++                if (stakedBalanceResult.status === 'fulfilled' &&
++                    stakedBalanceResult.value) {
++                    accountsForChain[address] = {
++                        ...accountsForChain[address],
++                        stakedBalance: stakedBalanceResult.value,
++                    };
+                 }
+-            }
++            });
++            // Wait for all promises to settle
++            await Promise.allSettled(balancePromises);
+             this.update((state) => {
+-                if (chainId === __classPrivateFieldGet(this, _AccountTrackerController_instances, "m", _AccountTrackerController_getCurrentChainId).call(this)) {
+-                    state.accounts = accountsForChain;
+-                }
+                 state.accountsByChainId[chainId] = accountsForChain;
+             });
+         }
 diff --git a/node_modules/@metamask/assets-controllers/dist/NftController.cjs b/node_modules/@metamask/assets-controllers/dist/NftController.cjs
 index 0f15eb6..179932b 100644
 --- a/node_modules/@metamask/assets-controllers/dist/NftController.cjs


### PR DESCRIPTION
## **Description**

Adds patch for Account Tracker parallelization. This is added in `@metamask/assets-controllers@59.0.0`.

This change is already in main - introduced in this PR https://github.com/MetaMask/metamask-mobile/pull/14768

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14856

## **Manual testing steps**

Test asset flows.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
