### PR TITLE
[External] chore: prevent TokenList rerenders

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
@@ -452,3 +452,5 @@ export const TokenListItem = React.memo(
     );
   },
 );
+
+TokenListItem.displayName = 'TokenListItem';

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useRef,
-  useState,
-  LegacyRef,
-  useMemo,
-  memo,
-  useCallback,
-} from 'react';
+import React, { useRef, useState, LegacyRef, memo, useCallback } from 'react';
 import { View } from 'react-native';
 import ActionSheet from '@metamask/react-native-actionsheet';
 import { useSelector } from 'react-redux';
@@ -22,33 +15,15 @@ import { TokenList } from './TokenList';
 import { TokenI } from './types';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletView.selectors';
 import { strings } from '../../../../locales/i18n';
-import { selectTokenSortConfig } from '../../../selectors/preferencesController';
-import {
-  refreshTokens,
-  sortAssets,
-  removeEvmToken,
-  goToAddEvmToken,
-} from './util';
+import { refreshTokens, removeEvmToken, goToAddEvmToken } from './util';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import {
-  selectEvmTokenFiatBalances,
-  selectEvmTokens,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  selectMultichainTokenListForAccountId,
-  ///: END:ONLY_INCLUDE_IF
-} from '../../../selectors/multichain';
-import { TraceName, endTrace, trace } from '../../../util/trace';
-import { getTraceTags } from '../../../util/sentry/tags';
-import { store } from '../../../store';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 import { TokenListControlBar } from './TokenListControlBar';
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-import { RootState } from '../../../reducers';
-///: END:ONLY_INCLUDE_IF
+import { selectSelectedInternalAccountId } from '../../../selectors/accountsController';
 import { ScamWarningModal } from './TokenList/ScamWarningModal';
+import { selectSortedTokenKeys } from '../../../selectors/tokenList';
 
 interface TokenListNavigationParamList {
   AddAsset: { assetType: string };
@@ -62,7 +37,6 @@ const Tokens = memo(() => {
     >();
   const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
-  const tokenSortConfig = useSelector(selectTokenSortConfig);
 
   // evm
   const evmNetworkConfigurationsByChainId = useSelector(
@@ -71,51 +45,18 @@ const Tokens = memo(() => {
   const currentChainId = useSelector(selectChainId);
   const nativeCurrencies = useSelector(selectNativeNetworkCurrencies);
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-  const evmTokens = useSelector(selectEvmTokens);
-  const tokenFiatBalances = useSelector(selectEvmTokenFiatBalances);
+  const selectedAccountId = useSelector(selectSelectedInternalAccountId);
 
   const actionSheet = useRef<typeof ActionSheet>();
   const [tokenToRemove, setTokenToRemove] = useState<TokenI>();
   const [refreshing, setRefreshing] = useState(false);
   const [isAddTokenEnabled, setIsAddTokenEnabled] = useState(true);
-  const selectedAccount = useSelector(selectSelectedInternalAccount);
-
-  // non-evm
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  const nonEvmTokens = useSelector((state: RootState) =>
-    selectMultichainTokenListForAccountId(state, selectedAccount?.id),
-  );
-  ///: END:ONLY_INCLUDE_IF
 
   const [showScamWarningModal, setShowScamWarningModal] = useState(false);
 
-  const tokenListData = isEvmSelected ? evmTokens : nonEvmTokens;
-
   const styles = createStyles(colors);
 
-  const sortedTokenKeys = useMemo(() => {
-    trace({
-      name: TraceName.Tokens,
-      tags: getTraceTags(store.getState()),
-    });
-
-    const tokensWithBalances: TokenI[] = tokenListData.map((token, i) => ({
-      ...token,
-      tokenFiatAmount: isEvmSelected ? tokenFiatBalances[i] : token.balanceFiat,
-    }));
-
-    const tokensSorted = sortAssets(tokensWithBalances, tokenSortConfig);
-
-    endTrace({ name: TraceName.Tokens });
-
-    return tokensSorted
-      .filter(({ address, chainId }) => address && chainId)
-      .map(({ address, chainId, isStaked }) => ({
-        address,
-        chainId,
-        isStaked,
-      }));
-  }, [tokenListData, tokenFiatBalances, isEvmSelected, tokenSortConfig]);
+  const sortedTokenKeys = useSelector(selectSortedTokenKeys);
 
   const showRemoveMenu = useCallback(
     (token: TokenI) => {
@@ -135,7 +76,7 @@ const Tokens = memo(() => {
         isEvmSelected,
         evmNetworkConfigurationsByChainId,
         nativeCurrencies,
-        selectedAccount,
+        selectedAccountId,
       });
       setRefreshing(false);
     });
@@ -143,7 +84,7 @@ const Tokens = memo(() => {
     isEvmSelected,
     evmNetworkConfigurationsByChainId,
     nativeCurrencies,
-    selectedAccount,
+    selectedAccountId,
   ]);
 
   const removeToken = useCallback(async () => {
@@ -195,10 +136,10 @@ const Tokens = memo(() => {
     [removeToken],
   );
 
-  const handleScamWarningModal = () => {
+  const handleScamWarningModal = useCallback(() => {
     setShowScamWarningModal(!showScamWarningModal);
-  };
-
+  }, [showScamWarningModal]);
+  
   return (
     <View
       style={styles.wrapper}
@@ -243,4 +184,6 @@ const Tokens = memo(() => {
   );
 });
 
-export default React.memo(Tokens);
+Tokens.displayName = 'Tokens';
+
+export default Tokens;

--- a/app/components/UI/Tokens/util/refreshTokens.ts
+++ b/app/components/UI/Tokens/util/refreshTokens.ts
@@ -11,20 +11,20 @@ interface RefreshTokensProps {
     { chainId: Hex; nativeCurrency: string }
   >;
   nativeCurrencies: string[];
-  selectedAccount?: InternalAccount;
+  selectedAccountId?: InternalAccount['id'];
 }
 
 export const refreshTokens = async ({
   isEvmSelected,
   evmNetworkConfigurationsByChainId,
   nativeCurrencies,
-  selectedAccount,
+  selectedAccountId,
 }: RefreshTokensProps) => {
   if (!isEvmSelected) {
     const { MultichainBalancesController } = Engine.context;
-    if (selectedAccount) {
+    if (selectedAccountId) {
       try {
-        await MultichainBalancesController.updateBalance(selectedAccount.id);
+        await MultichainBalancesController.updateBalance(selectedAccountId);
       } catch (error) {
         Logger.error(error as Error, 'Error while refreshing NonEvm tokens');
       }

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -100,6 +100,14 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
 );
 
 /**
+ * A memoized selector that returns the selected internal account id
+ */
+export const selectSelectedInternalAccountId = createDeepEqualSelector(
+  selectSelectedInternalAccount,
+  (account) => account?.id,
+);
+
+/**
  * A memoized selector that returns the internal accounts sorted by the last selected timestamp
  */
 export const selectOrderedInternalAccountsByLastSelected = createSelector(

--- a/app/selectors/tokenList.ts
+++ b/app/selectors/tokenList.ts
@@ -1,0 +1,69 @@
+import { selectTokenSortConfig } from './preferencesController';
+import { selectIsEvmNetworkSelected } from './multichainNetworkController';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { selectSelectedInternalAccount } from './accountsController';
+///: END:ONLY_INCLUDE_IF
+
+import {
+  selectEvmTokens,
+  selectEvmTokenFiatBalances,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  selectMultichainTokenListForAccountId,
+  ///: END:ONLY_INCLUDE_IF
+} from './multichain';
+import { RootState } from '../reducers';
+import { TokenI } from '../components/UI/Tokens/types';
+import { sortAssets } from '../components/UI/Tokens/util';
+import { TraceName, endTrace, trace } from '../util/trace';
+import { getTraceTags } from '../util/sentry/tags';
+import { store } from '../store';
+import { createDeepEqualSelector } from './util';
+
+// Deep equal selector is necessary, because prices can change little bit but order of tokens stays the same.
+export const selectSortedTokenKeys = createDeepEqualSelector(
+  [
+    selectEvmTokens,
+    selectEvmTokenFiatBalances,
+    selectIsEvmNetworkSelected,
+    selectTokenSortConfig,
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    (state: RootState) => {
+      const selectedAccount = selectSelectedInternalAccount(state);
+      return selectMultichainTokenListForAccountId(state, selectedAccount?.id);
+    },
+    ///: END:ONLY_INCLUDE_IF
+  ],
+  (
+    evmTokens,
+    tokenFiatBalances,
+    isEvmSelected,
+    tokenSortConfig,
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    nonEvmTokens,
+    ///: END:ONLY_INCLUDE_IF
+  ) => {
+    trace({
+      name: TraceName.Tokens,
+      tags: getTraceTags(store.getState()),
+    });
+
+    const tokenListData = isEvmSelected ? evmTokens : nonEvmTokens;
+
+    const tokensWithBalances: TokenI[] = tokenListData.map((token, i) => ({
+      ...token,
+      tokenFiatAmount: isEvmSelected ? tokenFiatBalances[i] : token.balanceFiat,
+    }));
+
+    const tokensSorted = sortAssets(tokensWithBalances, tokenSortConfig);
+
+    endTrace({ name: TraceName.Tokens });
+
+    return tokensSorted
+      .filter(({ address, chainId }) => address && chainId)
+      .map(({ address, chainId, isStaked }) => ({
+        address,
+        chainId,
+        isStaked,
+      }));
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When user switched to `Popular Networks` there were 2 extra rerenders because switching between networks will trigger refetch of `TokenRatesController` and `TokenListController`. These refetches caused some selectors to update, specifically ones used to generate `sortedTokenKeys`, but difference by update is usually so small, that order of `sortedTokenKeys` stays same anyway so it's unecessary to rerender to component.

We also agreed with @sahar-fehri that these updates are happening correctly (more info in Slack https://margelo.slack.com/archives/C08P7RJQU04/p1748003584532309?thread_ts=1747998202.840729&cid=C08P7RJQU04)

I moved generating `sortedTokenKeys` to separate selector which simplified component and thanks to deep equality it prevents rerenders unless order is really changed. I also added some `displayNames` and some missing `useCallback`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Switch to Popular networks on ETH
2. You should see only 1 rerender of `TokenList` component 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
3 rerenders before my changes
<img width="299" alt="Screenshot 2025-05-26 at 15 57 51" src="https://github.com/user-attachments/assets/2c02cb51-7bf3-4e03-b2a0-3dc3875662e4" />

### **After**
just 1 rerender
<img width="298" alt="Screenshot 2025-05-26 at 15 56 40" src="https://github.com/user-attachments/assets/e0067589-26f2-46a4-acba-4336c4acbec3" />



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
