### PR TITLE
fix: Ensure bottom modal height is large enough for tooltips on android

### DIFF
--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
@@ -38,7 +38,7 @@ export const TooltipModal = ({
   const { styles } = useStyles(styleSheet, { title: title ?? '' });
 
   return (
-    <BottomModal visible={open} onClose={() => setOpen(false)}>
+    <BottomModal visible={open} onClose={() => setOpen(false)} isTooltip>
       <View style={styles.modalView}>
         <View style={styles.modalHeader}>
           <ButtonIcon

--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.styles.ts
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.styles.ts
@@ -21,6 +21,8 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     wrapper: {
       justifyContent: 'flex-end',
+      // ensure the wrapper is big enough for tooltips on android 15
+      height: 400,
     },
   });
 };

--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.styles.ts
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.styles.ts
@@ -2,8 +2,9 @@ import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) => {
+const styleSheet = (params: { theme: Theme, vars: { isTooltip: boolean } }) => {
   const { theme } = params;
+  const isTooltip = params.vars.isTooltip
 
   return StyleSheet.create({
     bottomModal: {
@@ -22,7 +23,7 @@ const styleSheet = (params: { theme: Theme }) => {
     wrapper: {
       justifyContent: 'flex-end',
       // ensure the wrapper is big enough for tooltips on android 15
-      height: 400,
+      ...(isTooltip && { height: 400 }),
     },
   });
 };

--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
@@ -13,6 +13,7 @@ interface BottomModalProps {
   hideBackground?: boolean;
   testID?: string;
   visible?: boolean;
+  isTooltip?: boolean;
 }
 
 /**
@@ -25,9 +26,10 @@ const BottomModal = ({
   onClose,
   testID,
   visible = true,
+  isTooltip = false,
 }: BottomModalProps) => {
   const { colors } = useTheme();
-  const { styles } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, { isTooltip });
 
   return (
     <Modal


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On Android 15, the explicitly set height for the bottom modal wrapper is needed.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15420

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
