### PR TITLE
refactor: rm ts exception for getNetworkImageSource param

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -363,7 +363,7 @@ const BridgeView = () => {
               tokenBalance={latestSourceBalance?.displayBalance}
               networkImageSource={
                 sourceToken?.chainId
-                  ? //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
+                  ?
                     getNetworkImageSource({
                       chainId: sourceToken?.chainId,
                     })
@@ -391,7 +391,7 @@ const BridgeView = () => {
               token={destToken}
               networkImageSource={
                 destToken
-                  ? //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
+                  ?
                     getNetworkImageSource({ chainId: destToken?.chainId })
                   : undefined
               }

--- a/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
@@ -112,7 +112,6 @@ export const BridgeDestNetworksBar = () => {
   const renderDestChains = useCallback(
     () =>
       sortedDestChains.map((chain) => {
-        // @ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         const networkImage = getNetworkImageSource({ chainId: chain.chainId });
 
         const handleSelectNetwork = (chainId: Hex | CaipChainId) =>

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
@@ -70,7 +70,6 @@ export const BridgeDestTokenSelector: React.FC = () => {
         token={item}
         onPress={handleTokenPress}
         networkName={networkName}
-        //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         networkImageSource={getNetworkImageSource({ chainId: item.chainId as Hex })}
         isSelected={
           selectedDestToken?.address === item.address &&

--- a/app/components/UI/Bridge/components/BridgeSourceNetworksBar.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworksBar.tsx
@@ -76,7 +76,6 @@ export const BridgeSourceNetworksBar: React.FC<SourceNetworksButtonProps> = ({
       <Box key={chainId} style={styles.avatarContainer}>
       <AvatarNetwork
         key={chainId}
-        // @ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         imageSource={getNetworkImageSource({ chainId })}
         name={networkConfigurations[chainId]?.name}
         size={AvatarSize.Xs}

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
@@ -121,7 +121,6 @@ export const BridgeSourceTokenSelector: React.FC = () => {
           token={item}
           onPress={handleTokenPress}
           networkName={networkName}
-          // @ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
           networkImageSource={getNetworkImageSource({ chainId: item.chainId })}
           isSelected={
             selectedSourceToken?.address === item.address &&

--- a/app/components/UI/Bridge/components/NetworkRow.tsx
+++ b/app/components/UI/Bridge/components/NetworkRow.tsx
@@ -29,7 +29,6 @@ interface NetworkRowProps {
 export const NetworkRow: React.FC<NetworkRowProps> = ({ chainId, chainName, children }) => {
   const { styles } = useStyles(createStyles, {});
 
-  // @ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
   const imageSource = getNetworkImageSource({ chainId });
 
   return (

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -72,7 +72,6 @@ const NetworkBadge = ({ chainId }: NetworkBadgeProps) => {
     >
       <Badge
         variant={BadgeVariant.Network}
-        //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         imageSource={getNetworkImageSource({ chainId })}
         isScaled={false}
         size={AvatarSize.Sm}

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
@@ -62,7 +62,6 @@ const TransactionAsset = ({
 }: TransactionAssetProps) => {
   const networkName =
     NETWORK_TO_SHORT_NETWORK_NAME_MAP[chainId as AllowedBridgeChainIds];
-  //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
   const networkImageSource = getNetworkImageSource({ chainId });
 
   // Solana native SOL will also be the zero address for quote data from Bridge API only!

--- a/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/index.ts
+++ b/app/components/UI/Bridge/hooks/useMultichainBlockExplorerTxUrl/index.ts
@@ -85,7 +85,6 @@ export const useMultichainBlockExplorerTxUrl = ({
   }
 
   // Get network image source
-  //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
   const networkImageSource = getNetworkImageSource({
     chainId: formattedChainId as string,
   });

--- a/app/components/UI/NetworkVerificationInfo/NetworkVerificationInfo.tsx
+++ b/app/components/UI/NetworkVerificationInfo/NetworkVerificationInfo.tsx
@@ -113,7 +113,6 @@ const NetworkVerificationInfo = ({
 
   const networkImageSource = useMemo(
     () =>
-      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
       getNetworkImageSource({
         chainId: customNetworkInformation.chainId,
       }),

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -91,7 +91,6 @@ const PermissionsSummary = ({
   let chainImage: ImageSourcePropType;
   if (isNetworkSwitch && customNetworkInformation?.chainId) {
     chainName = customNetworkInformation?.chainName;
-    // @ts-expect-error getNetworkImageSource is not implemented in typescript
     chainImage = getNetworkImageSource({
       chainId: customNetworkInformation?.chainId,
     });
@@ -385,7 +384,7 @@ const PermissionsSummary = ({
                     }
                     imageSource={
                       isNonDappNetworkSwitch
-                        ? // @ts-expect-error getNetworkImageSource is not implemented in typescript
+                        ?
                           getNetworkImageSource({
                             chainId,
                           })

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -243,7 +243,6 @@ const AccountConnect = (props: AccountConnectProps) => {
       (network) => ({
         size: AvatarSize.Xs,
         name: network.name || '',
-        // @ts-expect-error getNetworkImageSource not yet typed
         imageSource: getNetworkImageSource({ chainId: network.chainId }),
       }),
     );
@@ -545,7 +544,6 @@ const AccountConnect = (props: AccountConnectProps) => {
           size: AvatarSize.Xs,
           // @ts-expect-error - networkConfigurations is not typed
           name: networkConfigurations[newSelectedChainId]?.name || '',
-          // @ts-expect-error - getNetworkImageSource is not typed
           imageSource: getNetworkImageSource({ chainId: newSelectedChainId }),
         }),
       );

--- a/app/components/Views/AccountPermissions/AccountPermissions.tsx
+++ b/app/components/Views/AccountPermissions/AccountPermissions.tsx
@@ -166,7 +166,6 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
         rpcUrl: network.rpcEndpoints[network.defaultRpcEndpointIndex].url,
         isSelected: false,
         chainId: network?.chainId,
-        //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         imageSource: getNetworkImageSource({
           chainId: network?.chainId,
         }),

--- a/app/components/Views/AccountPermissions/NetworkPermissionsConnected/NetworkPermissionsConnected.tsx
+++ b/app/components/Views/AccountPermissions/NetworkPermissionsConnected/NetworkPermissionsConnected.tsx
@@ -97,7 +97,6 @@ const NetworkPermissionsConnected = ({
       name: network.name,
       rpcUrl: network.rpcEndpoints[network.defaultRpcEndpointIndex].url,
       isSelected: false,
-      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
       imageSource: getNetworkImageSource({
         chainId: network?.chainId,
       }),

--- a/app/components/Views/AddAsset/components/NetworkListBottomSheet.tsx
+++ b/app/components/Views/AddAsset/components/NetworkListBottomSheet.tsx
@@ -59,7 +59,6 @@ export default function NetworkListBottomSheet({
               avatarProps={{
                 variant: AvatarVariant.Network,
                 name: network.name,
-                // @ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
                 imageSource: getNetworkImageSource({
                   chainId: network.chainId,
                 }),

--- a/app/components/Views/MultiRpcModal/MultiRpcModal.tsx
+++ b/app/components/Views/MultiRpcModal/MultiRpcModal.tsx
@@ -105,7 +105,6 @@ const MultiRpcModal = () => {
                     avatarProps={{
                       variant: AvatarVariant.Network,
                       name: networkConfiguration.name,
-                      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
                       imageSource: getNetworkImageSource({
                         chainId: networkConfiguration.chainId,
                       }),

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
@@ -176,7 +176,6 @@ const NetworkConnectMultiSelector = ({
       name: network.name,
       rpcUrl: network.rpcEndpoints[network.defaultRpcEndpointIndex].url,
       isSelected: false,
-      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
       imageSource: getNetworkImageSource({
         chainId: network?.chainId,
       }),

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -520,7 +520,6 @@ const NetworkSelector = () => {
 
       if (isNetworkUiRedesignEnabled() && isNoSearchResults(name)) return null;
 
-      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
       const image = getNetworkImageSource({ chainId: chainId?.toString() });
 
       if (isNetworkUiRedesignEnabled()) {

--- a/app/components/Views/NetworkSelector/RpcSelectionModal/RpcSelectionModal.tsx
+++ b/app/components/Views/NetworkSelector/RpcSelectionModal/RpcSelectionModal.tsx
@@ -119,7 +119,6 @@ const RpcSelectionModal: FC<RpcSelectionModalProps> = ({
       case CHAIN_IDS.LINEA_MAINNET:
         return images['LINEA-MAINNET'];
       default:
-        //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
         return getNetworkImageSource({
           chainId: showMultiRpcSelectModal?.chainId?.toString(),
         });

--- a/app/components/Views/Settings/IncomingTransactionsSettings/index.tsx
+++ b/app/components/Views/Settings/IncomingTransactionsSettings/index.tsx
@@ -100,7 +100,6 @@ const IncomingTransactionsSettings = () => {
         testId = INCOMING_LINEA_MAINNET_TOGGLE;
       }
 
-      //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
       const image = getNetworkImageSource({ chainId: chainId?.toString() });
 
       return (

--- a/app/components/Views/confirmations/hooks/useNetworkInfo.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkInfo.ts
@@ -34,7 +34,6 @@ const useNetworkInfo = (chainId?: string) => {
 
   const networkName = nickname || rpcName;
 
-  //@ts-expect-error - The utils/network file is still JS and this function expects a networkType, and should be optional
   const networkImage = getNetworkImageSource({ chainId: chainId?.toString() });
 
   return {

--- a/app/selectors/selectedNetworkController.ts
+++ b/app/selectors/selectedNetworkController.ts
@@ -139,7 +139,6 @@ export const makeSelectNetworkImageSource = () =>
 
       const networkConfig = networkConfigurations[chainId];
       if (networkConfig) {
-        // @ts-expect-error The utils/network file is still JS and this function expects a networkType, and should be optional
         return getNetworkImageSource({ chainId: networkConfig.chainId });
       }
       return getNetworkImageSource({

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -493,7 +493,7 @@ export const getNetworkNameFromProviderConfig = (providerConfig) => {
  * Gets the image source given both the network type and the chain ID.
  *
  * @param {object} params - Params that contains information about the network.
- * @param {string} params.networkType - Type of network from the provider.
+ * @param {string=} params.networkType - Type of network from the provider.
  * @param {string} params.chainId - ChainID of the network.
  * @returns {Object} - Image source of the network.
  */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updating the JSDoc comment informs the compiler the param is optional. This allows us to remove the ts-expect-error exception for getNetworkImageSource

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
