### PR TITLE
feat: prebuilt apps e2e

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -87,7 +87,8 @@ module.exports = {
   apps: {
     'ios.debug': {
       type: 'ios.app',
-      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/MetaMask.app',
+      binaryPath:
+        process.env.PREBUILT_IOS_APP_PATH || 'ios/build/Build/Products/Debug-iphonesimulator/MetaMask.app',
       build: 'yarn start:ios:e2e',
     },
     'ios.qa': {
@@ -98,7 +99,8 @@ module.exports = {
     },
     'android.debug': {
       type: 'android.apk',
-      binaryPath: 'android/app/build/outputs/apk/prod/debug/app-prod-debug.apk',
+      binaryPath: process.env.PREBUILT_ANDROID_APK_PATH || 'android/app/build/outputs/apk/prod/debug/app-prod-debug.apk',
+      testBinaryPath: process.env.PREBUILT_ANDROID_TEST_APK_PATH,
       build: 'yarn start:android:e2e',
     },
     'android.qa': {

--- a/docs/readme/testing.md
+++ b/docs/readme/testing.md
@@ -51,6 +51,15 @@ Ensure that these devices are set up. You can change the default devices at any 
     yarn test:e2e:android:debug:build
     ```
 
+  - **Using prebuilds**
+
+    Instead of building apps localy, you can download prebuilt `.app`/`.apk` files from Runway buckets and run the tests against them.
+
+    After downloading the prebuilt apps, paths to them should be set through the following environment variables:
+    - `PREBULT_IOS_APP_PATH` for iOS
+    - `PREBULT_ANDROID_APP_PATH` for Android
+    - `PREBULT_ANDROID_TEST_APP_PATH` for Android test app
+
 - **Run All Tests Locally**:
   - **iOS Debug**:
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the detox config, so the `test:e2e:ios:debug:run` command can run against an app/apk file specified by a path in an ENV variable, instead of relying on building the app locally.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14637

## **Manual testing steps**

iOS:
1. Download iOS runway build from [here](https://github.com/MetaMask/metamask-mobile?tab=readme-ov-file#download-and-install-the-development-build)
2. Set `PREBULT_IOS_APP_PATH` to the path of the downloaded .app file
3. Run `yarn test:e2e:ios:debug:run`

Android:

Currently the test apk is not available in runway so it must be built locally.

1. Download Android runway build from [here](https://github.com/MetaMask/metamask-mobile?tab=readme-ov-file#download-and-install-the-development-build)
2. Set `PREBULT_ANDROID_APK_PATH` to the path of the downloaded .app file and the `PREBUILT_ANDROID_TEST_APK_PATH` to the test apk
3. Run `yarn test:e2e:android:debug:run`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
