### PR TITLE
perf: add HD account tracing + fix add Snap account tracing

### DIFF
--- a/app/actions/multiSrp/index.ts
+++ b/app/actions/multiSrp/index.ts
@@ -3,6 +3,9 @@ import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import ExtendedKeyringTypes from '../../constants/keyringTypes';
 import Engine from '../../core/Engine';
 import { KeyringSelector } from '@metamask/keyring-controller';
+import { endPerformanceTrace, startPerformanceTrace } from '../../core/redux/slices/performance';
+import { PerformanceEventNames } from '../../core/redux/slices/performance/constants';
+import { store } from '../../store';
 
 export async function importNewSecretRecoveryPhrase(mnemonic: string) {
   const { KeyringController } = Engine.context;
@@ -84,6 +87,12 @@ export async function addNewHdAccount(
         type: ExtendedKeyringTypes.hd,
       };
 
+  store.dispatch(
+    startPerformanceTrace({
+      eventName: PerformanceEventNames.AddHdAccount,
+    }),
+  );
+
   const [addedAccountAddress] = await KeyringController.withKeyring(
     keyringSelector,
     async ({ keyring }) => await keyring.addAccounts(1),
@@ -93,4 +102,11 @@ export async function addNewHdAccount(
   if (name) {
     Engine.setAccountLabel(addedAccountAddress, name);
   }
+
+  // We consider the account to be created once it got selected and renamed.
+  store.dispatch(
+    endPerformanceTrace({
+      eventName: PerformanceEventNames.AddHdAccount,
+    }),
+  );
 }

--- a/app/core/SnapKeyring/MultichainWalletSnapClient.ts
+++ b/app/core/SnapKeyring/MultichainWalletSnapClient.ts
@@ -15,6 +15,9 @@ import Engine from '../Engine';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
+import { store } from '../../store';
+import { startPerformanceTrace } from '../redux/slices/performance';
+import { PerformanceEventNames } from '../redux/slices/performance/constants';
 
 export enum WalletClientType {
   Bitcoin = 'bitcoin',
@@ -106,6 +109,13 @@ export abstract class MultichainWalletSnapClient {
    *
    */
   async createAccount(options: MultichainWalletSnapOptions) {
+    // This flow is async and start here, to end in the `SnapKeyring.addAccountFinalize` method.
+    store.dispatch(
+      startPerformanceTrace({
+        eventName: PerformanceEventNames.AddSnapAccount,
+      }),
+    );
+
     return await this.withSnapKeyring(async (keyring) => {
       (keyring as unknown as SnapKeyring).createAccount(
         this.snapId,

--- a/app/core/SnapKeyring/SnapKeyring.ts
+++ b/app/core/SnapKeyring/SnapKeyring.ts
@@ -165,12 +165,6 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
           tags: getTraceTags(store.getState()),
         });
 
-        store.dispatch(
-          startPerformanceTrace({
-            eventName: PerformanceEventNames.AddSnapAccount,
-          }),
-        );
-
         // First, wait for the account to be fully saved.
         // NOTE: This might throw, so keep this in the `try` clause.
         const accountId = await onceSaved;

--- a/app/core/SnapKeyring/SnapKeyring.ts
+++ b/app/core/SnapKeyring/SnapKeyring.ts
@@ -17,7 +17,6 @@ import { store } from '../../store';
 import { MetaMetricsEvents } from '../../core/Analytics/MetaMetrics.events';
 import { trackSnapAccountEvent } from '../Analytics/helpers/SnapKeyring/trackSnapAccountEvent';
 import {
-  startPerformanceTrace,
   endPerformanceTrace,
 } from '../../core/redux/slices/performance';
 import { PerformanceEventNames } from '../redux/slices/performance/constants';

--- a/app/core/redux/slices/performance/constants.ts
+++ b/app/core/redux/slices/performance/constants.ts
@@ -1,4 +1,7 @@
+// Event name for the performance tracing:
 export const PerformanceEventNames = {
-  // Event name for the performance trace for adding a snap account into the accounts controller state
+  // When adding a Snap account.
   AddSnapAccount: 'ADD_SNAP_ACCOUNT',
+  // When adding a HD account.
+  AddHdAccount: 'ADD_HD_ACCOUNT',
 };

--- a/app/core/redux/slices/performance/index.ts
+++ b/app/core/redux/slices/performance/index.ts
@@ -97,6 +97,8 @@ const slice = createSlice({
 
       if (activeTrace) {
         const duration = Date.now() - activeTrace.startTime;
+        // eslint-disable-next-line no-console
+        console.debug(`-- ! perf: ${eventName} took ${duration.toFixed(2)}ms`);
         state.metrics.push({
           eventName,
           timestamp: activeTrace.startTime,


### PR DESCRIPTION
## **Description**

The `ADD_SNAP_ACCOUNT` was not starting at the right spot. This flow is async, and starts when we submit a request to the Snap, which will then notify the Snap keyring of the created account, and finally the Snap account will get persisted asynchronously.

Also added a new `ADD_HD_ACCOUNT` perf event to be able to compare both timing.

Finally, I've added a small debug log that could be helpful to get some perf timing without having to go through our visualization tool (we can discuss if that's a good thing or not, I just find it handy for now).

## **Related issues**

N/A

## **Manual testing steps**

1. Create a Solana account (you should see some timing in the console now)
2. Create an HD account (similar logs should be on the console)

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
