### PR TITLE
fix: cp-7.47.0 Replace commas when inputting numbers in `SnapUIInput`

### DIFF
--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -59,17 +59,17 @@ export const SnapUIInput = ({
   const getInputValue = (text: string) => {
     if (keyboardType === 'numeric') {
       // Mimic browser behaviour where commas are replaced.
-      return text.replace(/,/g, ".");
+      return text.replace(/,/g, '.');
     }
 
     return text;
   };
 
   const handleChange = (text: string) => {
-    const value = getInputValue(text);
+    const textValue = getInputValue(text);
 
-    setValue(value);
-    handleInputChange(name, value, form);
+    setValue(textValue);
+    handleInputChange(name, textValue, form);
   };
 
   const handleFocus = () => setCurrentFocusedInput(name);

--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
-import { TextInput, ViewStyle } from 'react-native';
+import { TextInput, ViewStyle, KeyboardTypeOptions } from 'react-native';
 import TextField, {
   TextFieldSize,
 } from '../../../component-library/components/Form/TextField';
@@ -18,6 +18,7 @@ export interface SnapUIInputProps {
   error?: string;
   style?: ViewStyle;
   disabled?: boolean;
+  keyboardType?: KeyboardTypeOptions;
 }
 
 export const SnapUIInput = ({
@@ -27,6 +28,7 @@ export const SnapUIInput = ({
   error,
   style,
   disabled,
+  keyboardType,
   ...props
 }: SnapUIInputProps) => {
   const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
@@ -54,9 +56,20 @@ export const SnapUIInput = ({
     }
   }, [inputRef, name, focusedInput]);
 
+  const getInputValue = (text: string) => {
+    if (keyboardType === 'numeric') {
+      // Mimic browser behaviour where commas are replaced.
+      return text.replace(/,/g, ".");
+    }
+
+    return text;
+  };
+
   const handleChange = (text: string) => {
-    setValue(text);
-    handleInputChange(name, text, form);
+    const value = getInputValue(text);
+
+    setValue(value);
+    handleInputChange(name, value, form);
   };
 
   const handleFocus = () => setCurrentFocusedInput(name);
@@ -77,6 +90,7 @@ export const SnapUIInput = ({
         onChangeText={handleChange}
         autoCapitalize="none"
         autoCorrect={false}
+        keyboardType={keyboardType}
         // We set a max height of 58px and let the input grow to fill the rest of the height next to a taller sibling element.
         // eslint-disable-next-line react-native/no-inline-styles
         style={{ maxHeight: 58, flexGrow: 1 }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mimic the browser behavior of replacing commas with dots for increased Snaps platform compatibility between mobile and extension.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15682

## **Manual testing steps**

1. Go to the Solana send flow
2. Use the keyboard to input a comma
3. See that it is replaced by a dot