### PR TITLE
chore: update bitrise.yml to re-enable iOS API specs

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -205,18 +205,18 @@ stages:
   run_smoke_e2e_ios_android_stage:
     workflows:
       # TODO: Re-enable in a future commit
-      #- run_ios_api_specs: {}
-      - run_trade_swimlane_ios_smoke: {}
-      - run_trade_swimlane_android_smoke: {}
-      - run_network_abstraction_swimlane_ios_smoke: {}
-      - run_network_abstraction_swimlane_android_smoke: {}
-      - run_network_expansion_swimlane_ios_smoke: {}
-      - run_network_expansion_swimlane_android_smoke: {}
-      - run_wallet_platform_swimlane_ios_smoke: {}
-      - run_wallet_platform_swimlane_android_smoke: {}
-      - run_tag_smoke_confirmations_ios: {}
-      - run_tag_smoke_confirmations_android: {}
-      - run_tag_smoke_confirmations_redesigned_ios: {}
+      - run_ios_api_specs: {}
+      # - run_trade_swimlane_ios_smoke: {}
+      # - run_trade_swimlane_android_smoke: {}
+      # - run_network_abstraction_swimlane_ios_smoke: {}
+      # - run_network_abstraction_swimlane_android_smoke: {}
+      # - run_network_expansion_swimlane_ios_smoke: {}
+      # - run_network_expansion_swimlane_android_smoke: {}
+      # - run_wallet_platform_swimlane_ios_smoke: {}
+      # - run_wallet_platform_swimlane_android_smoke: {}
+      # - run_tag_smoke_confirmations_ios: {}
+      # - run_tag_smoke_confirmations_android: {}
+      # - run_tag_smoke_confirmations_redesigned_ios: {}
       # - run_tag_multichain_permissions_ios: {}
       # - run_tag_multichain_permissions_android: {}
   build_regression_e2e_ios_android_stage:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -204,19 +204,18 @@ stages:
   #     - run_tag_multichain_permissions_android: {}
   run_smoke_e2e_ios_android_stage:
     workflows:
-      # TODO: Re-enable in a future commit
       - run_ios_api_specs: {}
-      # - run_trade_swimlane_ios_smoke: {}
-      # - run_trade_swimlane_android_smoke: {}
-      # - run_network_abstraction_swimlane_ios_smoke: {}
-      # - run_network_abstraction_swimlane_android_smoke: {}
-      # - run_network_expansion_swimlane_ios_smoke: {}
-      # - run_network_expansion_swimlane_android_smoke: {}
-      # - run_wallet_platform_swimlane_ios_smoke: {}
-      # - run_wallet_platform_swimlane_android_smoke: {}
-      # - run_tag_smoke_confirmations_ios: {}
-      # - run_tag_smoke_confirmations_android: {}
-      # - run_tag_smoke_confirmations_redesigned_ios: {}
+      - run_trade_swimlane_ios_smoke: {}
+      - run_trade_swimlane_android_smoke: {}
+      - run_network_abstraction_swimlane_ios_smoke: {}
+      - run_network_abstraction_swimlane_android_smoke: {}
+      - run_network_expansion_swimlane_ios_smoke: {}
+      - run_network_expansion_swimlane_android_smoke: {}
+      - run_wallet_platform_swimlane_ios_smoke: {}
+      - run_wallet_platform_swimlane_android_smoke: {}
+      - run_tag_smoke_confirmations_ios: {}
+      - run_tag_smoke_confirmations_android: {}
+      - run_tag_smoke_confirmations_redesigned_ios: {}
       # - run_tag_multichain_permissions_ios: {}
       # - run_tag_multichain_permissions_android: {}
   build_regression_e2e_ios_android_stage:


### PR DESCRIPTION

This commit modifies the `bitrise.yml` file by re-enabling the `run_ios_api_specs` workflow while commenting out several other workflows related to smoke tests for iOS and Android. This change is part of ongoing adjustments to the CI/CD pipeline.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/14523

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
