### PR TITLE
fix: cp-7.47.0 add MetaMask fee disclaimer text to bridge view

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
@@ -81,8 +81,5 @@ export const createStyles = (params: { theme: Theme }) => {
       paddingTop: 8,
       paddingBottom: 12,
     },
-    disclaimerText: {
-      textAlign: 'center',
-    },
   });
 };

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
@@ -22,13 +22,10 @@ export const createStyles = (params: { theme: Theme }) => {
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: theme.colors.background.default,
+      paddingTop: 12,
     },
     button: {
       width: '100%',
-    },
-    bottomSection: {
-      flex: 1,
-      justifyContent: 'flex-end',
     },
     arrowContainer: {
       position: 'relative',
@@ -83,6 +80,9 @@ export const createStyles = (params: { theme: Theme }) => {
       justifyContent: 'center',
       paddingTop: 8,
       paddingBottom: 12,
+    },
+    disclaimerText: {
+      textAlign: 'center',
     },
   });
 };

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -896,24 +896,7 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                       },
                                     ]
                                   }
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#686e7d",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    Includes 0.875% MM fee
-                                  </Text>
-                                </View>
+                                />
                               </View>
                             </View>
                             <View
@@ -1861,24 +1844,7 @@ exports[`BridgeView renders 1`] = `
                                       },
                                     ]
                                   }
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    style={
-                                      {
-                                        "color": "#686e7d",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    Includes 0.875% MM fee
-                                  </Text>
-                                </View>
+                                />
                               </View>
                             </View>
                             <View

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -896,7 +896,24 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                       },
                                     ]
                                   }
-                                />
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#686e7d",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    Includes 0.875% MM fee
+                                  </Text>
+                                </View>
                               </View>
                             </View>
                             <View
@@ -910,6 +927,7 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                     "justifyContent": "center",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 16,
+                                    "paddingTop": 12,
                                     "width": "100%",
                                   },
                                 ]
@@ -1843,7 +1861,24 @@ exports[`BridgeView renders 1`] = `
                                       },
                                     ]
                                   }
-                                />
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#686e7d",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    Includes 0.875% MM fee
+                                  </Text>
+                                </View>
                               </View>
                             </View>
                             <View
@@ -1857,6 +1892,7 @@ exports[`BridgeView renders 1`] = `
                                     "justifyContent": "center",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 16,
+                                    "paddingTop": 12,
                                     "width": "100%",
                                   },
                                 ]

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -69,7 +69,6 @@ import { BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchTokens } from '../../hooks/useSwitchTokens';
 import { parseUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
-import { theme } from '@storybook/react-native';
 
 export interface BridgeRouteParams {
   token?: BridgeToken;
@@ -405,8 +404,7 @@ const BridgeView = () => {
               token={destToken}
               networkImageSource={
                 destToken
-                  ? //@ts-expect-error - destToken is not typed
-                    getNetworkImageSource({ chainId: destToken?.chainId })
+                  ? getNetworkImageSource({ chainId: destToken?.chainId })
                   : undefined
               }
               testID="dest-token-area"

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -13,6 +13,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { Box } from '../../../Box/Box';
 import Text, {
   TextColor,
+  TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconName,
@@ -68,6 +69,7 @@ import { BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchTokens } from '../../hooks/useSwitchTokens';
 import { parseUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
+import { theme } from '@storybook/react-native';
 
 export interface BridgeRouteParams {
   token?: BridgeToken;
@@ -376,8 +378,7 @@ const BridgeView = () => {
               tokenBalance={latestSourceBalance?.displayBalance}
               networkImageSource={
                 sourceToken?.chainId
-                  ?
-                    getNetworkImageSource({
+                  ? getNetworkImageSource({
                       chainId: sourceToken?.chainId,
                     })
                   : undefined
@@ -404,7 +405,7 @@ const BridgeView = () => {
               token={destToken}
               networkImageSource={
                 destToken
-                  ?
+                  ? //@ts-expect-error - destToken is not typed
                     getNetworkImageSource({ chainId: destToken?.chainId })
                   : undefined
               }
@@ -422,6 +423,13 @@ const BridgeView = () => {
             {shouldDisplayQuoteDetails ? (
               <Box style={styles.quoteContainer}>
                 <QuoteDetailsCard />
+                <Text
+                  variant={TextVariant.BodyMD}
+                  color={TextColor.Alternative}
+                  style={styles.disclaimerText}
+                >
+                  {strings('bridge.fee_disclaimer')}
+                </Text>
               </Box>
             ) : shouldDisplayKeypad ? (
               <Box

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -13,7 +13,6 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { Box } from '../../../Box/Box';
 import Text, {
   TextColor,
-  TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconName,
@@ -421,13 +420,6 @@ const BridgeView = () => {
             {shouldDisplayQuoteDetails ? (
               <Box style={styles.quoteContainer}>
                 <QuoteDetailsCard />
-                <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
-                  style={styles.disclaimerText}
-                >
-                  {strings('bridge.fee_disclaimer')}
-                </Text>
               </Box>
             ) : shouldDisplayKeypad ? (
               <Box

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
@@ -31,6 +31,9 @@ const createStyles = ({ colors }: Theme) =>
       alignItems: 'center',
       gap: 4,
     },
+    disclaimerText: {
+      textAlign: 'center',
+    },
   });
 
 export default createStyles;

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -8,6 +8,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import Text, {
+  TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
@@ -46,7 +47,7 @@ import {
   selectSourceToken,
 } from '../../../../../core/redux/slices/bridge';
 
-const ANIMATION_DURATION_MS = 300;
+const ANIMATION_DURATION_MS = 50;
 
 if (
   Platform.OS === 'android' &&
@@ -156,179 +157,190 @@ const QuoteDetailsCard = () => {
     formattedQuoteData;
 
   return (
-    <Box style={styles.container}>
-      <Box
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.spaceBetween}
-      >
-        {!isSameChainId && (
-          <>
-            <Box
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
-              style={styles.networkContainer}
-            >
-              <NetworkBadge chainId={String(sourceToken.chainId)} />
-              <Icon name={IconName.Arrow2Right} size={IconSize.Sm} />
-              <NetworkBadge chainId={String(destToken.chainId)} />
-            </Box>
-            <Animated.View style={arrowStyle}>
-              <TouchableOpacity
-                onPress={toggleAccordion}
-                activeOpacity={0.7}
-                accessibilityRole="button"
-                accessibilityLabel={
-                  isExpanded ? 'Collapse quote details' : 'Expand quote details'
-                }
-                testID="expand-quote-details"
+    <Box>
+      <Box style={styles.container}>
+        <Box
+          flexDirection={FlexDirection.Row}
+          alignItems={AlignItems.center}
+          justifyContent={JustifyContent.spaceBetween}
+        >
+          {!isSameChainId && (
+            <>
+              <Box
+                flexDirection={FlexDirection.Row}
+                alignItems={AlignItems.center}
+                style={styles.networkContainer}
               >
-                <Icon
-                  name={IconName.ArrowDown}
-                  size={IconSize.Sm}
-                  color={theme.colors.icon.muted}
-                />
-              </TouchableOpacity>
-            </Animated.View>
-          </>
-        )}
-      </Box>
+                <NetworkBadge chainId={String(sourceToken.chainId)} />
+                <Icon name={IconName.Arrow2Right} size={IconSize.Sm} />
+                <NetworkBadge chainId={String(destToken.chainId)} />
+              </Box>
+              <Animated.View style={arrowStyle}>
+                <TouchableOpacity
+                  onPress={toggleAccordion}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    isExpanded
+                      ? 'Collapse quote details'
+                      : 'Expand quote details'
+                  }
+                  testID="expand-quote-details"
+                >
+                  <Icon
+                    name={IconName.ArrowDown}
+                    size={IconSize.Sm}
+                    color={theme.colors.icon.muted}
+                  />
+                </TouchableOpacity>
+              </Animated.View>
+            </>
+          )}
+        </Box>
 
-      {/* Always visible content */}
-      <KeyValueRow
-        field={{
-          label: {
-            text: strings('bridge.network_fee') || 'Network fee',
-            variant: TextVariant.BodyMDMedium,
-          },
-        }}
-        value={{
-          label: {
-            text: networkFee,
-            variant: TextVariant.BodyMD,
-          },
-        }}
-      />
-
-      <KeyValueRow
-        field={{
-          label: {
-            text: strings('bridge.time') || 'Time',
-            variant: TextVariant.BodyMDMedium,
-          },
-        }}
-        value={{
-          label: {
-            text: estimatedTime,
-            variant: TextVariant.BodyMD,
-          },
-        }}
-      />
-
-      {/* Quote info with gradient overlay */}
-      <Box>
+        {/* Always visible content */}
         <KeyValueRow
           field={{
             label: {
-              text: strings('bridge.quote') || 'Quote',
+              text: strings('bridge.network_fee') || 'Network fee',
               variant: TextVariant.BodyMDMedium,
-            },
-            tooltip: {
-              title: strings('bridge.quote_info_title'),
-              content: strings('bridge.quote_info_content'),
-              onPress: handleQuoteInfoPress,
-              size: TooltipSizes.Sm,
             },
           }}
           value={{
             label: {
-              text: rate,
+              text: networkFee,
               variant: TextVariant.BodyMD,
             },
           }}
         />
-        {!isExpanded && (
-          <Box style={styles.gradientContainer}>
-            <Svg height="30" width="100%">
-              <Defs>
-                <LinearGradient id="fadeGradient" x1="0" y1="0" x2="0" y2="1">
-                  <Stop
-                    offset="0"
-                    stopColor={theme.colors.background.default}
-                    stopOpacity="0"
-                  />
-                  <Stop
-                    offset="1"
-                    stopColor={theme.colors.background.default}
-                    stopOpacity="1"
-                  />
-                </LinearGradient>
-              </Defs>
-              <Rect
-                x="0"
-                y="0"
-                width="100%"
-                height="30"
-                fill="url(#fadeGradient)"
-              />
-            </Svg>
+
+        <KeyValueRow
+          field={{
+            label: {
+              text: strings('bridge.time') || 'Time',
+              variant: TextVariant.BodyMDMedium,
+            },
+          }}
+          value={{
+            label: {
+              text: estimatedTime,
+              variant: TextVariant.BodyMD,
+            },
+          }}
+        />
+
+        {/* Quote info with gradient overlay */}
+        <Box>
+          <KeyValueRow
+            field={{
+              label: {
+                text: strings('bridge.quote') || 'Quote',
+                variant: TextVariant.BodyMDMedium,
+              },
+              tooltip: {
+                title: strings('bridge.quote_info_title'),
+                content: strings('bridge.quote_info_content'),
+                onPress: handleQuoteInfoPress,
+                size: TooltipSizes.Sm,
+              },
+            }}
+            value={{
+              label: {
+                text: rate,
+                variant: TextVariant.BodyMD,
+              },
+            }}
+          />
+          {!isExpanded && (
+            <Box style={styles.gradientContainer}>
+              <Svg height="30" width="100%">
+                <Defs>
+                  <LinearGradient id="fadeGradient" x1="0" y1="0" x2="0" y2="1">
+                    <Stop
+                      offset="0"
+                      stopColor={theme.colors.background.default}
+                      stopOpacity="0"
+                    />
+                    <Stop
+                      offset="1"
+                      stopColor={theme.colors.background.default}
+                      stopOpacity="1"
+                    />
+                  </LinearGradient>
+                </Defs>
+                <Rect
+                  x="0"
+                  y="0"
+                  width="100%"
+                  height="30"
+                  fill="url(#fadeGradient)"
+                />
+              </Svg>
+            </Box>
+          )}
+        </Box>
+
+        {/* Expandable content */}
+        {isExpanded && (
+          <Box gap={12}>
+            <KeyValueRow
+              field={{
+                label: {
+                  text: strings('bridge.price_impact') || 'Price Impact',
+                  variant: TextVariant.BodyMDMedium,
+                },
+              }}
+              value={{
+                label: {
+                  text: priceImpact,
+                  variant: TextVariant.BodyMD,
+                },
+              }}
+            />
+
+            <KeyValueRow
+              field={{
+                label: (
+                  <Box
+                    flexDirection={FlexDirection.Row}
+                    alignItems={AlignItems.center}
+                    gap={4}
+                  >
+                    <TouchableOpacity
+                      onPress={handleSlippagePress}
+                      activeOpacity={0.6}
+                      testID="edit-slippage-button"
+                      style={styles.slippageButton}
+                    >
+                      <Text variant={TextVariant.BodyMDMedium}>
+                        {strings('bridge.slippage') || 'Slippage'}
+                      </Text>
+                      <Icon
+                        name={IconName.Edit}
+                        size={IconSize.Sm}
+                        color={IconColor.Muted}
+                      />
+                    </TouchableOpacity>
+                  </Box>
+                ),
+              }}
+              value={{
+                label: {
+                  text: slippage,
+                  variant: TextVariant.BodyMD,
+                },
+              }}
+            />
           </Box>
         )}
       </Box>
-
-      {/* Expandable content */}
-      {isExpanded && (
-        <Box gap={12}>
-          <KeyValueRow
-            field={{
-              label: {
-                text: strings('bridge.price_impact') || 'Price Impact',
-                variant: TextVariant.BodyMDMedium,
-              },
-            }}
-            value={{
-              label: {
-                text: priceImpact,
-                variant: TextVariant.BodyMD,
-              },
-            }}
-          />
-
-          <KeyValueRow
-            field={{
-              label: (
-                <Box
-                  flexDirection={FlexDirection.Row}
-                  alignItems={AlignItems.center}
-                  gap={4}
-                >
-                  <TouchableOpacity
-                    onPress={handleSlippagePress}
-                    activeOpacity={0.6}
-                    testID="edit-slippage-button"
-                    style={styles.slippageButton}
-                  >
-                    <Text variant={TextVariant.BodyMDMedium}>
-                      {strings('bridge.slippage') || 'Slippage'}
-                    </Text>
-                    <Icon
-                      name={IconName.Edit}
-                      size={IconSize.Sm}
-                      color={IconColor.Muted}
-                    />
-                  </TouchableOpacity>
-                </Box>
-              ),
-            }}
-            value={{
-              label: {
-                text: slippage,
-                variant: TextVariant.BodyMD,
-              },
-            }}
-          />
-        </Box>
-      )}
+      <Text
+        variant={TextVariant.BodyMD}
+        color={TextColor.Alternative}
+        style={styles.disclaimerText}
+      >
+        {strings('bridge.fee_disclaimer')}
+      </Text>
     </Box>
   );
 };

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -313,233 +313,137 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                       style={
                         [
                           {},
-                          {
-                            "backgroundColor": "#ffffff",
-                            "borderColor": "#b7bbc866",
-                            "borderRadius": 8,
-                            "borderWidth": 1,
-                            "gap": 12,
-                            "marginBottom": 12,
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "paddingVertical": 12,
-                          },
+                          undefined,
                         ]
                       }
                     >
                       <View
-                        alignItems="center"
-                        flexDirection="row"
-                        justifyContent="space-between"
                         style={
                           [
+                            {},
                             {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
+                              "backgroundColor": "#ffffff",
+                              "borderColor": "#b7bbc866",
+                              "borderRadius": 8,
+                              "borderWidth": 1,
+                              "gap": 12,
+                              "marginBottom": 12,
+                              "overflow": "hidden",
+                              "paddingHorizontal": 16,
+                              "paddingVertical": 12,
                             },
-                            undefined,
                           ]
                         }
                       >
                         <View
                           alignItems="center"
                           flexDirection="row"
+                          justifyContent="space-between"
                           style={
                             [
                               {
                                 "alignItems": "center",
                                 "flexDirection": "row",
+                                "justifyContent": "space-between",
                               },
-                              {
-                                "flexDirection": "row",
-                                "flexWrap": "wrap",
-                                "maxWidth": "80%",
-                              },
+                              undefined,
                             ]
                           }
                         >
                           <View
                             alignItems="center"
                             flexDirection="row"
-                            gap={2}
                             style={
                               [
                                 {
                                   "alignItems": "center",
                                   "flexDirection": "row",
-                                  "gap": 2,
                                 },
-                                undefined,
-                              ]
-                            }
-                          >
-                            <View
-                              onLayout={[Function]}
-                              style={{}}
-                              testID="badgenetwork"
-                            >
-                              <View
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#ffffff",
-                                    "borderRadius": 8,
-                                    "borderWidth": 1.5,
-                                    "height": 24,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "shadowColor": "#0000001a",
-                                    "shadowOffset": {
-                                      "height": 2,
-                                      "width": 0,
-                                    },
-                                    "shadowOpacity": 1,
-                                    "shadowRadius": 4,
-                                    "width": 24,
-                                  }
-                                }
-                              >
-                                <Image
-                                  onError={[Function]}
-                                  resizeMode="contain"
-                                  source={1}
-                                  style={
-                                    {
-                                      "height": 24,
-                                      "width": 24,
-                                    }
-                                  }
-                                  testID="network-avatar-image"
-                                />
-                              </View>
-                            </View>
-                            <Text
-                              accessibilityRole="text"
-                              style={
                                 {
-                                  "color": "#121314",
-                                  "fontFamily": "CentraNo1-Medium",
-                                  "fontSize": 16,
-                                  "fontWeight": "500",
-                                  "letterSpacing": 0,
-                                  "lineHeight": 24,
-                                }
-                              }
-                            >
-                              Ethereum Mainnet
-                            </Text>
-                          </View>
-                          <SvgMock
-                            color="#121314"
-                            fill="currentColor"
-                            height={16}
-                            name="Arrow2Right"
-                            style={
-                              {
-                                "height": 16,
-                                "width": 16,
-                              }
-                            }
-                            width={16}
-                          />
-                          <View
-                            alignItems="center"
-                            flexDirection="row"
-                            gap={2}
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
                                   "flexDirection": "row",
-                                  "gap": 2,
+                                  "flexWrap": "wrap",
+                                  "maxWidth": "80%",
                                 },
-                                undefined,
                               ]
                             }
                           >
                             <View
-                              onLayout={[Function]}
-                              style={{}}
-                              testID="badgenetwork"
-                            >
-                              <View
-                                style={
+                              alignItems="center"
+                              flexDirection="row"
+                              gap={2}
+                              style={
+                                [
                                   {
                                     "alignItems": "center",
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#ffffff",
-                                    "borderRadius": 8,
-                                    "borderWidth": 1.5,
-                                    "height": 24,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "shadowColor": "#0000001a",
-                                    "shadowOffset": {
-                                      "height": 2,
-                                      "width": 0,
-                                    },
-                                    "shadowOpacity": 1,
-                                    "shadowRadius": 4,
-                                    "width": 24,
-                                  }
-                                }
+                                    "flexDirection": "row",
+                                    "gap": 2,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <View
+                                onLayout={[Function]}
+                                style={{}}
+                                testID="badgenetwork"
                               >
-                                <Image
-                                  onError={[Function]}
-                                  resizeMode="contain"
-                                  source={1}
+                                <View
                                   style={
                                     {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "borderColor": "#ffffff",
+                                      "borderRadius": 8,
+                                      "borderWidth": 1.5,
                                       "height": 24,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "shadowColor": "#0000001a",
+                                      "shadowOffset": {
+                                        "height": 2,
+                                        "width": 0,
+                                      },
+                                      "shadowOpacity": 1,
+                                      "shadowRadius": 4,
                                       "width": 24,
                                     }
                                   }
-                                  testID="network-avatar-image"
-                                />
+                                >
+                                  <Image
+                                    onError={[Function]}
+                                    resizeMode="contain"
+                                    source={1}
+                                    style={
+                                      {
+                                        "height": 24,
+                                        "width": 24,
+                                      }
+                                    }
+                                    testID="network-avatar-image"
+                                  />
+                                </View>
                               </View>
-                            </View>
-                            <Text
-                              accessibilityRole="text"
-                              style={
-                                {
-                                  "color": "#121314",
-                                  "fontFamily": "CentraNo1-Medium",
-                                  "fontSize": 16,
-                                  "fontWeight": "500",
-                                  "letterSpacing": 0,
-                                  "lineHeight": 24,
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#121314",
+                                    "fontFamily": "CentraNo1-Medium",
+                                    "fontSize": 16,
+                                    "fontWeight": "500",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
-                              }
-                            >
-                              Optimism
-                            </Text>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "transform": [
-                                {
-                                  "rotate": "undefineddeg",
-                                },
-                              ],
-                            }
-                          }
-                        >
-                          <TouchableOpacity
-                            accessibilityLabel="Collapse quote details"
-                            accessibilityRole="button"
-                            activeOpacity={0.7}
-                            onPress={[Function]}
-                            testID="expand-quote-details"
-                          >
+                              >
+                                Ethereum Mainnet
+                              </Text>
+                            </View>
                             <SvgMock
-                              color="#9ca1af"
+                              color="#121314"
                               fill="currentColor"
                               height={16}
-                              name="ArrowDown"
+                              name="Arrow2Right"
                               style={
                                 {
                                   "height": 16,
@@ -548,375 +452,113 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                               }
                               width={16}
                             />
-                          </TouchableOpacity>
-                        </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                              "overflow": "hidden",
-                            },
-                            [
-                              undefined,
-                            ],
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-start",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
                             <View
+                              alignItems="center"
+                              flexDirection="row"
+                              gap={2}
                               style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Medium",
-                                    "fontSize": 16,
-                                    "fontWeight": "500",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                Network Fee
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Book",
-                                    "fontSize": 16,
-                                    "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                0.01
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                              "overflow": "hidden",
-                            },
-                            [
-                              undefined,
-                            ],
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-start",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Medium",
-                                    "fontSize": 16,
-                                    "fontWeight": "500",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                Time
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Book",
-                                    "fontSize": 16,
-                                    "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                1 min
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {},
-                            undefined,
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "justifyContent": "space-between",
-                                "overflow": "hidden",
-                              },
-                              [
-                                undefined,
-                              ],
-                            ]
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "flex-start",
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
-                                }
-                              }
-                            >
-                              <View
-                                style={
+                                [
                                   {
                                     "alignItems": "center",
                                     "flexDirection": "row",
-                                  }
-                                }
+                                    "gap": 2,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <View
+                                onLayout={[Function]}
+                                style={{}}
+                                testID="badgenetwork"
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Medium",
-                                      "fontSize": 16,
-                                      "fontWeight": "500",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                  testID="label"
-                                >
-                                  Quote
-                                </Text>
-                                <TouchableOpacity
-                                  accessibilityLabel="Why we recommend this quote tooltip"
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
+                                <View
                                   style={
                                     {
                                       "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "borderColor": "#ffffff",
                                       "borderRadius": 8,
+                                      "borderWidth": 1.5,
                                       "height": 24,
                                       "justifyContent": "center",
-                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "shadowColor": "#0000001a",
+                                      "shadowOffset": {
+                                        "height": 2,
+                                        "width": 0,
+                                      },
+                                      "shadowOpacity": 1,
+                                      "shadowRadius": 4,
                                       "width": 24,
                                     }
                                   }
                                 >
-                                  <SvgMock
-                                    color="#9ca1af"
-                                    fill="currentColor"
-                                    height={16}
-                                    name="Question"
+                                  <Image
+                                    onError={[Function]}
+                                    resizeMode="contain"
+                                    source={1}
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={16}
+                                    testID="network-avatar-image"
                                   />
-                                </TouchableOpacity>
+                                </View>
                               </View>
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#121314",
+                                    "fontFamily": "CentraNo1-Medium",
+                                    "fontSize": 16,
+                                    "fontWeight": "500",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                              >
+                                Optimism
+                              </Text>
                             </View>
                           </View>
                           <View
                             style={
                               {
-                                "alignItems": "flex-end",
-                                "flex": 1,
+                                "transform": [
+                                  {
+                                    "rotate": "undefineddeg",
+                                  },
+                                ],
                               }
                             }
                           >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
-                                }
-                              }
+                            <TouchableOpacity
+                              accessibilityLabel="Collapse quote details"
+                              accessibilityRole="button"
+                              activeOpacity={0.7}
+                              onPress={[Function]}
+                              testID="expand-quote-details"
                             >
-                              <View
+                              <SvgMock
+                                color="#9ca1af"
+                                fill="currentColor"
+                                height={16}
+                                name="ArrowDown"
                                 style={
                                   {
-                                    "alignItems": "center",
-                                    "flexDirection": "row",
+                                    "height": 16,
+                                    "width": 16,
                                   }
                                 }
-                              >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 16,
-                                      "fontWeight": "400",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                  testID="label"
-                                >
-                                  1 ETH = 24.4 USDC
-                                </Text>
-                              </View>
-                            </View>
+                                width={16}
+                              />
+                            </TouchableOpacity>
                           </View>
                         </View>
-                      </View>
-                      <View
-                        gap={12}
-                        style={
-                          [
-                            {
-                              "gap": 12,
-                            },
-                            undefined,
-                          ]
-                        }
-                      >
                         <View
                           style={
                             [
@@ -971,7 +613,7 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                   }
                                   testID="label"
                                 >
-                                  Price Impact
+                                  Network Fee
                                 </Text>
                               </View>
                             </View>
@@ -1015,7 +657,7 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                   }
                                   testID="label"
                                 >
-                                  -0.06%
+                                  0.01
                                 </Text>
                               </View>
                             </View>
@@ -1061,53 +703,159 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                   }
                                 }
                               >
-                                <View
-                                  alignItems="center"
-                                  flexDirection="row"
-                                  gap={4}
+                                <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flexDirection": "row",
-                                        "gap": 4,
-                                      },
-                                      undefined,
-                                    ]
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Medium",
+                                      "fontSize": 16,
+                                      "fontWeight": "500",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                  testID="label"
+                                >
+                                  Time
+                                </Text>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "alignItems": "flex-end",
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 8,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                  }
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Book",
+                                      "fontSize": 16,
+                                      "fontWeight": "400",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                  testID="label"
+                                >
+                                  1 min
+                                </Text>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            [
+                              {},
+                              undefined,
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "justifyContent": "space-between",
+                                  "overflow": "hidden",
+                                },
+                                [
+                                  undefined,
+                                ],
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-start",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
                                   }
                                 >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    Quote
+                                  </Text>
                                   <TouchableOpacity
-                                    activeOpacity={0.6}
+                                    accessibilityLabel="Why we recommend this quote tooltip"
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    activeOpacity={1}
+                                    disabled={false}
                                     onPress={[Function]}
+                                    onPressIn={[Function]}
+                                    onPressOut={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
-                                        "flexDirection": "row",
-                                        "gap": 4,
+                                        "borderRadius": 8,
+                                        "height": 24,
+                                        "justifyContent": "center",
+                                        "opacity": 1,
+                                        "width": 24,
                                       }
                                     }
-                                    testID="edit-slippage-button"
                                   >
-                                    <Text
-                                      accessibilityRole="text"
-                                      style={
-                                        {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Medium",
-                                          "fontSize": 16,
-                                          "fontWeight": "500",
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
-                                      }
-                                    >
-                                      Slippage
-                                    </Text>
                                     <SvgMock
                                       color="#9ca1af"
                                       fill="currentColor"
                                       height={16}
-                                      name="Edit"
+                                      name="Question"
                                       style={
                                         {
                                           "height": 16,
@@ -1120,21 +868,11 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                 </View>
                               </View>
                             </View>
-                          </View>
-                          <View
-                            style={
-                              {
-                                "alignItems": "flex-end",
-                                "flex": 1,
-                              }
-                            }
-                          >
                             <View
                               style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
+                                  "alignItems": "flex-end",
+                                  "flex": 1,
                                 }
                               }
                             >
@@ -1143,30 +881,317 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                   {
                                     "alignItems": "center",
                                     "flexDirection": "row",
+                                    "gap": 8,
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 16,
-                                      "fontWeight": "400",
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
                                     }
                                   }
-                                  testID="label"
                                 >
-                                  0.5%
-                                </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    1 ETH = 24.4 USDC
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          gap={12}
+                          style={
+                            [
+                              {
+                                "gap": 12,
+                              },
+                              undefined,
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "justifyContent": "space-between",
+                                  "overflow": "hidden",
+                                },
+                                [
+                                  undefined,
+                                ],
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-start",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    Price Impact
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-end",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    -0.06%
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "justifyContent": "space-between",
+                                  "overflow": "hidden",
+                                },
+                                [
+                                  undefined,
+                                ],
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-start",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    alignItems="center"
+                                    flexDirection="row"
+                                    gap={4}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "gap": 4,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      activeOpacity={0.6}
+                                      onPress={[Function]}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "gap": 4,
+                                        }
+                                      }
+                                      testID="edit-slippage-button"
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "CentraNo1-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        Slippage
+                                      </Text>
+                                      <SvgMock
+                                        color="#9ca1af"
+                                        fill="currentColor"
+                                        height={16}
+                                        name="Edit"
+                                        style={
+                                          {
+                                            "height": 16,
+                                            "width": 16,
+                                          }
+                                        }
+                                        width={16}
+                                      />
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-end",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    0.5%
+                                  </Text>
+                                </View>
                               </View>
                             </View>
                           </View>
                         </View>
                       </View>
+                      <Text
+                        accessibilityRole="text"
+                        style={
+                          {
+                            "color": "#686e7d",
+                            "fontFamily": "CentraNo1-Book",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0,
+                            "lineHeight": 24,
+                            "textAlign": "center",
+                          }
+                        }
+                      >
+                        Includes 0.875% MM fee
+                      </Text>
                     </View>
                   </View>
                 </View>
@@ -1493,233 +1518,137 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                       style={
                         [
                           {},
-                          {
-                            "backgroundColor": "#ffffff",
-                            "borderColor": "#b7bbc866",
-                            "borderRadius": 8,
-                            "borderWidth": 1,
-                            "gap": 12,
-                            "marginBottom": 12,
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "paddingVertical": 12,
-                          },
+                          undefined,
                         ]
                       }
                     >
                       <View
-                        alignItems="center"
-                        flexDirection="row"
-                        justifyContent="space-between"
                         style={
                           [
+                            {},
                             {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
+                              "backgroundColor": "#ffffff",
+                              "borderColor": "#b7bbc866",
+                              "borderRadius": 8,
+                              "borderWidth": 1,
+                              "gap": 12,
+                              "marginBottom": 12,
+                              "overflow": "hidden",
+                              "paddingHorizontal": 16,
+                              "paddingVertical": 12,
                             },
-                            undefined,
                           ]
                         }
                       >
                         <View
                           alignItems="center"
                           flexDirection="row"
+                          justifyContent="space-between"
                           style={
                             [
                               {
                                 "alignItems": "center",
                                 "flexDirection": "row",
+                                "justifyContent": "space-between",
                               },
-                              {
-                                "flexDirection": "row",
-                                "flexWrap": "wrap",
-                                "maxWidth": "80%",
-                              },
+                              undefined,
                             ]
                           }
                         >
                           <View
                             alignItems="center"
                             flexDirection="row"
-                            gap={2}
                             style={
                               [
                                 {
                                   "alignItems": "center",
                                   "flexDirection": "row",
-                                  "gap": 2,
                                 },
-                                undefined,
-                              ]
-                            }
-                          >
-                            <View
-                              onLayout={[Function]}
-                              style={{}}
-                              testID="badgenetwork"
-                            >
-                              <View
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#ffffff",
-                                    "borderRadius": 8,
-                                    "borderWidth": 1.5,
-                                    "height": 24,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "shadowColor": "#0000001a",
-                                    "shadowOffset": {
-                                      "height": 2,
-                                      "width": 0,
-                                    },
-                                    "shadowOpacity": 1,
-                                    "shadowRadius": 4,
-                                    "width": 24,
-                                  }
-                                }
-                              >
-                                <Image
-                                  onError={[Function]}
-                                  resizeMode="contain"
-                                  source={1}
-                                  style={
-                                    {
-                                      "height": 24,
-                                      "width": 24,
-                                    }
-                                  }
-                                  testID="network-avatar-image"
-                                />
-                              </View>
-                            </View>
-                            <Text
-                              accessibilityRole="text"
-                              style={
                                 {
-                                  "color": "#121314",
-                                  "fontFamily": "CentraNo1-Medium",
-                                  "fontSize": 16,
-                                  "fontWeight": "500",
-                                  "letterSpacing": 0,
-                                  "lineHeight": 24,
-                                }
-                              }
-                            >
-                              Ethereum Mainnet
-                            </Text>
-                          </View>
-                          <SvgMock
-                            color="#121314"
-                            fill="currentColor"
-                            height={16}
-                            name="Arrow2Right"
-                            style={
-                              {
-                                "height": 16,
-                                "width": 16,
-                              }
-                            }
-                            width={16}
-                          />
-                          <View
-                            alignItems="center"
-                            flexDirection="row"
-                            gap={2}
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
                                   "flexDirection": "row",
-                                  "gap": 2,
+                                  "flexWrap": "wrap",
+                                  "maxWidth": "80%",
                                 },
-                                undefined,
                               ]
                             }
                           >
                             <View
-                              onLayout={[Function]}
-                              style={{}}
-                              testID="badgenetwork"
-                            >
-                              <View
-                                style={
+                              alignItems="center"
+                              flexDirection="row"
+                              gap={2}
+                              style={
+                                [
                                   {
                                     "alignItems": "center",
-                                    "backgroundColor": "#ffffff",
-                                    "borderColor": "#ffffff",
-                                    "borderRadius": 8,
-                                    "borderWidth": 1.5,
-                                    "height": 24,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "shadowColor": "#0000001a",
-                                    "shadowOffset": {
-                                      "height": 2,
-                                      "width": 0,
-                                    },
-                                    "shadowOpacity": 1,
-                                    "shadowRadius": 4,
-                                    "width": 24,
-                                  }
-                                }
+                                    "flexDirection": "row",
+                                    "gap": 2,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <View
+                                onLayout={[Function]}
+                                style={{}}
+                                testID="badgenetwork"
                               >
-                                <Image
-                                  onError={[Function]}
-                                  resizeMode="contain"
-                                  source={1}
+                                <View
                                   style={
                                     {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "borderColor": "#ffffff",
+                                      "borderRadius": 8,
+                                      "borderWidth": 1.5,
                                       "height": 24,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "shadowColor": "#0000001a",
+                                      "shadowOffset": {
+                                        "height": 2,
+                                        "width": 0,
+                                      },
+                                      "shadowOpacity": 1,
+                                      "shadowRadius": 4,
                                       "width": 24,
                                     }
                                   }
-                                  testID="network-avatar-image"
-                                />
+                                >
+                                  <Image
+                                    onError={[Function]}
+                                    resizeMode="contain"
+                                    source={1}
+                                    style={
+                                      {
+                                        "height": 24,
+                                        "width": 24,
+                                      }
+                                    }
+                                    testID="network-avatar-image"
+                                  />
+                                </View>
                               </View>
-                            </View>
-                            <Text
-                              accessibilityRole="text"
-                              style={
-                                {
-                                  "color": "#121314",
-                                  "fontFamily": "CentraNo1-Medium",
-                                  "fontSize": 16,
-                                  "fontWeight": "500",
-                                  "letterSpacing": 0,
-                                  "lineHeight": 24,
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#121314",
+                                    "fontFamily": "CentraNo1-Medium",
+                                    "fontSize": 16,
+                                    "fontWeight": "500",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
                                 }
-                              }
-                            >
-                              Optimism
-                            </Text>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "transform": [
-                                {
-                                  "rotate": "undefineddeg",
-                                },
-                              ],
-                            }
-                          }
-                        >
-                          <TouchableOpacity
-                            accessibilityLabel="Expand quote details"
-                            accessibilityRole="button"
-                            activeOpacity={0.7}
-                            onPress={[Function]}
-                            testID="expand-quote-details"
-                          >
+                              >
+                                Ethereum Mainnet
+                              </Text>
+                            </View>
                             <SvgMock
-                              color="#9ca1af"
+                              color="#121314"
                               fill="currentColor"
                               height={16}
-                              name="ArrowDown"
+                              name="Arrow2Right"
                               style={
                                 {
                                   "height": 16,
@@ -1728,49 +1657,62 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                               }
                               width={16}
                             />
-                          </TouchableOpacity>
-                        </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                              "overflow": "hidden",
-                            },
-                            [
-                              undefined,
-                            ],
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-start",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
                             <View
+                              alignItems="center"
+                              flexDirection="row"
+                              gap={2}
                               style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 2,
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
+                              <View
+                                onLayout={[Function]}
+                                style={{}}
+                                testID="badgenetwork"
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "borderColor": "#ffffff",
+                                      "borderRadius": 8,
+                                      "borderWidth": 1.5,
+                                      "height": 24,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                      "shadowColor": "#0000001a",
+                                      "shadowOffset": {
+                                        "height": 2,
+                                        "width": 0,
+                                      },
+                                      "shadowOpacity": 1,
+                                      "shadowRadius": 4,
+                                      "width": 24,
+                                    }
+                                  }
+                                >
+                                  <Image
+                                    onError={[Function]}
+                                    resizeMode="contain"
+                                    source={1}
+                                    style={
+                                      {
+                                        "height": 24,
+                                        "width": 24,
+                                      }
+                                    }
+                                    testID="network-avatar-image"
+                                  />
+                                </View>
+                              </View>
                               <Text
                                 accessibilityRole="text"
                                 style={
@@ -1783,170 +1725,45 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                     "lineHeight": 24,
                                   }
                                 }
-                                testID="label"
                               >
-                                Network Fee
+                                Optimism
                               </Text>
                             </View>
                           </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flex": 1,
-                            }
-                          }
-                        >
                           <View
                             style={
                               {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
+                                "transform": [
+                                  {
+                                    "rotate": "undefineddeg",
+                                  },
+                                ],
                               }
                             }
                           >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
+                            <TouchableOpacity
+                              accessibilityLabel="Expand quote details"
+                              accessibilityRole="button"
+                              activeOpacity={0.7}
+                              onPress={[Function]}
+                              testID="expand-quote-details"
                             >
-                              <Text
-                                accessibilityRole="text"
+                              <SvgMock
+                                color="#9ca1af"
+                                fill="currentColor"
+                                height={16}
+                                name="ArrowDown"
                                 style={
                                   {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Book",
-                                    "fontSize": 16,
-                                    "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
+                                    "height": 16,
+                                    "width": 16,
                                   }
                                 }
-                                testID="label"
-                              >
-                                0.01
-                              </Text>
-                            </View>
+                                width={16}
+                              />
+                            </TouchableOpacity>
                           </View>
                         </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexDirection": "row",
-                              "justifyContent": "space-between",
-                              "overflow": "hidden",
-                            },
-                            [
-                              undefined,
-                            ],
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-start",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Medium",
-                                    "fontSize": 16,
-                                    "fontWeight": "500",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                Time
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                              }
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                }
-                              }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  {
-                                    "color": "#121314",
-                                    "fontFamily": "CentraNo1-Book",
-                                    "fontSize": 16,
-                                    "fontWeight": "400",
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
-                                }
-                                testID="label"
-                              >
-                                1 min
-                              </Text>
-                            </View>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {},
-                            undefined,
-                          ]
-                        }
-                      >
                         <View
                           style={
                             [
@@ -2001,42 +1818,8 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   }
                                   testID="label"
                                 >
-                                  Quote
+                                  Network Fee
                                 </Text>
-                                <TouchableOpacity
-                                  accessibilityLabel="Why we recommend this quote tooltip"
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "borderRadius": 8,
-                                      "height": 24,
-                                      "justifyContent": "center",
-                                      "opacity": 1,
-                                      "width": 24,
-                                    }
-                                  }
-                                >
-                                  <SvgMock
-                                    color="#9ca1af"
-                                    fill="currentColor"
-                                    height={16}
-                                    name="Question"
-                                    style={
-                                      {
-                                        "height": 16,
-                                        "width": 16,
-                                      }
-                                    }
-                                    width={16}
-                                  />
-                                </TouchableOpacity>
                               </View>
                             </View>
                           </View>
@@ -2079,7 +1862,111 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   }
                                   testID="label"
                                 >
-                                  1 ETH = 24.4 USDC
+                                  0.01
+                                </Text>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                                "justifyContent": "space-between",
+                                "overflow": "hidden",
+                              },
+                              [
+                                undefined,
+                              ],
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              {
+                                "alignItems": "flex-start",
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 8,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                  }
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Medium",
+                                      "fontSize": 16,
+                                      "fontWeight": "500",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                  testID="label"
+                                >
+                                  Time
+                                </Text>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "alignItems": "flex-end",
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 8,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                  }
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "CentraNo1-Book",
+                                      "fontSize": 16,
+                                      "fontWeight": "400",
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                  testID="label"
+                                >
+                                  1 min
                                 </Text>
                               </View>
                             </View>
@@ -2089,84 +1976,247 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                           style={
                             [
                               {},
-                              {
-                                "bottom": 0,
-                                "height": 30,
-                                "left": 0,
-                                "position": "absolute",
-                                "right": 0,
-                              },
+                              undefined,
                             ]
                           }
                         >
-                          <RNSVGSvgView
-                            bbHeight="30"
-                            bbWidth="100%"
-                            focusable={false}
-                            height="30"
+                          <View
                             style={
                               [
                                 {
-                                  "backgroundColor": "transparent",
-                                  "borderWidth": 0,
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "justifyContent": "space-between",
+                                  "overflow": "hidden",
                                 },
-                                {
-                                  "flex": 0,
-                                  "height": 30,
-                                  "width": "100%",
-                                },
+                                [
+                                  undefined,
+                                ],
                               ]
                             }
-                            width="100%"
                           >
-                            <RNSVGGroup
-                              fill={
+                            <View
+                              style={
                                 {
-                                  "payload": 4278190080,
-                                  "type": 0,
+                                  "alignItems": "flex-start",
+                                  "flex": 1,
                                 }
                               }
                             >
-                              <RNSVGDefs>
-                                <RNSVGLinearGradient
-                                  gradient={
-                                    [
-                                      0,
-                                      16777215,
-                                      1,
-                                      -1,
-                                    ]
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
                                   }
-                                  gradientTransform={null}
-                                  gradientUnits={0}
-                                  name="fadeGradient"
-                                  x1="0"
-                                  x2="0"
-                                  y1="0"
-                                  y2="1"
-                                />
-                              </RNSVGDefs>
-                              <RNSVGRect
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    Quote
+                                  </Text>
+                                  <TouchableOpacity
+                                    accessibilityLabel="Why we recommend this quote tooltip"
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    activeOpacity={1}
+                                    disabled={false}
+                                    onPress={[Function]}
+                                    onPressIn={[Function]}
+                                    onPressOut={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "borderRadius": 8,
+                                        "height": 24,
+                                        "justifyContent": "center",
+                                        "opacity": 1,
+                                        "width": 24,
+                                      }
+                                    }
+                                  >
+                                    <SvgMock
+                                      color="#9ca1af"
+                                      fill="currentColor"
+                                      height={16}
+                                      name="Question"
+                                      style={
+                                        {
+                                          "height": 16,
+                                          "width": 16,
+                                        }
+                                      }
+                                      width={16}
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "flex-end",
+                                  "flex": 1,
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "CentraNo1-Book",
+                                        "fontSize": 16,
+                                        "fontWeight": "400",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                    testID="label"
+                                  >
+                                    1 ETH = 24.4 USDC
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {},
+                                {
+                                  "bottom": 0,
+                                  "height": 30,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                },
+                              ]
+                            }
+                          >
+                            <RNSVGSvgView
+                              bbHeight="30"
+                              bbWidth="100%"
+                              focusable={false}
+                              height="30"
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 30,
+                                    "width": "100%",
+                                  },
+                                ]
+                              }
+                              width="100%"
+                            >
+                              <RNSVGGroup
                                 fill={
                                   {
-                                    "brushRef": "fadeGradient",
-                                    "type": 1,
+                                    "payload": 4278190080,
+                                    "type": 0,
                                   }
                                 }
-                                height="30"
-                                propList={
-                                  [
-                                    "fill",
-                                  ]
-                                }
-                                width="100%"
-                                x="0"
-                                y="0"
-                              />
-                            </RNSVGGroup>
-                          </RNSVGSvgView>
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        16777215,
+                                        1,
+                                        -1,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="fadeGradient"
+                                    x1="0"
+                                    x2="0"
+                                    y1="0"
+                                    y2="1"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGRect
+                                  fill={
+                                    {
+                                      "brushRef": "fadeGradient",
+                                      "type": 1,
+                                    }
+                                  }
+                                  height="30"
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                  width="100%"
+                                  x="0"
+                                  y="0"
+                                />
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
                         </View>
                       </View>
+                      <Text
+                        accessibilityRole="text"
+                        style={
+                          {
+                            "color": "#686e7d",
+                            "fontFamily": "CentraNo1-Book",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0,
+                            "lineHeight": 24,
+                            "textAlign": "center",
+                          }
+                        }
+                      >
+                        Includes 0.875% MM fee
+                      </Text>
                     </View>
                   </View>
                 </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3945,7 +3945,8 @@
     "bridge_to": "Bridge to",
     "title": "Bridge",
     "submitting_transaction": "Submitting",
-    "fetching_quote": "Fetching quote"
+    "fetching_quote": "Fetching quote",
+    "fee_disclaimer": "Includes 0.875% MM fee"
   },
   "quote_expired_modal": {
     "title": "New quotes are available",


### PR DESCRIPTION
## **Description**

This PR adds a fee disclaimer text to the Bridge View to inform users about the 0.875% MetaMask fee. This change improves transparency by clearly communicating the fee structure to users before they proceed with a bridge transaction.

## **Related issues**

Fixes: [MMS-2343](https://consensyssoftware.atlassian.net/browse/MMS-2343)

## **Manual testing steps**

1. Open the Bridge View
2. Verify that the fee disclaimer text "Includes 0.875% MM fee" appears below the quote details
3. Confirm the text is properly aligned and styled
4. Test with different screen sizes to ensure responsive layout

## **Screenshots/Recordings**

### **Before**

[Please add screenshot of Bridge View without fee disclaimer]

### **After**


https://github.com/user-attachments/assets/452f9b31-f797-4033-9f47-6b766627bc8d


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMS-2343]: https://consensyssoftware.atlassian.net/browse/MMS-2343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ