### PR TITLE
fix: cp-7.47.0 Add safe checksum method in `SendTo` page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(bridge): fix transaction history for EVM and Solana bridge transactions ([#14759](https://github.com/MetaMask/metamask-mobile/pull/14759))
 - fix(bridge): change networks properly when user switches between source and destination tokens ([#14812](https://github.com/MetaMask/metamask-mobile/pull/14812))
 - fix(bridge): fix(bridge): update quote details card toggle to handle same chain swaps and improve slippage button layout ([#15153](https://github.com/MetaMask/metamask-mobile/pull/15153))
+- fix(confirmations): fix the send crash when user puts unexpected address into recipient input([#15308](https://github.com/MetaMask/metamask-mobile/pull/15308))
 
 ## [7.45.2]
 

--- a/app/components/Views/confirmations/legacy/SendFlow/SendTo/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/SendFlow/SendTo/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SendTo Component should render 1`] = `
+exports[`SendTo Component render matches snapshot 1`] = `
 <RNCSafeAreaView
   edges={
     [

--- a/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.js
@@ -224,7 +224,7 @@ class SendFlow extends PureComponent {
     const { toAccount } = this.state;
     const { addressBook, globalChainId, internalAccounts } = this.props;
     const networkAddressBook = addressBook[globalChainId] || {};
-    const checksummedAddress = toChecksumAddress(toAccount);
+    const checksummedAddress = this.safeChecksumAddress(toAccount);
     return !!(
       networkAddressBook[checksummedAddress] ||
       internalAccounts.find((account) =>
@@ -376,12 +376,13 @@ class SendFlow extends PureComponent {
   };
 
   getAddressNameFromBookOrInternalAccounts = (toAccount) => {
+    console.log('OGP - getAddressNameFromBookOrInternalAccounts: ', toAccount);
     const { addressBook, internalAccounts, globalChainId } = this.props;
     if (!toAccount) return;
 
     const networkAddressBook = addressBook[globalChainId] || {};
 
-    const checksummedAddress = toChecksumAddress(toAccount);
+    const checksummedAddress = this.safeChecksumAddress(toAccount);
     const matchingAccount = internalAccounts.find((account) =>
       toLowerCaseEquals(account.address, checksummedAddress),
     );
@@ -426,6 +427,7 @@ class SendFlow extends PureComponent {
   };
 
   onToSelectedAddressChange = (toAccount) => {
+    console.log('OGP - onToSelectedAddressChange: ', toAccount);
     const currentChain =
       this.props.ambiguousAddressEntries &&
       this.props.ambiguousAddressEntries[this.props.globalChainId];
@@ -481,6 +483,14 @@ class SendFlow extends PureComponent {
     this.setState({ showAmbiguousAcountWarning: false });
   };
 
+  safeChecksumAddress = (address) => {
+    try {
+      return toChecksumAddress(address);
+    } catch (error) {
+      return address;
+    }
+  };
+
   render = () => {
     const { ticker, addressBook, globalChainId } = this.props;
     const {
@@ -499,7 +509,7 @@ class SendFlow extends PureComponent {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
 
-    const checksummedAddress = toAccount && toChecksumAddress(toAccount);
+    const checksummedAddress = this.safeChecksumAddress(toAccount);
     const existingAddressName = this.getAddressNameFromBookOrInternalAccounts(
       toEnsAddressResolved || toAccount,
     );

--- a/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.js
@@ -376,7 +376,6 @@ class SendFlow extends PureComponent {
   };
 
   getAddressNameFromBookOrInternalAccounts = (toAccount) => {
-    console.log('OGP - getAddressNameFromBookOrInternalAccounts: ', toAccount);
     const { addressBook, internalAccounts, globalChainId } = this.props;
     if (!toAccount) return;
 
@@ -427,7 +426,6 @@ class SendFlow extends PureComponent {
   };
 
   onToSelectedAddressChange = (toAccount) => {
-    console.log('OGP - onToSelectedAddressChange: ', toAccount);
     const currentChain =
       this.props.ambiguousAddressEntries &&
       this.props.ambiguousAddressEntries[this.props.globalChainId];

--- a/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.test.tsx
+++ b/app/components/Views/confirmations/legacy/SendFlow/SendTo/index.test.tsx
@@ -8,6 +8,7 @@ import SendTo from './index';
 import { ThemeContext, mockTheme } from '../../../../../../util/theme';
 import initialRootState from '../../../../../../util/test/initial-root-state';
 import { validateAddressOrENS } from '../../../../../../util/address';
+import { SendViewSelectorsIDs } from '../../../../../../../e2e/selectors/SendFlow/SendView.selectors';
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -54,7 +55,7 @@ describe('SendTo Component', () => {
     );
   });
 
-  it('should render', () => {
+  it('render matches snapshot', () => {
     const wrapper = render(
       <Provider store={store}>
         <ThemeContext.Provider value={mockTheme}>
@@ -65,7 +66,7 @@ describe('SendTo Component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should navigate to Amount screen', () => {
+  it('navigates to Amount screen', () => {
     const MOCK_TARGET_ADDRESS = '0x0000000000000000000000000000000000000000';
     const { navigate } = navigationPropMock;
     const routeProps = {
@@ -85,5 +86,24 @@ describe('SendTo Component', () => {
     );
     fireEvent.press(screen.getByText('Next'));
     expect(navigate).toHaveBeenCalledWith('Amount');
+  });
+
+  it('shows the warning message when the target address is invalid', () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={store}>
+        <ThemeContext.Provider value={mockTheme}>
+          <SendTo navigation={navigationPropMock} route={routeMock} />
+        </ThemeContext.Provider>
+      </Provider>,
+    );
+
+    const toInput = getByTestId(SendViewSelectorsIDs.ADDRESS_INPUT);
+    fireEvent.changeText(toInput, 'invalid address');
+
+    const expectedWarningMessage = getByText(
+      'No address has been set for this name.',
+    );
+
+    expect(expectedWarningMessage).toBeOnTheScreen();
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix an issue when user puts an unexpected value into `to` field in send flow. 

It appears from that [the issue](https://metamask.sentry.io/issues/6582066742/?project=2299799) is thrown by `toChecksumAddress` because it doesn't expect any incomplete address. However in send flow UX we let user to type in address themselves. 

To test this you can go `SendTo` page and put `K` for example - and see the crash. (Screenshot below is fixed version)

**Labels**
Adding `skip-sonar-cloud` as the raised issue was intentional.

![Screenshot 2025-05-14 at 06 44 09](https://github.com/user-attachments/assets/fda651bc-4925-40d8-95ca-2cabd7cbed66)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15094

## **Manual testing steps**

1. Go to send flow
2. Input an unexpected address 
3. Confirm warning shown - you shouldn't be proceed next step

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
