### PR TITLE
fix: disable option to remove Solana account

### DIFF
--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -130,8 +130,7 @@ const CaipAccountSelectorList = ({
       isSelected: boolean;
       caipAccountId: CaipAccountId;
     }) => {
-      if (isAccountRemoveable || !isRemoveAccountEnabled) return;
-
+      if (!isAccountRemoveable || !isRemoveAccountEnabled) return;
       Alert.alert(
         strings('accounts.remove_account_title'),
         strings('accounts.remove_account_message'),

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -130,11 +130,7 @@ const CaipAccountSelectorList = ({
       isSelected: boolean;
       caipAccountId: CaipAccountId;
     }) => {
-      if (
-        !isAccountRemoveable ||
-        !isRemoveAccountEnabled ||
-        isSolanaAddress(address)
-      ) return;
+      if (isAccountRemoveable || !isRemoveAccountEnabled) return;
 
       Alert.alert(
         strings('accounts.remove_account_title'),

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -261,7 +261,7 @@ const CaipAccountSelectorList = ({
         onLongPress({
           address,
           isAccountRemoveable:
-            type === KeyringTypes.simple || type === KeyringTypes.snap,
+            type === KeyringTypes.simple || (type === KeyringTypes.snap && isSolanaAddress(address)),
           isSelected: isSelectedAccount,
           caipAccountId,
         });

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -261,7 +261,7 @@ const CaipAccountSelectorList = ({
         onLongPress({
           address,
           isAccountRemoveable:
-            type === KeyringTypes.simple || (type === KeyringTypes.snap && isSolanaAddress(address)),
+            type === KeyringTypes.simple || (type === KeyringTypes.snap && !isSolanaAddress(address)),
           isSelected: isSelectedAccount,
           caipAccountId,
         });

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -1,5 +1,6 @@
 // Third party dependencies.
 import React, { useCallback, useRef } from 'react';
+import { isAddress as isSolanaAddress } from '@solana/addresses';
 import {
   Alert,
   InteractionManager,
@@ -129,7 +130,12 @@ const CaipAccountSelectorList = ({
       isSelected: boolean;
       caipAccountId: CaipAccountId;
     }) => {
-      if (!isAccountRemoveable || !isRemoveAccountEnabled) return;
+      if (
+        !isAccountRemoveable ||
+        !isRemoveAccountEnabled ||
+        isSolanaAddress(address)
+      ) return;
+
       Alert.alert(
         strings('accounts.remove_account_title'),
         strings('accounts.remove_account_message'),

--- a/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
+++ b/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
@@ -247,7 +247,7 @@ const EvmAccountSelectorList = ({
         onLongPress({
           address,
           isAccountRemoveable:
-            type === KeyringTypes.simple || (type === KeyringTypes.snap && isSolanaAddress(address)),
+            type === KeyringTypes.simple || (type === KeyringTypes.snap && !isSolanaAddress(address)),
           isSelected: isSelectedAccount,
           index,
         });

--- a/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
+++ b/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
@@ -13,6 +13,7 @@ import { useNavigation } from '@react-navigation/native';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 
+
 // External dependencies.
 import Cell, {
   CellVariant,
@@ -142,11 +143,7 @@ const EvmAccountSelectorList = ({
       isSelected: boolean;
       index: number;
     }) => {
-      if (
-        !isAccountRemoveable ||
-        !isRemoveAccountEnabled ||
-        isSolanaAddress(address)
-      ) return;
+      if (!isAccountRemoveable || !isRemoveAccountEnabled) return;
       Alert.alert(
         strings('accounts.remove_account_title'),
         strings('accounts.remove_account_message'),
@@ -250,7 +247,7 @@ const EvmAccountSelectorList = ({
         onLongPress({
           address,
           isAccountRemoveable:
-            type === KeyringTypes.simple || type === KeyringTypes.snap,
+            type === KeyringTypes.simple || (type === KeyringTypes.snap && isSolanaAddress(address)),
           isSelected: isSelectedAccount,
           index,
         });

--- a/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
+++ b/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
@@ -11,6 +11,7 @@ import { FlatList } from 'react-native-gesture-handler';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { isAddress as isSolanaAddress } from '@solana/addresses';
 
 // External dependencies.
 import Cell, {
@@ -141,7 +142,11 @@ const EvmAccountSelectorList = ({
       isSelected: boolean;
       index: number;
     }) => {
-      if (!isAccountRemoveable || !isRemoveAccountEnabled) return;
+      if (
+        !isAccountRemoveable ||
+        !isRemoveAccountEnabled ||
+        isSolanaAddress(address)
+      ) return;
       Alert.alert(
         strings('accounts.remove_account_title'),
         strings('accounts.remove_account_message'),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes the option to remove Solana snap accounts on the UI

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15616

## **Manual testing steps**

1. Add an account via private key
2. Long press the account until you see the option to remove it
3. Add a Solana account
4. Long press the account
5. The option to remove should not be displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Check https://github.com/MetaMask/metamask-mobile/issues/15616

### **After**

None

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
