### PR TITLE
fix: cp-7.47.0 don't show currency value unless amount is above zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- fix(bridge): don't show currency value unless amount is above zero ([#15798](https://github.com/MetaMask/metamask-mobile/pull/15798))
 
 ### Fixed
 - fix(bridge): show "Auto" slippage for Solana swaps

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -633,21 +633,16 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                       ]
                                     }
                                   >
-                                    <Text
-                                      accessibilityRole="text"
+                                    <View
                                       style={
-                                        {
-                                          "color": "#686e7d",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 16,
-                                          "fontWeight": "400",
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {},
+                                          {
+                                            "flex": 1,
+                                          },
+                                        ]
                                       }
-                                    >
-                                      $0
-                                    </Text>
+                                    />
                                     <Text
                                       accessibilityRole="text"
                                       style={
@@ -857,7 +852,18 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                         },
                                       ]
                                     }
-                                  />
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {},
+                                          {
+                                            "flex": 1,
+                                          },
+                                        ]
+                                      }
+                                    />
+                                  </View>
                                 </View>
                               </View>
                             </View>
@@ -1593,21 +1599,16 @@ exports[`BridgeView renders 1`] = `
                                       ]
                                     }
                                   >
-                                    <Text
-                                      accessibilityRole="text"
+                                    <View
                                       style={
-                                        {
-                                          "color": "#686e7d",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 16,
-                                          "fontWeight": "400",
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {},
+                                          {
+                                            "flex": 1,
+                                          },
+                                        ]
                                       }
-                                    >
-                                      $0
-                                    </Text>
+                                    />
                                     <Text
                                       accessibilityRole="text"
                                       style={
@@ -1817,7 +1818,18 @@ exports[`BridgeView renders 1`] = `
                                         },
                                       ]
                                     }
-                                  />
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {},
+                                          {
+                                            "flex": 1,
+                                          },
+                                        ]
+                                      }
+                                    />
+                                  </View>
                                 </View>
                               </View>
                             </View>

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -70,6 +70,9 @@ const createStyles = ({ vars }: { vars: { fontSize: number } }) =>
       height: 50,
       fontSize: vars.fontSize,
     },
+    currencyContainer: {
+      flex: 1,
+    },
   });
 
 export enum TokenInputAreaType {
@@ -267,9 +270,11 @@ export const TokenInputArea = forwardRef<
               <Skeleton width={80} height={24} />
             ) : (
               <>
-                {token && currencyValue ? (
-                  <Text color={TextColor.Alternative}>{currencyValue}</Text>
-                ) : null}
+                <Box style={styles.currencyContainer}>
+                  {token && amount && Number(amount) > 0 && currencyValue ? (
+                    <Text color={TextColor.Alternative}>{currencyValue}</Text>
+                  ) : null}
+                </Box>
                 {subtitle ? (
                   <Text
                     color={


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Prevents the display of the input token's currency value until the user has input an amount >0.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to bridge
2. See no currency value beneath source token amount input
3. Input amount >0
4. See currency value

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![image](https://github.com/user-attachments/assets/5c383611-cd71-4f2d-8898-da80532be1fb)

<!-- [screenshots/recordings] -->

### **After**
<img width="361" alt="Screenshot 2025-05-28 at 15 33 02" src="https://github.com/user-attachments/assets/35179b05-351e-4a4e-a780-f40b191490c7" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
