### PR TITLE
chore: replace RNFS with expo-filesystem for EntryScriptWeb3.js

### DIFF
--- a/app/core/EntryScriptWeb3.js
+++ b/app/core/EntryScriptWeb3.js
@@ -1,17 +1,12 @@
-import Device from '../util/device';
-import RNFS from 'react-native-fs';
+import * as FileSystem from 'expo-file-system';
 
 const EntryScriptWeb3 = {
   entryScriptWeb3: null,
   // Cache InpageBridgeWeb3 so that it is immediately available
   async init() {
-    this.entryScriptWeb3 = Device.isIos()
-      ? await RNFS.readFile(
-          `${RNFS.MainBundlePath}/InpageBridgeWeb3.js`,
-          'utf8',
-        )
-      : await RNFS.readFileAssets(`InpageBridgeWeb3.js`);
-
+    this.entryScriptWeb3 = await FileSystem.readAsStringAsync(
+      `${FileSystem.bundleDirectory}InpageBridgeWeb3.js`,
+    );
     return this.entryScriptWeb3;
   },
   async get() {

--- a/package.json
+++ b/package.json
@@ -304,6 +304,7 @@
     "expo": "52.0.27",
     "expo-build-properties": "~0.13.2",
     "expo-dev-client": "~5.0.18",
+    "expo-file-system": "~18.0.12",
     "fuse.js": "3.4.4",
     "he": "^1.2.0",
     "https-browserify": "0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17125,7 +17125,7 @@ expo-dev-menu@6.0.25:
   dependencies:
     expo-dev-menu-interface "1.9.3"
 
-expo-file-system@~18.0.7:
+expo-file-system@~18.0.12, expo-file-system@~18.0.7:
   version "18.0.12"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-18.0.12.tgz#6ceeeb0725f6c5faaf58112f18c073c2acfb3027"
   integrity sha512-HAkrd/mb8r+G3lJ9MzmGeuW2B+BxQR1joKfeCyY4deLl1zoZ48FrAWjgZjHK9aHUVhJ0ehzInu/NQtikKytaeg==


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. Using `expo-filesystem` will make this around ~20 times faster for Android and ~5 times faster for iOS
2. As result TTI to login screen dropped from ~3s to ~2s for mid-range Android phone and it's quite noticeable for end user

I would recommend also migrate rest of usages of RNFS to `expo-filesystem` in your app. It shouldn't be hard and it should be able to replace also `react-native-blob-util`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start the app
2. It should start about ~1s faster then before for mid range Android phones

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/342523f7-a26b-46d4-8cdf-402a8d5b4bfb



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
