### PR TITLE
feat: Add signed or submitted general alert to alert system

### DIFF
--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -2,4 +2,5 @@ export enum AlertKeys {
   Blockaid = 'blockaid',
   DomainMismatch = 'domain_mismatch',
   InsufficientBalance = 'insufficient_balance',
+  SignedOrSubmitted = 'signed_or_submitted',
 }

--- a/app/components/Views/confirmations/context/alert-system-context/alert-system-context.tsx
+++ b/app/components/Views/confirmations/context/alert-system-context/alert-system-context.tsx
@@ -102,7 +102,7 @@ export const AlertsContextProvider: React.FC<AlertsContextProviderProps> = ({
     setAlertConfirmed,
     unconfirmedDangerAlerts,
     unconfirmedFieldDangerAlerts,
-  } = useAlertsConfirmed(fieldAlerts);
+  } = useAlertsConfirmed([...fieldAlerts, ...generalAlerts]);
 
   const contextValue = useMemo(
     () => ({

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
@@ -10,11 +10,13 @@ import {
 } from '../../../../../util/test/confirm-data-helpers';
 import { useInsufficientBalanceAlert } from './useInsufficientBalanceAlert';
 import { useAccountTypeUpgrade } from './useAccountTypeUpgrade';
+import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
 
 jest.mock('./useBlockaidAlerts');
 jest.mock('./useDomainMismatchAlerts');
 jest.mock('./useInsufficientBalanceAlert');
 jest.mock('./useAccountTypeUpgrade');
+jest.mock('./useSignedOrSubmittedAlert');
 
 describe('useConfirmationAlerts', () => {
   const ALERT_MESSAGE_MOCK = 'This is a test alert message.';
@@ -57,12 +59,22 @@ describe('useConfirmationAlerts', () => {
     },
   ];
 
+  const mockSignedOrSubmittedAlert: Alert[] = [
+    {
+      key: 'signedOrSubmittedAlert',
+      title: 'Test Signed or Submitted Alert',
+      message: ALERT_MESSAGE_MOCK,
+      severity: Severity.Danger,
+    },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useBlockaidAlerts as jest.Mock).mockReturnValue([]);
     (useDomainMismatchAlerts as jest.Mock).mockReturnValue([]);
     (useInsufficientBalanceAlert as jest.Mock).mockReturnValue([]);
     (useAccountTypeUpgrade as jest.Mock).mockReturnValue([]);
+    (useSignedOrSubmittedAlert as jest.Mock).mockReturnValue([]);
   });
 
   it('returns empty array if no alerts', () => {
@@ -109,6 +121,9 @@ describe('useConfirmationAlerts', () => {
     (useAccountTypeUpgrade as jest.Mock).mockReturnValue(
       mockUpgradeAccountAlert,
     );
+    (useSignedOrSubmittedAlert as jest.Mock).mockReturnValue(
+      mockSignedOrSubmittedAlert,
+    );
     const { result } = renderHookWithProvider(() => useConfirmationAlerts(), {
       state: siweSignatureConfirmationState,
     });
@@ -116,6 +131,7 @@ describe('useConfirmationAlerts', () => {
       ...mockBlockaidAlerts,
       ...mockDomainMisMatchAlerts,
       ...mockInsufficientBalanceAlert,
+      ...mockSignedOrSubmittedAlert,
       ...mockUpgradeAccountAlert,
     ]);
   });

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import useBlockaidAlerts from './useBlockaidAlerts';
 import useDomainMismatchAlerts from './useDomainMismatchAlerts';
 import { useInsufficientBalanceAlert } from './useInsufficientBalanceAlert';
-import { Alert } from '../../types/alerts';
 import { useAccountTypeUpgrade } from './useAccountTypeUpgrade';
+import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
+import { Alert } from '../../types/alerts';
 
 function useSignatureAlerts(): Alert[] {
   const domainMismatchAlerts = useDomainMismatchAlerts();
@@ -13,10 +14,11 @@ function useSignatureAlerts(): Alert[] {
 
 function useTransactionAlerts(): Alert[] {
   const insufficientBalanceAlert = useInsufficientBalanceAlert();
+  const signedOrSubmittedAlert = useSignedOrSubmittedAlert();
 
   return useMemo(
-    () => [...insufficientBalanceAlert],
-    [insufficientBalanceAlert],
+    () => [...insufficientBalanceAlert, ...signedOrSubmittedAlert],
+    [insufficientBalanceAlert, signedOrSubmittedAlert],
   );
 }
 export default function useConfirmationAlerts(): Alert[] {

--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.test.ts
@@ -1,0 +1,74 @@
+import { TransactionStatus , TransactionType } from '@metamask/transaction-controller';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
+
+const MOCK_SIGNED_TRANSACTION_META = {
+  id: '1',
+  status: TransactionStatus.signed,
+  type: TransactionType.simpleSend,
+  from: '0x123',
+  to: '0x456',
+};
+
+const MOCK_SUBMITTED_TRANSACTION_META = {
+  id: '2',
+  status: TransactionStatus.submitted,
+  type: TransactionType.simpleSend,
+  from: '0x123',
+  to: '0x456',
+};
+
+describe('useSignedOrSubmittedAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty array if no transactions', () => {
+    const { result } = renderHookWithProvider(
+      () => useSignedOrSubmittedAlert(),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [],
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it.each([
+    ['signed', MOCK_SIGNED_TRANSACTION_META],
+    ['submitted', MOCK_SUBMITTED_TRANSACTION_META],
+  ])(
+    'returns alert if there is a %s transaction',
+    (_status, transactionMeta) => {
+      const { result } = renderHookWithProvider(
+        () => useSignedOrSubmittedAlert(),
+        {
+          state: {
+            engine: {
+              backgroundState: {
+                TransactionController: {
+                  transactions: [transactionMeta],
+                },
+              },
+            },
+          },
+        },
+      );
+      expect(result.current).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message:
+              'A previous transaction is still being signed or submitted.',
+          }),
+        ]),
+      );
+    },
+  );
+});

--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { AlertKeys } from '../../constants/alerts';
+import { Severity } from '../../types/alerts';
+import { strings } from '../../../../../../locales/i18n';
+
+import { useSelector } from 'react-redux';
+import { selectTransactions } from '../../../../../selectors/transactionController';
+
+const signedOrSubmittedStatuses = [
+  TransactionStatus.signed,
+  TransactionStatus.submitted,
+];
+
+export const useSignedOrSubmittedAlert = () => {
+  const transactions = useSelector(selectTransactions);
+
+  return useMemo(() => {
+    const showAlert = transactions.some((transaction) =>
+      signedOrSubmittedStatuses.includes(transaction.status),
+    );
+
+    if (!showAlert) {
+      return [];
+    }
+
+    return [
+      {
+        isBlocking: true,
+        key: AlertKeys.SignedOrSubmitted,
+        message: strings('alert_system.signed_or_submitted.message'),
+        severity: Severity.Danger,
+      },
+    ];
+  }, [transactions]);
+};

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -109,6 +109,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.Blockaid]: 'blockaid',
   [AlertKeys.DomainMismatch]: 'domain_mismatch',
   [AlertKeys.InsufficientBalance]: 'insufficient_balance',
+  [AlertKeys.SignedOrSubmitted]: 'signed_or_submitted',
 };
 
 function getAlertName(alertKey: string): string {

--- a/app/components/Views/confirmations/types/alerts.ts
+++ b/app/components/Views/confirmations/types/alerts.ts
@@ -75,5 +75,5 @@ export type Alert = {
   /**
    * The title of the alert.
    */
-  title: string;
+  title?: string;
 } & MessageOrContent;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -37,6 +37,9 @@
       "title": "Insufficient funds",
       "message": "You do not have enough %{nativeCurrency} in your account to pay for network fees.",
       "buy_action": "Buy %{nativeCurrency}"
+    },
+    "signed_or_submitted": {
+      "message": "A previous transaction is still being signed or submitted."
     }
   },
   "blockaid_banner": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add signed or submitted alert into general alerts.

See screenshot below how it looks.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5007

## **Manual testing steps**

N/A - Currently it's only possible to see if you enable redesigned `transfer` transactions.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

![Screenshot 2025-05-28 at 11 34 46](https://github.com/user-attachments/assets/5bb60ff6-83bc-4095-b1b1-138ac241b429)


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
