### PR TITLE
fix: eth_signTypedData_v4 on Multichain API

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -827,10 +827,11 @@ export const getRpcMethodMiddleware = ({
           });
         },
 
-        // TODO: Fix for Multichain API call via wallet_invokeMethod. Currently this RPC method is broken for Multichain.
-        // ticket with details regarding the issue here: https://github.com/MetaMask/MetaMask-planning/issues/4951
         eth_signTypedData_v4: async () => {
-          const data = JSON.parse(req.params[1]);
+          const data =
+            typeof req.params[1] === 'string'
+              ? JSON.parse(req.params[1])
+              : req.params[1];
           const chainId = data.domain.chainId;
 
           trace(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On Multichain API, `wallet_invokeMethod` unwraps the enveloped method payload as an object (see [here](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/src/handlers/wallet-invokeMethod.ts#L130)), meaning the current `eth_signTypedData_v4` handler setup on mobile would not properly parse it since it expects only a JSON string (see [here](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/RPCMethods/RPCMethodMiddleware.ts#L809))

We now parse the payload to make sure we conditionally handle it depending on receiving a string or an object.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4951

## **Manual testing steps**

1. Go to [Multichain Test Dapp](https://metamask.github.io/test-dapp-multichain/latest/) via in app browser
2. Connect to an EVM Chain
3. Make sure per dapp selected network is set to the chain in which the `eth_signTypedData_v4` request will be sent
4. In the scope for the selected chain, select the `eth_signTypedData_v4` method and press "Invoke Method" button

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/a7e9c607-c879-409d-a8ba-eedd4d0f52e5

### **After**

https://github.com/user-attachments/assets/3533951c-ee00-4414-99e7-efed3d21b2ee

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
