### PR TITLE
feat: Make standalone confirmations redirect to transactions view

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.test.ts
@@ -194,7 +194,7 @@ describe('useConfirmAction', () => {
     expect(clearSecurityAlertResponseSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates to transactions view if confirmation is of type staking deposit', async () => {
+  it('navigates to transactions view if confirmation is standalone confirmation', async () => {
     const { result } = renderHookWithProvider(() => useConfirmActions(), {
       state: stakingDepositConfirmationState,
     });

--- a/app/components/Views/confirmations/hooks/useConfirmActions.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmActions.ts
@@ -1,18 +1,19 @@
 import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 
-import PPOMUtil from '../../../../lib/ppom/ppom-util';
+import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import Routes from '../../../../constants/navigation/Routes';
+import PPOMUtil from '../../../../lib/ppom/ppom-util';
+import { RootState } from '../../../../reducers';
 import { MetaMetricsEvents } from '../../../hooks/useMetrics';
-import { isSignatureRequest, isStakingConfirmation } from '../utils/confirm';
+import { isSignatureRequest } from '../utils/confirm';
 import { useLedgerContext } from '../context/ledger-context';
 import { useQRHardwareContext } from '../context/qr-hardware-context';
 import useApprovalRequest from './useApprovalRequest';
 import { useSignatureMetrics } from './signatures/useSignatureMetrics';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
-import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../../../reducers';
+import { useStandaloneConfirmation } from './ui/useStandaloneConfirmation';
 
 export const useConfirmActions = () => {
   const {
@@ -32,9 +33,7 @@ export const useConfirmActions = () => {
   const shouldUseSmartTransaction = useSelector(
     (state: RootState) => selectShouldUseSmartTransaction(state, transactionMetadata?.chainId)
   );
-  const isOneOfTheStakingConfirmations = isStakingConfirmation(
-    transactionMetadata?.type as string,
-  );
+  const { isStandaloneConfirmation } = useStandaloneConfirmation();
 
   const isSignatureReq =
     approvalRequest?.type && isSignatureRequest(approvalRequest?.type);
@@ -70,7 +69,7 @@ export const useConfirmActions = () => {
       handleErrors: false,
     });
 
-    if (isOneOfTheStakingConfirmations) {
+    if (isStandaloneConfirmation) {
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     } else {
       navigation.goBack();
@@ -89,7 +88,7 @@ export const useConfirmActions = () => {
     captureSignatureMetrics,
     onRequestConfirm,
     isSignatureReq,
-    isOneOfTheStakingConfirmations,
+    isStandaloneConfirmation,
     shouldUseSmartTransaction,
   ]);
 

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -18,8 +18,7 @@ const isRemoteFeatureFlagValuesValid = (
   isObject(obj) &&
   hasProperty(obj, 'signatures') &&
   hasProperty(obj, 'staking_confirmations') &&
-  hasProperty(obj, 'contract_interaction') &&
-  hasProperty(obj, 'transfer');
+  hasProperty(obj, 'contract_interaction');
 
 const confirmationRedesignFlagsDefaultValues: ConfirmationRedesignRemoteFlags =
   {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to redirect all redesigned standalone confirmations to the transactions view. 

So instead of just staking confirmations, redirect all standalone confirmations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4816

## **Manual testing steps**

Only possible to test it out via setting FEATURE_FLAG_REDESIGNED_TRANSFER to true, so can be skipped manual test for now.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
