### PR TITLE
fix: horizontal network picker not appearing in bridge and vertical + horizontal scroll (#15219)

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
@@ -15,7 +15,7 @@ import { BridgeNetworkSelectorBase } from '../BridgeNetworkSelectorBase';
 import { NetworkRow } from '../NetworkRow';
 import Routes from '../../../../../constants/navigation/Routes';
 import { selectChainId } from '../../../../../selectors/networkController';
-
+import { BridgeViewMode } from '../../types';
 export interface BridgeDestNetworkSelectorRouteParams {
   shouldGoToTokens?: boolean;
 }
@@ -42,7 +42,9 @@ export const BridgeDestNetworkSelector: React.FC = () => {
     if (route.params.shouldGoToTokens) {
       navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
         screen: Routes.BRIDGE.MODALS.DEST_TOKEN_SELECTOR,
-        params: {},
+        params: {
+          bridgeViewMode: BridgeViewMode.Bridge,
+        },
       });
     }
   }, [dispatch, navigation, route.params.shouldGoToTokens]);

--- a/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworksBar.tsx
@@ -8,7 +8,7 @@ import Button, {
 import { strings } from '../../../../../locales/i18n';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';
-import { StyleSheet, ScrollView } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -34,6 +34,8 @@ import { AlignItems, FlexDirection } from '../../Box/box.types';
 import AvatarNetwork from '../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 import { AvatarSize } from '../../../../component-library/components/Avatars/Avatar';
 import { selectChainId } from '../../../../selectors/networkController';
+// Using ScrollView from react-native-gesture-handler to fix scroll issues with the bottom sheet
+import { ScrollView } from 'react-native-gesture-handler';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { SolScope } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -560,6 +560,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                             }
                           >
                             <RCTScrollView
+                              collapsable={false}
                               contentContainerStyle={
                                 {
                                   "alignItems": "center",
@@ -569,6 +570,8 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                 }
                               }
                               horizontal={true}
+                              onGestureHandlerEvent={[Function]}
+                              onGestureHandlerStateChange={[Function]}
                               showsHorizontalScrollIndicator={false}
                               style={
                                 {
@@ -760,6 +763,8 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                           </View>
                           <RCTScrollView
                             ListEmptyComponent={[Function]}
+                            bounces={true}
+                            collapsable={false}
                             data={
                               [
                                 {
@@ -801,6 +806,8 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                             getItemCount={[Function]}
                             keyExtractor={[Function]}
                             onContentSizeChange={[Function]}
+                            onGestureHandlerEvent={[Function]}
+                            onGestureHandlerStateChange={[Function]}
                             onLayout={[Function]}
                             onMomentumScrollBegin={[Function]}
                             onMomentumScrollEnd={[Function]}
@@ -809,7 +816,11 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                             onScrollEndDrag={[Function]}
                             removeClippedSubviews={false}
                             renderItem={[Function]}
+                            renderScrollComponent={[Function]}
+                            scrollEnabled={true}
                             scrollEventThrottle={0.0001}
+                            showsHorizontalScrollIndicator={false}
+                            showsVerticalScrollIndicator={true}
                             stickyHeaderIndices={[]}
                             viewabilityConfigCallbackPairs={[]}
                           >

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -790,6 +790,8 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                           </View>
                           <RCTScrollView
                             ListEmptyComponent={[Function]}
+                            bounces={true}
+                            collapsable={false}
                             data={
                               [
                                 {
@@ -853,6 +855,8 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                             getItemCount={[Function]}
                             keyExtractor={[Function]}
                             onContentSizeChange={[Function]}
+                            onGestureHandlerEvent={[Function]}
+                            onGestureHandlerStateChange={[Function]}
                             onLayout={[Function]}
                             onMomentumScrollBegin={[Function]}
                             onMomentumScrollEnd={[Function]}
@@ -861,7 +865,11 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                             onScrollEndDrag={[Function]}
                             removeClippedSubviews={false}
                             renderItem={[Function]}
+                            renderScrollComponent={[Function]}
+                            scrollEnabled={true}
                             scrollEventThrottle={0.0001}
+                            showsHorizontalScrollIndicator={false}
+                            showsVerticalScrollIndicator={true}
                             stickyHeaderIndices={[]}
                             viewabilityConfigCallbackPairs={[]}
                           >

--- a/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback, useMemo, useRef } from 'react';
-import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+// Using FlatList from react-native-gesture-handler to fix scroll issues with the bottom sheet
+import { FlatList } from 'react-native-gesture-handler';
 import { Box } from '../../Box/Box';
 import Text, {
   TextVariant,
@@ -20,16 +26,13 @@ import { BridgeToken } from '../types';
 import { Skeleton } from '../../../../component-library/components/Skeleton';
 import { useAssetMetadata } from '../hooks/useAssetMetadata';
 import { CaipChainId, Hex } from '@metamask/utils';
+// We use ReusableModal instead of BottomSheet to prevent the keyboard from pushing the search input off screen
 import ReusableModal, { ReusableModalRef } from '../../ReusableModal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const createStyles = (params: { theme: Theme }) => {
   const { theme } = params;
   return StyleSheet.create({
-    content: {
-      flex: 1,
-      backgroundColor: theme.colors.background.default,
-    },
     headerTitle: {
       flex: 1,
       textAlign: 'center',
@@ -67,6 +70,11 @@ const createStyles = (params: { theme: Theme }) => {
     skeletonItemRows: {
       flex: 1,
     },
+    // This section is so we can use ReusableModal styled like BottomSheet
+    content: {
+      flex: 1,
+      backgroundColor: theme.colors.background.default,
+    },
     screen: { justifyContent: 'flex-end' },
     sheet: {
       backgroundColor: theme.colors.background.default,
@@ -81,6 +89,7 @@ const createStyles = (params: { theme: Theme }) => {
       marginTop: 8,
       alignSelf: 'center',
     },
+    // End section
   });
 };
 
@@ -224,13 +233,7 @@ export const BridgeTokenSelectorBase: React.FC<
       ref={modalRef}
       style={[styles.screen, { marginTop: safeAreaInsets.top }]}
     >
-      <Box
-        style={[
-          styles.content,
-          styles.sheet,
-          { paddingBottom: safeAreaInsets.bottom },
-        ]}
-      >
+      <Box style={[styles.content,styles.sheet, { paddingBottom: safeAreaInsets.bottom }]}>
         <Box style={styles.notch} />
         <Box gap={4}>
           <BottomSheetHeader>
@@ -278,6 +281,10 @@ export const BridgeTokenSelectorBase: React.FC<
               ? renderEmptyList
               : LoadingSkeleton
           }
+          showsVerticalScrollIndicator
+          showsHorizontalScrollIndicator={false}
+          bounces
+          scrollEnabled
         />
       </Box>
     </ReusableModal>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the following issues:
1. The horizontal network picker was missing
2. Horizontal scroll not working in the network picker
3. Vertical scroll not working for token list

It also maintains the ability to swipe down and close the modals.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Bridge
4. Open source token selector
5. Verify that you can vertically scroll token list
6. Open destination, token selector
7. Verify that you can vertically scroll token list
8. Verify that you can horizontally scroll network list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->




https://github.com/user-attachments/assets/c05ba05b-4c16-4e3f-a862-64d920bf7b27





## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
