### PR TITLE
perf: cp-7.46.0 optimise useGetFormattedTokensPerChain reselector recomputations

### DIFF
--- a/app/components/hooks/useGetFormattedTokensPerChain.tsx
+++ b/app/components/hooks/useGetFormattedTokensPerChain.tsx
@@ -1,4 +1,8 @@
 import { useSelector } from 'react-redux';
+import { useEffect, useMemo, useRef } from 'react';
+import { MarketDataDetails, Token } from '@metamask/assets-controllers';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { isEqual } from 'lodash';
 import { selectAllTokens } from '../../selectors/tokensController';
 import { selectAllTokenBalances } from '../../selectors/tokenBalancesController';
 import {
@@ -10,17 +14,13 @@ import {
   selectChainId,
   selectNetworkConfigurations,
 } from '../../selectors/networkController';
-import { selectTokenMarketData } from '../../selectors/tokenRatesController';
+import { selectTokenMarketPriceData } from '../../selectors/tokenRatesController';
 import {
   selectCurrencyRates,
   selectCurrentCurrency,
 } from '../../selectors/currencyRateController';
-import { MarketDataDetails, Token } from '@metamask/assets-controllers';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { isTestNet } from '../../util/networks';
 import { selectShowFiatInTestnets } from '../../selectors/settings';
-import { useMemo } from 'react';
-
 interface AllTokens {
   [chainId: string]: {
     [tokenAddress: string]: Token[];
@@ -51,6 +51,32 @@ export interface MarketDataMapping {
   };
 }
 
+/**
+ * Ensures that a field is a stable reference.
+ * For example a consumer of a hook could unintentionally pass in a hardcoded array:
+ * ```
+ * useGetFormattedTokensPerChain([internalAccount]) // BAD since it always is a new reference!
+ * ```
+ *
+ * Using this allows the consumer of the hook to be a bit more flexible
+ * ```
+ * useGetFormattedTokensPerChain([internalAccount]) // This is okay now
+ * ```
+ * @param value - unstable property
+ * @returns - stable property
+ */
+const useStableReference = <T,>(value: T) => {
+  const ref = useRef(value);
+
+  useEffect(() => {
+    if (!isEqual(ref.current, value)) {
+      ref.current = value;
+    }
+  }, [value]);
+
+  return ref.current;
+};
+
 export const useGetFormattedTokensPerChain = (
   accounts: InternalAccount[],
   shouldAggregateAcrossChains: boolean, // We don't always want to aggregate across chains.
@@ -61,6 +87,9 @@ export const useGetFormattedTokensPerChain = (
     tokensWithBalances: TokensWithBalances[];
   }[];
 } => {
+  const stableAccounts = useStableReference(accounts);
+  const stableAllChainIDs = useStableReference(allChainIDs);
+
   // TODO: [SOLANA] Revisit this before shipping, `selectAllTokenBalances` selector needs to most likely be replaced by a non evm supported version
   const currentChainId = useSelector(selectChainId);
   const importedTokens: AllTokens = useSelector(selectAllTokens);
@@ -75,7 +104,7 @@ export const useGetFormattedTokensPerChain = (
     selectAllTokenBalances,
   );
 
-  const marketData: MarketDataMapping = useSelector(selectTokenMarketData);
+  const marketData = useSelector(selectTokenMarketPriceData);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const currencyRates = useSelector(selectCurrencyRates);
   const showFiatOnTestnets = useSelector(selectShowFiatInTestnets);
@@ -83,13 +112,14 @@ export const useGetFormattedTokensPerChain = (
   return useMemo(() => {
     //If the current network is a testnet, UI should display 0 unless conversions are enabled
     const validAccounts =
-      accounts.length > 0 && accounts.every((item) => item !== undefined);
+      stableAccounts.length > 0 &&
+      stableAccounts.every((item) => item !== undefined);
     if (!validAccounts || (isTestNet(currentChainId) && !showFiatOnTestnets)) {
       return {};
     }
 
     const networksToFormat = shouldAggregateAcrossChains
-      ? allChainIDs
+      ? stableAllChainIDs
       : [currentChainId];
 
     function getTokenFiatBalances({
@@ -104,7 +134,7 @@ export const useGetFormattedTokensPerChain = (
       accountAddress: string;
       chainId: string;
       tokenExchangeRates: {
-        [tokenAddress: string]: MarketDataDetails;
+        [tokenAddress: string]: { price: number };
       };
       conversionRate: number;
       decimalsToShow: number | undefined;
@@ -146,7 +176,7 @@ export const useGetFormattedTokensPerChain = (
       }[];
     } = {};
 
-    for (const account of accounts) {
+    for (const account of stableAccounts) {
       const formattedPerNetwork = [];
       for (const singleChain of networksToFormat) {
         // Skip if the network configuration doesn't exist
@@ -179,8 +209,8 @@ export const useGetFormattedTokensPerChain = (
 
     return result;
   }, [
-    accounts,
-    allChainIDs,
+    stableAccounts,
+    stableAllChainIDs,
     allNetworks,
     currentChainId,
     currentCurrency,

--- a/app/selectors/tokenBalancesController.ts
+++ b/app/selectors/tokenBalancesController.ts
@@ -5,6 +5,7 @@ import { RootState } from '../reducers';
 import { TokenBalancesControllerState } from '@metamask/assets-controllers';
 import { selectSelectedInternalAccountAddress } from './accountsController';
 import { selectEvmChainId } from './networkController';
+import { createDeepEqualSelector } from './util';
 
 const selectTokenBalancesControllerState = (state: RootState) =>
   state.engine.backgroundState.TokenBalancesController;
@@ -29,7 +30,7 @@ export const selectContractBalances = createSelector(
     ]?.[chainId as Hex] ?? {},
 );
 
-export const selectAllTokenBalances = createSelector(
+export const selectAllTokenBalances = createDeepEqualSelector(
   selectTokenBalancesControllerState,
   (tokenBalancesControllerState: TokenBalancesControllerState) =>
     tokenBalancesControllerState.tokenBalances,

--- a/app/selectors/tokenRatesController.test.ts
+++ b/app/selectors/tokenRatesController.test.ts
@@ -1,0 +1,137 @@
+import { MarketDataDetails } from '@metamask/assets-controllers';
+import { RootState } from '../reducers';
+import {
+  selectContractExchangeRates,
+  selectContractExchangeRatesByChainId,
+  selectTokenMarketData,
+  selectTokenMarketDataByChainId,
+  selectTokenMarketPriceData,
+} from './tokenRatesController';
+
+const createMockState = () =>
+  ({
+    engine: {
+      backgroundState: {
+        TokenRatesController: {
+          marketData: {},
+        },
+      },
+    },
+  } as RootState);
+
+const createMockMarketTokenDetails = () => {
+  const mockChainMarketDetails = {
+    '0x111': {
+      price: 0.1,
+    } as MarketDataDetails,
+  };
+  return mockChainMarketDetails;
+};
+
+describe('selectContractExchangeRates', () => {
+  const arrange = () => {
+    const mockState = createMockState();
+    const mockChainMarketDetails = createMockMarketTokenDetails();
+    mockState.engine.backgroundState.TokenRatesController.marketData = {
+      '0x1': mockChainMarketDetails,
+    };
+
+    return {
+      mockChainMarketDetails,
+      mockState,
+    };
+  };
+
+  it('returns marketData for selected chain', () => {
+    const { mockState, mockChainMarketDetails } = arrange();
+    expect(selectContractExchangeRates(mockState)).toStrictEqual(
+      mockChainMarketDetails,
+    );
+  });
+});
+
+describe('selectContractExchangeRatesByChainId', () => {
+  const arrange = () => {
+    const mockState = createMockState();
+    const mockChainMarketDetails = createMockMarketTokenDetails();
+    mockState.engine.backgroundState.TokenRatesController.marketData = {
+      '0x1': mockChainMarketDetails,
+    };
+
+    return {
+      mockChainMarketDetails,
+      mockState,
+    };
+  };
+
+  it('returns marketData for explicitly provided chain id', () => {
+    const { mockState, mockChainMarketDetails } = arrange();
+    expect(
+      selectContractExchangeRatesByChainId(mockState, '0x1'),
+    ).toStrictEqual(mockChainMarketDetails);
+  });
+});
+
+describe('selectTokenMarketData', () => {
+  it('returns market data for all chains and tokens', () => {
+    const mockState = createMockState();
+    expect(selectTokenMarketData(mockState)).toStrictEqual(
+      mockState.engine.backgroundState.TokenRatesController.marketData,
+    );
+  });
+});
+
+describe('selectTokenMarketPriceData', () => {
+  const arrange = () => {
+    const mockState = createMockState();
+    const mockChainMarketDetails = createMockMarketTokenDetails();
+    mockChainMarketDetails['0x111'].allTimeHigh = 50;
+    mockState.engine.backgroundState.TokenRatesController.marketData = {
+      '0x1': mockChainMarketDetails,
+    };
+
+    return {
+      mockChainMarketDetails,
+      mockState,
+    };
+  };
+
+  it('returns slimmed market data with only the price field', () => {
+    const { mockState, mockChainMarketDetails } = arrange();
+    const result = selectTokenMarketPriceData(mockState);
+    expect(result).toStrictEqual({
+      '0x1': {
+        '0x111': { price: mockChainMarketDetails['0x111'].price },
+      },
+    });
+  });
+});
+
+describe('selectTokenMarketDataByChainId', () => {
+  const arrange = () => {
+    const mockState = createMockState();
+    const mockChainMarketDetails = createMockMarketTokenDetails();
+    mockState.engine.backgroundState.TokenRatesController.marketData = {
+      '0x1': mockChainMarketDetails,
+    };
+
+    return {
+      mockChainMarketDetails,
+      mockState,
+    };
+  };
+
+  it('returns marketData for explicitly provided chain id', () => {
+    const { mockState, mockChainMarketDetails } = arrange();
+    expect(selectTokenMarketDataByChainId(mockState, '0x1')).toStrictEqual(
+      mockChainMarketDetails,
+    );
+  });
+
+  it('fallbacks to an empty object', () => {
+    const { mockState } = arrange();
+    expect(selectTokenMarketDataByChainId(mockState, '0x999')).toStrictEqual(
+      {},
+    );
+  });
+});

--- a/app/selectors/tokenRatesController.ts
+++ b/app/selectors/tokenRatesController.ts
@@ -5,7 +5,6 @@ import { RootState } from '../reducers';
 import { selectEvmChainId } from './networkController';
 import { Hex } from '@metamask/utils';
 import { createDeepEqualSelector } from './util';
-import Logger from '../util/Logger';
 
 /**
  * utility similar to lodash.mapValues.
@@ -48,16 +47,11 @@ export const selectTokenMarketData = createSelector(
 export const selectTokenMarketPriceData = createDeepEqualSelector(
   [selectTokenMarketData],
   (marketData) => {
-    try {
-      const marketPriceData = mapValues(marketData, (tokenData) =>
-        mapValues(tokenData, (tokenInfo) => ({ price: tokenInfo?.price })),
-      );
+    const marketPriceData = mapValues(marketData, (tokenData) =>
+      mapValues(tokenData, (tokenInfo) => ({ price: tokenInfo?.price })),
+    );
 
-      return marketPriceData;
-    } catch (e) {
-      Logger.log('FAILED', marketData, e);
-      throw e;
-    }
+    return marketPriceData;
   },
 );
 

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -82,7 +82,7 @@ export const selectDetectedTokens = createSelector(
     ],
 );
 
-export const selectAllTokens = createSelector(
+export const selectAllTokens = createDeepEqualSelector(
   selectTokensControllerState,
   (tokensControllerState: TokensControllerState) =>
     tokensControllerState?.allTokens,


### PR DESCRIPTION
## **Description**

This hook uses selectors the kept recomputing and returning new data.
We have now made some of these selectors use `createDeepEqualSelector` so they don't recompute, as well as a more specific market data selector to just grab the price property.

## **Related issues**

Fixes:

## **Manual testing steps**

N/A - no changes have been made.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
