### PR TITLE
perf: cp-7.47.0 Improve `useSnapAssetDisplay` performance

### DIFF
--- a/app/components/Snaps/SnapUIAssetSelector/useSnapAssetDisplay.tsx
+++ b/app/components/Snaps/SnapUIAssetSelector/useSnapAssetDisplay.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   CaipAccountId,
   CaipAssetType,
@@ -19,7 +20,6 @@ import {
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { RootState } from '../../../reducers';
 import { getNonEvmNetworkImageSourceByChainId } from '../../../util/networks/customNetworks';
-import { useMemo } from 'react';
 
 /**
  * An asset for the SnapUIAssetSelector.
@@ -161,6 +161,7 @@ export const useSnapAssetSelectorData = ({
     const formatted: SnapUIAsset[] = filteredAssets.map(formatAsset);
 
     return formatted;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assets]);
 
   return formattedAssets;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves performance of the `useSnapAssetDisplay` hook by memoizing the result of the hook. Also changes the order so we don't spend time formatting assets that will be filtered out.

## **Manual testing steps**

1. Test that the Solana send flow still works
