### PR TITLE
perf: reduce constant re-renders from component size calculations

### DIFF
--- a/app/component-library/hooks/useComponentSize.ts
+++ b/app/component-library/hooks/useComponentSize.ts
@@ -1,14 +1,12 @@
 /* eslint-disable import/prefer-default-export */
-import { useCallback, useState } from 'react';
+import { useCallback, useRef } from 'react';
 import { LayoutChangeEvent } from 'react-native';
 
 export const useComponentSize = () => {
-  const [size, setSize] = useState<null | { width: number; height: number }>(
-    null,
-  );
+  const sizeRef = useRef<null | { width: number; height: number }>(null);
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
-    setSize({ width, height });
+    sizeRef.current = { width, height };
   }, []);
-  return { size, onLayout };
+  return { size: sizeRef.current, onLayout };
 };


### PR DESCRIPTION

## **Description**

Reduces re-renders from component size calculations.
Although the render time is small, this adds up quite quickly, especially on list items.

It does this by swapping out the `useState` which performs renders on every state change (size calculation), with `useRef` which is a mutable object and doesn't perform re-renders on size calculations.

Example: Switching portfolio view/popular networks and single network.

With current hook: ~250 renders
![Screenshot 2025-04-28 at 16 00 12](https://github.com/user-attachments/assets/619b8494-2bdb-44f1-914d-a334f14019c0)

When using refs: ~60 renders
![Screenshot 2025-04-28 at 15 49 45](https://github.com/user-attachments/assets/047c05db-ad76-42ae-ad2f-90e3f8a545ba)

## **Related issues**

Fixes:

## **Manual testing steps**

Check that the App still functions correctly, I've done a sweep through asset features.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
