### PR TITLE
fix: capture exception with Sentry instead throwing the error

### DIFF
--- a/app/store/getPersistentState/getPersistentState.test.ts
+++ b/app/store/getPersistentState/getPersistentState.test.ts
@@ -1,0 +1,229 @@
+import { getPersistentState } from './getPersistentState';
+import { StateMetadata } from '@metamask/base-controller';
+
+describe('getPersistentState', () => {
+  it('return empty state', () => {
+    expect(getPersistentState({}, {})).toStrictEqual({});
+  });
+
+  it('return empty state when no properties are persistent', () => {
+    const persistentState = getPersistentState(
+      { count: 1 },
+      { count: { anonymous: false, persist: false } },
+    );
+    expect(persistentState).toStrictEqual({});
+  });
+
+  it('return persistent state', () => {
+    const persistentState = getPersistentState(
+      {
+        password: 'secret password',
+        privateKey: '123',
+        network: 'mainnet',
+        tokens: ['DAI', 'USDC'],
+      },
+      {
+        password: {
+          anonymous: false,
+          persist: true,
+        },
+        privateKey: {
+          anonymous: false,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+        tokens: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      password: 'secret password',
+      privateKey: '123',
+    });
+  });
+
+  it('use function to derive persistent state', () => {
+    const normalizeTransactionHash = (hash: string) => hash.toLowerCase();
+
+    const persistentState = getPersistentState(
+      {
+        transactionHash: '0X1234',
+      },
+      {
+        transactionHash: {
+          anonymous: false,
+          persist: normalizeTransactionHash,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ transactionHash: '0x1234' });
+  });
+
+  it('allow returning a partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: { hash: string; value: number }) => ({
+      value: txMeta.value,
+    });
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: false,
+          persist: getPersistentTxMeta,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ txMeta: { value: 10 } });
+  });
+
+  it('allow returning a nested partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => ({
+      history: txMeta.history.map((entry) => ({ value: entry.value })),
+      value: txMeta.value,
+    });
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: false,
+          persist: getPersistentTxMeta,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({
+      txMeta: { history: [{ value: 9 }], value: 10 },
+    });
+  });
+
+  it('allow transforming types in a persist function', () => {
+    const persistentState = getPersistentState(
+      {
+        count: '1',
+      },
+      {
+        count: {
+          anonymous: false,
+          persist: (count) => Number(count),
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ count: 1 });
+  });
+
+  // New test cases for the two key changes
+
+  it('exclude state property when no metadata exists for a key', () => {
+    const state = {
+      password: 'secret password',
+      privateKey: '123',
+      network: 'mainnet',
+    };
+    const metadata = {
+      password: {
+        anonymous: false,
+        persist: true,
+      },
+      privateKey: {
+        anonymous: false,
+        persist: true,
+      },
+    } as unknown as StateMetadata<typeof state>;
+
+    const persistentState = getPersistentState(state, metadata);
+
+    expect(persistentState).toStrictEqual({
+      password: 'secret password',
+      privateKey: '123',
+    });
+  });
+
+  it('exclude state property when an error occurs during derivation', () => {
+    const state = {
+      password: 'secret password',
+      privateKey: '123',
+      network: 'mainnet',
+    };
+    const metadata = {
+      password: {
+        anonymous: false,
+        persist: true,
+      },
+      privateKey: {
+        anonymous: false,
+        persist: () => {
+          throw new Error('Derivation error');
+        },
+      },
+    } as unknown as StateMetadata<typeof state>;
+
+    const persistentState = getPersistentState(state, metadata);
+
+    expect(persistentState).toStrictEqual({
+      password: 'secret password',
+    });
+  });
+
+  it('exclude nested objects without metadata', () => {
+    const state = {
+      user: {
+        name: 'John',
+        settings: {
+          theme: 'dark',
+          notifications: true,
+        },
+      },
+      preferences: {
+        language: 'en',
+        currency: 'USD',
+      },
+    };
+    const metadata = {
+      user: {
+        anonymous: false,
+        persist: true,
+      },
+    } as unknown as StateMetadata<typeof state>;
+
+    const persistentState = getPersistentState(state, metadata);
+
+    expect(persistentState).toStrictEqual({
+      user: {
+        name: 'John',
+        settings: {
+          theme: 'dark',
+          notifications: true,
+        },
+      },
+    });
+  });
+});

--- a/app/store/getPersistentState/getPersistentState.ts
+++ b/app/store/getPersistentState/getPersistentState.ts
@@ -52,13 +52,10 @@ function deriveStateFromMetadata<ControllerState extends StateConstraint>(
       }
       return derivedState;
     } catch (error) {
-      // Throw error after timeout so that it is captured as a console error
-      // (and by Sentry) without interrupting state-related operations
-      setTimeout(() => {
-        // This is what change from the original base controller implementation
-        // This is a temporary solution to capture the error for extraneous data that we did not detect
-        captureException(error as unknown as Error);
-      });
+      // This is what change from the original base controller implementation
+      // This is a temporary solution to capture the error for extraneous data that we did not detect
+      captureException(error as unknown as Error);
+
       return derivedState;
     }
   }, {} as never);

--- a/app/store/getPersistentState/getPersistentState.ts
+++ b/app/store/getPersistentState/getPersistentState.ts
@@ -1,0 +1,65 @@
+import { StateConstraint, StateMetadata } from '@metamask/base-controller';
+import { Json } from '@metamask/utils';
+import { captureException } from '@sentry/react-native';
+
+/**! IMPORTANT: THIS IS MEANT TO BE TEMPORARY, WE SHOULD NOT USE THIS AND USE THE VERSION IN BASE-CONTROLLER INSTEAD.
+ * The reason why we are using this now, it's because we have controllers state without metadata.
+ * An epic will be created to add the metadata to the controllers state without it.
+ * As an example of a property without metadata: "swapsTransactions" in TransactionController
+ */
+
+/**
+ * Returns the subset of state that should be persisted.
+ *
+ * @param state - The controller state.
+ * @param metadata - The controller state metadata, which describes which pieces of state should be persisted.
+ * @returns The subset of controller state that should be persisted.
+ */
+export function getPersistentState<ControllerState extends StateConstraint>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
+): Record<keyof ControllerState, Json> {
+  return deriveStateFromMetadata(state, metadata, 'persist');
+}
+
+/**
+ * Use the metadata to derive state according to the given metadata property.
+ *
+ * @param state - The full controller state.
+ * @param metadata - The controller metadata.
+ * @param metadataProperty - The metadata property to use to derive state.
+ * @returns The metadata-derived controller state.
+ */
+function deriveStateFromMetadata<ControllerState extends StateConstraint>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
+  metadataProperty: 'anonymous' | 'persist',
+): Record<keyof ControllerState, Json> {
+  return (Object.keys(state) as (keyof ControllerState)[]).reduce<
+    Record<keyof ControllerState, Json>
+  >((derivedState, key) => {
+    try {
+      const stateMetadata = metadata[key];
+      if (!stateMetadata) {
+        throw new Error(`No metadata found for '${String(key)}'`);
+      }
+      const propertyMetadata = stateMetadata[metadataProperty];
+      const stateProperty = state[key];
+      if (typeof propertyMetadata === 'function') {
+        derivedState[key] = propertyMetadata(stateProperty);
+      } else if (propertyMetadata) {
+        derivedState[key] = stateProperty;
+      }
+      return derivedState;
+    } catch (error) {
+      // Throw error after timeout so that it is captured as a console error
+      // (and by Sentry) without interrupting state-related operations
+      setTimeout(() => {
+        // This is what change from the original base controller implementation
+        // This is a temporary solution to capture the error for extraneous data that we did not detect
+        captureException(error as unknown as Error);
+      });
+      return derivedState;
+    }
+  }, {} as never);
+}

--- a/app/store/persistConfig.ts
+++ b/app/store/persistConfig.ts
@@ -8,7 +8,7 @@ import Logger from '../util/Logger';
 import Device from '../util/device';
 import { UserState } from '../reducers/user';
 import Engine, { EngineContext } from '../core/Engine';
-import { getPersistentState } from '@metamask/base-controller';
+import { getPersistentState } from './getPersistentState/getPersistentState';
 
 const TIMEOUT = 40000;
 const STORAGE_THROTTLE_DELAY = 200;


### PR DESCRIPTION
## **Description**

Capture exception instead of throwing an error at the getPersistentState. This is a re implementation of what we have at the base controller.

This is the longer term solution: https://github.com/MetaMask/core/issues/5545

## **Related issues**

Fixes: #15453 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
