### PR TITLE
fix(bridge): implement dynamic refresh rate in QuoteExpiredModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - fix(bridge): show "Auto" slippage for Solana swaps
 
+
 ### Added
 
 - feat(identity): rebrand "Profile syncing" to "Backup and sync", adding a dedicated settings menu and more ([#15003](https://github.com/MetaMask/metamask-mobile/pull/15003))
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(bridge): implement dynamic refresh rate in QuoteExpiredModal ([#15157](https://github.com/MetaMask/metamask-mobile/pull/15157))
 - fix(bridge): keyboard not appearing when error banner is displayed ([#14862](https://github.com/MetaMask/metamask-mobile/pull/14862))
 - fix(bridge): fix not switching networks when selecting source token ([#14712](https://github.com/MetaMask/metamask-mobile/pull/14712))
 - fix: update confirmation font sizes ([#14715](https://github.com/MetaMask/metamask-mobile/pull/14715))

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/QuoteExpiredModal.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/QuoteExpiredModal.test.tsx
@@ -24,6 +24,10 @@ jest.mock('../../hooks/useBridgeQuoteRequest', () => ({
   useBridgeQuoteRequest: () => mockUpdateQuoteParams,
 }));
 
+jest.mock('../../utils/quoteUtils', () => ({
+  getQuoteRefreshRate: jest.fn(() => 15000),
+}));
+
 const initialMetrics = {
   frame: { x: 0, y: 0, width: 320, height: 640 },
   insets: { top: 0, left: 0, right: 0, bottom: 0 },

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/QuoteExpiredModal.tsx
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/QuoteExpiredModal.tsx
@@ -18,8 +18,13 @@ import { useStyles } from '../../../../../component-library/hooks';
 import createStyles from './QuoteExpiredModal.styles';
 import { useBridgeQuoteRequest } from '../../hooks/useBridgeQuoteRequest';
 import Engine from '../../../../../core/Engine';
-import { setIsSubmittingTx } from '../../../../../core/redux/slices/bridge';
-import { useDispatch } from 'react-redux';
+import {
+  selectBridgeFeatureFlags,
+  selectSourceToken,
+  setIsSubmittingTx,
+} from '../../../../../core/redux/slices/bridge';
+import { useDispatch, useSelector } from 'react-redux';
+import { getQuoteRefreshRate } from '../../utils/quoteUtils';
 
 const QuoteExpiredModal = () => {
   const navigation = useNavigation();
@@ -27,6 +32,10 @@ const QuoteExpiredModal = () => {
   const { styles } = useStyles(createStyles, {});
   const updateQuoteParams = useBridgeQuoteRequest();
   const dispatch = useDispatch();
+  const sourceToken = useSelector(selectSourceToken);
+  const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
+  const refreshRate =
+    getQuoteRefreshRate(bridgeFeatureFlags, sourceToken) / 1000;
 
   const handleClose = () => {
     navigation.goBack();
@@ -62,7 +71,9 @@ const QuoteExpiredModal = () => {
       </BottomSheetHeader>
       <View style={styles.container}>
         <Text variant={TextVariant.BodyMD}>
-          {strings('quote_expired_modal.description')}
+          {strings('quote_expired_modal.description', {
+            refreshRate,
+          })}
         </Text>
       </View>
       <BottomSheetFooter

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
               }
             }
           >
-            Rates update every 10 seconds, so tap Get new quote when you're ready.
+            Rates update every 15 seconds, so tap Get new quote when you're ready.
           </Text>
         </View>
         <View

--- a/app/components/UI/Bridge/utils/quoteUtils.test.ts
+++ b/app/components/UI/Bridge/utils/quoteUtils.test.ts
@@ -11,7 +11,7 @@ import type {
 import { Hex } from '@metamask/utils';
 
 describe('quoteUtils', () => {
-  const DEFAULT_REFRESH_RATE = 5 * 1000; // 5 seconds
+  const DEFAULT_REFRESH_RATE = 30 * 1000; // 30 seconds
 
   describe('getQuoteRefreshRate', () => {
     const mockChainConfig: ChainConfiguration = {

--- a/app/components/UI/Bridge/utils/quoteUtils.ts
+++ b/app/components/UI/Bridge/utils/quoteUtils.ts
@@ -4,7 +4,7 @@ import {
 } from '@metamask/bridge-controller';
 import type { BridgeToken } from '../types';
 
-const DEFAULT_REFRESH_RATE = 5 * 1000; // 5 seconds
+const DEFAULT_REFRESH_RATE = 30 * 1000; // 30 seconds
 
 /**
  * Gets the refresh rate for quotes based on feature flags and source token

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3925,7 +3925,7 @@
   },
   "quote_expired_modal": {
     "title": "New quotes are available",
-    "description": "Rates update every 10 seconds, so tap Get new quote when you're ready.",
+    "description": "Rates update every {{refreshRate}} seconds, so tap Get new quote when you're ready.",
     "get_new_quote": "Get new quote"
   },
   "bridge_transaction_details": {


### PR DESCRIPTION
## **Description**

Updates the default bridge quote refresh rate from 10 seconds to 30 seconds and adds dynamic refresh rate handling in QuoteExpiredModal. This change improves performance by reducing unnecessary API calls while maintaining quote freshness.

## **Related issues**

Fixes: [MMS-2389](https://consensyssoftware.atlassian.net/browse/MMS-2389)

## **Manual testing steps**

1. Navigate to the Bridge feature
2. Verify that quotes refresh according to the bridge config in feature flags
3. Test QuoteExpiredModal to ensure it handles dynamic refresh rates correctly
4. Verify quotes update properly based on chain configuration
5. Test on both iOS and Android

## **Screenshots/Recordings**

N/A - No visual changes

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria


[MMS-2389]: https://consensyssoftware.atlassian.net/browse/MMS-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ