### PR TITLE
feat: add red styling for insufficient balance on solana swaps

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -15,7 +15,7 @@ import {
 import { renderNumber } from '../../../../../util/number';
 import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { BridgeToken } from '../../types';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import Button, {
@@ -35,6 +35,8 @@ import { selectMultichainAssetsRates } from '../../../../../selectors/multichain
 ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
+import { useLatestBalance } from '../../hooks/useLatestBalance';
+import { parseUnits } from 'ethers/lib/utils';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -146,7 +148,23 @@ export const TokenInputArea = forwardRef<
       selectNetworkConfigurations,
     );
     const { quoteRequest } = useSelector(selectBridgeControllerState);
-    const isInsufficientBalance = quoteRequest?.insufficientBal;
+
+    const latestBalance = useLatestBalance({
+      address: token?.address,
+      decimals: token?.decimals,
+      chainId: token?.chainId,
+      balance: token?.balance,
+    });
+    const isValidAmount =
+    amount !== undefined && amount !== '.' && token?.decimals;
+
+    // quoteRequest.insufficientBal is undefined for Solana quotes, so we need to manually check if the source amount is greater than the balance
+    const isInsufficientBalance =
+    quoteRequest?.insufficientBal ||
+    (isValidAmount &&
+      parseUnits(amount, token.decimals).gt(
+        latestBalance?.atomicBalance ?? BigNumber.from(0),
+      ));
 
     let nonEvmMultichainAssetRates = {};
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Accounts for Solana balances when determining if a user has insufficient balance for a swap and makes the text red if so.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Solana swaps
2. Input amount greater than balance
3. See red text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
