### PR TITLE
fix: pass entropySource to default account created cp-7.47.0

### DIFF
--- a/app/core/SnapKeyring/MultichainWalletSnapClient.ts
+++ b/app/core/SnapKeyring/MultichainWalletSnapClient.ts
@@ -185,6 +185,7 @@ export abstract class MultichainWalletSnapClient {
             await this.createAccount(
               {
                 scope: this.getScope(),
+                entropySource,
               },
               {
                 displayConfirmation: false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pr passes the missing entropySource for the default account created during discoverAccounts. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-234

## **Manual testing steps**

1. Create a fresh wallet
2. Import a srp with out any solana accounts
3. See that there is a default solana account created. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
