### PR TITLE
fix: Auto reject terminated Snap dialogs

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -160,6 +160,7 @@ import {
   SnapControllerGetSnapStateAction,
   SnapControllerUpdateSnapStateAction,
 } from './controllers/snaps';
+import { RestrictedMethods } from '../Permissions/constants';
 ///: END:ONLY_INCLUDE_IF
 import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
 import {
@@ -199,7 +200,6 @@ import { isProductSafetyDappScanningEnabled } from '../../util/phishingDetection
 import { appMetadataControllerInit } from './controllers/app-metadata-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { toFormattedAddress } from '../../util/address';
-import { RestrictedMethods } from '../Permissions/constants';
 
 const NON_EMPTY = 'NON_EMPTY';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If a Snap crashes we want to reject it's dialog so that it closes since the dialog will be unresponsive anyway. This mirrors the implementation in the extension: https://github.com/MetaMask/metamask-extension/blob/7a22dbc2ea9d47efd4901c7326ccf3ab4218b1c3/app/scripts/metamask-controller.js#L3113-L3130
