### PR TITLE
fix: flask build application id mismatch

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -247,8 +247,26 @@ buildAndroidRunQA(){
 
 buildAndroidRunFlask(){
 	prebuild_android
-	#react-native run-android --port=$WATCHER_PORT --variant=flaskDebug --active-arch-only
-	npx expo run:android --no-install  --port $WATCHER_PORT --variant 'flaskDebug'
+	# Add debug info
+	echo "METAMASK_BUILD_TYPE: ${METAMASK_BUILD_TYPE}"
+	echo "Running with Flask variant, which should use app ID: io.metamask.flask"
+	
+	# Build the debug app explicitly first to ensure we have the proper app ID
+	cd android && ./gradlew assembleFlaskDebug --no-daemon && cd ..
+	
+	# Install the explicitly built APK with the correct package name
+	adb install -r android/app/build/outputs/apk/flask/debug/app-flask-debug.apk
+	
+	# Launch the app
+	echo "Launching app: io.metamask.flask"
+	adb shell am start -n io.metamask.flask/io.metamask.MainActivity
+	
+	# Provide instructions for starting the development server
+	echo ""
+	echo "🚀 App installed and launched successfully!"
+	echo "📱 Now start the Metro development server in a separate terminal with:"
+	echo "    yarn watch"
+	echo ""
 }
 
 buildIosDevBuild(){


### PR DESCRIPTION
## Description
This PR resolves an issue where running `yarn start:android:flask` fails during installation with the error message:
"No development build (io.metamask) for this project is installed."

## Root Cause
The problem occurs because Expo's installation process doesn't correctly handle the applicationIdSuffix in the Flask variant, causing it to look for "io.metamask" instead of "io.metamask.flask".

When using the standard Expo command `npx expo run:android --variant 'flaskDebug'`, Expo incorrectly identifies the application's package name. This appears to be a limitation in how Expo's tooling interacts with Android product flavors and application ID suffixes.

## Changes
- Updated the buildAndroidRunFlask function in scripts/build.sh to bypass Expo's problematic installation process
- Implemented a direct approach that builds, installs, and launches the app explicitly with the correct package name
- Added clear guidance for developers to start the Metro server in a separate terminal

The implementation:
```bash
buildAndroidRunFlask(){
	prebuild_android
	# Add debug info
	echo "METAMASK_BUILD_TYPE: ${METAMASK_BUILD_TYPE}"
	echo "Running with Flask variant, which should use app ID: io.metamask.flask"
	
	# Build the debug app explicitly first to ensure we have the proper app ID
	cd android && ./gradlew assembleFlaskDebug --no-daemon && cd ..
	
	# Install the explicitly built APK with the correct package name
	adb install -r android/app/build/outputs/apk/flask/debug/app-flask-debug.apk
	
	# Launch the app
	echo "Launching app: io.metamask.flask"
	adb shell am start -n io.metamask.flask/io.metamask.MainActivity
	
	# Provide instructions for starting the development server
	echo ""
	echo "🚀 App installed and launched successfully!"
	echo "📱 Now start the Metro development server in a separate terminal with:"
	echo "    yarn watch"
	echo ""
}
```

## **Related issues**

Fixes:

## **Manual testing steps**

0. Run `yarn setup:flask`
1. Run `yarn start:android:flask` to build and install the app
2. Verify the app installs successfully with package name "io.metamask.flask"
3. Run `yarn watch` in a separate terminal to start the Metro server
4. Confirm the app connects to the Metro server properly and hot reload works


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
