### PR TITLE
fix(bridge): update quote details card toggle to handle same chain swaps and improve slippage button layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(swaps): set default slippage when source or destination token is not stablecoin ([#14730](https://github.com/MetaMask/metamask-mobile/pull/14730))
 - fix(bridge): fix transaction history for EVM and Solana bridge transactions ([#14759](https://github.com/MetaMask/metamask-mobile/pull/14759))
 - fix(bridge): change networks properly when user switches between source and destination tokens ([#14812](https://github.com/MetaMask/metamask-mobile/pull/14812))
+- fix(bridge): fix(bridge): update quote details card toggle to handle same chain swaps and improve slippage button layout ([#15153](https://github.com/MetaMask/metamask-mobile/pull/15153))
 
 ## [7.44.0]
 

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
@@ -26,6 +26,11 @@ const createStyles = ({ colors }: Theme) =>
       flexWrap: 'wrap',
       maxWidth: '80%',
     },
+    slippageButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
   });
 
 export default createStyles;

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
   TouchableOpacity,
   LayoutAnimation,
@@ -94,7 +94,21 @@ const QuoteDetailsCard = () => {
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
 
+  const isSameChainId = sourceToken?.chainId === destToken?.chainId;
+
+  // Initialize expanded state based on whether destination is Solana or it's a Solana swap
+  useEffect(() => {
+    if (isSameChainId) {
+      setIsExpanded(true);
+    }
+  }, [isSameChainId]);
+
   const toggleAccordion = useCallback(() => {
+    // Don't allow toggling if destination is Solana or it's a Solana swap
+    if (isSameChainId) {
+      return;
+    }
+
     LayoutAnimation.configureNext(
       LayoutAnimation.create(
         ANIMATION_DURATION_MS,
@@ -108,7 +122,7 @@ const QuoteDetailsCard = () => {
     rotationValue.value = withTiming(newExpandedState ? 1 : 0, {
       duration: ANIMATION_DURATION_MS,
     });
-  }, [isExpanded, rotationValue]);
+  }, [isExpanded, rotationValue, isSameChainId]);
 
   const arrowStyle = useAnimatedStyle(() => {
     const rotation = interpolate(rotationValue.value, [0, 1], [0, 180]);
@@ -142,8 +156,6 @@ const QuoteDetailsCard = () => {
   const { networkFee, estimatedTime, rate, priceImpact, slippage } =
     formattedQuoteData;
 
-  const isSameChainId = sourceToken.chainId === destToken.chainId;
-
   return (
     <Box style={styles.container}>
       <Box
@@ -151,40 +163,36 @@ const QuoteDetailsCard = () => {
         alignItems={AlignItems.center}
         justifyContent={JustifyContent.spaceBetween}
       >
-        {!isSameChainId ? (
-          <Box
-            flexDirection={FlexDirection.Row}
-            alignItems={AlignItems.center}
-            style={styles.networkContainer}
-          >
-            <NetworkBadge chainId={String(sourceToken.chainId)} />
-            <Icon name={IconName.Arrow2Right} size={IconSize.Sm} />
-            <NetworkBadge chainId={String(destToken.chainId)} />
-          </Box>
-        ) : (
-          <Box>
-            <></>
-          </Box>
-        )}
-        <Box>
-          <Animated.View style={arrowStyle}>
-            <TouchableOpacity
-              onPress={toggleAccordion}
-              activeOpacity={0.7}
-              accessibilityRole="button"
-              accessibilityLabel={
-                isExpanded ? 'Collapse quote details' : 'Expand quote details'
-              }
-              testID="expand-quote-details"
+        {!isSameChainId && (
+          <>
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              style={styles.networkContainer}
             >
-              <Icon
-                name={IconName.ArrowDown}
-                size={IconSize.Sm}
-                color={theme.colors.icon.muted}
-              />
-            </TouchableOpacity>
-          </Animated.View>
-        </Box>
+              <NetworkBadge chainId={String(sourceToken.chainId)} />
+              <Icon name={IconName.Arrow2Right} size={IconSize.Sm} />
+              <NetworkBadge chainId={String(destToken.chainId)} />
+            </Box>
+            <Animated.View style={arrowStyle}>
+              <TouchableOpacity
+                onPress={toggleAccordion}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  isExpanded ? 'Collapse quote details' : 'Expand quote details'
+                }
+                testID="expand-quote-details"
+              >
+                <Icon
+                  name={IconName.ArrowDown}
+                  size={IconSize.Sm}
+                  color={theme.colors.icon.muted}
+                />
+              </TouchableOpacity>
+            </Animated.View>
+          </>
+        )}
       </Box>
 
       {/* Always visible content */}
@@ -295,17 +303,18 @@ const QuoteDetailsCard = () => {
                   alignItems={AlignItems.center}
                   gap={4}
                 >
-                  <Text variant={TextVariant.BodyMDMedium}>
-                    {strings('bridge.slippage') || 'Slippage'}
-                  </Text>
                   <TouchableOpacity
                     onPress={handleSlippagePress}
                     activeOpacity={0.6}
                     testID="edit-slippage-button"
+                    style={styles.slippageButton}
                   >
+                    <Text variant={TextVariant.BodyMDMedium}>
+                      {strings('bridge.slippage') || 'Slippage'}
+                    </Text>
                     <Icon
                       name={IconName.Edit}
-                      size={IconSize.Xs}
+                      size={IconSize.Sm}
                       color={IconColor.Muted}
                     />
                   </TouchableOpacity>

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -518,44 +518,35 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                         </View>
                         <View
                           style={
-                            [
-                              {},
-                              undefined,
-                            ]
+                            {
+                              "transform": [
+                                {
+                                  "rotate": "undefineddeg",
+                                },
+                              ],
+                            }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "transform": [
-                                  {
-                                    "rotate": "undefineddeg",
-                                  },
-                                ],
-                              }
-                            }
+                          <TouchableOpacity
+                            accessibilityLabel="Collapse quote details"
+                            accessibilityRole="button"
+                            activeOpacity={0.7}
+                            onPress={[Function]}
+                            testID="expand-quote-details"
                           >
-                            <TouchableOpacity
-                              accessibilityLabel="Collapse quote details"
-                              accessibilityRole="button"
-                              activeOpacity={0.7}
-                              onPress={[Function]}
-                              testID="expand-quote-details"
-                            >
-                              <SvgMock
-                                color="#9ca1af"
-                                height={16}
-                                name="ArrowDown"
-                                style={
-                                  {
-                                    "height": 16,
-                                    "width": 16,
-                                  }
+                            <SvgMock
+                              color="#9ca1af"
+                              height={16}
+                              name="ArrowDown"
+                              style={
+                                {
+                                  "height": 16,
+                                  "width": 16,
                                 }
-                                width={16}
-                              />
-                            </TouchableOpacity>
-                          </View>
+                              }
+                              width={16}
+                            />
+                          </TouchableOpacity>
                         </View>
                       </View>
                       <View
@@ -1082,37 +1073,44 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                     ]
                                   }
                                 >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Medium",
-                                        "fontSize": 16,
-                                        "fontWeight": "500",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
-                                    }
-                                  >
-                                    Slippage
-                                  </Text>
                                   <TouchableOpacity
                                     activeOpacity={0.6}
                                     onPress={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "flexDirection": "row",
+                                        "gap": 4,
+                                      }
+                                    }
                                     testID="edit-slippage-button"
                                   >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "CentraNo1-Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Slippage
+                                    </Text>
                                     <SvgMock
                                       color="#9ca1af"
-                                      height={12}
+                                      height={16}
                                       name="Edit"
                                       style={
                                         {
-                                          "height": 12,
-                                          "width": 12,
+                                          "height": 16,
+                                          "width": 16,
                                         }
                                       }
-                                      width={12}
+                                      width={16}
                                     />
                                   </TouchableOpacity>
                                 </View>
@@ -1696,44 +1694,35 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                         </View>
                         <View
                           style={
-                            [
-                              {},
-                              undefined,
-                            ]
+                            {
+                              "transform": [
+                                {
+                                  "rotate": "undefineddeg",
+                                },
+                              ],
+                            }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "transform": [
-                                  {
-                                    "rotate": "undefineddeg",
-                                  },
-                                ],
-                              }
-                            }
+                          <TouchableOpacity
+                            accessibilityLabel="Expand quote details"
+                            accessibilityRole="button"
+                            activeOpacity={0.7}
+                            onPress={[Function]}
+                            testID="expand-quote-details"
                           >
-                            <TouchableOpacity
-                              accessibilityLabel="Expand quote details"
-                              accessibilityRole="button"
-                              activeOpacity={0.7}
-                              onPress={[Function]}
-                              testID="expand-quote-details"
-                            >
-                              <SvgMock
-                                color="#9ca1af"
-                                height={16}
-                                name="ArrowDown"
-                                style={
-                                  {
-                                    "height": 16,
-                                    "width": 16,
-                                  }
+                            <SvgMock
+                              color="#9ca1af"
+                              height={16}
+                              name="ArrowDown"
+                              style={
+                                {
+                                  "height": 16,
+                                  "width": 16,
                                 }
-                                width={16}
-                              />
-                            </TouchableOpacity>
-                          </View>
+                              }
+                              width={16}
+                            />
+                          </TouchableOpacity>
                         </View>
                       </View>
                       <View


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses the following:

- Added logic to prevent toggling the accordion if the source and destination tokens are on the same chain.
- Initialized expanded state based on the chain ID comparison.
- Enhanced the layout of the slippage button for better alignment and spacing.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to solana swap screen
2. Try to fetch a quote
3. You should not see the option to expand/close the quote details card

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
