### PR TITLE
feat: Add clear confirmation on back swipe for `transfer` confirmations

### DIFF
--- a/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { transferConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import { getNavbar } from '../../UI/navbar/navbar';
@@ -34,6 +35,11 @@ jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
   useConfirmationMetricEvents: jest.fn(),
 }));
 
+jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const noop = () => undefined;
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -48,6 +54,7 @@ jest.mock('@react-navigation/native', () => {
 });
 
 describe('Transfer', () => {
+  const mockUseClearConfirmationOnBackSwipe = jest.mocked(useClearConfirmationOnBackSwipe);
   const mockTrackPageViewedEvent = jest.fn();
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
   const mockUseConfirmationMetricEvents = jest.mocked(
@@ -77,6 +84,7 @@ describe('Transfer', () => {
       state: transferConfirmationState,
     });
 
+    expect(mockUseClearConfirmationOnBackSwipe).toHaveBeenCalled();
     expect(getByText('0xDc477...0c164')).toBeDefined();
     expect(getByText('Network Fee')).toBeDefined();
     expect(getNavbar).toHaveBeenCalled();

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { SimulationDetails } from '../../../../../UI/SimulationDetails/SimulationDetails';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import useNavbar from '../../../hooks/ui/useNavbar';
@@ -17,6 +18,7 @@ const Transfer = () => {
   const { styles } = useStyles(styleSheet, {});
   const { trackPageViewedEvent } = useConfirmationMetricEvents();
 
+  useClearConfirmationOnBackSwipe();
   useNavbar(strings('confirm.review'));
 
   useEffect(trackPageViewedEvent, [trackPageViewedEvent]);

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
@@ -65,7 +65,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
       });
     });
 
-    it('should add a gestureEnd listener when mounted', () => {
+    it('adds a gestureEnd listener when mounted', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
       expect(mockAddListener).toHaveBeenCalledTimes(1);
@@ -75,7 +75,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
       );
     });
 
-    it('should call onReject when gestureEnd event is triggered', () => {
+    it('calls onReject when gestureEnd event is triggered', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
       const gestureEndCallback = mockAddListener.mock.calls[0][1];
       gestureEndCallback();
@@ -83,14 +83,14 @@ describe('useClearConfirmationOnBackSwipe', () => {
       expect(mockOnReject).toHaveBeenCalledTimes(1);
     });
 
-    it('should call unsubscribe when unmounted', () => {
+    it('calls unsubscribe when unmounted', () => {
       const { unmount } = renderHook(() => useClearConfirmationOnBackSwipe());
       unmount();
 
       expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
     });
 
-    it('should not set up Android back handler', () => {
+    it('does not set up Android back handler', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
       expect(BackHandler.addEventListener).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
       });
     });
 
-    it('should add a hardware back press listener when mounted', () => {
+    it('adds a hardware back press listener when mounted', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
       expect(BackHandler.addEventListener).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
       );
     });
 
-    it('should call onReject when hardware back press is triggered', () => {
+    it('calls onReject when hardware back press is triggered', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
       const backHandlerCallback = (BackHandler.addEventListener as jest.Mock)
         .mock.calls[0][1];
@@ -125,14 +125,14 @@ describe('useClearConfirmationOnBackSwipe', () => {
       expect(result).toBe(true);
     });
 
-    it('should remove back handler listener when unmounted', () => {
+    it('removes back handler listener when unmounted', () => {
       const { unmount } = renderHook(() => useClearConfirmationOnBackSwipe());
       unmount();
 
       expect(mockBackHandlerRemove).toHaveBeenCalledTimes(1);
     });
 
-    it('should not set up iOS gesture listener', () => {
+    it('does not set up iOS gesture listener', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
       expect(mockAddListener).not.toHaveBeenCalled();

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -8,7 +8,8 @@ import { useConfirmActions } from '../useConfirmActions';
 import { useStandaloneConfirmation } from './useStandaloneConfirmation';
 
 const useClearConfirmationOnBackSwipe = () => {
-  const navigation = useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation =
+    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
   const { isStandaloneConfirmation } = useStandaloneConfirmation();
   const { onReject } = useConfirmActions();
 
@@ -20,7 +21,7 @@ const useClearConfirmationOnBackSwipe = () => {
 
       return unsubscribe;
     }
-  }, [navigation, onReject]);
+  }, [isStandaloneConfirmation, navigation, onReject]);
 
   useEffect(() => {
     if (isStandaloneConfirmation && Device.isAndroid()) {
@@ -29,14 +30,14 @@ const useClearConfirmationOnBackSwipe = () => {
         () => {
           onReject();
           return true;
-        }
+        },
       );
 
       return () => {
         backHandlerSubscription.remove();
       };
     }
-  }, [onReject]);
+  }, [isStandaloneConfirmation, onReject]);
 };
 
 export default useClearConfirmationOnBackSwipe;

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -5,23 +5,25 @@ import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
 import { StakeNavigationParamsList } from '../../../../UI/Stake/types';
 import { useConfirmActions } from '../useConfirmActions';
+import { useStandaloneConfirmation } from './useStandaloneConfirmation';
 
 const useClearConfirmationOnBackSwipe = () => {
   const navigation = useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const { isStandaloneConfirmation } = useStandaloneConfirmation();
   const { onReject } = useConfirmActions();
 
   useEffect(() => {
-    if (Device.isIos()) {
+    if (isStandaloneConfirmation && Device.isIos()) {
       const unsubscribe = navigation.addListener('gestureEnd', () => {
         onReject();
       });
 
-    return unsubscribe;
+      return unsubscribe;
     }
   }, [navigation, onReject]);
 
   useEffect(() => {
-    if (Device.isAndroid()) {
+    if (isStandaloneConfirmation && Device.isAndroid()) {
       const backHandlerSubscription = BackHandler.addEventListener(
         'hardwareBackPress',
         () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to implement `useClearConfirmationOnBackSwipe` for `transfer` confirmations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4815

## **Manual testing steps**

Only possible to test it out via setting `FEATURE_FLAG_REDESIGNED_TRANSFER` to `true`, so can be skipped manual test for now.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
