### PR TITLE
feat: Track number_of_hd_entropies for a user

### DIFF
--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -11,6 +11,7 @@ export enum UserProfileProperty {
   PRIMARY_CURRENCY = 'primary_currency',
   CURRENT_CURRENCY = 'current_currency',
   HAS_MARKETING_CONSENT = 'has_marketing_consent',
+  NUMBER_OF_HD_ENTROPIES = 'number_of_hd_entropies',
 }
 
 export interface UserProfileMetaData {
@@ -24,4 +25,5 @@ export interface UserProfileMetaData {
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
   [UserProfileProperty.HAS_MARKETING_CONSENT]: string;
+  [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: number;
 }

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -59,20 +59,6 @@ describe('generateUserProfileAnalyticsMetaData', () => {
   describe('NUMBER_OF_HD_ENTROPIES', () => {
     const testCases = [
       {
-        name: 'with undefined keyrings',
-        state: {
-          engine: {
-            backgroundState: {
-              KeyringController: {
-                keyrings: undefined,
-                keyringsMetadata: undefined,
-              },
-            },
-          },
-        },
-        expected: 0,
-      },
-      {
         name: 'with empty keyrings array',
         state: {
           engine: {

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -1,13 +1,14 @@
 import generateUserProfileAnalyticsMetaData from './generateUserProfileAnalyticsMetaData';
 import { UserProfileProperty } from './UserProfileAnalyticsMetaData.types';
-import {Appearance} from 'react-native';
+import { Appearance } from 'react-native';
+import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 
 const mockGetState = jest.fn();
 jest.mock('../../../store', () => ({
-    store: {
-      getState: jest.fn(() => mockGetState()),
-    },
-  }));
+  store: {
+    getState: jest.fn(() => mockGetState()),
+  },
+}));
 
 const mockIsMetricsEnabled = jest.fn();
 jest.mock('../../../core/Analytics', () => ({
@@ -16,9 +17,15 @@ jest.mock('../../../core/Analytics', () => ({
   },
 }));
 
-jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
-
 describe('generateUserProfileAnalyticsMetaData', () => {
+  beforeEach(() => {
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const mockState = {
     engine: {
       backgroundState: {
@@ -29,11 +36,141 @@ describe('generateUserProfileAnalyticsMetaData', () => {
           isMultiAccountBalancesEnabled: false,
           securityAlertsEnabled: true,
         },
+        KeyringController: {
+          keyrings: [
+            {
+              type: ExtendedKeyringTypes.hd,
+              accounts: ['0x1', '0x2'],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: '01JPM6NFVGW8V8KKN34053JVFT',
+              name: '',
+            },
+          ],
+        },
       },
     },
     user: { appTheme: 'os' },
     security: { dataCollectionForMarketing: true },
   };
+
+  describe('NUMBER_OF_HD_ENTROPIES', () => {
+    const testCases = [
+      {
+        name: 'with undefined keyrings',
+        state: {
+          engine: {
+            backgroundState: {
+              KeyringController: {
+                keyrings: undefined,
+                keyringsMetadata: undefined,
+              },
+            },
+          },
+        },
+        expected: 0,
+      },
+      {
+        name: 'with empty keyrings array',
+        state: {
+          engine: {
+            backgroundState: {
+              KeyringController: {
+                keyrings: [],
+              },
+            },
+          },
+        },
+        expected: 0,
+      },
+      {
+        name: 'with one HD keyring',
+        state: {
+          engine: {
+            backgroundState: {
+              KeyringController: {
+                keyrings: [
+                  {
+                    type: ExtendedKeyringTypes.hd,
+                    accounts: ['0x123'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        expected: 1,
+      },
+      {
+        name: 'with two HD keyrings',
+        state: {
+          engine: {
+            backgroundState: {
+              KeyringController: {
+                keyrings: [
+                  {
+                    type: ExtendedKeyringTypes.hd,
+                    accounts: ['0x123'],
+                  },
+                  {
+                    type: ExtendedKeyringTypes.hd,
+                    accounts: ['0x456'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        expected: 2,
+      },
+      {
+        name: 'with mixed keyring types',
+        state: {
+          engine: {
+            backgroundState: {
+              KeyringController: {
+                keyrings: [
+                  {
+                    type: ExtendedKeyringTypes.hd,
+                    accounts: ['0x123'],
+                  },
+                  {
+                    type: ExtendedKeyringTypes.simple,
+                    accounts: ['0x456'],
+                  },
+                  {
+                    type: ExtendedKeyringTypes.qr,
+                    accounts: ['0x789'],
+                  },
+                  {
+                    type: ExtendedKeyringTypes.hd,
+                    accounts: ['0xabc'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        expected: 2,
+      },
+    ];
+
+    testCases.forEach(({ name, state, expected }) => {
+      it(name, () => {
+        mockGetState.mockReturnValue({
+          ...mockState,
+          ...state,
+        });
+
+        const metadata = generateUserProfileAnalyticsMetaData();
+        expect(metadata[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(
+          expected,
+        );
+      });
+    });
+  });
 
   it('returns metadata', () => {
     mockGetState.mockReturnValue(mockState);
@@ -48,6 +185,7 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
       [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
       [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 1,
     });
   });
 
@@ -55,14 +193,29 @@ describe('generateUserProfileAnalyticsMetaData', () => {
     [UserProfileProperty.ON, true],
     [UserProfileProperty.OFF, false],
   ])('returns marketing consent "%s"', (expected, stateConsentValue) => {
-    mockGetState.mockReturnValue({ ...mockState, security: { dataCollectionForMarketing: stateConsentValue } });
+    mockGetState.mockReturnValue({
+      ...mockState,
+      security: { dataCollectionForMarketing: stateConsentValue },
+    });
 
     const metadata = generateUserProfileAnalyticsMetaData();
-    expect(metadata[UserProfileProperty.HAS_MARKETING_CONSENT]).toEqual(expected);
+    expect(metadata[UserProfileProperty.HAS_MARKETING_CONSENT]).toEqual(
+      expected,
+    );
   });
 
   it('returns default metadata when missing preferences controller', () => {
-    mockGetState.mockReturnValue({ ...mockState, engine: {} });
+    mockGetState.mockReturnValue({
+      ...mockState,
+      engine: {
+        backgroundState: {
+          KeyringController: {
+            keyrings: [],
+            keyringsMetadata: [],
+          },
+        },
+      },
+    });
 
     const metadata = generateUserProfileAnalyticsMetaData();
     expect(metadata).toMatchObject({
@@ -71,6 +224,7 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
       [UserProfileProperty.SECURITY_PROVIDERS]: '',
+      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0,
     });
   });
 

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -21,14 +21,7 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
   const isDataCollectionForMarketingEnabled =
     reduxState?.security?.dataCollectionForMarketing;
 
-  let numberOfHDEntropies = 0;
-  try {
-    const hdKeyrings = selectHDKeyrings(reduxState);
-    numberOfHDEntropies = hdKeyrings?.length ?? 0;
-  } catch (error) {
-    // If the selector throws due to undefined keyrings, default to 0
-    numberOfHDEntropies = 0;
-  }
+  const hdKeyrings = selectHDKeyrings(reduxState);
 
   return {
     [UserProfileProperty.ENABLE_OPENSEA_API]:
@@ -54,7 +47,7 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
       isDataCollectionForMarketingEnabled
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
-    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: numberOfHDEntropies,
+    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: hdKeyrings.length,
   };
 };
 

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -4,6 +4,7 @@ import {
   UserProfileMetaData,
   UserProfileProperty,
 } from './UserProfileAnalyticsMetaData.types';
+import { selectHDKeyrings } from '../../../selectors/keyringController';
 
 /**
  * Generate user profile analytics meta data
@@ -18,7 +19,16 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
   const appThemeStyle =
     appTheme === 'os' ? Appearance.getColorScheme() : appTheme;
   const isDataCollectionForMarketingEnabled =
-      reduxState?.security?.dataCollectionForMarketing;
+    reduxState?.security?.dataCollectionForMarketing;
+
+  let numberOfHDEntropies = 0;
+  try {
+    const hdKeyrings = selectHDKeyrings(reduxState);
+    numberOfHDEntropies = hdKeyrings?.length ?? 0;
+  } catch (error) {
+    // If the selector throws due to undefined keyrings, default to 0
+    numberOfHDEntropies = 0;
+  }
 
   return {
     [UserProfileProperty.ENABLE_OPENSEA_API]:
@@ -40,9 +50,11 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
         : UserProfileProperty.OFF,
     [UserProfileProperty.SECURITY_PROVIDERS]:
       preferencesController?.securityAlertsEnabled ? 'blockaid' : '',
-    [UserProfileProperty.HAS_MARKETING_CONSENT]: isDataCollectionForMarketingEnabled
+    [UserProfileProperty.HAS_MARKETING_CONSENT]:
+      isDataCollectionForMarketingEnabled
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
+    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: numberOfHDEntropies,
   };
 };
 


### PR DESCRIPTION
## **Description**

We want to be able to track if a specific user profile is utilizing the new Multi SRP feature. To achieve this we are adding in a new piece of user metadata called `number_of_hd_entropies` which provides the number of current SRPs by the user in the HD keyring. To calculate this we are using the number of hdKeyrings provided by the selectHDKeyrings. 

This PR also requires that the `number_of_hd_entropies` is shipped in the mobile segment schema which is handled in this PR: https://github.com/Consensys/segment-schema/pull/269

Equivalent extension PR: https://github.com/MetaMask/metamask-mobile/pull/15466


## **Related issues**

Progresses: https://github.com/MetaMask/accounts-planning/issues/928
Resolves: https://consensyssoftware.atlassian.net/browse/MUL-120

## **Manual testing steps**

This is is only a metrics change and thus has no user facing changes. 

## **Screenshots/Recordings**


### **Before**



### **After**


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
