### PR TITLE
feat: Enable general alert banners for transaction confirmations

### DIFF
--- a/app/components/Views/confirmations/components/general-alert-banner/general-alert-banner.styles.ts
+++ b/app/components/Views/confirmations/components/general-alert-banner/general-alert-banner.styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native';
 
 const styleSheet = () => StyleSheet.create({
     wrapper: {
-      marginBottom: 10,
+      marginBottom: 24,
     },
     details: { marginLeft: 10, marginBottom: 10 },
     detailsItem: {

--- a/app/components/Views/confirmations/components/general-alert-banner/general-alert-banner.tsx
+++ b/app/components/Views/confirmations/components/general-alert-banner/general-alert-banner.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { View } from 'react-native';
 import { useAlerts } from '../../context/alert-system-context';
 import BannerAlert from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert';
 import styleSheet from './general-alert-banner.styles';
@@ -16,7 +15,7 @@ const GeneralAlertBanner = () => {
 
   // Temporary loop throw all general alerts until design team establishes a design for multiple general alerts
   return (
-    <View>
+    <>
       {generalAlerts.map((selectedAlert, index) => (
         <BannerAlert
           key={`banner-alert-${index}`}
@@ -27,7 +26,7 @@ const GeneralAlertBanner = () => {
           testID={`security-alert-banner-${index}`}
         />
       ))}
-    </View>
+    </>
   );
 };
 

--- a/app/components/Views/confirmations/hooks/alerts/useSecurityAlertResponse.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSecurityAlertResponse.ts
@@ -1,12 +1,19 @@
 import { useSelector } from 'react-redux';
 
 import { selectSignatureSecurityAlertResponse } from '../../selectors/security-alerts';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 
 // todo: the hook to be extended to include transactions
 export function useSecurityAlertResponse() {
-  const { securityAlertResponse } = useSelector(
+  const transactionMetadata = useTransactionMetadataRequest();
+
+  const { securityAlertResponse: signatureSecurityAlertResponse } = useSelector(
     selectSignatureSecurityAlertResponse,
   );
 
-  return { securityAlertResponse };
+  return {
+    securityAlertResponse:
+      transactionMetadata?.securityAlertResponse ??
+      signatureSecurityAlertResponse,
+  };
 }

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLocation.test.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLocation.test.ts
@@ -132,6 +132,26 @@ describe('useConfirmationLocation', () => {
     expect(result.current).toBe(CONFIRMATION_EVENT_LOCATIONS.STAKING_CLAIM);
   });
 
+  it.each([
+    [TransactionType.simpleSend],
+    [TransactionType.tokenMethodTransfer],
+    [TransactionType.tokenMethodTransferFrom],
+  ])('returns TRANSFER location for %s transactions', (transactionType) => {
+    mockUseApprovalRequest.mockReturnValue(
+      createApprovalRequestMock({
+        type: ApprovalType.Transaction,
+        requestData: {},
+      }),
+    );
+
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: transactionType,
+    } as unknown as TransactionMeta);
+
+    const { result } = renderHook(() => useConfirmationLocation());
+    expect(result.current).toBe(CONFIRMATION_EVENT_LOCATIONS.TRANSFER);
+  });
+
   it('returns undefined for transaction approvals with unknown transaction type', () => {
     mockUseApprovalRequest.mockReturnValue(
       createApprovalRequestMock({

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationLocation.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationLocation.ts
@@ -12,35 +12,38 @@ import useApprovalRequest, {
 } from '../useApprovalRequest';
 
 const ConfirmationLocationMap = {
-    [TransactionType.personalSign]: () =>
-      CONFIRMATION_EVENT_LOCATIONS.PERSONAL_SIGN,
-    [TransactionType.signTypedData]: ({
-      signatureRequestVersion,
-    }: {
-      signatureRequestVersion: string;
-    }) => {
-      if (signatureRequestVersion === 'V1')
-        return CONFIRMATION_EVENT_LOCATIONS.TYPED_SIGN_V1;
-      return CONFIRMATION_EVENT_LOCATIONS.TYPED_SIGN_V3_V4;
-    },
-    [ApprovalType.Transaction]: ({
-      transactionType,
-    }: {
-      transactionType?: TransactionType;
-    }) => {
-      switch (transactionType) {
-        case TransactionType.stakingDeposit:
-          return CONFIRMATION_EVENT_LOCATIONS.STAKING_DEPOSIT;
-        case TransactionType.stakingUnstake:
-          return CONFIRMATION_EVENT_LOCATIONS.STAKING_WITHDRAWAL;
-        case TransactionType.stakingClaim:
-          return CONFIRMATION_EVENT_LOCATIONS.STAKING_CLAIM;
-        default:
-          return undefined;
-      }
-    },
-  };
-
+  [TransactionType.personalSign]: () =>
+    CONFIRMATION_EVENT_LOCATIONS.PERSONAL_SIGN,
+  [TransactionType.signTypedData]: ({
+    signatureRequestVersion,
+  }: {
+    signatureRequestVersion: string;
+  }) => {
+    if (signatureRequestVersion === 'V1')
+      return CONFIRMATION_EVENT_LOCATIONS.TYPED_SIGN_V1;
+    return CONFIRMATION_EVENT_LOCATIONS.TYPED_SIGN_V3_V4;
+  },
+  [ApprovalType.Transaction]: ({
+    transactionType,
+  }: {
+    transactionType?: TransactionType;
+  }) => {
+    switch (transactionType) {
+      case TransactionType.stakingDeposit:
+        return CONFIRMATION_EVENT_LOCATIONS.STAKING_DEPOSIT;
+      case TransactionType.stakingUnstake:
+        return CONFIRMATION_EVENT_LOCATIONS.STAKING_WITHDRAWAL;
+      case TransactionType.stakingClaim:
+        return CONFIRMATION_EVENT_LOCATIONS.STAKING_CLAIM;
+      case TransactionType.simpleSend:
+      case TransactionType.tokenMethodTransfer:
+      case TransactionType.tokenMethodTransferFrom:
+        return CONFIRMATION_EVENT_LOCATIONS.TRANSFER;
+      default:
+        return undefined;
+    }
+  },
+};
 
 const determineConfirmationLocation = ({
   approvalRequest,
@@ -100,4 +103,3 @@ export const useConfirmationLocation = ():
 
   return location;
 };
-

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationMetricEvents.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationMetricEvents.ts
@@ -67,6 +67,28 @@ export function useConfirmationMetricEvents() {
       trackEvent(event);
     };
 
+    const trackBlockaidAlertLinkClickedEvent = () => {
+      const signatureType = signatureRequest?.type;
+      const signatureFromAddress = signatureRequest?.messageParams?.from;
+      const transactionType = transactionMeta?.type;
+      const transactionFromAddress = transactionMeta?.txParams?.from;
+
+      const type = transactionType ?? signatureType;
+      const fromAddress = transactionFromAddress ?? signatureFromAddress;
+
+      const event = generateEvent({
+        createEventBuilder,
+        metametricsEvent: CONFIRMATION_EVENTS.BLOCKAID_ALERT_LINK_CLICKED,
+        properties: {
+          external_link_clicked: 'security_alert_support_link',
+          from_address: fromAddress,
+          location,
+          type,
+        },
+      });
+      trackEvent(event);
+    };
+
     const setConfirmationMetric = (metricParams: ConfirmationMetrics) => {
       if (!transactionMeta && !signatureRequest) {
         return;
@@ -81,6 +103,7 @@ export function useConfirmationMetricEvents() {
 
     return {
       trackAdvancedDetailsToggledEvent,
+      trackBlockaidAlertLinkClickedEvent,
       trackTooltipClickedEvent,
       trackPageViewedEvent,
       setConfirmationMetric,

--- a/app/core/Analytics/events/confirmations/constants.ts
+++ b/app/core/Analytics/events/confirmations/constants.ts
@@ -11,4 +11,5 @@ export enum CONFIRMATION_EVENT_LOCATIONS {
   STAKING_DEPOSIT = 'staking_deposit',
   STAKING_WITHDRAWAL = 'staking_withdrawal',
   STAKING_CLAIM = 'staking_claim',
+  TRANSFER = 'transfer',
 }

--- a/app/core/Analytics/events/confirmations/events.ts
+++ b/app/core/Analytics/events/confirmations/events.ts
@@ -5,6 +5,7 @@ import {
 
 enum EVENT_NAME {
   ADVANCED_DETAILS_CLICKED = 'Confirmation Advanced Details Clicked',
+  BLOCKAID_ALERT_LINK_CLICKED = 'Blockaid Alert Link Clicked',
   TOOLTIP_CLICKED = 'Confirmation Tooltip Clicked',
   SCREEN_VIEWED = 'Confirmation Screen Viewed',
 }
@@ -25,6 +26,9 @@ const createEvent = (name: EVENT_NAME | TRANSACTION_EVENT_NAMES) =>
 
 export const CONFIRMATION_EVENTS = {
   ADVANCED_DETAILS_CLICKED: createEvent(EVENT_NAME.ADVANCED_DETAILS_CLICKED),
+  BLOCKAID_ALERT_LINK_CLICKED: createEvent(
+    EVENT_NAME.BLOCKAID_ALERT_LINK_CLICKED,
+  ),
   SCREEN_VIEWED: createEvent(EVENT_NAME.SCREEN_VIEWED),
   TOOLTIP_CLICKED: createEvent(EVENT_NAME.TOOLTIP_CLICKED),
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR enables general alert banners for transaction confirmations. Which only able to apply blockaid banners for now. 

Please see that it doesn't break signature confirmations. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4820

## **Manual testing steps**

Only possible to test it out via setting FEATURE_FLAG_REDESIGNED_TRANSFER to true, so can be skipped manual test for now. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No Blockaid banners.

### **After**


https://github.com/user-attachments/assets/c147cc9f-e459-4499-866d-d8b95619db57


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
