### PR TITLE
fix: Remove ethereum: prefix in account details QR code for non EVM accounts cp-7.47.0

### DIFF
--- a/app/components/UI/ReceiveRequest/index.js
+++ b/app/components/UI/ReceiveRequest/index.js
@@ -33,6 +33,7 @@ import { withMetricsAwareness } from '../../../components/hooks/useMetrics';
 import { getDecimalChainId } from '../../../util/networks';
 import QRAccountDisplay from '../../Views/QRAccountDisplay';
 import PNG_MM_LOGO_PATH from '../../../images/branding/fox.png';
+import { isEthAddress } from '../../../util/address';
 
 const { height: windowHeight, width: windowWidth } = Dimensions.get('window');
 
@@ -240,6 +241,10 @@ class ReceiveRequest extends PureComponent {
     const theme = this.context || mockTheme;
     const styles = createStyles(theme);
 
+    const qrValue = isEthAddress(this.props.selectedAddress)
+      ? `ethereum:${this.props.selectedAddress}@${this.props.chainId}`
+      : this.props.selectedAddress;
+
     return (
       <SafeAreaView style={styles.wrapper}>
         <View style={styles.body}>
@@ -248,7 +253,7 @@ class ReceiveRequest extends PureComponent {
               logo={PNG_MM_LOGO_PATH}
               logoSize={35}
               logoMargin={5}
-              value={`ethereum:${this.props.selectedAddress}@${this.props.chainId}`}
+              value={qrValue}
               size={windowWidth / 2}
             />
           </View>

--- a/app/components/Views/AddressQRCode/index.js
+++ b/app/components/Views/AddressQRCode/index.js
@@ -19,6 +19,7 @@ import { protectWalletModalVisible } from '../../../actions/user';
 import ClipboardManager from '../../../core/ClipboardManager';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
+import { isEthAddress } from '../../../util/address';
 
 const WIDTH = Dimensions.get('window').width - 88;
 
@@ -138,6 +139,10 @@ class AddressQRCode extends PureComponent {
     const colors = theme.colors;
     const styles = createStyles(theme);
 
+    const qrValue = isEthAddress(this.props.selectedAddress) 
+      ? `ethereum:${this.props.selectedAddress}`
+      : this.props.selectedAddress;
+
     return (
       <View style={styles.root}>
         <View style={styles.wrapper}>
@@ -154,7 +159,7 @@ class AddressQRCode extends PureComponent {
           <View style={styles.qrCodeContainer}>
             <View style={styles.qrCode}>
               <QRCode
-                value={`ethereum:${this.props.selectedAddress}`}
+                value={qrValue}
                 size={Dimensions.get('window').width - 160}
               />
             </View>


### PR DESCRIPTION
## **Description**

This PR fixes a bug where the QR account details/receive were adding the prefix ethereum:<public address>. This is meant to handle deeplinking but since we do not support deeplinking on Solana this would simply just break. Instead, for sol accounts, we should simply not render this prefix. This is the same behaviour that we have on extension. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15395
Resolves https://consensyssoftware.atlassian.net/browse/MUL-238

## **Manual testing steps**

1. You need to run the app on a physical device to test this change. The easiest way to do this is with expo and an Android phone. See the metamask readme for instructions.
2. import the wallet
3. create a solana account either with the popup or by selecting the account selector, clicking add new account or hardware wallet and selecting solana 
4. once your solana account is created and set as the current account, click on the scan icon at the top of the wallet view beside your account name
5. this will open the camera, allow the permissions and then click on your account
6. a qr code with your solana public address should appear
7. scan the qr code with another phone.
8. the qr code should NOT have the `ethereum:` beside the address
9. then go back to the wallet view
10. click on the blue actions button in the middle of the bottom tab menu
11. click on Receive, again, a qr code should render
12. scan this qr code with another phone and notice that it DOES NOT have the ethereum prefix before the public address.
13. Repeat the above steps but change your selected account to an ethereum account
14. the ethereum prefix should be present. If you have metamask installed, it should prompt you to deeplink into the app (this prefix is used for deeplinks) 

## **Screenshots/Recordings**

### **Before**
<image src="https://github.com/user-attachments/assets/6a1c9323-ca72-4923-a09f-c6fbe3117bdb" height="500" width="300"/>

<image src="https://github.com/user-attachments/assets/465a3485-36bc-4085-a9cb-86e178421ff8" height="500" width="300"/>


### **After**


<image src="https://github.com/user-attachments/assets/8d77ade6-0ee0-4441-8c49-9b3c89609e98" height="600" width="300"/>

<image src="https://github.com/user-attachments/assets/12940113-2c0c-4eb8-af72-2c461ac66936" height="600" width="300"/>

#### Ethereum still contains the correct prefix

<image src="https://github.com/user-attachments/assets/f626a620-a8f6-46af-a8b7-6109f06d632e" height="600" width="300"/>


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
