### PR TITLE
test: add Backup and Sync toggle e2e test

### DIFF
--- a/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.tsx
+++ b/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.tsx
@@ -160,6 +160,7 @@ const BackupAndSyncToggle = ({
           }}
           thumbColor={theme.brandColors.white}
           ios_backgroundColor={colors.border.muted}
+          testID="toggle-backupAndSync"
         />
       </View>
       <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>

--- a/e2e/pages/Settings/BackupAndSyncView.js
+++ b/e2e/pages/Settings/BackupAndSyncView.js
@@ -1,0 +1,32 @@
+import TestHelpers from '../../helpers';
+import { BackupAndSyncViewSelectorsIDs } from '../../selectors/Settings/BackupAndSyncView.selectors';
+import Gestures from '../../utils/Gestures';
+import Matchers from '../../utils/Matchers';
+
+class BackupAndSyncView {
+
+    get accountSyncToggle() {
+        return Matchers.getElementByID(
+            BackupAndSyncViewSelectorsIDs.ACCOUNT_SYNC_TOGGLE,
+        )
+    }
+
+    get backupAndSyncToggle() {
+        return Matchers.getElementByID(
+            BackupAndSyncViewSelectorsIDs.BACKUP_AND_SYNC_TOGGLE,
+        );
+    }
+
+  async toggleBackupAndSync() {
+   await Gestures.waitAndTap(this.backupAndSyncToggle);
+   await TestHelpers.delay(2000);
+  }
+
+  async toggleAccountSync() {
+   await Gestures.waitAndTap(this.accountSyncToggle);
+    await TestHelpers.delay(2000);
+  }
+
+}
+
+export default new BackupAndSyncView();

--- a/e2e/pages/Settings/SettingsView.js
+++ b/e2e/pages/Settings/SettingsView.js
@@ -50,6 +50,12 @@ class SettingsView {
     );
   }
 
+  get backupAndSyncSectionButton() {
+    return Matchers.getElementByID(
+      SettingsViewSelectorsIDs.BACKUP_AND_SYNC,
+    );
+  }
+
   get alertButton() {
     return device.getPlatform() === 'android'
       ? Matchers.getElementByText(CommonSelectorsText.YES_ALERT_BUTTON)
@@ -124,6 +130,10 @@ class SettingsView {
 
   async tapYesAlertButton() {
     await Gestures.tap(this.alertButton);
+  }
+
+  async tapBackupAndSync() {
+    await Gestures.tap(this.backupAndSyncSectionButton);
   }
 }
 

--- a/e2e/selectors/Settings/BackupAndSyncView.selectors.js
+++ b/e2e/selectors/Settings/BackupAndSyncView.selectors.js
@@ -1,0 +1,4 @@
+export const BackupAndSyncViewSelectorsIDs = {
+    ACCOUNT_SYNC_TOGGLE: 'toggle-accountSyncing',
+    BACKUP_AND_SYNC_TOGGLE: 'toggle-backupAndSync',
+  };

--- a/e2e/specs/identity/account-syncing/account-sync-settings-toggle.spec.js
+++ b/e2e/specs/identity/account-syncing/account-sync-settings-toggle.spec.js
@@ -1,0 +1,149 @@
+import { SDK } from '@metamask/profile-sync-controller';
+import {
+  IDENTITY_TEAM_PASSWORD,
+  IDENTITY_TEAM_SEED_PHRASE,
+  IDENTITY_TEAM_STORAGE_KEY,
+} from '../utils/constants';
+import {
+  startMockServer,
+  stopMockServer,
+} from '../../../api-mocking/mock-server';
+import { getAccountsSyncMockResponse } from './mock-data';
+import { importWalletWithRecoveryPhrase } from '../../../viewHelper';
+import TestHelpers from '../../../helpers';
+import WalletView from '../../../pages/wallet/WalletView';
+import AccountListBottomSheet from '../../../pages/wallet/AccountListBottomSheet';
+import Assertions from '../../../utils/Assertions';
+import AddAccountBottomSheet from '../../../pages/wallet/AddAccountBottomSheet';
+import AccountActionsBottomSheet from '../../../pages/wallet/AccountActionsBottomSheet';
+import { mockIdentityServices } from '../utils/mocks';
+import { SmokeWalletPlatform } from '../../../tags';
+import { USER_STORAGE_FEATURE_NAMES } from '@metamask/profile-sync-controller/sdk';
+import TabBarComponent from '../../../pages/wallet/TabBarComponent';
+import SettingsView from '../../../pages/Settings/SettingsView';
+import BackupAndSyncView from '../../../pages/Settings/BackupAndSyncView';
+import CommonView from '../../../pages/CommonView';
+
+describe(
+  SmokeWalletPlatform(
+    'Sync and Backup settings - Account Sync toggle',
+  ),
+  () => {
+    const ADDED_ACCOUNT = 'Account 3';
+    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8000;
+    let decryptedAccountNames = '';
+    let mockServer;
+
+    beforeAll(async () => {
+      await TestHelpers.reverseServerPort();
+
+      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+
+      const accountsSyncMockResponse = await getAccountsSyncMockResponse();
+
+      const { userStorageMockttpControllerInstance } =
+        await mockIdentityServices(mockServer);
+
+      await userStorageMockttpControllerInstance.setupPath(
+        USER_STORAGE_FEATURE_NAMES.accounts,
+        mockServer,
+        {
+          getResponse: accountsSyncMockResponse,
+        },
+      );
+
+      decryptedAccountNames = await Promise.all(
+        accountsSyncMockResponse.map(async (response) => {
+          const decryptedAccountName = await SDK.Encryption.decryptString(
+            response.Data,
+            IDENTITY_TEAM_STORAGE_KEY,
+          );
+          return JSON.parse(decryptedAccountName).n;
+        }),
+      );
+
+      await TestHelpers.launchApp({
+        newInstance: true,
+        delete: true,
+        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+      });
+    });
+
+    afterAll(async () => {
+      if (mockServer) {
+        await stopMockServer(mockServer);
+      }
+    });
+
+    it('should not sync new accounts when accounts sync toggle is off ', async () => {
+      await importWalletWithRecoveryPhrase(
+        {
+          seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
+          password: IDENTITY_TEAM_PASSWORD,
+        }
+      );
+
+      await WalletView.tapIdenticon();
+      await Assertions.checkIfVisible(AccountListBottomSheet.accountList);
+      await TestHelpers.delay(4000);
+
+      for (const accountName of decryptedAccountNames) {
+        await Assertions.checkIfVisible(
+          AccountListBottomSheet.getAccountElementByAccountName(accountName),
+        );
+      }
+
+      await AccountListBottomSheet.swipeToDismissAccountsModal();
+      await Assertions.checkIfNotVisible(
+        AccountListBottomSheet.accountList,
+      );
+
+      await TabBarComponent.tapSettings();
+      await Assertions.checkIfVisible(SettingsView.backupAndSyncSectionButton);
+      await SettingsView.tapBackupAndSync();
+
+      await Assertions.checkIfVisible(BackupAndSyncView.backupAndSyncToggle);
+      await BackupAndSyncView.toggleAccountSync();
+      await TestHelpers.delay(2000);
+
+      await CommonView.tapBackButton();
+      await Assertions.checkIfVisible(SettingsView.backupAndSyncSectionButton);
+      await TabBarComponent.tapWallet();
+      await Assertions.checkIfVisible(WalletView.container);
+
+      await WalletView.tapIdenticon();
+      await Assertions.checkIfVisible(AccountListBottomSheet.accountList);
+      await TestHelpers.delay(2000);
+
+      await AccountListBottomSheet.tapAddAccountButton();
+      await AddAccountBottomSheet.tapCreateAccount();
+
+      await Assertions.checkIfElementToHaveText(
+        WalletView.accountName,
+        ADDED_ACCOUNT,
+      );
+
+      await TestHelpers.launchApp({
+        newInstance: true,
+        delete: true,
+        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+      });
+
+
+      await importWalletWithRecoveryPhrase(
+        {
+          seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
+          password: IDENTITY_TEAM_PASSWORD,
+        }
+      );
+
+      await WalletView.tapIdenticon();
+      await Assertions.checkIfVisible(AccountListBottomSheet.accountList);
+      await TestHelpers.delay(2000);
+
+      await Assertions.checkIfNotVisible(
+        AccountListBottomSheet.getAccountElementByAccountName(ADDED_ACCOUNT),
+      );
+    });
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
 Add E2E test to ensure account sync toggle works as expected. 
Other scenarios will be added in a different PR
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

Not Required. Original feature PR has been manually tested
E2E tests should pass and test logic can be validated in review

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
