### PR TITLE
perf: cp-7.46.0 prevent account notification rerenders

### DIFF
--- a/app/reducers/notification/index.js
+++ b/app/reducers/notification/index.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { NotificationTypes } from '../../util/notifications';
 const { TRANSACTION, SIMPLE } = NotificationTypes;
 
@@ -26,8 +27,13 @@ const enqueue = (notifications, notification) => [
 ];
 const dequeue = (notifications) => notifications.slice(1);
 
-export const currentNotificationSelector = (state) =>
-  state?.notifications[0] || {};
+export const currentNotificationSelector = createSelector(
+  (
+    /** @type {import('..').RootState} */
+    state,
+  ) => state?.notifications,
+  (notifications) => notifications[0] || {},
+);
 
 const notificationReducer = (state = initialState, action) => {
   const { notifications } = state;


### PR DESCRIPTION
## **Description**

We had an unstable selector that cause this component to constantly re-render.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
