### PR TITLE
fix: avoid creating Sentry exception events when notification display fails

### DIFF
--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -145,7 +145,7 @@ class NotificationManager {
   _showNotification = async (data) => {
     if (this._backgroundMode) {
       const { title, message } = constructTitleAndMessage(data);
-      const id = data?.transaction?.id || '';
+      const id = data?.transaction?.id;
       if (id) {
         this._transactionToView.push(id);
       }

--- a/app/util/notifications/services/NotificationService.ts
+++ b/app/util/notifications/services/NotificationService.ts
@@ -254,35 +254,39 @@ class NotificationsService {
     data?: unknown;
     id?: string;
   }): Promise<void> => {
-    await notifee.displayNotification({
-      id,
-      title,
-      body,
-      // Notifee can only store and handle data strings
-      data: { dataStr: JSON.stringify(data) },
-      android: {
-        smallIcon: 'ic_notification_small',
-        largeIcon: 'ic_notification',
-        channelId: channelId ?? ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
-        pressAction: {
-          id: pressActionId,
-          launchActivity: LAUNCH_ACTIVITY,
+    try {
+      await notifee.displayNotification({
+        id,
+        title,
+        body,
+        // Notifee can only store and handle data strings
+        data: { dataStr: JSON.stringify(data) },
+        android: {
+          smallIcon: 'ic_notification_small',
+          largeIcon: 'ic_notification',
+          channelId: channelId ?? ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
+          pressAction: {
+            id: pressActionId,
+            launchActivity: LAUNCH_ACTIVITY,
+          },
+          tag: id,
         },
-        tag: id,
-      },
-      ios: {
-        launchImageName: 'Default',
-        sound: 'default',
-        interruptionLevel: 'critical',
-        foregroundPresentationOptions: {
-          alert: true,
-          sound: true,
-          badge: true,
-          banner: true,
-          list: true,
+        ios: {
+          launchImageName: 'Default',
+          sound: 'default',
+          interruptionLevel: 'critical',
+          foregroundPresentationOptions: {
+            alert: true,
+            sound: true,
+            badge: true,
+            banner: true,
+            list: true,
+          },
         },
-      },
-    });
+      });
+    } catch (error) {
+      Logger.log('Error displaying notification ', error);
+    }
   };
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Change summary**
- Remove the fallback empty string for the notification id
- Wrap display notification in a try/catch block. Add errors to Sentry breadcrumbs and do not dispatch a new Sentry exception event

For context, here's the Notification interface where it describes how the notification id is used

```js
export interface Notification {
    /**
     * A unique identifier for your notification.
     *
     * Notifications with the same ID will be created as the same instance, allowing you to update
     * a notification which already exists on the device.
     *
     * Defaults to a random string if not provided.
     */
    id?: string;
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #14301

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
