### PR TITLE
test: add extra param to waitAndTap to reduce flakiness while selecting a network 

### DIFF
--- a/e2e/pages/Network/NetworkListModal.js
+++ b/e2e/pages/Network/NetworkListModal.js
@@ -70,8 +70,7 @@ class NetworkListModal {
 
   async changeNetworkTo(networkName, custom) {
     const elem = this.getCustomNetwork(networkName, custom);
-    await TestHelpers.delay(3000);
-    await Gestures.waitAndTap(elem);
+    await Gestures.waitAndTap(elem, { delayBeforeTap: 2500 });
     await TestHelpers.delay(3000);
   }
 
@@ -84,7 +83,8 @@ class NetworkListModal {
   }
 
   async tapTestNetworkSwitch() {
-    await Gestures.waitAndTap(this.testNetToggle);
+    await Gestures.waitAndTap(this.testNetToggle, { delayBeforeTap: 2500 });
+
   }
 
   async longPressOnNetwork(networkName) {
@@ -104,8 +104,8 @@ class NetworkListModal {
   }
 
   async tapAddNetworkButton() {
-    await TestHelpers.delay(3000);
-    await Gestures.waitAndTap(this.addPopularNetworkButton);
+    await Gestures.waitAndTap(this.addPopularNetworkButton, { delayBeforeTap: 2500 });
+
   }
   async deleteNetwork() {
     await Gestures.waitAndTap(this.deleteButton);

--- a/e2e/pages/swaps/SwapView.js
+++ b/e2e/pages/swaps/SwapView.js
@@ -6,6 +6,7 @@ import {
 import Matchers from '../../utils/Matchers';
 import Gestures from '../../utils/Gestures';
 import TestHelpers from '../..//helpers';
+import { waitFor } from 'detox';
 
 class SwapView {
   get quoteSummary() {
@@ -30,6 +31,16 @@ class SwapView {
     return Matchers.getElementByText(SwapViewSelectorsTexts.I_UNDERSTAND);
   }
 
+  async isPriceWarningDisplayed() {
+    try {
+      const element = await this.iUnderstandLabel;
+      await waitFor(element).toBeVisible().withTimeout(5000);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   generateSwapCompleteLabel(sourceToken, destinationToken) {
     let title = SwapViewSelectorsTexts.SWAP_CONFIRMED;
     title = title.replace('{{sourceToken}}', sourceToken);
@@ -48,11 +59,12 @@ class SwapView {
   }
 
   async tapIUnderstandPriceWarning() {
-    try {
-      await Gestures.waitAndTap(this.iUnderstandLabel, 3000);
-    } catch (e) {
+    const isDisplayed = await this.isPriceWarningDisplayed();
+    if (isDisplayed) {
+      await Gestures.waitAndTap(this.iUnderstandLabel);
+    } else {
       // eslint-disable-next-line no-console
-      console.log(`Price warning not displayed: ${e}`);
+      console.log('Price warning not displayed');
     }
   }
 }

--- a/e2e/utils/Gestures.js
+++ b/e2e/utils/Gestures.js
@@ -56,6 +56,7 @@ class Gestures {
   static async waitAndTap(elementID, timeout = 15000) {
     const element = await elementID;
     await waitFor(element).toBeVisible().withTimeout(timeout);
+    await new Promise(resolve => setTimeout(resolve, 2000));
     await element.tap();
   }
 

--- a/e2e/utils/Gestures.js
+++ b/e2e/utils/Gestures.js
@@ -51,12 +51,18 @@ class Gestures {
    * Wait for an element to be visible and then tap it.
    *
    * @param {Promise<Detox.IndexableNativeElement | Detox.SystemElement>} elementID - ID of the element to tap
-   * @param {number} timeout - Timeout for waiting (default: 8000ms)
+   * @param {Object} [options={}] - Configuration options
+   * @param {number} [options.timeout=15000] - Timeout for waiting in milliseconds
+   * @param {number} [options.delayBeforeTap=0] - Additional delay in milliseconds before tapping after element is visible
    */
-  static async waitAndTap(elementID, timeout = 15000) {
+  static async waitAndTap(elementID, options = {}) {
+    const { timeout = 15000, delayBeforeTap = 0 } = options;
     const element = await elementID;
     await waitFor(element).toBeVisible().withTimeout(timeout);
-    await new Promise(resolve => setTimeout(resolve, 2000));
+  
+    if (delayBeforeTap > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayBeforeTap)); // in some cases the element is visible but not fully interactive yet.
+    }
     await element.tap();
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A regression test is failing because Detox tries to tap the toggle to display testnets before it's ready for interaction. Even though the element is visible, it isn't yet interactive when the tap occurs. I notice some of the tests are also flaking because of this same behavior. For example, tapping on a network from the network list bottom sheet.


My approach would be to add an options parameter in the waitAndTap function: delayTap

So we go from
```
  static async waitAndTap(elementID, timeout = 15000) {
    const element = await elementID;
    await waitFor(element).toBeVisible().withTimeout(timeout);
    await element.tap();
  }

```
which essentially waits until the element is visible and then taps.
to
```
  static async waitAndTap(elementID, options = {}) {
    const { timeout = 15000, delayBeforeTap = 0 } = options;
    const element = await elementID;
    await waitFor(element).toBeVisible().withTimeout(timeout);
  
    if (delayBeforeTap > 0) {
      await new Promise((resolve) => setTimeout(resolve, delayBeforeTap)); // in some cases the element is visible but not fully interactive yet.
    }
    await element.tap();
    return element; // Return the element for potential chaining
  }
```
which  in addition to waiting for the element to be visible before tapping, checks whether we want to add a delay before tapping. By default, there will be no delay before tapping.


 See video of flaky behavior

https://github.com/user-attachments/assets/1abd9cb5-871a-482e-968a-4dc8712ac95b




## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
