### PR TITLE
fix: only show SRP pill when we have multiple SRPs

### DIFF
--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -319,11 +319,13 @@ export function getLabelTextByAddress(address: string) {
     }))
     .filter((keyring) => keyring.type === ExtendedKeyringTypes.hd);
   const keyring = internalAccount?.metadata?.keyring;
+  // We do show pills only if we have multiple SRPs (and thus, multiple HD keyrings).
+  const shouldShowSrpPill = hdKeyringsWithMetadata.length > 1;
 
   if (keyring) {
     switch (keyring.type) {
       case ExtendedKeyringTypes.hd:
-        if (hdKeyringsWithMetadata.length > 1) {
+        if (shouldShowSrpPill) {
           const hdKeyringIndex = hdKeyringsWithMetadata.findIndex(
             (kr: KeyringObject) =>
               kr.accounts.find((account) =>
@@ -344,14 +346,19 @@ export function getLabelTextByAddress(address: string) {
         return strings('accounts.imported');
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       case KeyringTypes.snap: {
-        const { entropySource } = internalAccount?.options || {};
-        if (entropySource) {
-          const hdKeyringIndex = hdKeyringsWithMetadata.findIndex(
-            (kr) => kr.metadata.id === entropySource,
-          );
-          // -1 means the address is not found in any of the hd keyrings
-          if (hdKeyringIndex !== -1) {
-            return strings('accounts.srp_index', { index: hdKeyringIndex + 1 });
+        // TODO: We should return multiple labels if one day we allow 3rd party Snaps (since they might have 2 pills:
+        // 1. For the SRP (if they provide `options.entropySource`)
+        // 2. For the "Snap tag" (`accounts.snap_account_tag`)
+        if (shouldShowSrpPill) {
+          const { entropySource } = internalAccount?.options || {};
+          if (entropySource) {
+            const hdKeyringIndex = hdKeyringsWithMetadata.findIndex(
+              (kr) => kr.metadata.id === entropySource,
+            );
+            // -1 means the address is not found in any of the hd keyrings
+            if (hdKeyringIndex !== -1) {
+              return strings('accounts.srp_index', { index: hdKeyringIndex + 1 });
+            }
           }
         }
 


### PR DESCRIPTION
## **Description**

We were showing the SRP pill for Solana accounts even when we add only 1 SRP (== 1 HD keyring).

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/926

## **Manual testing steps**

1. Create a Solana account
2. It should not have any SRP pill showing up
3. Import a new SRP
4. You should now see an SRP pills under HD accounts and Solana accounts

## **Screenshots/Recordings**


### **Before**

![Screenshot 2025-05-07 at 19 16 09](https://github.com/user-attachments/assets/7e4bd78b-a9ed-4c00-a493-6d6a9acd980f)


### **After**

![Screenshot 2025-05-07 at 19 22 45](https://github.com/user-attachments/assets/07130464-3b8c-428a-8f2f-247eec103b1d)
![Screenshot 2025-05-07 at 19 24 14](https://github.com/user-attachments/assets/1f5d230d-47bf-41e5-a259-6f54ba1907fb)
![Screenshot 2025-05-07 at 19 24 41](https://github.com/user-attachments/assets/41774ce9-78a8-497c-900e-ad818cb48bfb)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
