### PR TITLE
fix: Bridge long token values show the right hand side, make it show the left

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -409,6 +409,12 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                           onBlur={[Function]}
                                           onFocus={[Function]}
                                           placeholder="0"
+                                          selection={
+                                            {
+                                              "end": 0,
+                                              "start": 0,
+                                            }
+                                          }
                                           showSoftInputOnFocus={false}
                                           style={
                                             {
@@ -792,6 +798,12 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                           onBlur={[Function]}
                                           onFocus={[Function]}
                                           placeholder="0"
+                                          selection={
+                                            {
+                                              "end": 0,
+                                              "start": 0,
+                                            }
+                                          }
                                           showSoftInputOnFocus={false}
                                           style={
                                             {
@@ -1357,6 +1369,12 @@ exports[`BridgeView renders 1`] = `
                                           onBlur={[Function]}
                                           onFocus={[Function]}
                                           placeholder="0"
+                                          selection={
+                                            {
+                                              "end": 0,
+                                              "start": 0,
+                                            }
+                                          }
                                           showSoftInputOnFocus={false}
                                           style={
                                             {
@@ -1740,6 +1758,12 @@ exports[`BridgeView renders 1`] = `
                                           onBlur={[Function]}
                                           onFocus={[Function]}
                                           placeholder="0"
+                                          selection={
+                                            {
+                                              "end": 0,
+                                              "start": 0,
+                                            }
+                                          }
                                           showSoftInputOnFocus={false}
                                           style={
                                             {

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -56,6 +56,7 @@ const createStyles = () =>
       borderWidth: 0,
       lineHeight: 50,
       height: 50,
+      textAlign: 'left',
     },
   });
 
@@ -222,6 +223,7 @@ export const TokenInputArea = forwardRef<
                   onBlur={() => {
                     onBlur?.();
                   }}
+                  selection={{ start: 0, end: 0 }}
                 />
               )}
             </Box>

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -39,6 +39,8 @@ import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { parseUnits } from 'ethers/lib/utils';
 import parseAmount from '../../../Ramp/utils/parseAmount';
 
+const MAX_DECIMALS = 5;
+
 const createStyles = () =>
   StyleSheet.create({
     content: {
@@ -207,7 +209,7 @@ export const TokenInputArea = forwardRef<
               ) : (
                 <Input
                   ref={inputRef}
-                  value={amount ? parseAmount(amount, 7) : amount}
+                  value={amount ? parseAmount(amount, MAX_DECIMALS) : amount}
                   style={styles.input}
                   isDisabled={false}
                   isReadonly={tokenType === TokenInputAreaType.Destination}

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -37,6 +37,7 @@ import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { parseUnits } from 'ethers/lib/utils';
+import parseAmount from '../../../Ramp/utils/parseAmount';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -207,7 +208,7 @@ export const TokenInputArea = forwardRef<
               ) : (
                 <Input
                   ref={inputRef}
-                  value={amount}
+                  value={amount ? parseAmount(amount, 7) : amount}
                   style={styles.input}
                   isDisabled={false}
                   isReadonly={tokenType === TokenInputAreaType.Destination}

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -57,7 +57,6 @@ const createStyles = () =>
       borderWidth: 0,
       lineHeight: 50,
       height: 50,
-      textAlign: 'left',
     },
   });
 

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -223,6 +223,8 @@ export const TokenInputArea = forwardRef<
                   onBlur={() => {
                     onBlur?.();
                   }}
+                  // Android only issue, for long numbers, the input field will focus on the right hand side
+                  // Force it to focus on the left hand side
                   selection={{ start: 0, end: 0 }}
                 />
               )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue in android only where if the destination token amount is a very long number it would only show the decimal part now we will show the same as iOS which would be the significant digit on the left first.

It also truncates to 5 decimals max.

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MMS-2387
https://consensyssoftware.atlassian.net/browse/MMS-2395

https://github.com/MetaMask/metamask-mobile/issues/15604

## **Manual testing steps**

Android only

1. Go to Bridge
2. Request a quote for a dest token with 18 decimals (e.g. ETH)
3. The amount should show the left hand side significant digits rather than the right hand side decimals
4. Should also show 5 decimals max

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="815" alt="Screenshot 2025-05-14 at 2 51 36 PM" src="https://github.com/user-attachments/assets/ed3fc73f-1060-44e4-a74f-1912fd1e5d4a" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
