### PR TITLE
fix: Fallback to regular transaction submit for legacy transactions

### DIFF
--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -2,7 +2,7 @@ import {
   TransactionParams,
   TransactionController,
   TransactionMeta,
-  type PublishBatchHookTransaction
+  type PublishBatchHookTransaction,
 } from '@metamask/transaction-controller';
 import SmartTransactionsController, {
   SmartTransactionsControllerSmartTransactionEvent,
@@ -28,6 +28,7 @@ import { Messenger } from '@metamask/base-controller';
 import { addSwapsTransaction } from '../swaps/swaps-transactions';
 import { Hex } from '@metamask/utils';
 import { isPerDappSelectedNetworkEnabled } from '../networks';
+import { isLegacyTransaction } from '../transactions';
 
 export type AllowedActions = never;
 
@@ -177,7 +178,8 @@ class SmartTransactionHook {
     const useRegularTransactionSubmit = { transactionHash: undefined };
     if (
       !this.#shouldUseSmartTransaction ||
-      this.#transactionMeta.origin === RAMPS_SEND
+      this.#transactionMeta.origin === RAMPS_SEND ||
+      isLegacyTransaction(this.#transactionMeta)
     ) {
       return useRegularTransactionSubmit;
     }

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -12,6 +12,7 @@ import {
 import {
   isEIP1559Transaction,
   TransactionType,
+  TransactionEnvelopeType,
 } from '@metamask/transaction-controller';
 import { swapsUtils } from '@metamask/swaps-controller';
 import Engine from '../../core/Engine';
@@ -178,6 +179,17 @@ const actionKeys = {
     'transactions.tx_review_staking_unstake',
   ),
 };
+
+/**
+ * Checks if a transaction is a legacy transaction by examining its type.
+ * Legacy transactions are identified by the TransactionEnvelopeType.legacy type.
+ *
+ * @param {object} transactionMeta - The transaction metadata to check
+ * @returns {boolean} true if the transaction is a legacy transaction, false otherwise
+ */
+export function isLegacyTransaction(transactionMeta) {
+  return transactionMeta?.txParams?.type === TransactionEnvelopeType.legacy;
+}
 
 /**
  * Generates transfer data for specified method

--- a/app/util/transactions/index.test.ts
+++ b/app/util/transactions/index.test.ts
@@ -41,11 +41,12 @@ import {
   getTransactionById,
   UPGRADE_SMART_ACCOUNT_ACTION_KEY,
   DOWNGRADE_SMART_ACCOUNT_ACTION_KEY,
+  isLegacyTransaction
 } from '.';
 import Engine from '../../core/Engine';
 import { strings } from '../../../locales/i18n';
 import { EIP_7702_REVOKE_ADDRESS } from '../../components/Views/confirmations/hooks/7702/useEIP7702Accounts';
-import { TransactionType } from '@metamask/transaction-controller';
+import { TransactionType, TransactionEnvelopeType, TransactionMeta } from '@metamask/transaction-controller';
 import { Provider } from '@metamask/network-controller';
 import BigNumber from 'bignumber.js';
 
@@ -1283,5 +1284,56 @@ describe('Transactions utils :: getTransactionById', () => {
     const result = getTransactionById('tx1', mockTransactionController);
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('Transactions utils :: isLegacyTransaction', () => {
+  it('returns true for a transaction with legacy type', () => {
+    const transactionMeta = {
+      txParams: {
+        type: TransactionEnvelopeType.legacy,
+        from: '0x123',
+        to: '0x456',
+        gasPrice: '0x77359400',
+      },
+    };
+
+    expect(isLegacyTransaction(transactionMeta)).toBe(true);
+  });
+
+  it('returns false for an EIP-1559 transaction', () => {
+    const transactionMeta = {
+      txParams: {
+        type: TransactionEnvelopeType.feeMarket,
+        from: '0x123',
+        to: '0x456',
+        maxFeePerGas: '0x77359400',
+        maxPriorityFeePerGas: '0x1',
+      },
+    };
+
+    expect(isLegacyTransaction(transactionMeta)).toBe(false);
+  });
+
+  it('returns false for a transaction without type field', () => {
+    const transactionMeta = {
+      txParams: {
+        from: '0x123',
+        to: '0x456',
+        gasPrice: '0x77359400',
+      },
+    };
+
+    expect(isLegacyTransaction(transactionMeta)).toBe(false);
+  });
+
+  it('returns false for undefined transactionMeta', () => {
+    // @ts-expect-error Testing undefined input
+    expect(isLegacyTransaction(undefined)).toBe(false);
+  });
+
+  it('returns false for transactionMeta without txParams', () => {
+    const transactionMeta = {};
+    expect(isLegacyTransaction(transactionMeta as Partial<TransactionMeta>)).toBe(false);
   });
 });


### PR DESCRIPTION
## **Description**
Fallback to regular transaction submit (instead of as a smart transaction) for legacy transactions.

This PR is very similar to the one made in the extension: https://github.com/MetaMask/metamask-extension/pull/31280

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15457

## **Manual testing steps**

1. Connect to [test dapp](https://metamask.github.io/test-dapp/) (on BNB or Ethereum mainnet)
2. STX enabled
3. Click on SEND LEGACY TRANSACTION
4. Confirm
![image](https://github.com/user-attachments/assets/7fbb1b9f-225e-4fc3-9617-4e6d6c912beb)


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
