### PR TITLE
fix: Removes transaction simulations from send flow confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(multi-srp): display errors only after all the words are have been entered ([#14607](https://github.com/MetaMask/metamask-mobile/pull/14607))
 - fix(wallet-ux): increased touchable area for account picker so it is easier to select ([#14762](https://github.com/MetaMask/metamask-mobile/pull/14762))
 - fix(multi-srp): display alternative text color when in dark mode([#14718](https://github.com/MetaMask/metamask-mobile/pull/14718))
+- fix(confirmations): remove transaction simulations from wallet initiated send flow ([#14994](https://github.com/MetaMask/metamask-mobile/pull/14994))
 
 ### Fixed
 

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -122,8 +122,6 @@ import {
   selectConfirmationMetrics,
   updateConfirmationMetric,
 } from '../../../../../../core/redux/slices/confirmationMetrics';
-import SimulationDetails from '../../../../../UI/SimulationDetails/SimulationDetails';
-import { selectUseTransactionSimulations } from '../../../../../../selectors/preferencesController';
 import {
   validateSufficientTokenBalance,
   validateSufficientBalance,
@@ -286,10 +284,6 @@ class Confirm extends PureComponent {
      * Update confirmation metrics
      */
     updateConfirmationMetric: PropTypes.func,
-    /**
-     * Indicates whether the transaction simulations feature is enabled
-     */
-    useTransactionSimulations: PropTypes.bool,
     /**
      * Object containing blockaid validation response for confirmation
      */
@@ -1379,9 +1373,6 @@ class Confirm extends PureComponent {
       gasEstimateType,
       isNativeTokenBuySupported,
       shouldUseSmartTransaction,
-      transactionMetadata,
-      transactionState,
-      useTransactionSimulations,
     } = this.props;
     const { nonce } = this.props.transaction;
     const {
@@ -1412,7 +1403,6 @@ class Confirm extends PureComponent {
     const isLedgerAccount = isHardwareAccount(fromSelectedAddress, [
       ExtendedKeyringTypes.ledger,
     ]);
-    const transactionSimulationData = transactionMetadata?.simulationData;
 
     const isTestNetwork = isTestNet(chainId);
 
@@ -1486,16 +1476,6 @@ class Confirm extends PureComponent {
               </View>
             </View>
           )}
-          {useTransactionSimulations &&
-            transactionState?.id &&
-            transactionMetadata && (
-              <View style={styles.simulationWrapper}>
-                <SimulationDetails
-                  transaction={transactionMetadata}
-                  enableMetrics
-                />
-              </View>
-            )}
           <TransactionReview
             gasSelected={this.state.gasSelected}
             primaryCurrency={primaryCurrency}
@@ -1643,7 +1623,6 @@ const mapStateToProps = (state) => {
     shouldUseSmartTransaction: selectShouldUseSmartTransaction(state),
     confirmationMetricsById: selectConfirmationMetrics(state),
     transactionMetadata: selectCurrentTransactionMetadata(state),
-    useTransactionSimulations: selectUseTransactionSimulations(state),
     securityAlertResponse: selectCurrentTransactionSecurityAlertResponse(state),
     maxValueMode: state.transaction.maxValueMode,
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Transaction simulations should not appear in "Send" flow initiated by wallet. We must trust the result since this transaction is initiated from wallet. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4786

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
