### PR TITLE
cp-7.46.0 srp pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(bridge): fetch token metadata for Bridge token pickers if not already available ([#14699](https://github.com/MetaMask/metamask-mobile/pull/14699))
 - feat(bridge): use `BridgeStatusController` for EVM and Solana Bridge transaction submission ([#14708](https://github.com/MetaMask/metamask-mobile/pull/14708))
 - feat: real time dapp scanning BrowserTab ([#14515](https://github.com/MetaMask/metamask-mobile/pull/14515))
+- feat(multi-srp): add new srp pills labels ([#14829](https://github.com/MetaMask/metamask-mobile/pull/14829))
 
 ### Changed
 

--- a/app/components/UI/AccountApproval/index.test.tsx
+++ b/app/components/UI/AccountApproval/index.test.tsx
@@ -24,6 +24,12 @@ jest.mock('../../../core/Engine', () => {
               accounts: ['0xC4966c0D659D99699BFD7EB54D8fafEE40e4a756'],
             },
           ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
         },
       },
       AccountsController: {

--- a/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.test.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AccountFromToInfoCard.test.tsx
@@ -14,6 +14,7 @@ import { createMockAccountsControllerState } from '../../../util/test/accountsCo
 import { RootState } from '../../../reducers';
 import { AssetsContractController } from '@metamask/assets-controllers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { MOCK_KEYRING_CONTROLLER_STATE } from '../../../util/test/keyringControllerTestUtils';
 
 const MOCK_ADDRESS_1 = '0xe64dD0AB5ad7e8C5F2bf6Ce75C34e187af8b920A';
 const MOCK_ADDRESS_2 = '0x519d2CE57898513F676a5C3b66496c3C394c9CC7';
@@ -50,6 +51,11 @@ const mockInitialState: DeepPartial<RootState> = {
         },
       },
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
+      KeyringController: {
+        vault: 'mock-vault',
+        isUnlocked: true,
+        ...MOCK_KEYRING_CONTROLLER_STATE,
+      },
     },
   },
 };
@@ -63,6 +69,8 @@ const mockGetERC20BalanceOf = jest.fn().mockReturnValue(0x0186a0);
 jest.mock('../../../core/Engine', () => {
   const { MOCK_ACCOUNTS_CONTROLLER_STATE: mockAccountsControllerState } =
     jest.requireActual('../../../util/test/accountsControllerTestUtils');
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+
   return {
     context: {
       TokensController: {
@@ -72,11 +80,18 @@ jest.mock('../../../core/Engine', () => {
         state: {
           keyrings: [
             {
+              type: KeyringTypes.hd,
               accounts: [
                 '0xe64dD0AB5ad7e8C5F2bf6Ce75C34e187af8b920A',
                 '0x519d2CE57898513F676a5C3b66496c3C394c9CC7',
                 '0x07Be9763a718C0539017E2Ab6fC42853b4aEeb6B',
               ],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
             },
           ],
         },

--- a/app/components/UI/AccountOverview/index.test.tsx
+++ b/app/components/UI/AccountOverview/index.test.tsx
@@ -14,6 +14,8 @@ const mockedEngine = Engine;
 jest.mock('../../../core/Engine', () => {
   const { MOCK_ACCOUNTS_CONTROLLER_STATE: mockAccountsControllerState } =
     jest.requireActual('../../../util/test/accountsControllerTestUtils');
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+
   return {
     init: () => mockedEngine.init({}),
     context: {
@@ -24,7 +26,13 @@ jest.mock('../../../core/Engine', () => {
             {
               accounts: ['0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272'],
               index: 0,
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
             },
           ],
         },

--- a/app/components/UI/Bridge/components/DestinationAccountSelector.tsx/DestinationAccountSelector.test.tsx
+++ b/app/components/UI/Bridge/components/DestinationAccountSelector.tsx/DestinationAccountSelector.test.tsx
@@ -7,26 +7,48 @@ import DestinationAccountSelector from './index';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 
 // Mock Engine
-jest.mock('../../../../../core/Engine', () => ({
-  context: {
-    AccountsController: {
-      state: {
-        internalAccounts: {
-          accounts: {
-            '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi': {
-              address: '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
-              name: 'Account 1',
-            },
-            '5vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi': {
-              address: '5vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
-              name: 'Account 2',
+jest.mock('../../../../../core/Engine', () => {
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+  return {
+    context: {
+      AccountsController: {
+        state: {
+          internalAccounts: {
+            accounts: {
+              '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi': {
+                address: '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+                name: 'Account 1',
+              },
+              '5vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi': {
+                address: '5vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+                name: 'Account 2',
+              },
             },
           },
         },
       },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: [
+                '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+                '5vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+              ],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
+        },
+      },
     },
-  },
-}));
+  };
+});
 
 // Mock React Native Linking
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
@@ -140,7 +162,9 @@ describe('DestinationAccountSelector', () => {
   it('clears destination address when close button is pressed', () => {
     const { getByTestId, store } = renderComponent();
     // The close button is a ButtonIcon component with IconName.Close
-    const closeButton = getByTestId('cellselect').findByProps({ iconName: 'Close' });
+    const closeButton = getByTestId('cellselect').findByProps({
+      iconName: 'Close',
+    });
     fireEvent.press(closeButton);
 
     const actions = store.getActions();
@@ -186,7 +210,9 @@ describe('DestinationAccountSelector', () => {
 
   it('clears destination when close button is pressed', () => {
     const { getByTestId, store } = renderComponent();
-    const closeButton = getByTestId('cellselect').findByProps({ iconName: 'Close' });
+    const closeButton = getByTestId('cellselect').findByProps({
+      iconName: 'Close',
+    });
     fireEvent.press(closeButton);
 
     const actions = store.getActions();

--- a/app/components/UI/WalletAccount/WalletAccount.test.tsx
+++ b/app/components/UI/WalletAccount/WalletAccount.test.tsx
@@ -39,12 +39,15 @@ const mockAccount: Account = {
 jest.mock('../../../core/Engine', () => {
   const { MOCK_ACCOUNTS_CONTROLLER_STATE: mockAccountsControllerState } =
     jest.requireActual('../../../util/test/accountsControllerTestUtils');
+  const { MOCK_KEYRING_CONTROLLER_STATE: mockKeyringControllerState } =
+    jest.requireActual('../../../util/test/keyringControllerTestUtils');
   return {
     context: {
       AccountsController: {
         ...mockAccountsControllerState,
         state: mockAccountsControllerState,
       },
+      KeyringController: { state: mockKeyringControllerState },
     },
   };
 });

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -65,6 +65,7 @@ jest.mock('../../../core/Engine', () => {
     [MOCK_ADDRESS_1, MOCK_ADDRESS_2],
     MOCK_ADDRESS_1,
   );
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
 
   return {
     context: {
@@ -80,6 +81,22 @@ jest.mock('../../../core/Engine', () => {
       },
       AccountsController: {
         state: mockAccountsState,
+      },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: [MOCK_ADDRESS_1, MOCK_ADDRESS_2],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
+        },
       },
     },
   };

--- a/app/components/Views/AccountConnect/AccountConnectMultiSelector/AccountConnectMultiSelector.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnectMultiSelector/AccountConnectMultiSelector.test.tsx
@@ -23,31 +23,51 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-jest.mock('../../../../core/Engine', () => ({
-  context: {
-    PermissionController: {
-      revokeAllPermissions: jest.fn(),
-    },
-    AccountsController: {
-      state: {
-        internalAccounts: {
-          accounts: {
-            '0x1234': {
-              address: '0x1234',
-              name: 'Account 1',
-              type: 'simple',
-            },
-            '0x5678': {
-              address: '0x5678',
-              name: 'Account 2',
-              type: 'simple',
+jest.mock('../../../../core/Engine', () => {
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+  return {
+    context: {
+      PermissionController: {
+        revokeAllPermissions: jest.fn(),
+      },
+      AccountsController: {
+        state: {
+          internalAccounts: {
+            accounts: {
+              '0x1234': {
+                address: '0x1234',
+                name: 'Account 1',
+                type: 'simple',
+              },
+              '0x5678': {
+                address: '0x5678',
+                name: 'Account 2',
+                type: 'simple',
+              },
             },
           },
         },
       },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: ['0x1234', '0x5678'],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
+        },
+      },
     },
-  },
-}));
+  };
+});
 
 const mockAccounts = [
   {

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -23,6 +23,8 @@ jest.mock('../../../util/address', () => {
 jest.mock('../../../core/Engine', () => {
   const { MOCK_ACCOUNTS_CONTROLLER_STATE: mockAccountsControllerState } =
     jest.requireActual('../../../util/test/accountsControllerTestUtils');
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+
   return {
     getTotalEvmFiatAccountBalance: jest.fn().mockReturnValue({
       totalNativeTokenBalance: { amount: '1', unit: 'ETH' },
@@ -61,6 +63,13 @@ jest.mock('../../../core/Engine', () => {
           keyrings: [
             {
               accounts: ['0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272'],
+              type: KeyringTypes.hd,
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
             },
           ],
         },

--- a/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
+++ b/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
@@ -10,37 +10,56 @@ import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmat
 import * as TransactionMetadataRequestHook from '../../../hooks/transactions/useTransactionMetadataRequest';
 import ContractInteraction from './contract-interaction';
 
-jest.mock('../../../../../../core/Engine', () => ({
-  getTotalFiatAccountBalance: () => ({ tokenFiat: 10 }),
-  context: {
-    NetworkController: {
-      getNetworkConfigurationByNetworkClientId: jest.fn(),
-    },
-    GasFeeController: {
-      startPolling: jest.fn(),
-      stopPollingByPollingToken: jest.fn(),
-    },
-    AccountsController: {
-      state: {
-        internalAccounts: {
-          accounts: {
-            '0x0000000000000000000000000000000000000000': {
-              address: '0x0000000000000000000000000000000000000000',
+jest.mock('../../../../../../core/Engine', () => {
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+  return {
+    context: {
+      getTotalFiatAccountBalance: () => ({ tokenFiat: 10 }),
+      NetworkController: {
+        getNetworkConfigurationByNetworkClientId: jest.fn(),
+      },
+      GasFeeController: {
+        startPolling: jest.fn(),
+        stopPollingByPollingToken: jest.fn(),
+      },
+      AccountsController: {
+        state: {
+          internalAccounts: {
+            accounts: {
+              '0x0000000000000000000000000000000000000000': {
+                address: '0x0000000000000000000000000000000000000000',
+              },
             },
           },
         },
       },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: ['0x0000000000000000000000000000000000000000'],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
+        },
+      },
     },
-  },
-  getTotalEvmFiatAccountBalance: jest.fn().mockReturnValue({
-    ethFiat: 0,
-    ethFiat1dAgo: 0,
-    tokenFiat: 0,
-    tokenFiat1dAgo: 0,
-    totalNativeTokenBalance: '0',
-    ticker: 'ETH',
-  }),
-}));
+    getTotalEvmFiatAccountBalance: jest.fn().mockReturnValue({
+      ethFiat: 0,
+      ethFiat1dAgo: 0,
+      tokenFiat: 0,
+      tokenFiat1dAgo: 0,
+      totalNativeTokenBalance: '0',
+      ticker: 'ETH',
+    }),
+  };
+});
 
 jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),

--- a/app/components/Views/confirmations/components/rows/account-network-info-row/account-network-info-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/account-network-info-row/account-network-info-row.test.tsx
@@ -4,22 +4,41 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { personalSignatureConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
 import AccountNetworkInfo from './account-network-info-row';
 
-jest.mock('../../../../../../core/Engine', () => ({
-  getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
-  context: {
-    AccountsController: {
-      state: {
-        internalAccounts: {
-          accounts: {
-            '1': {
-              address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+jest.mock('../../../../../../core/Engine', () => {
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
+  return {
+    getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
+    context: {
+      AccountsController: {
+        state: {
+          internalAccounts: {
+            accounts: {
+              '1': {
+                address: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+              },
             },
           },
         },
       },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: ['0x935e73edb9ff52e23bac7f7e043a1ecd06d05477'],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          ],
+        },
+      },
     },
-  },
-}));
+  };
+});
 
 describe('AccountNetworkInfo', () => {
   it('should render correctly', async () => {

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.test.tsx
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.test.tsx
@@ -72,6 +72,7 @@ const mockInitialState: DeepPartial<RootState> = {
       },
       KeyringController: {
         keyrings: [{ accounts: ['0x'], type: 'HD Key Tree' }],
+        keyringsMetadata: [{ id: '01JNG71B7GTWH0J1TSJY9891S0', name: '' }],
       },
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
     },
@@ -149,6 +150,7 @@ jest.mock('../../../../../../core/Engine', () => {
               accounts: ['0x15249D1a506AFC731Ee941d0D40Cf33FacD34E58'],
             },
           ],
+          keyringsMetadata: [{ id: '01JNG71B7GTWH0J1TSJY9891S0', name: '' }],
         },
       },
       TransactionController: {

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/index.test.jsx
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/index.test.jsx
@@ -13,6 +13,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import * as TransactionUtils from '../../../../../../util/transactions';
 // eslint-disable-next-line import/no-namespace
 import { FALSE_POSITIVE_REPOST_LINE_TEST_ID } from '../BlockaidBanner/BlockaidBanner.constants';
+import { MOCK_KEYRING_CONTROLLER_STATE } from '../../../../../../util/test/keyringControllerTestUtils';
 
 jest.mock('../../../../../../util/transactions', () => ({
   ...jest.requireActual('../../../../../../util/transactions'),
@@ -68,14 +69,24 @@ const MOCK_ACCOUNTS_CONTROLLER_STATE =
 
 jest.mock('../../../../../../core/Engine', () => {
   const { MOCK_ACCOUNTS_CONTROLLER_STATE: mockAccountsControllerState } =
-    jest.requireActual('../../../../../../util/test/accountsControllerTestUtils');
+    jest.requireActual(
+      '../../../../../../util/test/accountsControllerTestUtils',
+    );
+  const { KeyringTypes } = jest.requireActual('@metamask/keyring-controller');
   return {
     context: {
       KeyringController: {
         state: {
           keyrings: [
             {
+              type: KeyringTypes.hd,
               accounts: ['0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272'],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
             },
           ],
         },
@@ -122,6 +133,7 @@ const mockState = {
         securityAlertsEnabled: true,
       },
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
+      KeyringController: MOCK_KEYRING_CONTROLLER_STATE,
     },
   },
   settings: {

--- a/app/core/__mocks__/MockedEngine.ts
+++ b/app/core/__mocks__/MockedEngine.ts
@@ -7,7 +7,9 @@ import { MOCK_KEYRING_CONTROLLER_STATE } from '../../util/test/keyringController
 export const mockedEngine = {
   init: () => Engine.init({}),
   context: {
-    KeyringController: MOCK_KEYRING_CONTROLLER_STATE,
+    KeyringController: {
+      state: MOCK_KEYRING_CONTROLLER_STATE,
+    },
     NetworkController: {
       getNetworkClientById: (networkClientId: NetworkClientId) => {
         if (networkClientId === 'linea_goerli') {

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -22,9 +22,10 @@ import {
 import {
   mockHDKeyringAddress,
   mockQrKeyringAddress,
+  mockSecondHDKeyringAddress,
   mockSimpleKeyringAddress,
   mockSnapAddress1,
-  mockSnapAddress2,
+  mockSolanaAddress,
 } from '../test/keyringControllerTestUtils';
 import {
   internalAccount1,
@@ -59,7 +60,8 @@ jest.mock('../../core/Engine', () => {
       KeyringController: {
         ...MOCK_KEYRING_CONTROLLER_STATE,
         state: {
-          keyrings: [...MOCK_KEYRING_CONTROLLER_STATE.state.keyrings],
+          keyrings: [...MOCK_KEYRING_CONTROLLER_STATE.keyrings],
+          keyringsMetadata: [...MOCK_KEYRING_CONTROLLER_STATE.keyringsMetadata],
         },
       },
       AccountsController: {
@@ -474,12 +476,6 @@ describe('getLabelTextByAddress,', () => {
     expect(getLabelTextByAddress(mockSnapAddress1)).toBe('Snaps (Beta)');
   });
 
-  it('returns the snap name if account is a Snap keyring and there is a snap name', () => {
-    expect(getLabelTextByAddress(mockSnapAddress2)).toBe(
-      'MetaMask Simple Snap Keyring',
-    );
-  });
-
   it('should return null if address is empty', () => {
     expect(getLabelTextByAddress('')).toBe(null);
   });
@@ -488,6 +484,14 @@ describe('getLabelTextByAddress,', () => {
     expect(
       getLabelTextByAddress('0xD5955C0d639D99699Bfd7Ec54d9FaFEe40e4D278'),
     ).toBe(null);
+  });
+
+  it('returns srp label for hd accounts when there are multiple hd keyrings', () => {
+    expect(getLabelTextByAddress(mockSecondHDKeyringAddress)).toBe('SRP #2');
+  });
+
+  it('returns srp label for snap accounts that uses hd keyring for its entropy source', () => {
+    expect(getLabelTextByAddress(mockSolanaAddress)).toBe('SRP #1');
   });
 });
 describe('getAddressAccountType', () => {

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -35,6 +35,7 @@ import Logger from '../../../app/util/Logger';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { AddressBookControllerState } from '@metamask/address-book-controller';
 import {
+  isEqualCaseInsensitive,
   type NetworkType,
   toChecksumHexAddress,
 } from '@metamask/controller-utils';
@@ -44,6 +45,7 @@ import type {
 } from '@metamask/network-controller';
 import {
   AccountImportStrategy,
+  KeyringObject,
   KeyringTypes,
 } from '@metamask/keyring-controller';
 import { type Hex, isHexString } from '@metamask/utils';
@@ -307,10 +309,33 @@ export function getInternalAccountByAddress(
  */
 export function getLabelTextByAddress(address: string) {
   if (!address) return null;
+  const { KeyringController } = Engine.context;
+  const { keyrings, keyringsMetadata } = KeyringController.state;
   const internalAccount = getInternalAccountByAddress(address);
+  const hdKeyringsWithMetadata = keyrings
+    .map((keyring, index) => ({
+      ...keyring,
+      metadata: keyringsMetadata[index],
+    }))
+    .filter((keyring) => keyring.type === ExtendedKeyringTypes.hd);
   const keyring = internalAccount?.metadata?.keyring;
+
   if (keyring) {
     switch (keyring.type) {
+      case ExtendedKeyringTypes.hd:
+        if (hdKeyringsWithMetadata.length > 1) {
+          const hdKeyringIndex = hdKeyringsWithMetadata.findIndex(
+            (kr: KeyringObject) =>
+              kr.accounts.find((account) =>
+                isEqualCaseInsensitive(account, address),
+              ),
+          );
+          // -1 means the address is not found in any of the hd keyrings
+          if (hdKeyringIndex !== -1) {
+            return strings('accounts.srp_index', { index: hdKeyringIndex + 1 }); // Add 1 to make it 1-indexed
+          }
+        }
+        break;
       case ExtendedKeyringTypes.ledger:
         return strings('accounts.ledger');
       case ExtendedKeyringTypes.qr:
@@ -318,11 +343,26 @@ export function getLabelTextByAddress(address: string) {
       case ExtendedKeyringTypes.simple:
         return strings('accounts.imported');
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-      case KeyringTypes.snap:
-        return (
-          internalAccount?.metadata.snap?.name ||
-          strings('accounts.snap_account_tag')
+      case KeyringTypes.snap: {
+        const { entropySource } = internalAccount?.options || {};
+        if (entropySource) {
+          const hdKeyringIndex = hdKeyringsWithMetadata.findIndex(
+            (kr) => kr.metadata.id === entropySource,
+          );
+          // -1 means the address is not found in any of the hd keyrings
+          if (hdKeyringIndex !== -1) {
+            return strings('accounts.srp_index', { index: hdKeyringIndex + 1 });
+          }
+        }
+
+        const isPreinstalledSnap = PREINSTALLED_SNAPS.some(
+          (snap) => snap.snapId === internalAccount?.metadata.snap?.id,
         );
+
+        if (!isPreinstalledSnap) {
+          return strings('accounts.snap_account_tag');
+        }
+      }
       ///: END:ONLY_INCLUDE_IF
     }
   }

--- a/app/util/test/accountsControllerTestUtils.ts
+++ b/app/util/test/accountsControllerTestUtils.ts
@@ -20,9 +20,11 @@ import {
 import { KeyringTypes } from '@metamask/keyring-controller';
 import {
   mockQrKeyringAddress,
+  mockSecondHDKeyringAddress,
   mockSimpleKeyringAddress,
   mockSnapAddress1,
   mockSnapAddress2,
+  mockSolanaAddress,
 } from './keyringControllerTestUtils';
 
 export function createMockUuidFromAddress(address: string): AccountId {
@@ -224,6 +226,16 @@ export const internalAccount2 = createMockInternalAccount(
   'Account 2',
 );
 
+export const expectedSecondHDKeyringUuid = createMockUuidFromAddress(
+  mockSecondHDKeyringAddress,
+);
+
+export const mockSecondHDKeyringInternalAccount = createMockInternalAccount(
+  mockSecondHDKeyringAddress,
+  'Second HD Keyring Account',
+  KeyringTypes.hd,
+);
+
 // used as a default mock for other tests
 export const MOCK_ACCOUNTS_CONTROLLER_STATE: AccountsControllerState = {
   internalAccounts: {
@@ -269,6 +281,18 @@ const mockSnapAccount2InternalAccount: InternalAccount =
     KeyringTypes.snap,
   );
 
+const mockSolanaInternalAccount: InternalAccount = {
+  ...createMockInternalAccount(
+    mockSolanaAddress,
+    'Solana Account',
+    KeyringTypes.snap,
+  ),
+  options: {
+    imported: true,
+    entropySource: '01JNG7170V9X27V5NFDTY04PJ4',
+  },
+};
+
 export const MOCK_ACCOUNTS_CONTROLLER_STATE_WITH_KEYRING_TYPES: AccountsControllerState =
   {
     ...MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -290,6 +314,8 @@ export const MOCK_ACCOUNTS_CONTROLLER_STATE_WITH_KEYRING_TYPES: AccountsControll
             },
           },
         },
+        [expectedSecondHDKeyringUuid]: mockSecondHDKeyringInternalAccount,
+        [mockSolanaInternalAccount.id]: mockSolanaInternalAccount,
       },
     },
   };

--- a/app/util/test/keyringControllerTestUtils.ts
+++ b/app/util/test/keyringControllerTestUtils.ts
@@ -12,6 +12,9 @@ export const mockHDKeyringAddress =
   '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
 export const mockSnapAddress1 = '0x6f92dC30B1e8E71D4A33B5dF06a812B9aAbCD2e9';
 export const mockSnapAddress2 = '0x8A4bD37F19C94A72E8Fe0fA97dD1422a65E53b718';
+export const mockSolanaAddress = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+export const mockSecondHDKeyringAddress =
+  '0xf5E7127d55ed72EBe33d2b0540cc82baF3E31561';
 
 const MOCK_DEFAULT_KEYRINGS: KeyringObject[] = [
   {
@@ -27,8 +30,12 @@ const MOCK_DEFAULT_KEYRINGS: KeyringObject[] = [
     type: KeyringTypes.hd,
   },
   {
-    accounts: [mockSnapAddress1, mockSnapAddress2],
+    accounts: [mockSnapAddress1, mockSnapAddress2, mockSolanaAddress],
     type: KeyringTypes.snap,
+  },
+  {
+    accounts: [mockSecondHDKeyringAddress],
+    type: KeyringTypes.hd,
   },
 ];
 
@@ -52,24 +59,20 @@ const MOCK_SNAP_KEYRING_METADATA: KeyringMetadata = {
   name: '',
 };
 
+const MOCK_SECOND_HD_KEYRING_METADATA: KeyringMetadata = {
+  id: '01JSJNVTJEPSHZSNWAD3JT0PJN',
+  name: '',
+};
+
 const MOCK_DEFAULT_KEYRINGS_METADATA: KeyringMetadata[] = [
   MOCK_SIMPLE_KEYRING_METADATA,
   MOCK_QR_KEYRING_METADATA,
   MOCK_HD_KEYRING_METADATA,
   MOCK_SNAP_KEYRING_METADATA,
+  MOCK_SECOND_HD_KEYRING_METADATA,
 ];
 
 export const MOCK_KEYRING_CONTROLLER_STATE = {
-  keyring: {
-    keyrings: [
-      {
-        mnemonic:
-          'one two three four five six seven eight nine ten eleven twelve',
-      },
-    ],
-  },
-  state: {
-    keyrings: MOCK_DEFAULT_KEYRINGS,
-    keyringsMetadata: MOCK_DEFAULT_KEYRINGS_METADATA,
-  },
+  keyrings: MOCK_DEFAULT_KEYRINGS,
+  keyringsMetadata: MOCK_DEFAULT_KEYRINGS_METADATA,
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -730,6 +730,7 @@
     "receive": "RECEIVE"
   },
   "accounts": {
+    "srp_index": "SRP #{{index}}",
     "snap_account_tag": "Snaps (Beta)",
     "create_new_account": "Create a new account",
     "import_account": "Import an account",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

This PR adds new SRP labels when there are multiple srps, or when an account derives entropy from a srp.

Changes:
1. Updated tests to mock keyring metadata
2. Updated `getLabelTextByAddress` in `app/util/address/index.ts` to check for multiple srps when its an hd account and entropySource for snap accounts.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution? -->

Fixes:
https://consensyssoftware.atlassian.net/browse/MMMULTISRP-186?atlOrigin=eyJpIjoiZDg5NTZhMmEzYjgwNGNiYmIyNDE2NGU5ZjMxNTg0NzAiLCJwIjoiaiJ9

1. Import a new srp
2. Click on account selector
4. See that there are two accounts with the SRP # label.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- [screenshots/recordings] -->
![Screenshot 2025-04-24 at 20 51
04](https://github.com/user-attachments/assets/00b37a22-671b-4f09-9383-8f7c72b5ce8c) ![Screenshot 2025-04-24 at 20 50
10](https://github.com/user-attachments/assets/1dcd7df9-dd52-4af6-be6f-e70b2f67e822)

<!-- [screenshots/recordings] -->

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
