### PR TITLE
fix: E2E test for the fix of the issue 15523

### DIFF
--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -458,6 +458,7 @@ class FixtureBuilder {
             },
           ],
           activeTab: 1692550481062,
+          favicons: []
         },
         modals: {
           networkModalVisible: false,

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -214,6 +214,10 @@ class Browser {
     );
   }
 
+  /**
+   * Enters url in the input field but doesn't navigate to it.
+   * Can be used to test search or autocomplete
+   */
   async searchForUrl(url) {
     await this.tapUrlInputBox();
     await device.disableSynchronization(); // because animations makes typing into the browser slow

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -213,6 +213,13 @@ class Browser {
       `${TEST_DAPP_LOCAL_URL}/request?method=eth_sendTransaction&params=${encodedParams}`,
     );
   }
+
+  async searchForUrl(url) {
+    await this.tapUrlInputBox();
+    await device.disableSynchronization(); // because animations makes typing into the browser slow
+    await Gestures.replaceTextInField(this.urlInputBoxID, url);
+    await device.enableSynchronization(); // re-enabling synchronization
+  }
 }
 
 export default new Browser();

--- a/e2e/specs/browser/open-site-with-broken-svg.spec.js
+++ b/e2e/specs/browser/open-site-with-broken-svg.spec.js
@@ -4,11 +4,11 @@ import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import {loginToApp} from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {withFixtures} from '../../fixtures/fixture-helper';
-import {Regression} from '../../tags';
+import {SmokeWalletPlatform} from '../../tags';
 import TestHelpers from '../../helpers';
 import Assertions from '../../utils/Assertions';
 
-describe(Regression('Search for a website with broken SVG and open it'), () => {
+describe(SmokeWalletPlatform('Search for a website with broken SVG and open it'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     await TestHelpers.reverseServerPort();

--- a/e2e/specs/browser/open-site-with-broken-svg.spec.js
+++ b/e2e/specs/browser/open-site-with-broken-svg.spec.js
@@ -24,8 +24,8 @@ describe(SmokeConfirmations('Search for a website with broken SVG and open it'),
       async () => {
         await loginToApp();
         await TabBarComponent.tapBrowser();
-        await Browser.navigateToURL("https://app.ens.domains");
-        await Browser.searchForUrl("app.ens.domains");
+        await Browser.navigateToURL('https://app.ens.domains');
+        await Browser.searchForUrl('app.ens.domains');
         await TestHelpers.delay(5000); // Wait for SVG images to load and not crash
         await expect(element(by.text('E'))).not.toExist(); // Validate that SVG is loaded and text placeholder logo is not displayed
       },

--- a/e2e/specs/browser/open-site-with-broken-svg.spec.js
+++ b/e2e/specs/browser/open-site-with-broken-svg.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+import Browser from '../../pages/Browser/BrowserView';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import {loginToApp} from '../../viewHelper';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {withFixtures} from '../../fixtures/fixture-helper';
+import {SmokeConfirmations} from '../../tags';
+import TestHelpers from '../../helpers';
+
+describe(SmokeConfirmations('Search for a website with broken SVG and open it'), () => {
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+    await TestHelpers.reverseServerPort();
+  });
+
+  it('Open app.ens.domains', async () => {
+    await withFixtures(
+      {
+        dapp: false,
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock: false,
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapBrowser();
+        await Browser.navigateToURL("https://app.ens.domains");
+        await Browser.searchForUrl("app.ens.domains");
+        await TestHelpers.delay(5000); // Wait for SVG images to load and not crash
+        await expect(element(by.text('E'))).not.toExist(); // Validate that SVG is loaded and text placeholder logo is not displayed
+      },
+    );
+  });
+});

--- a/e2e/specs/browser/open-site-with-broken-svg.spec.js
+++ b/e2e/specs/browser/open-site-with-broken-svg.spec.js
@@ -4,10 +4,11 @@ import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import {loginToApp} from '../../viewHelper';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {withFixtures} from '../../fixtures/fixture-helper';
-import {SmokeConfirmations} from '../../tags';
+import {Regression} from '../../tags';
 import TestHelpers from '../../helpers';
+import Assertions from "../../utils/Assertions";
 
-describe(SmokeConfirmations('Search for a website with broken SVG and open it'), () => {
+describe(Regression('Search for a website with broken SVG and open it'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     await TestHelpers.reverseServerPort();
@@ -27,7 +28,7 @@ describe(SmokeConfirmations('Search for a website with broken SVG and open it'),
         await Browser.navigateToURL('https://app.ens.domains');
         await Browser.searchForUrl('app.ens.domains');
         await TestHelpers.delay(5000); // Wait for SVG images to load and not crash
-        await expect(element(by.text('E'))).not.toExist(); // Validate that SVG is loaded and text placeholder logo is not displayed
+        await Assertions.checkIfElementWithTextDoesNotExist('E'); // Validate that SVG is loaded and text placeholder logo is not displayed
       },
     );
   });

--- a/e2e/specs/browser/open-site-with-broken-svg.spec.js
+++ b/e2e/specs/browser/open-site-with-broken-svg.spec.js
@@ -6,7 +6,7 @@ import FixtureBuilder from '../../fixtures/fixture-builder';
 import {withFixtures} from '../../fixtures/fixture-helper';
 import {Regression} from '../../tags';
 import TestHelpers from '../../helpers';
-import Assertions from "../../utils/Assertions";
+import Assertions from '../../utils/Assertions';
 
 describe(Regression('Search for a website with broken SVG and open it'), () => {
   beforeAll(async () => {

--- a/e2e/utils/Assertions.js
+++ b/e2e/utils/Assertions.js
@@ -296,6 +296,10 @@ class Assertions {
       .toExist()
       .withTimeout(timeout);
   }
+
+  static async checkIfElementWithTextDoesNotExist(text) {
+    return await expect(element(by.text(text))).not.toExist();
+  }
 }
 
 export default Assertions;


### PR DESCRIPTION
Crash on Android was fixed in the PR https://github.com/MetaMask/metamask-mobile/pull/15544

To make this E2E test work I had to update **fixtures** with an empty **favourites** array for the browser. Otherwise, app is throwing an error **[MetaMask DEBUG]: Error fetching or caching favicon: [TypeError: Cannot read property 'find' of undefined]** and not loading SVG icons.

Additionally, I have to turn off **testSpecificMock**. If it's turned on, we load SVG icons via mockServer (http://10.0.2.2:8000/proxy?url=https://app.ens.domains/favicon.svg) and this url returns incorrect Content-type header **text/html** which is filtered out in the patch (react-native-svg+15.11.2.patch, line 16), 
but in prod app we load URL https://app.ens.domains/favicon.svg which returns Content-type **image/svg+xml**

I added E2E test for it which fails if Icon is not loading or if App is crashing. Video:
https://github.com/user-attachments/assets/2efa7fac-83e6-4f3d-a72c-4b8670984784


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
