### PR TITLE
fix: Solana account reveal SRP with multiple imported SRPs cp-7.47.0

### DIFF
--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -39,6 +39,7 @@ import {
   isHDOrFirstPartySnapAccount,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   isSnapAccount,
+  toFormattedAddress,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../util/address';
 import { removeAccountsFromPermissions } from '../../../core/Permissions';
@@ -82,7 +83,7 @@ const AccountActions = () => {
 
   const keyringId = useMemo(() => {
     const keyring = existingKeyrings.find((kr) =>
-      kr.accounts.includes(selectedAccount.address.toLowerCase()),
+      kr.accounts.includes(toFormattedAddress(selectedAccount.address)),
     );
     return keyring?.metadata.id;
   }, [existingKeyrings, selectedAccount.address]);
@@ -427,18 +428,16 @@ const AccountActions = () => {
             testID={AccountActionsBottomSheetSelectorsIDs.SHOW_PRIVATE_KEY}
           />
         )}
-        {
-          selectedAddress && isHDOrFirstPartySnapAccount(selectedAccount) && (
-            <AccountAction
-              actionTitle={strings('accounts.reveal_secret_recovery_phrase')}
-              iconName={IconName.Key}
-              onPress={goToExportSRP}
-              testID={
-                AccountActionsBottomSheetSelectorsIDs.SHOW_SECRET_RECOVERY_PHRASE
-              }
-            />
-          )
-        }
+        {selectedAddress && isHDOrFirstPartySnapAccount(selectedAccount) && (
+          <AccountAction
+            actionTitle={strings('accounts.reveal_secret_recovery_phrase')}
+            iconName={IconName.Key}
+            onPress={goToExportSRP}
+            testID={
+              AccountActionsBottomSheetSelectorsIDs.SHOW_SECRET_RECOVERY_PHRASE
+            }
+          />
+        )}
         {selectedAddress && isHardwareAccount(selectedAddress) && (
           <AccountAction
             actionTitle={strings('accounts.remove_hardware_account')}

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -37,9 +37,9 @@ import { useMetrics } from '../../../components/hooks/useMetrics';
 import {
   isHardwareAccount,
   isHDOrFirstPartySnapAccount,
+  toFormattedAddress,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   isSnapAccount,
-  toFormattedAddress,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../util/address';
 import { removeAccountsFromPermissions } from '../../../core/Permissions';

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -23,9 +23,7 @@ import {
 } from '../../../util/networks';
 
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import {
-  selectProviderConfig,
-} from '../../../selectors/networkController';
+import { selectProviderConfig } from '../../../selectors/networkController';
 import { strings } from '../../../../locales/i18n';
 // Internal dependencies
 import styleSheet from './AccountActions.styles';
@@ -37,7 +35,6 @@ import { useMetrics } from '../../../components/hooks/useMetrics';
 import {
   isHardwareAccount,
   isHDOrFirstPartySnapAccount,
-  toFormattedAddress,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   isSnapAccount,
   ///: END:ONLY_INCLUDE_IF
@@ -51,7 +48,6 @@ import Engine from '../../../core/Engine';
 import BlockingActionModal from '../../UI/BlockingActionModal';
 import { useTheme } from '../../../util/theme';
 import { useEIP7702Networks } from '../confirmations/hooks/7702/useEIP7702Networks';
-import { selectKeyrings } from '../../../selectors/keyringController';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
 
@@ -79,14 +75,10 @@ const AccountActions = () => {
     return { KeyringController, PreferencesController };
   }, []);
 
-  const existingKeyrings = useSelector(selectKeyrings);
-
-  const keyringId = useMemo(() => {
-    const keyring = existingKeyrings.find((kr) =>
-      kr.accounts.includes(toFormattedAddress(selectedAccount.address)),
-    );
-    return keyring?.metadata.id;
-  }, [existingKeyrings, selectedAccount.address]);
+  const keyringId = useMemo(
+    () => selectedAccount.options.entropySource,
+    [selectedAccount.options.entropySource],
+  );
 
   const providerConfig = useSelector(selectProviderConfig);
 
@@ -120,9 +112,7 @@ const AccountActions = () => {
       }
       return undefined;
     }
-  }, [
-    selectedAccount,
-  ]);
+  }, [selectedAccount]);
 
   const goToBrowserUrl = (url: string, title: string) => {
     navigate('Webview', {


### PR DESCRIPTION
## **Description**
This PR fixes an issue that was leading to the wrong SRP being displayed when clicking Reveal Secret Recovery Phrase from the account list actions. This issue only effected Solana accounts. Essentially, if you tried to reveal the SRP of a specific Solana account from the accounts list, it would always show you SRP # 1. This is because the logic was using address lookup for the keyring ID instead of the entropy source. 

Here are some logs of the state when interacting with a Solana account that belongs to SRP# 3.  that makes this easier to understand.

```JSON
 LOG  existingKeyrings [
  {
    "type": "HD Key Tree",
    "accounts": [
      "0x9502171dcf537a5e48ea962e100d37040f25d744"
    ],
    "metadata": {
      "id": "01JWH57HTXN0PMD9CWF961PJB6",
      "name": ""
    }
  },
  {
    "type": "Snap Keyring",
    "accounts": [
      "DtMUkCoeyzs35B6EpQQxPyyog6TRwXxV1W1Acp8nWBNa",
      "GM4iccdbdSF1qN3Bqmdksfk7iuxYhWzC8T3XbizStAdE",
      "ATrXkbX2eEPuusRoLyRMW88wcPT2aho2Lk3xErnjjFH",
      "2pLbzZ22oS37z1k5hjGSboKcXPh9VpB3VwvxzUbwG9GZ",
      "CerpP3XJe8u18FA67rZ6CXKEEw8a2VeokgBJm5bxGqzF"
    ],
    "metadata": {
      "id": "01JWH57KJYCHSAQ4GTXB1JWEXZ",
      "name": ""
    }
  },
  {
    "type": "QR Hardware Wallet Device",
    "accounts": [],
    "metadata": {
      "id": "01JWH58J9QS21F051771G55R7T",
      "name": ""
    }
  },
  {
    "type": "HD Key Tree",
    "accounts": [
      "0xe97921123828562c2785f632b50b26fdd743e069"
    ],
    "metadata": {
      "id": "01JWH58XWT3P9EF686PXESRQ46",
      "name": ""
    }
  },
  {
    "type": "HD Key Tree",
    "accounts": [
      "0xf018ec7c4459b4b2aedc53661481acc64c0df745"
    ],
    "metadata": {
      "id": "01JWH59K0PPD3C1GFQGZEH5R0T",
      "name": ""
    }
  }
]

 // SOL account 
 LOG  selectedAccount {
  "type": "solana:data-account",
  "id": "415ea1ce-6083-4508-a0d1-7c9e3b35d096",
  "address": "CerpP3XJe8u18FA67rZ6CXKEEw8a2VeokgBJm5bxGqzF",
  "options": {
    "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
    "entropySource": "01JWH59K0PPD3C1GFQGZEH5R0T",
    "derivationPath": "m/44'/501'/0'/0'",
    "index": 0
  },
  "methods": [
    "signAndSendTransaction",
    "signTransaction",
    "signMessage",
    "signIn"
  ],
  "scopes": [
    "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
    "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
    "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
  ],
  "metadata": {
    "name": "Solana Account 5",
    "importTime": 1748627672620,
    "keyring": {
      "type": "Snap Keyring"
    },
    "snap": {
      "id": "npm:@metamask/solana-wallet-snap",
      "name": "Solana",
      "enabled": true
    },
    "lastSelected": 0,
    "nameLastUpdatedAt": 1748627672621
  }
}

// ETH account

 LOG  selectedAccount {
  "id": "0ea33abb-3424-4521-a4c8-6e8d460b6f45",
  "address": "0xf018ec7c4459b4b2aedc53661481acc64c0df745",
  "options": {
    "entropySource": "01JWH59K0PPD3C1GFQGZEH5R0T"
  },
  "methods": [
    "personal_sign",
    "eth_sign",
    "eth_signTransaction",
    "eth_signTypedData_v1",
    "eth_signTypedData_v3",
    "eth_signTypedData_v4"
  ],
  "scopes": [
    "eip155:0"
  ],
  "type": "eip155:eoa",
  "metadata": {
    "name": "Account 3",
    "importTime": 1748627672090,
    "keyring": {
      "type": "HD Key Tree"
    },
    "lastSelected": 1748627672624
  }
}
```

My fix uses the entropy source of each account to lookup the correct keyring that this account belongs to instead of relying on the address which does not work for Snap Accounts.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15814

## **Manual testing steps**

1. Create a wallet 
2. create a solana account from the account list via "add account or hardware wallet" then select solana. This sol account is derived from SRP 1
3. import a new SRP.
4. create a new solana account, this time under the second SRP
5. You should now have two SRPs in your account list (marked by the tags) and at least one eth and sol account per SRP. Each account is tagged with the SRP that it belongs with
6. Now, open the account list and select the solana account that belongs to SRP 2. Click the three dot menu and press "Reveal Secret Recovery Phrase".
7. Go through the quiz
8. input your password
9. reveal SRP
10. the SRP that is displayed should be the second SRP.
11. Repeat this process with all your accounts and ensure that SRP that is displayed is the correct one.

## **Screenshots/Recordings**

### **Before**

Not provided because it revealed the SRP of an account. 

### **After**

Not provided because it revealed the SRP of an account. 

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
