### PR TITLE
chore: updating deprecated button shape

### DIFF
--- a/app/components/UI/AccountApproval/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AccountApproval/__snapshots__/index.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`AccountApproval should render correctly 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -475,7 +475,7 @@ exports[`AccountApproval should render correctly 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },

--- a/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ActionView/__snapshots__/index.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`ActionView should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -157,7 +157,7 @@ exports[`ActionView should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/UI/CollectibleModal/__snapshots__/CollectibleModal.test.tsx.snap
+++ b/app/components/UI/CollectibleModal/__snapshots__/CollectibleModal.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`CollectibleModal should render correctly 1`] = `
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },

--- a/app/components/UI/CustomAlert/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/CustomAlert/__snapshots__/index.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`CustomAlert should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/UI/DeleteWalletModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/DeleteWalletModal/__snapshots__/index.test.tsx.snap
@@ -398,7 +398,7 @@ exports[`DeleteWalletModal should render correctly 1`] = `
                     [
                       [
                         {
-                          "borderRadius": 100,
+                          "borderRadius": 12,
                           "justifyContent": "center",
                           "padding": 15,
                         },
@@ -456,7 +456,7 @@ exports[`DeleteWalletModal should render correctly 1`] = `
                     [
                       [
                         {
-                          "borderRadius": 100,
+                          "borderRadius": 12,
                           "justifyContent": "center",
                           "padding": 15,
                         },

--- a/app/components/UI/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -1120,7 +1120,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -2301,7 +2301,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -3562,7 +3562,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },

--- a/app/components/UI/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -1201,7 +1201,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -2384,7 +2384,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/LedgerModals/Steps/__snapshots__/OpenETHAppStep.test.tsx.snap
+++ b/app/components/UI/LedgerModals/Steps/__snapshots__/OpenETHAppStep.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`OpenETHAppStep matches snapshot 1`] = `
       [
         [
           {
-            "borderRadius": 100,
+            "borderRadius": 12,
             "justifyContent": "center",
             "padding": 15,
           },

--- a/app/components/UI/NetworkInfo/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkInfo/__snapshots__/index.test.tsx.snap
@@ -268,7 +268,7 @@ exports[`NetworkInfo render correctly 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -605,7 +605,7 @@ exports[`NetworkInfo render correctly with EVM network without ticker 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -863,7 +863,7 @@ exports[`NetworkInfo render correctly with non-EVM selected 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },

--- a/app/components/UI/OnboardingWizard/Coachmark/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Coachmark/__snapshots__/index.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Coachmark should render correctly 1`] = `
           [
             [
               {
-                "borderRadius": 100,
+                "borderRadius": 12,
                 "justifyContent": "center",
                 "padding": 15,
               },

--- a/app/components/UI/OnboardingWizard/Step2/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step2/__snapshots__/index.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Step2 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/OnboardingWizard/Step3/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step3/__snapshots__/index.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`Step3 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/OnboardingWizard/Step4/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step4/__snapshots__/index.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`Step4 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/OnboardingWizard/Step5/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step5/__snapshots__/index.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`Step5 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/OnboardingWizard/Step6/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step6/__snapshots__/index.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`Step6 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/OnboardingWizard/Step7/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/OnboardingWizard/Step7/__snapshots__/index.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Step7 should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/PaymentRequest/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`PaymentRequest renders correctly 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },
@@ -317,7 +317,7 @@ exports[`PaymentRequest renders correctly 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },

--- a/app/components/UI/PermissionsSummary/__snapshots__/PermissionsSummary.test.tsx.snap
+++ b/app/components/UI/PermissionsSummary/__snapshots__/PermissionsSummary.test.tsx.snap
@@ -1042,7 +1042,7 @@ exports[`PermissionsSummary should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -1104,7 +1104,7 @@ exports[`PermissionsSummary should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -1673,7 +1673,7 @@ exports[`PermissionsSummary should render correctly for network switch 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -1735,7 +1735,7 @@ exports[`PermissionsSummary should render correctly for network switch 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -2366,7 +2366,7 @@ exports[`PermissionsSummary should render only the account permissions card when
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -2427,7 +2427,7 @@ exports[`PermissionsSummary should render only the account permissions card when
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -2949,7 +2949,7 @@ exports[`PermissionsSummary should render only the network permissions card when
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -3010,7 +3010,7 @@ exports[`PermissionsSummary should render only the network permissions card when
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -4115,7 +4115,7 @@ exports[`PermissionsSummary should render the tab view when both showAccountsOnl
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -4177,7 +4177,7 @@ exports[`PermissionsSummary should render the tab view when both showAccountsOnl
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -603,7 +603,7 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -1267,7 +1267,7 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -1931,7 +1931,7 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -3534,7 +3534,7 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -5137,7 +5137,7 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -6819,7 +6819,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -8109,7 +8109,7 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },
@@ -9710,7 +9710,7 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -12377,7 +12377,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -13667,7 +13667,7 @@ exports[`BuildQuote View renders correctly 1`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },
@@ -15307,7 +15307,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -16662,7 +16662,7 @@ exports[`BuildQuote View renders correctly 2`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },
@@ -17324,7 +17324,7 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -17988,7 +17988,7 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/GetStarted/__snapshots__/GetStarted.test.tsx.snap
@@ -599,7 +599,7 @@ exports[`GetStarted renders correctly 1`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },
@@ -1257,7 +1257,7 @@ exports[`GetStarted renders correctly 2`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },
@@ -2330,7 +2330,7 @@ exports[`GetStarted renders correctly when sdkError is present 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
@@ -8351,7 +8351,7 @@ exports[`NetworkSwitcher View renders correctly with errors 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -8992,7 +8992,7 @@ exports[`NetworkSwitcher View renders correctly with errors 2`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -9633,7 +9633,7 @@ exports[`NetworkSwitcher View renders correctly with no data 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -1426,7 +1426,7 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -2931,7 +2931,7 @@ exports[`OrderDetails renders a completed order 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -5884,7 +5884,7 @@ exports[`OrderDetails renders a failed order 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -8425,7 +8425,7 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -9972,7 +9972,7 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                       [
                                         [
                                           {
-                                            "borderRadius": 100,
+                                            "borderRadius": 12,
                                             "justifyContent": "center",
                                             "padding": 15,
                                           },
@@ -11526,7 +11526,7 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1439,7 +1439,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                                   [
                                                     [
                                                       {
-                                                        "borderRadius": 100,
+                                                        "borderRadius": 12,
                                                         "justifyContent": "center",
                                                         "padding": 15,
                                                       },
@@ -3779,7 +3779,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                           [
                                                             [
                                                               {
-                                                                "borderRadius": 100,
+                                                                "borderRadius": 12,
                                                                 "justifyContent": "center",
                                                                 "padding": 15,
                                                               },
@@ -4128,7 +4128,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                           [
                                                             [
                                                               {
-                                                                "borderRadius": 100,
+                                                                "borderRadius": 12,
                                                                 "justifyContent": "center",
                                                                 "padding": 15,
                                                               },
@@ -4402,7 +4402,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                                           [
                                                             [
                                                               {
-                                                                "borderRadius": 100,
+                                                                "borderRadius": 12,
                                                                 "justifyContent": "center",
                                                                 "padding": 15,
                                                               },
@@ -5539,7 +5539,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                                     [
                                                       [
                                                         {
-                                                          "borderRadius": 100,
+                                                          "borderRadius": 12,
                                                           "justifyContent": "center",
                                                           "padding": 15,
                                                         },
@@ -6345,7 +6345,7 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -7095,7 +7095,7 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -7845,7 +7845,7 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -8595,7 +8595,7 @@ exports[`Quotes renders quotes expired screen 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Regions/__snapshots__/Regions.test.tsx.snap
@@ -685,7 +685,7 @@ exports[`Regions View renders correctly 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -1933,7 +1933,7 @@ exports[`Regions View renders correctly with error 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -3176,7 +3176,7 @@ exports[`Regions View renders correctly with sdkError 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },
@@ -3926,7 +3926,7 @@ exports[`Regions View renders correctly with selectedRegion 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -4671,7 +4671,7 @@ exports[`Regions View renders correctly with unsupportedRegion 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -5824,7 +5824,7 @@ exports[`Regions View renders correctly with unsupportedRegion 2`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },
@@ -6977,7 +6977,7 @@ exports[`Regions View renders regions modal when pressing select button 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },

--- a/app/components/UI/ReceiveRequest/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/ReceiveRequest/__snapshots__/index.test.tsx.snap
@@ -664,7 +664,7 @@ exports[`ReceiveRequest render matches snapshot 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -1392,7 +1392,7 @@ exports[`ReceiveRequest render with different ticker matches snapshot 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -2120,7 +2120,7 @@ exports[`ReceiveRequest render without buy matches snapshot 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },

--- a/app/components/UI/StyledButton/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/StyledButton/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`StyledButton should render correctly on Android the button with type ca
     style={
       [
         {
-          "borderRadius": 100,
+          "borderRadius": 12,
           "justifyContent": "center",
           "padding": 15,
         },
@@ -35,7 +35,7 @@ exports[`StyledButton should render correctly on Android the button with type co
     style={
       [
         {
-          "borderRadius": 100,
+          "borderRadius": 12,
           "justifyContent": "center",
           "padding": 15,
         },
@@ -60,7 +60,7 @@ exports[`StyledButton should render correctly on Android the button with type no
     style={
       [
         {
-          "borderRadius": 100,
+          "borderRadius": 12,
           "justifyContent": "center",
           "padding": 15,
         },
@@ -86,7 +86,7 @@ exports[`StyledButton should render correctly on Android the button with type or
     style={
       [
         {
-          "borderRadius": 100,
+          "borderRadius": 12,
           "justifyContent": "center",
           "padding": 15,
         },
@@ -108,7 +108,7 @@ exports[`StyledButton should render correctly on iOS the button with type cancel
   containerStyle={
     [
       {
-        "borderRadius": 100,
+        "borderRadius": 12,
         "justifyContent": "center",
         "padding": 15,
       },
@@ -145,7 +145,7 @@ exports[`StyledButton should render correctly on iOS the button with type confir
   containerStyle={
     [
       {
-        "borderRadius": 100,
+        "borderRadius": 12,
         "justifyContent": "center",
         "padding": 15,
       },
@@ -181,7 +181,7 @@ exports[`StyledButton should render correctly on iOS the button with type normal
   containerStyle={
     [
       {
-        "borderRadius": 100,
+        "borderRadius": 12,
         "justifyContent": "center",
         "padding": 15,
       },
@@ -218,7 +218,7 @@ exports[`StyledButton should render correctly on iOS the button with type orange
   containerStyle={
     [
       {
-        "borderRadius": 100,
+        "borderRadius": 12,
         "justifyContent": "center",
         "padding": 15,
       },

--- a/app/components/UI/StyledButton/styledButtonStyles.ts
+++ b/app/components/UI/StyledButton/styledButtonStyles.ts
@@ -6,7 +6,7 @@ const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
       padding: 15,
-      borderRadius: 100,
+      borderRadius: 12,
       justifyContent: 'center',
     },
     text: {

--- a/app/components/UI/Swaps/__snapshots__/QuotesView.test.ts.snap
+++ b/app/components/UI/Swaps/__snapshots__/QuotesView.test.ts.snap
@@ -1772,7 +1772,7 @@ exports[`QuotesView should render quote screen 1`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },

--- a/app/components/UI/SwitchCustomNetwork/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SwitchCustomNetwork/__snapshots__/index.test.tsx.snap
@@ -364,7 +364,7 @@ exports[`SwitchCustomNetwork should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -426,7 +426,7 @@ exports[`SwitchCustomNetwork should render correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/UI/WhatsNewModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/WhatsNewModal/__snapshots__/index.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`WhatsNewModal should render correctly 1`] = `
                             [
                               [
                                 {
-                                  "borderRadius": 100,
+                                  "borderRadius": 12,
                                   "justifyContent": "center",
                                   "padding": 15,
                                 },

--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -925,7 +925,7 @@ exports[`AccountBackupStep1 should render correctly 1`] = `
                                     [
                                       [
                                         {
-                                          "borderRadius": 100,
+                                          "borderRadius": 12,
                                           "justifyContent": "center",
                                           "padding": 15,
                                         },

--- a/app/components/Views/AccountBackupStep1B/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1B/__snapshots__/index.test.tsx.snap
@@ -1071,7 +1071,7 @@ exports[`AccountBackupStep1B should render correctly 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },

--- a/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
+++ b/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
@@ -1150,7 +1150,7 @@ exports[`AccountConnect renders correctly with base request 1`] = `
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -1212,7 +1212,7 @@ exports[`AccountConnect renders correctly with base request 1`] = `
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -2422,7 +2422,7 @@ exports[`AccountConnect renders correctly with request including chains and acco
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -2484,7 +2484,7 @@ exports[`AccountConnect renders correctly with request including chains and acco
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -3694,7 +3694,7 @@ exports[`AccountConnect renders correctly with request including only chains 1`]
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -3756,7 +3756,7 @@ exports[`AccountConnect renders correctly with request including only chains 1`]
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },
@@ -355,7 +355,7 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },

--- a/app/components/Views/AddBookmark/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AddBookmark/__snapshots__/index.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`AddBookmark should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -260,7 +260,7 @@ exports[`AddBookmark should render correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/Views/CollectibleView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/CollectibleView/__snapshots__/index.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`CollectibleView Snapshot renders correctly 1`] = `
                     [
                       [
                         {
-                          "borderRadius": 100,
+                          "borderRadius": 12,
                           "justifyContent": "center",
                           "padding": 15,
                         },
@@ -423,7 +423,7 @@ exports[`CollectibleView Snapshot renders correctly 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },

--- a/app/components/Views/ConnectQRHardware/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ConnectQRHardware/__snapshots__/index.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`ConnectQRHardware renders correctly to match snapshot 1`] = `
           [
             [
               {
-                "borderRadius": 100,
+                "borderRadius": 12,
                 "justifyContent": "center",
                 "padding": 15,
               },

--- a/app/components/Views/DetectedTokens/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/DetectedTokens/__snapshots__/index.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`DetectedTokens Component matches snapshot when no detected tokens 1`] =
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -125,7 +125,7 @@ exports[`DetectedTokens Component matches snapshot when no detected tokens 1`] =
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -776,7 +776,7 @@ exports[`DetectedTokens Component renders correctly with detected tokens 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },
@@ -839,7 +839,7 @@ exports[`DetectedTokens Component renders correctly with detected tokens 1`] = `
         [
           [
             {
-              "borderRadius": 100,
+              "borderRadius": 12,
               "justifyContent": "center",
               "padding": 15,
             },

--- a/app/components/Views/EnterPasswordSimple/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/EnterPasswordSimple/__snapshots__/index.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`EnterPasswordSimple should render correctly 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -1488,7 +1488,7 @@ exports[`ImportFromSecretRecoveryPhrase should render correctly 1`] = `
                                   [
                                     [
                                       {
-                                        "borderRadius": 100,
+                                        "borderRadius": 12,
                                         "justifyContent": "center",
                                         "padding": 15,
                                       },

--- a/app/components/Views/ImportPrivateKey/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportPrivateKey/__snapshots__/index.test.tsx.snap
@@ -618,7 +618,7 @@ exports[`ImportPrivateKey should render correctly 1`] = `
                                 [
                                   [
                                     {
-                                      "borderRadius": 100,
+                                      "borderRadius": 12,
                                       "justifyContent": "center",
                                       "padding": 15,
                                     },

--- a/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
@@ -613,7 +613,7 @@ exports[`LedgerConnect render matches latest snapshot 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/Views/NftDetails/__snapshots__/NftDetails.test.ts.snap
+++ b/app/components/Views/NftDetails/__snapshots__/NftDetails.test.ts.snap
@@ -1383,7 +1383,7 @@ exports[`NftDetails should render correctly 1`] = `
                             [
                               [
                                 {
-                                  "borderRadius": 100,
+                                  "borderRadius": 12,
                                   "justifyContent": "center",
                                   "padding": 15,
                                 },

--- a/app/components/Views/OfflineMode/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/OfflineMode/__snapshots__/index.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`OfflineMode should render correctly 1`] = `
           [
             [
               {
-                "borderRadius": 100,
+                "borderRadius": 12,
                 "justifyContent": "center",
                 "padding": 15,
               },

--- a/app/components/Views/ProtectWalletMandatoryModal/__snapshots__/ProtectWalletMandatoryModal.test.tsx.snap
+++ b/app/components/Views/ProtectWalletMandatoryModal/__snapshots__/ProtectWalletMandatoryModal.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`ProtectWalletMandatoryModal renders correctly 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },
@@ -443,7 +443,7 @@ exports[`ProtectWalletMandatoryModal renders correctly on iPhoneX 1`] = `
             [
               [
                 {
-                  "borderRadius": 100,
+                  "borderRadius": 12,
                   "justifyContent": "center",
                   "padding": 15,
                 },

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -362,7 +362,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -731,7 +731,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -792,7 +792,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -1087,7 +1087,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -1148,7 +1148,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -1443,7 +1443,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -1504,7 +1504,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },

--- a/app/components/Views/Settings/NetworksSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/NetworksSettings/__snapshots__/index.test.tsx.snap
@@ -979,7 +979,7 @@ exports[`NetworksSettings should render correctly 1`] = `
                           [
                             [
                               {
-                                "borderRadius": 100,
+                                "borderRadius": 12,
                                 "justifyContent": "center",
                                 "padding": 15,
                               },

--- a/app/components/Views/confirmations/legacy/Approval/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/Approval/__snapshots__/index.test.tsx.snap
@@ -1028,7 +1028,7 @@ exports[`Approval render matches snapshot 1`] = `
                                                 [
                                                   [
                                                     {
-                                                      "borderRadius": 100,
+                                                      "borderRadius": 12,
                                                       "justifyContent": "center",
                                                       "padding": 15,
                                                     },
@@ -1089,7 +1089,7 @@ exports[`Approval render matches snapshot 1`] = `
                                                 [
                                                   [
                                                     {
-                                                      "borderRadius": 100,
+                                                      "borderRadius": 12,
                                                       "justifyContent": "center",
                                                       "padding": 15,
                                                     },

--- a/app/components/Views/confirmations/legacy/Approve/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/Approve/__snapshots__/index.test.tsx.snap
@@ -808,7 +808,7 @@ exports[`Approve renders transaction approval 1`] = `
                                                   [
                                                     [
                                                       {
-                                                        "borderRadius": 100,
+                                                        "borderRadius": 12,
                                                         "justifyContent": "center",
                                                         "padding": 15,
                                                       },
@@ -869,7 +869,7 @@ exports[`Approve renders transaction approval 1`] = `
                                                   [
                                                     [
                                                       {
-                                                        "borderRadius": 100,
+                                                        "borderRadius": 12,
                                                         "justifyContent": "center",
                                                         "padding": 15,
                                                       },

--- a/app/components/Views/confirmations/legacy/ApproveView/Approve/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/ApproveView/Approve/__snapshots__/index.test.tsx.snap
@@ -808,7 +808,7 @@ exports[`Approve renders transaction approval 1`] = `
                                                   [
                                                     [
                                                       {
-                                                        "borderRadius": 100,
+                                                        "borderRadius": 12,
                                                         "justifyContent": "center",
                                                         "padding": 15,
                                                       },
@@ -869,7 +869,7 @@ exports[`Approve renders transaction approval 1`] = `
                                                   [
                                                     [
                                                       {
-                                                        "borderRadius": 100,
+                                                        "borderRadius": 12,
                                                         "justifyContent": "center",
                                                         "padding": 15,
                                                       },

--- a/app/components/Views/confirmations/legacy/SendFlow/Amount/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/SendFlow/Amount/__snapshots__/index.test.tsx.snap
@@ -628,7 +628,7 @@ exports[`Amount converts ERC-20 token value to USD 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -1324,7 +1324,7 @@ exports[`Amount converts ETH to USD 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -2037,7 +2037,7 @@ exports[`Amount converts USD to ERC-20 token value 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -2750,7 +2750,7 @@ exports[`Amount converts USD to ETH 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -3445,7 +3445,7 @@ exports[`Amount displays correct balance 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -4140,7 +4140,7 @@ exports[`Amount does not show a warning when conversion rate is available 1`] = 
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -4801,7 +4801,7 @@ exports[`Amount does not show a warning when transfering collectibles 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -5498,7 +5498,7 @@ exports[`Amount proceeds if balance is sufficient while on Native primary curren
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -6189,7 +6189,7 @@ exports[`Amount proceeds if balance is sufficient while on Native primary curren
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -6873,7 +6873,7 @@ exports[`Amount renders correctly 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -7563,7 +7563,7 @@ exports[`Amount shows a warning when conversion rate is not available 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },
@@ -8301,7 +8301,7 @@ exports[`Amount shows an error message if balance is insufficient 1`] = `
                               [
                                 [
                                   {
-                                    "borderRadius": 100,
+                                    "borderRadius": 12,
                                     "justifyContent": "center",
                                     "padding": 15,
                                   },

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/__snapshots__/index.test.tsx.snap
@@ -1720,7 +1720,7 @@ exports[`Confirm should render correctly 1`] = `
                             [
                               [
                                 {
-                                  "borderRadius": 100,
+                                  "borderRadius": 12,
                                   "justifyContent": "center",
                                   "padding": 15,
                                 },

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/components/CustomGasModal/__snapshots__/CustomGasModal.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/components/CustomGasModal/__snapshots__/CustomGasModal.test.tsx.snap
@@ -977,7 +977,7 @@ exports[`CustomGasModal should render correctly 1`] = `
                         [
                           [
                             {
-                              "borderRadius": 100,
+                              "borderRadius": 12,
                               "justifyContent": "center",
                               "padding": 15,
                             },

--- a/app/components/Views/confirmations/legacy/SendFlow/SendTo/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/SendFlow/SendTo/__snapshots__/index.test.tsx.snap
@@ -422,7 +422,7 @@ exports[`SendTo Component render matches snapshot 1`] = `
           [
             [
               {
-                "borderRadius": 100,
+                "borderRadius": 12,
                 "justifyContent": "center",
                 "padding": 15,
               },

--- a/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/__snapshots__/index.test.jsx.snap
+++ b/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/__snapshots__/index.test.jsx.snap
@@ -625,7 +625,7 @@ exports[`ApproveTransactionModal render matches snapshot 1`] = `
                                       [
                                         [
                                           {
-                                            "borderRadius": 100,
+                                            "borderRadius": 12,
                                             "justifyContent": "center",
                                             "padding": 15,
                                           },
@@ -686,7 +686,7 @@ exports[`ApproveTransactionModal render matches snapshot 1`] = `
                                       [
                                         [
                                           {
-                                            "borderRadius": 100,
+                                            "borderRadius": 12,
                                             "justifyContent": "center",
                                             "padding": 15,
                                           },

--- a/app/components/Views/confirmations/legacy/components/EditGasFeeLegacyUpdate/__snapshots__/EditGasFeeLegacyUpdate.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/components/EditGasFeeLegacyUpdate/__snapshots__/EditGasFeeLegacyUpdate.test.tsx.snap
@@ -922,7 +922,7 @@ exports[`EditGasFeeLegacyUpdate should match snapshot 1`] = `
                 [
                   [
                     {
-                      "borderRadius": 100,
+                      "borderRadius": 12,
                       "justifyContent": "center",
                       "padding": 15,
                     },

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/__snapshots__/index.test.jsx.snap
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/__snapshots__/index.test.jsx.snap
@@ -1085,7 +1085,7 @@ exports[`TransactionReview should match snapshot 1`] = `
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },
@@ -1146,7 +1146,7 @@ exports[`TransactionReview should match snapshot 1`] = `
                   [
                     [
                       {
-                        "borderRadius": 100,
+                        "borderRadius": 12,
                         "justifyContent": "center",
                         "padding": 15,
                       },

--- a/app/components/Views/confirmations/legacy/components/TypedSign/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/confirmations/legacy/components/TypedSign/__snapshots__/index.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`TypedSign onConfirm signs message 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -309,7 +309,7 @@ exports[`TypedSign onConfirm signs message 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -617,7 +617,7 @@ exports[`TypedSign onReject rejects message 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },
@@ -679,7 +679,7 @@ exports[`TypedSign onReject rejects message 1`] = `
               [
                 [
                   {
-                    "borderRadius": 100,
+                    "borderRadius": 12,
                     "justifyContent": "center",
                     "padding": 15,
                   },


### PR DESCRIPTION
## **Description**

This PR updates the deprecated StyledButton component's border radius from a fully rounded pill shape (borderRadius: 100) to rounded rectangle (borderRadius: 12) to align with the homepage redesign and brand evolution updates.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Navigate to any screen that uses StyledButton components (modals, confirmations, settings, etc.)
2. Verify that buttons now display with rounded rectangle shape (12px border radius)

## **Screenshots/Recordings**

### **Before**
- Inconsistent rectangle (DS Buttons) and deprecated pill-shaped buttons

https://github.com/user-attachments/assets/22898b86-5632-451d-bcdf-381d44fc3528

### **After**
- Most button should be rounded rectangle buttons (borderRadius: 12)

https://github.com/user-attachments/assets/822221df-707c-4370-b5e5-749ff66588e3

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


### Update on `Button` shape changes across products:

*Mobile* (released in `v7.48.0`)
* https://github.com/MetaMask/metamask-mobile/pull/14540

*Extension* (released in `v12.18.0`)
* https://github.com/MetaMask/metamask-extension/pull/31818
* https://github.com/MetaMask/metamask-extension/pull/32802
* https://github.com/MetaMask/metamask-extension/pull/32809

*Portfolio* (released in [prod](https://portfolio.metamask.io/))
* https://github.com/consensys-vertical-apps/metamask-portfolio/pull/1690

*Developer Dashboard*
* https://github.com/MetaMask/metamask-developer-dashboard/pull/262

*Phishing Detect Page*
* https://github.com/MetaMask/phishing-warning/pull/194 