### PR TITLE
feat: Add pending transaction alert

### DIFF
--- a/app/components/Views/confirmations/components/UI/info-row/alert-row/constants.ts
+++ b/app/components/Views/confirmations/components/UI/info-row/alert-row/constants.ts
@@ -3,5 +3,5 @@ export enum RowAlertKey {
   Blockaid = 'blockaid',
   EstimatedFee = 'estimatedFee',
   RequestFrom = 'requestFrom',
-  Speed = 'speed',
+  PendingTransaction = 'pendingTransaction',
 }

--- a/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.test.tsx
@@ -192,6 +192,18 @@ describe('AlertModal', () => {
     expect(getByText('Mock content')).toBeDefined();
   });
 
+  it('renders message component correctly', async () => {
+    (useAlerts as jest.Mock).mockReturnValue({
+      ...baseMockUseAlerts,
+      fieldAlerts: [{
+        ...mockAlerts[0],
+        message: <Text>{'Mock message'}</Text>,
+      }]
+    });
+    const { getByText } = render(<AlertModal />);
+    expect(getByText('Mock message')).toBeDefined();
+  });
+
   it('does not render checkbox if is a blocking alert', async () => {
     (useAlerts as jest.Mock).mockReturnValue({
       ...baseMockUseAlerts,

--- a/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.tsx
@@ -73,7 +73,13 @@ const Content: React.FC<ContentProps> = ({
   <View style={[styles.content, { backgroundColor }]}>
     {selectedAlert.content ?? (
       <>
-        <Text style={styles.message}>{selectedAlert.message}</Text>
+        {
+          typeof selectedAlert.message === 'string' ? (
+            <Text style={styles.message}>{selectedAlert.message}</Text>
+          ) : (
+            selectedAlert.message
+          )
+        }
         {selectedAlert.alertDetails && (
           <>
             <Text style={styles.message} variant={TextVariant.BodyMDBold}>

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details/gas-fee-details.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details/gas-fee-details.tsx
@@ -16,7 +16,6 @@ import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfir
 import { GasFeeModal } from '../../../modals/gas-fee-modal';
 import InfoSection from '../../../UI/info-row/info-section';
 import AlertRow from '../../../UI/info-row/alert-row';
-import InfoRow from '../../../UI/info-row';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import { GasSpeed } from '../../../gas/gas-speed';
 import styleSheet from './gas-fee-details.styles';
@@ -114,9 +113,12 @@ const GasFeesDetails = ({ disableUpdate = false }) => {
           </View>
         </AlertRow>
         {isUserFeeLevelExists && (
-          <InfoRow label={strings('transactions.gas_modal.speed')}>
+          <AlertRow
+            alertField={RowAlertKey.PendingTransaction}
+            label={strings('transactions.gas_modal.speed')}
+          >
             <GasSpeed />
-          </InfoRow>
+          </AlertRow>
         )}
       </InfoSection>
       {gasModalVisible && (

--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -2,5 +2,6 @@ export enum AlertKeys {
   Blockaid = 'blockaid',
   DomainMismatch = 'domain_mismatch',
   InsufficientBalance = 'insufficient_balance',
+  PendingTransaction = 'pending_transaction',
   SignedOrSubmitted = 'signed_or_submitted',
 }

--- a/app/components/Views/confirmations/constants/url.ts
+++ b/app/components/Views/confirmations/constants/url.ts
@@ -1,0 +1,2 @@
+export const SPEEDUP_CANCEL_TRANSACTION_URL =
+  'https://support.metamask.io/transactions-and-gas/transactions/how-to-speed-up-or-cancel-a-pending-transaction/';

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
@@ -11,12 +11,14 @@ import {
 import { useInsufficientBalanceAlert } from './useInsufficientBalanceAlert';
 import { useAccountTypeUpgrade } from './useAccountTypeUpgrade';
 import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
+import { usePendingTransactionAlert } from './usePendingTransactionAlert';
 
 jest.mock('./useBlockaidAlerts');
 jest.mock('./useDomainMismatchAlerts');
 jest.mock('./useInsufficientBalanceAlert');
 jest.mock('./useAccountTypeUpgrade');
 jest.mock('./useSignedOrSubmittedAlert');
+jest.mock('./usePendingTransactionAlert');
 
 describe('useConfirmationAlerts', () => {
   const ALERT_MESSAGE_MOCK = 'This is a test alert message.';
@@ -68,6 +70,15 @@ describe('useConfirmationAlerts', () => {
     },
   ];
 
+  const mockPendingTransactionAlert: Alert[] = [
+    {
+      key: 'pendingTransactionAlert',
+      title: 'Test Pending Transaction Alert',
+      message: ALERT_MESSAGE_MOCK,
+      severity: Severity.Warning,
+    },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useBlockaidAlerts as jest.Mock).mockReturnValue([]);
@@ -75,6 +86,7 @@ describe('useConfirmationAlerts', () => {
     (useInsufficientBalanceAlert as jest.Mock).mockReturnValue([]);
     (useAccountTypeUpgrade as jest.Mock).mockReturnValue([]);
     (useSignedOrSubmittedAlert as jest.Mock).mockReturnValue([]);
+    (usePendingTransactionAlert as jest.Mock).mockReturnValue([]);
   });
 
   it('returns empty array if no alerts', () => {
@@ -124,6 +136,9 @@ describe('useConfirmationAlerts', () => {
     (useSignedOrSubmittedAlert as jest.Mock).mockReturnValue(
       mockSignedOrSubmittedAlert,
     );
+    (usePendingTransactionAlert as jest.Mock).mockReturnValue(
+      mockPendingTransactionAlert,
+    );
     const { result } = renderHookWithProvider(() => useConfirmationAlerts(), {
       state: siweSignatureConfirmationState,
     });
@@ -131,6 +146,7 @@ describe('useConfirmationAlerts', () => {
       ...mockBlockaidAlerts,
       ...mockDomainMisMatchAlerts,
       ...mockInsufficientBalanceAlert,
+      ...mockPendingTransactionAlert,
       ...mockSignedOrSubmittedAlert,
       ...mockUpgradeAccountAlert,
     ]);

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -4,6 +4,7 @@ import useDomainMismatchAlerts from './useDomainMismatchAlerts';
 import { useInsufficientBalanceAlert } from './useInsufficientBalanceAlert';
 import { useAccountTypeUpgrade } from './useAccountTypeUpgrade';
 import { useSignedOrSubmittedAlert } from './useSignedOrSubmittedAlert';
+import { usePendingTransactionAlert } from './usePendingTransactionAlert';
 import { Alert } from '../../types/alerts';
 
 function useSignatureAlerts(): Alert[] {
@@ -15,10 +16,15 @@ function useSignatureAlerts(): Alert[] {
 function useTransactionAlerts(): Alert[] {
   const insufficientBalanceAlert = useInsufficientBalanceAlert();
   const signedOrSubmittedAlert = useSignedOrSubmittedAlert();
+  const pendingTransactionAlert = usePendingTransactionAlert();
 
   return useMemo(
-    () => [...insufficientBalanceAlert, ...signedOrSubmittedAlert],
-    [insufficientBalanceAlert, signedOrSubmittedAlert],
+    () => [
+      ...insufficientBalanceAlert,
+      ...pendingTransactionAlert,
+      ...signedOrSubmittedAlert,
+    ],
+    [insufficientBalanceAlert, pendingTransactionAlert, signedOrSubmittedAlert],
   );
 }
 export default function useConfirmationAlerts(): Alert[] {

--- a/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.test.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.test.tsx
@@ -1,0 +1,135 @@
+import {
+  TransactionStatus,
+  TransactionType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { usePendingTransactionAlert } from './usePendingTransactionAlert';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+const MOCK_SUBMITTED_TRANSACTION_META = {
+  id: '1',
+  status: TransactionStatus.submitted,
+  type: TransactionType.simpleSend,
+  chainId: '0x1',
+} as unknown as TransactionMeta;
+
+const MOCK_SIGNED_TRANSACTION = {
+  id: '3',
+  status: TransactionStatus.signed,
+  type: TransactionType.simpleSend,
+  chainId: '0x1',
+} as unknown as TransactionMeta;
+
+const MOCK_ANOTHER_CHAIN_PENDING_TRANSACTION = {
+  id: '2',
+  status: TransactionStatus.submitted,
+  type: TransactionType.simpleSend,
+  chainId: '0x2',
+} as unknown as TransactionMeta;
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+
+describe('usePendingTransactionAlert', () => {
+  const mockUseTransactionMetadataRequest = jest.mocked(useTransactionMetadataRequest);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTransactionMetadataRequest.mockReturnValue(MOCK_SUBMITTED_TRANSACTION_META);
+  });
+
+  it('returns alert if there is a submitted transaction (pending)', () => {
+    const { result } = renderHookWithProvider(
+      () => usePendingTransactionAlert(),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [
+                  MOCK_SUBMITTED_TRANSACTION_META,
+                  MOCK_ANOTHER_CHAIN_PENDING_TRANSACTION,
+                ],
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Pending transaction',
+        }),
+      ]),
+    );
+  });
+
+  it('returns alert if there are multiple transactions with at least one submitted (pending)', () => {
+    const { result } = renderHookWithProvider(
+      () => usePendingTransactionAlert(),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [
+                  MOCK_SUBMITTED_TRANSACTION_META,
+                  MOCK_SIGNED_TRANSACTION,
+                  MOCK_ANOTHER_CHAIN_PENDING_TRANSACTION,
+                ],
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Pending transaction',
+        }),
+      ]),
+    );
+  });
+
+  it('does not return an alert if no transactions', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+    const { result } = renderHookWithProvider(
+      () => usePendingTransactionAlert(),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [],
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('does not return an alert if transaction is not pending and on the same chain', () => {
+    const { result } = renderHookWithProvider(
+      () => usePendingTransactionAlert(),
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [
+                  MOCK_SIGNED_TRANSACTION,
+                  MOCK_ANOTHER_CHAIN_PENDING_TRANSACTION,
+                ],
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(result.current).toEqual([]);
+  });
+});

--- a/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useMemo } from 'react';
+import { Linking } from 'react-native';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+
+import { strings } from '../../../../../../locales/i18n';
+import { selectTransactions } from '../../../../../selectors/transactionController';
+import Text from '../../../../../component-library/components/Texts/Text';
+import ButtonLink from '../../../../../component-library/components/Buttons/Button/variants/ButtonLink';
+import { SPEEDUP_CANCEL_TRANSACTION_URL } from '../../constants/url';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { AlertKeys } from '../../constants/alerts';
+import { Severity } from '../../types/alerts';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+export const usePendingTransactionAlert = () => {
+  const transactions = useSelector(selectTransactions);
+  const transactionMeta = useTransactionMetadataRequest();
+
+  return useMemo(() => {
+    if (!transactionMeta) {
+      return [];
+    }
+
+    const showAlert = transactions.some(
+      (transaction) =>
+        transaction.status === TransactionStatus.submitted &&
+        transaction.chainId === transactionMeta.chainId,
+    );
+
+    if (!showAlert) {
+      return [];
+    }
+
+    return [
+      {
+        isBlocking: false,
+        key: AlertKeys.PendingTransaction,
+        field: RowAlertKey.PendingTransaction,
+        message: (
+          <>
+            <Text>{strings('alert_system.pending_transaction.message')}</Text>
+            <ButtonLink
+              label={strings('alert_system.pending_transaction.learn_more')}
+              onPress={() => Linking.openURL(SPEEDUP_CANCEL_TRANSACTION_URL)}
+            />
+          </>
+        ),
+        title: strings('alert_system.pending_transaction.title'),
+        severity: Severity.Warning,
+      },
+    ];
+  }, [transactions]);
+};

--- a/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingTransactionAlert.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Linking } from 'react-native';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
@@ -51,5 +50,5 @@ export const usePendingTransactionAlert = () => {
         severity: Severity.Warning,
       },
     ];
-  }, [transactions]);
+  }, [transactions, transactionMeta]);
 };

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -110,6 +110,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.DomainMismatch]: 'domain_mismatch',
   [AlertKeys.InsufficientBalance]: 'insufficient_balance',
   [AlertKeys.SignedOrSubmitted]: 'signed_or_submitted',
+  [AlertKeys.PendingTransaction]: 'pending_transaction',
 };
 
 function getAlertName(alertKey: string): string {

--- a/app/components/Views/confirmations/types/alerts.ts
+++ b/app/components/Views/confirmations/types/alerts.ts
@@ -18,7 +18,7 @@ type MessageOrContent =
       /**
        * The message is a summary of the alert details.
        */
-      message?: string;
+      message?: string | ReactElement;
     }
   | {
       /**
@@ -29,7 +29,7 @@ type MessageOrContent =
       /**
        * The message is a summary of the alert details.
        */
-      message: string;
+      message: string | ReactElement;
     };
 
 /**

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -40,6 +40,11 @@
     },
     "signed_or_submitted": {
       "message": "A previous transaction is still being signed or submitted."
+    },
+    "pending_transaction": {
+      "title": "Pending transaction",
+      "message": "This transaction won't go through until the previous transaction is complete.",
+      "learn_more": "Learn how to cancel or speed up a transaction."
     }
   },
   "blockaid_banner": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add pending transaction warning alert into speed row.

See recording below how it looks.

Adding `No QA needed` as these transaction confirmations not live.
Adding `No Smoke e2e needed` as these transactions doesn't affect with no user flow or current e2e tests.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5045

## **Manual testing steps**

1. Have another "submitted" transaction in state.
2. Trigger another transaction confirmation to see warning.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No "speed" warning

### **After**


https://github.com/user-attachments/assets/10ae3972-6a14-404a-9434-3731e9fa3367



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
