### PR TITLE
perf: prevent unnecessary AssetPollingProvider hook re-renders

### DIFF
--- a/app/components/hooks/AssetPolling/useAccountTrackerPolling.test.ts
+++ b/app/components/hooks/AssetPolling/useAccountTrackerPolling.test.ts
@@ -125,20 +125,6 @@ describe('useAccountTrackerPolling', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
-  it('should return accountsByChainId from the state', () => {
-    const { result } = renderHookWithProvider(
-      () => useAccountTrackerPolling(),
-      {
-        state,
-      },
-    );
-
-    expect(result.current.accountsByChainId).toEqual({
-      '0x1': {},
-      '0x2': {},
-    });
-  });
-
   it('should poll only for current network if selected one is not popular', () => {
     const { unmount } = renderHookWithProvider(
       () => useAccountTrackerPolling(),

--- a/app/components/hooks/AssetPolling/useAccountTrackerPolling.ts
+++ b/app/components/hooks/AssetPolling/useAccountTrackerPolling.ts
@@ -7,7 +7,6 @@ import {
   selectSelectedNetworkClientId,
 } from '../../../selectors/networkController';
 import Engine from '../../../core/Engine';
-import { selectAccountsByChainId } from '../../../selectors/accountTrackerController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
@@ -24,8 +23,6 @@ const useAccountTrackerPolling = ({
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
-
-  const accountsByChainId = useSelector(selectAccountsByChainId);
   const networkClientIdsConfig = Object.values(
     networkConfigurationsPopularNetworks,
   ).map((network) => ({
@@ -60,10 +57,6 @@ const useAccountTrackerPolling = ({
       ),
     input,
   });
-
-  return {
-    accountsByChainId,
-  };
 };
 
 export default useAccountTrackerPolling;

--- a/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
+++ b/app/components/hooks/AssetPolling/useCurrencyRatePolling.ts
@@ -8,10 +8,6 @@ import {
   selectIsPopularNetwork,
 } from '../../../selectors/networkController';
 import Engine from '../../../core/Engine';
-import {
-  selectConversionRate,
-  selectCurrencyRates,
-} from '../../../selectors/currencyRateController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
@@ -28,10 +24,6 @@ const useCurrencyRatePolling = () => {
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-
-  // Selectors returning state updated by the polling
-  const conversionRate = useSelector(selectConversionRate);
-  const currencyRates = useSelector(selectCurrencyRates);
 
   // if all networks are selected, poll all popular networks
   const networkConfigurationsToPoll =
@@ -63,11 +55,6 @@ const useCurrencyRatePolling = () => {
       ),
     input: isEvmSelected ? [{ nativeCurrencies }] : [],
   });
-
-  return {
-    conversionRate,
-    currencyRates,
-  };
 };
 
 export default useCurrencyRatePolling;

--- a/app/components/hooks/AssetPolling/useTokenBalancesPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenBalancesPolling.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../selectors/networkController';
 import { Hex } from '@metamask/utils';
 import { isPortfolioViewEnabled } from '../../../util/networks';
-import { selectAllTokenBalances } from '../../../selectors/tokenBalancesController';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
@@ -21,9 +20,6 @@ const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-
-  // Selectors returning state updated by the polling
-  const tokenBalances = useSelector(selectAllTokenBalances);
 
   const networkConfigurationsToPoll =
     isAllNetworksSelected && isPopularNetwork && isPortfolioViewEnabled()
@@ -48,10 +44,6 @@ const useTokenBalancesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
       ? chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex }))
       : [],
   });
-
-  return {
-    tokenBalances,
-  };
 };
 
 export default useTokenBalancesPolling;

--- a/app/components/hooks/AssetPolling/useTokenDetectionPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenDetectionPolling.ts
@@ -55,8 +55,6 @@ const useTokenDetectionPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
           ]
         : [],
   });
-
-  return {};
 };
 
 export default useTokenDetectionPolling;

--- a/app/components/hooks/AssetPolling/useTokenListPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenListPolling.ts
@@ -9,10 +9,6 @@ import {
 } from '../../../selectors/networkController';
 import { Hex } from '@metamask/utils';
 import { isPortfolioViewEnabled } from '../../../util/networks';
-import {
-  selectERC20TokensByChain,
-  selectTokenList,
-} from '../../../selectors/tokenListController';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
 const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
@@ -24,10 +20,6 @@ const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-
-  // Selectors returning state updated by the polling
-  const tokenList = useSelector(selectTokenList);
-  const tokenListByChain = useSelector(selectERC20TokensByChain);
 
   // if all networks are selected, poll all popular networks
   const filteredChainIds =
@@ -49,11 +41,6 @@ const useTokenListPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
       ? chainIdsToPoll.map((chainId) => ({ chainId: chainId as Hex }))
       : [],
   });
-
-  return {
-    tokenList,
-    tokenListByChain,
-  };
 };
 
 export default useTokenListPolling;

--- a/app/components/hooks/AssetPolling/useTokenRatesPolling.ts
+++ b/app/components/hooks/AssetPolling/useTokenRatesPolling.ts
@@ -8,10 +8,6 @@ import {
   selectIsPopularNetwork,
 } from '../../../selectors/networkController';
 import { Hex } from '@metamask/utils';
-import {
-  selectContractExchangeRates,
-  selectTokenMarketData,
-} from '../../../selectors/tokenRatesController';
 import { isPortfolioViewEnabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 
@@ -24,10 +20,6 @@ const useTokenRatesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const isAllNetworksSelected = useSelector(selectIsAllNetworks);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-
-  // Selectors returning state updated by the polling
-  const contractExchangeRates = useSelector(selectContractExchangeRates);
-  const tokenMarketData = useSelector(selectTokenMarketData);
 
   // if all networks are selected, poll all popular networks
   const filteredChainIds =
@@ -53,11 +45,6 @@ const useTokenRatesPolling = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
         ]
       : [],
   });
-
-  return {
-    contractExchangeRates,
-    tokenMarketData,
-  };
 };
 
 export default useTokenRatesPolling;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

These polling hooks were selecting and returning results, which were never used by the Provider. Because of this, the provider was re-rendering when the hook selectors changed. This does not happen now.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMASSETS-844

## **Manual testing steps**

N/A, just test that Assets are working correctly.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-05-22 at 18 03 18](https://github.com/user-attachments/assets/4676d7ad-5cf2-4bc5-b6f5-19a7ce056334)

### **After**

![Screenshot 2025-05-22 at 18 04 35](https://github.com/user-attachments/assets/5ae40454-0a51-4af5-9a25-db87ec7caaf2)

https://www.loom.com/share/53070c0eee9a462ab5515e6953fb387a?sid=b1f0e39d-e1e8-4577-886d-d3a39d10d724

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
