### PR TITLE
fix: multichain balance checks in legacy confirmations

### DIFF
--- a/app/components/Views/confirmations/legacy/Approval/components/TransactionEditor/index.js
+++ b/app/components/Views/confirmations/legacy/Approval/components/TransactionEditor/index.js
@@ -42,7 +42,7 @@ import {
   selectConversionRateByChainId,
   selectCurrentCurrency,
 } from '../../../../../../../selectors/currencyRateController';
-import { selectAccounts } from '../../../../../../../selectors/accountTrackerController';
+import { selectAccountsByChainId } from '../../../../../../../selectors/accountTrackerController';
 import { selectContractBalances } from '../../../../../../../selectors/tokenBalancesController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../../selectors/accountsController';
 import { selectGasFeeEstimates } from '../../../../../../../selectors/confirmTransaction';
@@ -561,12 +561,13 @@ class TransactionEditor extends PureComponent {
   validateTotal = (totalGas) => {
     let error = '';
     const {
+      chainId,
       ticker,
       transaction: { value, from, assetType },
     } = this.props;
 
     const checksummedFrom = safeToChecksumAddress(from) || '';
-    const fromAccount = this.props.accounts[checksummedFrom];
+    const fromAccount = this.props.accounts[chainId]?.[checksummedFrom] ?? {};
     const { balance } = fromAccount;
     const weiBalance = hexToBN(balance);
     const totalGasValue = hexToBN(totalGas);
@@ -968,7 +969,7 @@ const mapStateToProps = (state) => {
   const chainId = transaction?.chainId;
 
   return {
-    accounts: selectAccounts(state),
+    accounts: selectAccountsByChainId(state),
     contractBalances: selectContractBalances(state),
     networkType: selectProviderTypeByChainId(state, chainId),
     selectedAddress: selectSelectedInternalAccountFormattedAddress(state),

--- a/app/components/Views/confirmations/legacy/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/Approve/index.js
@@ -48,7 +48,6 @@ import {
   selectEvmNetworkConfigurationsByChainId,
   selectProviderTypeByChainId,
   selectRpcUrlByChainId,
-  selectEvmChainId,
 } from '../../../../../selectors/networkController';
 import {
   selectConversionRateByChainId,
@@ -56,7 +55,7 @@ import {
 } from '../../../../../selectors/currencyRateController';
 import { selectTokensLength } from '../../../../../selectors/tokensController';
 import {
-  selectAccounts,
+  selectAccountsByChainId,
   selectAccountsLength,
 } from '../../../../../selectors/accountTrackerController';
 import ShowBlockExplorer from '../components/ApproveTransactionReview/ShowBlockExplorer';
@@ -413,12 +412,13 @@ class Approve extends PureComponent {
   validateGas = (total) => {
     let error;
     const {
+      chainId,
       ticker,
       transaction: { from },
       accounts,
     } = this.props;
 
-    const fromAccount = accounts[safeToChecksumAddress(from)];
+    const fromAccount = accounts[chainId]?.[safeToChecksumAddress(from)] ?? {};
 
     const weiBalance = hexToBN(fromAccount.balance);
     const totalTransactionValue = hexToBN(total);
@@ -965,7 +965,7 @@ const mapStateToProps = (state) => {
   const networkClientId = transaction?.networkId;
 
   return {
-    accounts: selectAccounts(state),
+    accounts: selectAccountsByChainId(state),
     ticker: selectNativeCurrencyByChainId(state, chainId),
     transaction,
     transactions: selectTransactions(state),

--- a/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
@@ -57,6 +57,7 @@ import {
 import { selectTokensLength } from '../../../../../../selectors/tokensController';
 import {
   selectAccounts,
+  selectAccountsByChainId,
   selectAccountsLength,
 } from '../../../../../../selectors/accountTrackerController';
 import ShowBlockExplorer from '../../components/ApproveTransactionReview/ShowBlockExplorer';
@@ -425,12 +426,13 @@ class Approve extends PureComponent {
   validateGas = (total) => {
     let error;
     const {
+      chainId,
       ticker,
       transaction: { from },
       accounts,
     } = this.props;
 
-    const fromAccount = accounts[safeToChecksumAddress(from)];
+    const fromAccount = accounts[chainId]?.[safeToChecksumAddress(from)] ?? {};
 
     const weiBalance = hexToBN(fromAccount.balance);
     const totalTransactionValue = hexToBN(total);
@@ -978,7 +980,7 @@ const mapStateToProps = (state) => {
   const networkClientId = transaction?.networkClientId;
 
   return {
-    accounts: selectAccounts(state),
+    accounts: selectAccountsByChainId(state),
     ticker: selectNativeCurrencyByChainId(state, chainId),
     transaction,
     transactions: selectTransactions(state),


### PR DESCRIPTION
## **Description**

When validating the balance in the legacy transaction confirmations, ensure the relevant chain balance is used, rather than the global network balance.

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
