### PR TITLE
fix:  update account label text in permission summary selectors

### DIFF
--- a/e2e/selectors/Browser/PermissionSummaryBottomSheet.selectors.js
+++ b/e2e/selectors/Browser/PermissionSummaryBottomSheet.selectors.js
@@ -10,5 +10,5 @@ export const PermissionSummaryBottomSheetSelectorsText = {
   CONNECTED_ACCOUNTS_TEXT: enContent.accounts.connected_accounts_title,
   ADD_NETWORK_PERMISSION: enContent.permissions.title_add_network_permission,
   ETHEREUM_MAINNET_LABEL: 'Ethereum Main Network',
-  ACCOUNT_ONE_LABEL: 'Account 1',
+  ACCOUNT_ONE_LABEL: 'Connected to  Account 1',
 };

--- a/e2e/specs/multichain/permission-system-summary-default-permissions.spec.js
+++ b/e2e/specs/multichain/permission-system-summary-default-permissions.spec.js
@@ -40,14 +40,7 @@ describe(
           await ConnectedAccountsModal.tapManagePermissionsButton();
 
           // Step 3: Verify account permissions
-          const accountLabelElement =
-            await PermissionSummaryBottomSheet.accountPermissionLabelContainer;
-          const accountLabelAttributes =
-            await accountLabelElement.getAttributes();
-          const accountLabel = accountLabelAttributes.label;
-
-          await Assertions.checkIfTextMatches(
-            accountLabel,
+          await Assertions.checkIfTextIsDisplayed(
             PermissionSummaryBottomSheetSelectorsText.ACCOUNT_ONE_LABEL,
           );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix flaky test `e2e/specs/multichain/permission-system-summary-default-permissions.spec.js`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://app.bitrise.io/build/93e94117-2b9d-422c-b9cd-87ca5c89f2df?tab=tests

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/e5a7cde2-5cea-420b-895c-f14a39a1e1e9
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
