### PR TITLE
revert: Reduce bottom sheet loading animations (#14920)

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.constants.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.constants.ts
@@ -8,12 +8,12 @@ import { AnimationDuration } from '../../../../../constants/animation.constants'
  * The animation duration used for initial render.
  */
 export const DEFAULT_BOTTOMSHEETDIALOG_DISPLAY_DURATION =
-  AnimationDuration.Immediately;
+  AnimationDuration.Regularly;
 /**
  * This number represents the swipe speed to meet the velocity threshold.
  */
 export const DEFAULT_BOTTOMSHEETDIALOG_SWIPETHRESHOLD_DURATION =
-  AnimationDuration.Immediately;
+  AnimationDuration.Regularly;
 /**
  * This indicates that 60% of the sheet needs to be offscreen to meet the distance threshold.
  */

--- a/app/component-library/components/Overlay/Overlay.constants.ts
+++ b/app/component-library/components/Overlay/Overlay.constants.ts
@@ -4,4 +4,4 @@
 import { AnimationDuration } from '../../constants/animation.constants';
 
 // Defaults
-export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Immediately;
+export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Regularly;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This reverts commit [561014f496acdc8ecdd41bdec53e4e90106362b2](https://github.com/MetaMask/metamask-mobile/commit/561014f496acdc8ecdd41bdec53e4e90106362b2) as it removes confirmation animations.

[Slack thread](https://consensys.slack.com/archives/C0354T27M5M/p1746097853530279)

## **Related issues**

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
