### PR TITLE
fix: fix error when no pricePercentageChange found

### DIFF
--- a/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.test.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.test.tsx
@@ -72,6 +72,33 @@ const mockMultichainAssetsRatesPositive = {
     },
 };
 
+const mockMultichainAssetsRatesWithNoPercentChange = {
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+    marketData: {
+
+    },
+    rate: '147.98',
+  },
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv':
+    {
+      marketData: {
+        pricePercentChange: {
+          P1D: +2.7,
+        },
+      },
+      rate: '0.00624788',
+    },
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+    {
+      marketData: {
+        pricePercentChange: {
+          P1D: +0.5,
+        },
+      },
+      rate: '0.999998',
+    },
+};
+
 const mockMultichainAssetsRatesNegative = {
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
     marketData: {
@@ -113,6 +140,20 @@ describe('NonEvmAggregatedPercentage', () => {
   });
   afterEach(() => {
     (useSelector as jest.Mock).mockClear();
+  });
+
+  it('renders with no crash if pricePercentChange was not found', () => {
+    jest
+      .spyOn(multichain, 'getMultichainNetworkAggregatedBalance')
+      .mockReturnValue(mockGetMultichainNetworkAggregatedBalance);
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      if (selector === selectCurrentCurrency) return 'USD';
+      if (selector === selectMultichainAssetsRates)
+        return mockMultichainAssetsRatesWithNoPercentChange;
+    });
+    const {  getByTestId } = render(<NonEvmAggregatedPercentage />);
+
+    expect(getByTestId(FORMATTED_PERCENTAGE_TEST_ID).props.children).toBeDefined();
   });
 
   it('renders positive percentage change correctly', () => {

--- a/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
@@ -71,7 +71,7 @@ const NonEvmAggregatedPercentage = ({
       (total1dAgo: number, item: { id: CaipAssetType; fiatAmount: number }) => {
         const pricePercentChange1d =
           multichainAssetsRates?.[item.id]?.marketData?.pricePercentChange
-            .P1D ?? 0;
+            ?.P1D ?? 0;
         const splTokenFiat1dAgo = getCalculatedTokenAmount1dAgo(
           Number(item.fiatAmount),
           pricePercentChange1d,


### PR DESCRIPTION
## **Description**
Fixes error that occurs when we do not get pricePercentChange in marketData from snap.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="449" alt="Screenshot 2025-05-08 at 11 15 30" src="https://github.com/user-attachments/assets/72f01962-a37c-48ce-ba50-7e6e8750d82e" />

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
