### PR TITLE
fix: Fix hook useEIP7702Networks to not check for atomic batch support if env variable MM_SMART_ACCOUNT_UI_ENABLED is not enabled.

### DIFF
--- a/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
+++ b/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
@@ -38,6 +38,9 @@ export const useEIP7702Networks = (address: string) => {
   );
 
   const { pending, value } = useAsyncResultOrThrow(async () => {
+    if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+      return [];
+    }
     const chainIds = Object.keys(networkList) as Hex[];
 
     return await Engine.context.TransactionController.isAtomicBatchSupported({


### PR DESCRIPTION
## **Description**

Fix hook useEIP7702Networks to not check for atomic batch support if env variable MM_SMART_ACCOUNT_UI_ENABLED is not enabled.

## **Related issues**
NA

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
