### PR TITLE
chore: Further optimize AccountsSelectorList

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -674,7 +674,7 @@ const AppFlow = () => {
       />
       <Stack.Screen name={Routes.OPTIONS_SHEET} component={OptionsSheet} />
       <Stack.Screen
-        name="EditAccountName"
+        name={Routes.EDIT_ACCOUNT_NAME}
         component={EditAccountName}
         options={{ animationEnabled: true }}
       />

--- a/app/components/UI/AccountSelectorList/AccountSelectorList.test.tsx
+++ b/app/components/UI/AccountSelectorList/AccountSelectorList.test.tsx
@@ -30,6 +30,13 @@ const MOCK_ACCOUNTS_CONTROLLER_STATE = createMockAccountsControllerState([
   PERSONAL_ACCOUNT,
 ]);
 
+// Mock InteractionManager to run callbacks immediately in tests
+const { InteractionManager } = jest.requireActual('react-native');
+
+InteractionManager.runAfterInteractions = jest.fn(async (callback) =>
+  callback(),
+);
+
 jest.mock('../../../util/address', () => {
   const actual = jest.requireActual('../../../util/address');
   return {
@@ -303,6 +310,10 @@ describe('AccountSelectorList', () => {
     await waitFor(() => {
       const rightAccessories = getAllByTestId(RIGHT_ACCESSORY_TEST_ID);
       expect(rightAccessories.length).toBe(2);
+
+      // Check that each right accessory contains the expected content
+      expect(rightAccessories[0].props.children).toContain(BUSINESS_ACCOUNT);
+      expect(rightAccessories[1].props.children).toContain(PERSONAL_ACCOUNT);
 
       expect(toJSON()).toMatchSnapshot();
     });

--- a/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
+++ b/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
@@ -1,6 +1,12 @@
 // Third party dependencies.
-import React, { useCallback, useRef } from 'react';
-import { Alert, ListRenderItem, View, ViewStyle } from 'react-native';
+import React, { useCallback, useRef, useMemo } from 'react';
+import {
+  Alert,
+  InteractionManager,
+  ListRenderItem,
+  View,
+  ViewStyle,
+} from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -16,11 +22,7 @@ import SensitiveText, {
   SensitiveTextLength,
 } from '../../../component-library/components/Texts/SensitiveText';
 import AvatarGroup from '../../../component-library/components/Avatars/AvatarGroup';
-import {
-  formatAddress,
-  getLabelTextByAddress,
-  safeToChecksumAddress,
-} from '../../../util/address';
+import { formatAddress, getLabelTextByAddress } from '../../../util/address';
 import { AvatarAccountType } from '../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { isDefaultAccountName } from '../../../util/ENSUtils';
 import { strings } from '../../../../locales/i18n';
@@ -69,6 +71,11 @@ const AccountSelectorList = ({
     shallowEqual,
   );
   const getKeyExtractor = ({ address }: Account) => address;
+
+  const selectedAddressesLookup = useMemo(() => {
+    if (!selectedAddresses?.length) return null;
+    return new Set(selectedAddresses.map((addr) => addr.toLowerCase()));
+  }, [selectedAddresses]);
 
   const renderAccountBalances = useCallback(
     ({ fiatBalance, tokens }: Assets, address: string) => {
@@ -134,37 +141,39 @@ const AccountSelectorList = ({
           {
             text: strings('accounts.yes_remove_it'),
             onPress: async () => {
-              // TODO: Refactor account deletion logic to make more robust.
-              const selectedAddressOverride = selectedAddresses?.[0];
-              const account = accounts.find(
-                ({ isSelected: isAccountSelected, address: accountAddress }) =>
-                  selectedAddressOverride
-                    ? safeToChecksumAddress(selectedAddressOverride) ===
-                      safeToChecksumAddress(accountAddress)
-                    : isAccountSelected,
-              ) as Account;
-              let nextActiveAddress = account.address;
-              if (isSelected) {
-                const nextActiveIndex = index === 0 ? 1 : index - 1;
-                nextActiveAddress = accounts[nextActiveIndex]?.address;
-              }
-              // Switching accounts on the PreferencesController must happen before account is removed from the KeyringController, otherwise UI will break.
-              // If needed, place Engine.setSelectedAddress in onRemoveImportedAccount callback.
-              onRemoveImportedAccount?.({
-                removedAddress: address,
-                nextActiveAddress,
+              InteractionManager.runAfterInteractions(async () => {
+                // Determine which account should be active after removal
+                let nextActiveAddress: string;
+
+                if (isSelected) {
+                  // If removing the selected account, choose an adjacent one
+                  const nextActiveIndex = index === 0 ? 1 : index - 1;
+                  nextActiveAddress = accounts[nextActiveIndex]?.address;
+                } else {
+                  // Not removing selected account, so keep current selection
+                  nextActiveAddress =
+                    selectedAddresses?.[0] ||
+                    accounts.find((acc) => acc.isSelected)?.address ||
+                    '';
+                }
+
+                // Switching accounts on the PreferencesController must happen before account is removed from the KeyringController, otherwise UI will break.
+                // If needed, place Engine.setSelectedAddress in onRemoveImportedAccount callback.
+                onRemoveImportedAccount?.({
+                  removedAddress: address,
+                  nextActiveAddress,
+                });
+                await Engine.context.KeyringController.removeAccount(address);
+                // Revocation of accounts from PermissionController is needed whenever accounts are removed.
+                // If there is an instance where this is not the case, this logic will need to be updated.
+                removeAccountsFromPermissions([address]);
               });
-              await Engine.context.KeyringController.removeAccount(address);
-              // Revocation of accounts from PermissionController is needed whenever accounts are removed.
-              // If there is an instance where this is not the case, this logic will need to be updated.
-              removeAccountsFromPermissions([address]);
             },
           },
         ],
         { cancelable: false },
       );
     },
-    /* eslint-disable-next-line */
     [
       accounts,
       onRemoveImportedAccount,
@@ -208,13 +217,8 @@ const AccountSelectorList = ({
         cellVariant = CellVariant.Select;
       }
       let isSelectedAccount = isSelected;
-      if (selectedAddresses) {
-        const lowercasedSelectedAddresses = selectedAddresses.map(
-          (selectedAddress: string) => selectedAddress.toLowerCase(),
-        );
-        isSelectedAccount = lowercasedSelectedAddresses.includes(
-          address.toLowerCase(),
-        );
+      if (selectedAddressesLookup) {
+        isSelectedAccount = selectedAddressesLookup.has(address.toLowerCase());
       }
 
       const cellStyle: ViewStyle = {
@@ -282,7 +286,7 @@ const AccountSelectorList = ({
       renderAccountBalances,
       ensByAccountAddress,
       isLoading,
-      selectedAddresses,
+      selectedAddressesLookup,
       isMultiSelect,
       isSelectWithoutMenu,
       renderRightAccessory,
@@ -295,17 +299,25 @@ const AccountSelectorList = ({
     // Handle auto scroll to account
     if (!accounts.length || !isAutoScrollEnabled) return;
     if (accountsLengthRef.current !== accounts.length) {
-      const selectedAddressOverride = selectedAddresses?.[0];
-      const account = accounts.find(({ isSelected, address }) =>
-        selectedAddressOverride
-          ? safeToChecksumAddress(selectedAddressOverride) ===
-            safeToChecksumAddress(address)
-          : isSelected,
-      );
+      // Find the selected account more efficiently
+      let selectedAccount: Account | undefined;
+
+      if (selectedAddresses?.length) {
+        const selectedAddressLower = selectedAddresses[0].toLowerCase();
+        selectedAccount = accounts.find(
+          (acc) => acc.address.toLowerCase() === selectedAddressLower,
+        );
+      }
+      // Fall back to the account with isSelected flag if no override or match found
+      if (!selectedAccount) {
+        selectedAccount = accounts.find((acc) => acc.isSelected);
+      }
+
       accountListRef?.current?.scrollToOffset({
-        offset: account?.yOffset,
+        offset: selectedAccount?.yOffset,
         animated: false,
       });
+
       accountsLengthRef.current = accounts.length;
     }
   }, [accounts, selectedAddresses, isAutoScrollEnabled]);

--- a/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
+++ b/app/components/UI/AccountSelectorList/AccountSelectorList.tsx
@@ -74,7 +74,11 @@ const AccountSelectorList = ({
 
   const selectedAddressesLookup = useMemo(() => {
     if (!selectedAddresses?.length) return null;
-    return new Set(selectedAddresses.map((addr) => addr.toLowerCase()));
+    const lookupSet = new Set<string>();
+    selectedAddresses.forEach((addr) => {
+      if (addr) lookupSet.add(addr.toLowerCase());
+    });
+    return lookupSet;
   }, [selectedAddresses]);
 
   const renderAccountBalances = useCallback(
@@ -299,7 +303,6 @@ const AccountSelectorList = ({
     // Handle auto scroll to account
     if (!accounts.length || !isAutoScrollEnabled) return;
     if (accountsLengthRef.current !== accounts.length) {
-      // Find the selected account more efficiently
       let selectedAccount: Account | undefined;
 
       if (selectedAddresses?.length) {

--- a/app/components/UI/AccountSelectorList/__snapshots__/AccountSelectorList.test.tsx.snap
+++ b/app/components/UI/AccountSelectorList/__snapshots__/AccountSelectorList.test.tsx.snap
@@ -911,7 +911,7 @@ exports[`AccountSelectorList renders all accounts with right accessory 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#4459ff1a",
             "flexDirection": "row",
           }
         }
@@ -1193,6 +1193,34 @@ exports[`AccountSelectorList renders all accounts with right accessory 1`] = `
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            accessibilityRole="checkbox"
+            accessible={true}
+            style={
+              {
+                "backgroundColor": "#4459ff1a",
+                "bottom": 0,
+                "flexDirection": "row",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 4,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#4459ff",
+                  "borderRadius": 2,
+                  "marginLeft": 4,
+                  "marginVertical": 4,
+                  "width": 4,
+                }
+              }
+            />
           </View>
         </TouchableOpacity>
         <View

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -415,7 +415,7 @@ const AccountActions = () => {
   ]);
 
   const goToEditAccountName = () => {
-    navigate('EditAccountName', { selectedAccount });
+    navigate(Routes.EDIT_ACCOUNT_NAME, { selectedAccount });
   };
 
   const isExplorerVisible = Boolean(

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { View } from 'react-native';
+import { InteractionManager, View } from 'react-native';
 
 // External dependencies.
 import AccountSelectorList from '../../UI/AccountSelectorList';
@@ -80,19 +80,21 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   const _onSelectAccount = useCallback(
     (address: string) => {
-      Engine.setSelectedAddress(address);
-      sheetRef.current?.onCloseBottomSheet();
-      onSelectAccount?.(address);
+      InteractionManager.runAfterInteractions(() => {
+        Engine.setSelectedAddress(address);
+        sheetRef.current?.onCloseBottomSheet();
+        onSelectAccount?.(address);
 
-      // Track Event: "Switched Account"
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.SWITCHED_ACCOUNT)
-          .addProperties({
-            source: 'Wallet Tab',
-            number_of_accounts: accounts?.length,
-          })
-          .build(),
-      );
+        // Track Event: "Switched Account"
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.SWITCHED_ACCOUNT)
+            .addProperties({
+              source: 'Wallet Tab',
+              number_of_accounts: accounts?.length,
+            })
+            .build(),
+        );
+      });
     },
     [accounts?.length, onSelectAccount, trackEvent, createEventBuilder],
   );

--- a/app/components/Views/EditAccountName/EditAccountName.test.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.test.tsx
@@ -31,6 +31,13 @@ jest.mock('../../../core/Engine', () => ({
   },
 }));
 
+// Mock InteractionManager to run callbacks immediately in tests
+const { InteractionManager } = jest.requireActual('react-native');
+
+InteractionManager.runAfterInteractions = jest.fn(async (callback) =>
+  callback(),
+);
+
 const mockInitialState = {
   swaps: { '0x1': { isLive: true }, hasOnboarded: false, isLive: true },
   wizard: {

--- a/app/components/Views/EditAccountName/EditAccountName.tsx
+++ b/app/components/Views/EditAccountName/EditAccountName.tsx
@@ -7,7 +7,7 @@ import {
   ParamListBase,
 } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { SafeAreaView } from 'react-native';
+import { InteractionManager, SafeAreaView } from 'react-native';
 
 // External dependencies
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -105,26 +105,29 @@ const EditAccountName = () => {
   };
 
   const saveAccountName = async () => {
-    if (accountName && accountName.length > 0 && selectedAccount?.address) {
-      Engine.setAccountLabel(selectedAccount?.address, accountName);
-      navigate('WalletView');
+    InteractionManager.runAfterInteractions(async () => {
+      if (accountName && accountName.length > 0 && selectedAccount?.address) {
+        Engine.setAccountLabel(selectedAccount?.address, accountName);
+        navigate('WalletView');
 
-      try {
-        const analyticsProperties = async () => {
-          const accountType = getAddressAccountType(selectedAccount?.address);
-          const account_type = accountType === 'QR' ? 'hardware' : accountType;
-          return { account_type, chain_id: getDecimalChainId(chainId) };
-        };
-        const analyticsProps = await analyticsProperties();
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.ACCOUNT_RENAMED)
-            .addProperties({ ...analyticsProps })
-            .build(),
-        );
-      } catch {
-        return {};
+        try {
+          const analyticsProperties = async () => {
+            const accountType = getAddressAccountType(selectedAccount?.address);
+            const account_type =
+              accountType === 'QR' ? 'hardware' : accountType;
+            return { account_type, chain_id: getDecimalChainId(chainId) };
+          };
+          const analyticsProps = await analyticsProperties();
+          trackEvent(
+            createEventBuilder(MetaMetricsEvents.ACCOUNT_RENAMED)
+              .addProperties({ ...analyticsProps })
+              .build(),
+          );
+        } catch {
+          return {};
+        }
       }
-    }
+    });
   };
 
   return (

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -199,6 +199,7 @@ const Routes = {
   },
   ///: END:ONLY_INCLUDE_IF
   FOX_LOADER: 'FoxLoader',
+  EDIT_ACCOUNT_NAME: 'EditAccountName',
 };
 
 export default Routes;


### PR DESCRIPTION
## **Description**
This Pr is a follow up to the various performance improvenents we have been making across the app. While this is not a major improvement I do believe we see perceived performance improvements by leveraging `InteractionManager.runAfterInteractions` from react native ([see docs](https://reactnative.dev/docs/interactionmanager)). Essentially what this does it schedules long running synchronous tasks to execute after UI interactions have completed (animations and touch events) while this does not change how long it takes to execute these actions, it ensures that the UI does not stutter as much while waiting for complex tasks to run. In this PR I leveraged this in the following ways...

1. wrapped the `onChangeSelectedAccount` in a `runAfterInteractions`
    - This ensures that the selected account change occurs after any interactions/animations on the screen have completed.
2. wrapped the logic to remove an account in a `runAfterInteractions`
    - Once again, this ensures that the UI is finished drawing before it begins to remove the account. This is useful since removing the account fires so many state updates that typically cause the AccountsList to re render.
3. wrapped the change account name logic in a `runAfterInteractions`
    - This allows the modal to close and return to the home page before the account name gets changed. This improves the perceived performance of this call.

4. Memoized the `selectedAddresses` into a Set for faster lookup and to avoid re renders.
    - old vs new logic...

```ts
// old
if (selectedAddresses) {
        const lowercasedSelectedAddresses = selectedAddresses.map(
          (selectedAddress: string) => selectedAddress.toLowerCase(),
        );
        isSelectedAccount = lowercasedSelectedAddresses.includes(
          address.toLowerCase(),
        );
      }
```

```ts
// new
let isSelectedAccount = isSelected;
      if (selectedAddressesLookup) {
        isSelectedAccount = selectedAddressesLookup.has(address.toLowerCase());
      }
```

this is an improvement in two ways, first we do not need to re create the array every time this method is called. And secondly, `set.has(item)` is an `O(1)` operation vs array.includes being `O(n)`

5. removed excessive `safeToChecksumAddress` calls
    - Instead of calling  `safeToChecksumAddress` (which does not work for Solana accounts anyway) I opted for toLowerCase instead which is slightly faster and is more appropriate for Solana accounts.

6. Improve the remove account logic
    - This improvement moves the `if (isSelected) {` to the top so that in this case we do not perform the unnecessary `accounts.find(` call. 
    - improved readability.

7. refactored `onContentSizeChanged`
    - This change only calls `accounts.find` if `selectedAddresses?.length` exists.
    - Improved readability 

## **Related issues**

Fixes:

## **Manual testing steps**

1. edit `.js.env` and change the `METAMASK_BUILD_TYPE` to `beta`
2. import / create a wallet
3. open the account list
4. change the selected account
5. open the account list again, create a solana account 
6. re open the account list, long press the solana account, then remove the account
7. re open the account list, click on the three dot menu of any account, click on edit account name, then edit the account name and hit save


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
// changing selected account 

https://github.com/user-attachments/assets/e3e04a13-be34-444c-9d06-fe1058fe1366


![Screenshot 2025-04-29 at 2 53 34 PM](https://github.com/user-attachments/assets/8de25a56-ad22-4afb-b820-63676fcd293e)

![Screenshot 2025-04-29 at 2 53 40 PM](https://github.com/user-attachments/assets/d15b3827-0e74-4f24-b44a-1880e6908e0c)


// removing a solana account


https://github.com/user-attachments/assets/76910675-cf5e-4cfd-87b3-3fd6b808051e

![Screenshot 2025-04-29 at 2 56 37 PM](https://github.com/user-attachments/assets/92a7e38b-00b8-4dae-9687-e4d89cf3b93e)


![Screenshot 2025-04-29 at 2 56 44 PM](https://github.com/user-attachments/assets/db920911-c6da-4e88-93c4-2b21d07932f6)


![Screenshot 2025-04-29 at 2 56 52 PM](https://github.com/user-attachments/assets/46482adb-ab0e-4b0f-8dbb-8e805e831e98)

// changing account name


https://github.com/user-attachments/assets/59a1e614-5d70-414e-ad22-fdc447df48b7


![Screenshot 2025-04-29 at 2 59 10 PM](https://github.com/user-attachments/assets/690ac554-ad06-403b-bbd3-37ebc3e31c87)

![Screenshot 2025-04-29 at 2 59 20 PM](https://github.com/user-attachments/assets/bf869030-d6c1-43ee-9146-efe7e78e623a)

### **After**
// Changing selected account


https://github.com/user-attachments/assets/1b1ae148-4563-4d8b-9139-554ccae61f64

![Screenshot 2025-04-29 at 2 29 48 PM](https://github.com/user-attachments/assets/56fce485-c76c-45d5-8925-005b6777d6b6)

![Screenshot 2025-04-29 at 2 30 36 PM](https://github.com/user-attachments/assets/735ca707-de7e-4d8b-8f5e-0b564178f39c)

// removing a Solana account


https://github.com/user-attachments/assets/7f8b8939-d5e9-4a00-917b-553ce5cda187

![Screenshot 2025-04-29 at 2 33 46 PM](https://github.com/user-attachments/assets/a7530f16-e30d-41c0-a96a-477285c1ef68)

![Screenshot 2025-04-29 at 2 34 05 PM](https://github.com/user-attachments/assets/811be374-e31d-4f18-9af6-84a92ec2963a)

// changing account name.


https://github.com/user-attachments/assets/0e395732-574b-479e-b457-2f9715bbe397

![Screenshot 2025-04-29 at 2 39 14 PM](https://github.com/user-attachments/assets/caaacfad-4e9b-4f02-bcd0-19dc27e7f93d)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
