### PR TITLE
fix: validate network configuration currency before update rates

### DIFF
--- a/app/components/UI/Tokens/util/refreshEvmTokens.test.ts
+++ b/app/components/UI/Tokens/util/refreshEvmTokens.test.ts
@@ -74,22 +74,9 @@ describe('refreshEvmTokens', () => {
 
     expect(
       Engine.context.TokenRatesController.updateExchangeRatesByChainId,
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      Engine.context.TokenRatesController.updateExchangeRatesByChainId,
     ).toHaveBeenCalledWith([
-      {
-        chainId: '0x1',
-        nativeCurrency: 'ETH',
-      },
-    ]);
-    expect(
-      Engine.context.TokenRatesController.updateExchangeRatesByChainId,
-    ).toHaveBeenCalledWith([
-      {
-        chainId: '0x89',
-        nativeCurrency: 'POL',
-      },
+      { chainId: '0x1', nativeCurrency: 'ETH' },
+      { chainId: '0x89', nativeCurrency: 'POL' },
     ]);
   });
 

--- a/app/components/UI/Tokens/util/refreshTokens.test.ts
+++ b/app/components/UI/Tokens/util/refreshTokens.test.ts
@@ -77,22 +77,9 @@ describe('refreshTokens', () => {
 
     expect(
       Engine.context.TokenRatesController.updateExchangeRatesByChainId,
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      Engine.context.TokenRatesController.updateExchangeRatesByChainId,
     ).toHaveBeenCalledWith([
-      {
-        chainId: '0x1',
-        nativeCurrency: 'ETH',
-      },
-    ]);
-    expect(
-      Engine.context.TokenRatesController.updateExchangeRatesByChainId,
-    ).toHaveBeenCalledWith([
-      {
-        chainId: '0x89',
-        nativeCurrency: 'POL',
-      },
+      { chainId: '0x1', nativeCurrency: 'ETH' },
+      { chainId: '0x89', nativeCurrency: 'POL' },
     ]);
   });
 

--- a/app/components/UI/Tokens/util/tokenRefreshUtils.test.ts
+++ b/app/components/UI/Tokens/util/tokenRefreshUtils.test.ts
@@ -84,9 +84,25 @@ describe('performEvmRefresh', () => {
 
     expect(
       Engine.context.TokenRatesController.updateExchangeRatesByChainId,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledWith([
+      { chainId: '0x1', nativeCurrency: 'ETH' },
+      { chainId: '0x2', nativeCurrency: 'BNB' },
+    ]);
 
     expect(Logger.error).not.toHaveBeenCalled();
+  });
+
+  it('filters network configurations when updating token exchange rates', async () => {
+    // This is a rare edge-case. NetworkConfigurations should have a native currency
+    const invalidNetworkConfiguration = {
+      '0x1': { chainId: '0x1', nativeCurrency: undefined as unknown as string },
+    } as const;
+    const currencies = ['ETH'];
+
+    await performEvmRefresh(invalidNetworkConfiguration, currencies);
+    expect(
+      Engine.context.TokenRatesController.updateExchangeRatesByChainId,
+    ).toHaveBeenCalledWith([]); // This controller handles when there is no chains to update
   });
 
   it('should catch and log error if any action fails', async () => {

--- a/app/components/UI/Tokens/util/tokenRefreshUtils.ts
+++ b/app/components/UI/Tokens/util/tokenRefreshUtils.ts
@@ -34,13 +34,10 @@ export const performEvmRefresh = async (
     }),
     AccountTrackerController.refresh(networkClientIds),
     CurrencyRateController.updateExchangeRate(nativeCurrencies),
-    ...Object.values(evmNetworkConfigurationsByChainId).map((network) =>
-      TokenRatesController.updateExchangeRatesByChainId([
-        {
-          chainId: network.chainId,
-          nativeCurrency: network.nativeCurrency,
-        },
-      ]),
+    TokenRatesController.updateExchangeRatesByChainId(
+      Object.values(evmNetworkConfigurationsByChainId).filter(
+        (n) => n.chainId && n.nativeCurrency,
+      ),
     ),
   ];
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a rare edge-case where invoking token refreshes with a network that is missing a currency rate causes the app to crash.

This also adds a small performance improvement to update token exchange rates in batch.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15006

## **Manual testing steps**

N/A - I've not found a nice way to replicate this sentry error.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
