### PR TITLE
feat: Adds missing metrics for `transfer` confirmation redesign

### DIFF
--- a/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
@@ -8,6 +8,18 @@ import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmat
 import { getNavbar } from '../../UI/navbar/navbar';
 import Transfer from './transfer';
 
+jest.mock('../../../hooks/useTokenAmount', () => ({
+  useTokenAmount: jest.fn(() => ({
+    usdValue: '3.359625',
+  })),
+}));
+
+jest.mock('../../../hooks/useTransferAssetType', () => ({
+  useTransferAssetType: jest.fn(() => ({
+    assetType: 'erc20',
+  })),
+}));
+
 jest.mock('../../../../../hooks/AssetPolling/AssetPollingProvider', () => ({
   AssetPollingProvider: () => null,
 }));
@@ -69,6 +81,7 @@ describe('Transfer', () => {
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
+  const mockSetConfirmationMetric = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -79,6 +92,7 @@ describe('Transfer', () => {
 
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackPageViewedEvent: mockTrackPageViewedEvent,
+      setConfirmationMetric: mockSetConfirmationMetric,
     } as unknown as ReturnType<typeof useConfirmationMetricEvents>);
   });
 
@@ -103,6 +117,12 @@ describe('Transfer', () => {
       onReject: mockOnReject,
       addBackButton: true,
       theme: expect.any(Object),
+    });
+    expect(mockSetConfirmationMetric).toHaveBeenCalledWith({
+      properties: {
+        transaction_transfer_usd_value: '3.359625',
+        asset_type: 'erc20',
+      },
     });
   });
 

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -10,6 +10,8 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 import useNavbar from '../../../hooks/ui/useNavbar';
 import { MMM_ORIGIN } from '../../../constants/confirmations';
 import { useMaxValueRefresher } from '../../../hooks/useMaxValueRefresher';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { useTransferAssetType } from '../../../hooks/useTransferAssetType';
 import FromTo from '../../rows/transactions/from-to';
 import GasFeesDetails from '../../rows/transactions/gas-fee-details';
 import AdvancedDetailsRow from '../../rows/transactions/advanced-details-row/advanced-details-row';
@@ -18,13 +20,25 @@ import NetworkRow from '../../rows/transactions/network-row';
 
 const Transfer = () => {
   const transactionMetadata = useTransactionMetadataRequest();
-  const { trackPageViewedEvent } = useConfirmationMetricEvents();
   const isDappTransfer = transactionMetadata?.origin !== MMM_ORIGIN;
+  const { usdValue } = useTokenAmount();
+  const { assetType } = useTransferAssetType();
+  const { trackPageViewedEvent, setConfirmationMetric } =
+    useConfirmationMetricEvents();
 
   useClearConfirmationOnBackSwipe();
   useNavbar(strings('confirm.review'));
   useMaxValueRefresher();
   useEffect(trackPageViewedEvent, [trackPageViewedEvent]);
+
+  useEffect(() => {
+    setConfirmationMetric({
+      properties: {
+        transaction_transfer_usd_value: usdValue,
+        asset_type: assetType,
+      },
+    });
+  }, [assetType, usdValue, setConfirmationMetric]);
 
   return (
     <View>

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
@@ -12,7 +12,7 @@ import { useFeeCalculations } from './useFeeCalculations';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 import { updateTransactionGasFees } from '../../../../../util/transaction-controller';
 import { useGasFeeEstimateLevelOptions } from './useGasFeeEstimateLevelOptions';
-import '../../utils/time'
+import '../../utils/time';
 
 jest.mock('../../../../../util/transaction-controller');
 jest.mock('../../utils/time', () => ({

--- a/app/components/Views/confirmations/hooks/useNetworkInfo.test.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkInfo.test.ts
@@ -41,5 +41,6 @@ describe('useNetworkInfo', () => {
     );
     expect(result?.current?.networkName).toEqual('Ethereum Mainnet');
     expect(result?.current?.networkImage).toEqual(1);
+    expect(result?.current?.networkNativeCurrency).toEqual('ETH');
   });
 });

--- a/app/components/Views/confirmations/hooks/useNetworkInfo.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkInfo.ts
@@ -31,6 +31,7 @@ const useNetworkInfo = (chainId?: string) => {
 
   const rpcUrl = rpcEndpoints[defaultRpcEndpointIndex].url;
   const rpcName = rpcEndpoints[defaultRpcEndpointIndex].name ?? rpcUrl;
+  const networkNativeCurrency = networkConfiguration.nativeCurrency;
 
   const networkName = nickname || rpcName;
 
@@ -39,6 +40,7 @@ const useNetworkInfo = (chainId?: string) => {
   return {
     networkName,
     networkImage,
+    networkNativeCurrency,
   };
 };
 

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -196,7 +196,7 @@ describe('ERC20 token transactions', () => {
   });
 });
 
-describe('Edge cases and improved readability', () => {
+describe('Edge cases', () => {
   it('handles very small USD amounts that result in zero', async () => {
     const smallExchangeRateState = merge({}, transferConfirmationState, {
       engine: {

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -1,10 +1,17 @@
-import { useTokenAmount } from './useTokenAmount';
+import { waitFor } from '@testing-library/react-native';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import {
   stakingDepositConfirmationState,
   transferConfirmationState,
 } from '../../../../util/test/confirm-data-helpers';
-import { waitFor } from '@testing-library/react-native';
+import { useTokenAmount } from './useTokenAmount';
+
+jest.mock('./useNetworkInfo', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    networkNativeCurrency: 'ETH',
+  })),
+}));
 
 describe('useTokenAmount', () => {
   describe('returns amount and fiat display values', () => {
@@ -18,6 +25,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
+          usdValue: '0.359625',
         });
       });
     });
@@ -32,6 +40,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
+          usdValue: '0.359625',
         });
       });
     });
@@ -46,6 +55,7 @@ describe('useTokenAmount', () => {
           amount: '0.001',
           amountPrecise: '0.001',
           fiat: '$3.60',
+          usdValue: '3.59625',
         });
       });
     });

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -29,7 +29,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
-          usdValue: '0.36',
+          usdValue: null,
         });
       });
     });
@@ -44,7 +44,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
-          usdValue: '0.36',
+          usdValue: null,
         });
       });
     });
@@ -59,7 +59,7 @@ describe('useTokenAmount', () => {
           amount: '0.001',
           amountPrecise: '0.001',
           fiat: '$3.60',
-          usdValue: '3.60',
+          usdValue: null,
         });
       });
     });
@@ -106,7 +106,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$539.44', // 0.1 * 3596.25 * 1.5
-        usdValue: '539.44',
+        usdValue: null,
       });
     });
   });
@@ -190,7 +190,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$719.25', // 0.1 * 3596.25 * 2.0
-        usdValue: '719.25', // 0.1 * 2.0 * 3596.25
+        usdValue: null,
       });
     });
   });
@@ -229,8 +229,7 @@ describe('Edge cases', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.usdValue).not.toBe(null);
-      expect(result.current.usdValue).toBe('0.00'); // Very small amounts round to '0.00'
+      expect(result.current.usdValue).toBe(null);
     });
   });
 
@@ -244,7 +243,7 @@ describe('Edge cases', () => {
         amount: '0.0001',
         amountPrecise: '0.0001',
         fiat: '$0.36',
-        usdValue: '0.36',
+        usdValue: null,
       });
     });
   });
@@ -279,6 +278,38 @@ describe('Edge cases', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
+        usdValue: null,
+      });
+    });
+  });
+
+  it('calculates USD value when usdConversionRateFromCurrencyRates is not available', async () => {
+    const stateWithoutUsdRate = merge({}, transferConfirmationState, {
+      engine: {
+        backgroundState: {
+          CurrencyRateController: {
+            currentCurrency: 'usd',
+            currencyRates: {
+              ETH: {
+                conversionDate: 1732887955.694,
+                conversionRate: 3596.25,
+                // No usdConversionRate property
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: stateWithoutUsdRate,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        amount: '0.0001',
+        amountPrecise: '0.0001',
+        fiat: '$0.36',
         usdValue: null,
       });
     });

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -15,7 +15,8 @@ jest.mock('./useNetworkInfo', () => ({
   })),
 }));
 
-const mockData = '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000016345785d8a0000';
+const mockData =
+  '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045000000000000000000000000000000000000000000000000016345785d8a0000';
 
 describe('useTokenAmount', () => {
   describe('returns amount and fiat display values', () => {
@@ -29,7 +30,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
-          usdValue: null,
+          usdValue: '0.36',
         });
       });
     });
@@ -44,22 +45,25 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
-          usdValue: null,
+          usdValue: '0.36',
         });
       });
     });
 
     it('for a staking deposit and with amountWei defined', async () => {
-      const { result } = renderHookWithProvider(() => useTokenAmount({ amountWei: '1000000000000000' }), {
-        state: stakingDepositConfirmationState,
-      });
+      const { result } = renderHookWithProvider(
+        () => useTokenAmount({ amountWei: '1000000000000000' }),
+        {
+          state: stakingDepositConfirmationState,
+        },
+      );
 
       await waitFor(() => {
         expect(result.current).toEqual({
           amount: '0.001',
           amountPrecise: '0.001',
           fiat: '$3.60',
-          usdValue: null,
+          usdValue: '3.60',
         });
       });
     });
@@ -68,33 +72,37 @@ describe('useTokenAmount', () => {
 
 describe('ERC20 token transactions', () => {
   const erc20TokenAddress = '0x6b175474e89094c44da98b954eedeac495271d0f';
-  const checksumErc20TokenAddress = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+  const checksumErc20TokenAddress =
+    '0x6B175474E89094C44Da98b954EedeAC495271d0F';
 
-  const createERC20State = (contractExchangeRate = 1.5) => merge({}, transferConfirmationState, {
-    engine: {
-      backgroundState: {
-        TokenRatesController: {
-          marketData: {
-            '0x1': {
-              [checksumErc20TokenAddress]: {
-                price: contractExchangeRate,
+  const createERC20State = (contractExchangeRate = 1.5) =>
+    merge({}, transferConfirmationState, {
+      engine: {
+        backgroundState: {
+          TokenRatesController: {
+            marketData: {
+              '0x1': {
+                [checksumErc20TokenAddress]: {
+                  price: contractExchangeRate,
+                },
               },
             },
           },
-        },
-        TransactionController: {
-          transactions: [{
-            type: TransactionType.tokenMethodTransfer,
-            txParams: {
-              to: erc20TokenAddress,
-              data: mockData,
-              from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
-            },
-          }],
+          TransactionController: {
+            transactions: [
+              {
+                type: TransactionType.tokenMethodTransfer,
+                txParams: {
+                  to: erc20TokenAddress,
+                  data: mockData,
+                  from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+                },
+              },
+            ],
+          },
         },
       },
-    },
-  });
+    });
 
   it('calculates correct fiat and USD values for ERC20 token transfer', async () => {
     const { result } = renderHookWithProvider(() => useTokenAmount(), {
@@ -106,7 +114,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$539.44', // 0.1 * 3596.25 * 1.5
-        usdValue: null,
+        usdValue: '539.44',
       });
     });
   });
@@ -121,7 +129,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
-        usdValue: null,
+        usdValue: '0.00',
       });
     });
   });
@@ -136,14 +144,16 @@ describe('ERC20 token transactions', () => {
             },
           },
           TransactionController: {
-            transactions: [{
-              type: TransactionType.tokenMethodTransfer,
-              txParams: {
-                to: erc20TokenAddress,
-                data: mockData,
-                from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+            transactions: [
+              {
+                type: TransactionType.tokenMethodTransfer,
+                txParams: {
+                  to: erc20TokenAddress,
+                  data: mockData,
+                  from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+                },
               },
-            }],
+            ],
           },
         },
       },
@@ -158,7 +168,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
-        usdValue: null,
+        usdValue: '0.00',
       });
     });
   });
@@ -168,14 +178,16 @@ describe('ERC20 token transactions', () => {
       engine: {
         backgroundState: {
           TransactionController: {
-            transactions: [{
-              type: TransactionType.contractInteraction,
-              txParams: {
-                to: erc20TokenAddress,
-                data: mockData,
-                from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+            transactions: [
+              {
+                type: TransactionType.contractInteraction,
+                txParams: {
+                  to: erc20TokenAddress,
+                  data: mockData,
+                  from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+                },
               },
-            }],
+            ],
           },
         },
       },
@@ -190,7 +202,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$719.25', // 0.1 * 3596.25 * 2.0
-        usdValue: null,
+        usdValue: '719.25',
       });
     });
   });
@@ -211,14 +223,16 @@ describe('Edge cases', () => {
             },
           },
           TransactionController: {
-            transactions: [{
-              type: TransactionType.tokenMethodTransfer,
-              txParams: {
-                to: '0x6b175474e89094c44da98b954eedeac495271d0f',
-                data: mockData,
-                from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+            transactions: [
+              {
+                type: TransactionType.tokenMethodTransfer,
+                txParams: {
+                  to: '0x6b175474e89094c44da98b954eedeac495271d0f',
+                  data: mockData,
+                  from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+                },
               },
-            }],
+            ],
           },
         },
       },
@@ -243,7 +257,7 @@ describe('Edge cases', () => {
         amount: '0.0001',
         amountPrecise: '0.0001',
         fiat: '$0.36',
-        usdValue: null,
+        usdValue: '0.36',
       });
     });
   });
@@ -256,14 +270,16 @@ describe('Edge cases', () => {
             marketData: {},
           },
           TransactionController: {
-            transactions: [{
-              type: TransactionType.tokenMethodTransfer,
-              txParams: {
-                to: '0x6b175474e89094c44da98b954eedeac495271d0f',
-                data: mockData,
-                from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+            transactions: [
+              {
+                type: TransactionType.tokenMethodTransfer,
+                txParams: {
+                  to: '0x6b175474e89094c44da98b954eedeac495271d0f',
+                  data: mockData,
+                  from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164',
+                },
               },
-            }],
+            ],
           },
         },
       },
@@ -278,7 +294,7 @@ describe('Edge cases', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
-        usdValue: null,
+        usdValue: '0.00',
       });
     });
   });
@@ -293,7 +309,7 @@ describe('Edge cases', () => {
               ETH: {
                 conversionDate: 1732887955.694,
                 conversionRate: 3596.25,
-                // No usdConversionRate property
+                usdConversionRate: null,
               },
             },
           },

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -58,8 +58,10 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
   );
   const { networkNativeCurrency } = useNetworkInfo(chainId as Hex);
   const currencyRates = useSelector(selectCurrencyRates);
-  const usdConversionRate =
-    currencyRates?.[networkNativeCurrency as string]?.usdConversionRate ?? 0;
+  const usdConversionRateFromCurrencyRates =
+    currencyRates?.[networkNativeCurrency as string]?.usdConversionRate;
+  const usdConversionRate = usdConversionRateFromCurrencyRates ?? 0;
+
 
   const tokenAddress = safeToChecksumAddress(txParams?.to) || NATIVE_TOKEN_ADDRESS;
   const { value: decimals, pending } = useTokenDecimals(tokenAddress, networkClientId);
@@ -91,7 +93,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       // Native
       fiat = amount.times(nativeConversionRate);
       const usdAmount = amount.times(usdConversionRate);
-      usdValue = usdAmount.isZero() ? null : usdAmount.toFixed(2);
+      usdValue = usdConversionRateFromCurrencyRates ? null : usdAmount.toFixed(2);
       break;
     }
     case TransactionType.contractInteraction:
@@ -101,7 +103,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       fiat = amount.times(nativeConversionRate).times(contractExchangeRate);
 
       const usdAmount = amount.times(contractExchangeRate).times(usdConversionRate);
-      usdValue = usdAmount.isZero() ? null : usdAmount.toFixed(2);
+      usdValue = usdConversionRateFromCurrencyRates ? null : usdAmount.toFixed(2);
       break;
     }
     default: {

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -7,7 +7,7 @@ import { Hex } from '@metamask/utils';
 import I18n from '../../../../../locales/i18n';
 import { formatAmount, formatAmountMaxPrecision } from '../../../UI/SimulationDetails/formatAmount';
 import { RootState } from '../../../../reducers';
-import { selectConversionRateByChainId } from '../../../../selectors/currencyRateController';
+import { selectConversionRateByChainId, selectCurrencyRates } from '../../../../selectors/currencyRateController';
 import { selectContractExchangeRatesByChainId } from '../../../../selectors/tokenRatesController';
 import { safeToChecksumAddress } from '../../../../util/address';
 import { toBigNumber } from '../../../../util/number';
@@ -18,6 +18,7 @@ import { NATIVE_TOKEN_ADDRESS } from '../constants/tokens';
 import { ERC20_DEFAULT_DECIMALS, fetchErc20Decimals } from '../utils/token';
 import { parseStandardTokenTransactionData } from '../utils/transaction';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
+import useNetworkInfo from './useNetworkInfo';
 
 interface TokenAmountProps {
   /**
@@ -30,6 +31,7 @@ interface TokenAmount {
   amountPrecise: string | undefined;
   amount: string | undefined;
   fiat: string | undefined;
+  usdValue: string | undefined;
 }
 
 const useTokenDecimals = (tokenAddress: Hex, networkClientId?: NetworkClientId) => useAsyncResult(
@@ -54,6 +56,10 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       selectConversionRateByChainId(state, chainId as Hex),
     ) ?? 1,
   );
+  const { networkNativeCurrency } = useNetworkInfo(chainId as Hex);
+  const currencyRates = useSelector(selectCurrencyRates);
+  const usdConversionRate =
+    currencyRates?.[networkNativeCurrency as string]?.usdConversionRate ?? 0;
 
   const tokenAddress = safeToChecksumAddress(txParams?.to) || NATIVE_TOKEN_ADDRESS;
   const { value: decimals, pending } = useTokenDecimals(tokenAddress, networkClientId);
@@ -63,6 +69,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       amountPrecise: undefined,
       amount: undefined,
       fiat: undefined,
+      usdValue: undefined,
     };
   }
 
@@ -74,6 +81,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
   const amount = calcTokenAmount(value ?? '0', Number(decimals ?? ERC20_DEFAULT_DECIMALS));
 
   let fiat;
+  let usdValue;
 
   switch (transactionType) {
     case TransactionType.simpleSend:
@@ -82,6 +90,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
     case TransactionType.stakingUnstake: {
       // Native
       fiat = amount.times(nativeConversionRate);
+      usdValue = amount.times(usdConversionRate).toString();
       break;
     }
     case TransactionType.contractInteraction:
@@ -89,6 +98,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       // ERC20
       const contractExchangeRate = contractExchangeRates?.[tokenAddress]?.price ?? 1;
       fiat = amount.times(nativeConversionRate).times(contractExchangeRate);
+      usdValue = amount.times(contractExchangeRate).times(usdConversionRate).toString();
       break;
     }
     default: {
@@ -100,5 +110,6 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
     amountPrecise: formatAmountMaxPrecision(I18n.locale, amount),
     amount: formatAmount(I18n.locale, amount),
     fiat: fiat ? fiatFormatter(fiat) : undefined,
+    usdValue,
   };
 };

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -93,7 +93,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       // Native
       fiat = amount.times(nativeConversionRate);
       const usdAmount = amount.times(usdConversionRate);
-      usdValue = usdConversionRateFromCurrencyRates ? null : usdAmount.toFixed(2);
+      usdValue = usdConversionRateFromCurrencyRates ? usdAmount.toFixed(2): null;
       break;
     }
     case TransactionType.contractInteraction:
@@ -103,7 +103,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       fiat = amount.times(nativeConversionRate).times(contractExchangeRate);
 
       const usdAmount = amount.times(contractExchangeRate).times(usdConversionRate);
-      usdValue = usdConversionRateFromCurrencyRates ? null : usdAmount.toFixed(2);
+      usdValue = usdConversionRateFromCurrencyRates ? usdAmount.toFixed(2) : null;
       break;
     }
     default: {

--- a/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
+++ b/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
@@ -19,10 +19,6 @@ const mockUseTransactionMetadataRequest =
 const mockUseAsyncResult = useAsyncResult as jest.MockedFunction<
   typeof useAsyncResult
 >;
-const mockMemoizedGetTokenStandardAndDetails =
-  memoizedGetTokenStandardAndDetails as jest.MockedFunction<
-    typeof memoizedGetTokenStandardAndDetails
-  >;
 
 describe('useTransferAssetType', () => {
   beforeEach(() => {

--- a/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
+++ b/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
@@ -239,33 +239,6 @@ describe('useTransferAssetType', () => {
     ]);
   });
 
-  it('calls memoizedGetTokenStandardAndDetails with correct parameters inside async function', async () => {
-    const mockTransactionMetadata = {
-      type: TransactionType.tokenMethodTransferFrom,
-      txParams: { to: '0x123' },
-      networkClientId: 'mainnet',
-    };
-
-    mockUseTransactionMetadataRequest.mockReturnValue(
-      mockTransactionMetadata as unknown as TransactionMeta,
-    );
-
-    let asyncFunction: () => Promise<any>;
-    mockUseAsyncResult.mockImplementation((fn, deps) => {
-      asyncFunction = fn;
-      return { value: undefined, pending: false };
-    });
-
-    renderHook(() => useTransferAssetType());
-
-    await asyncFunction!();
-
-    expect(mockMemoizedGetTokenStandardAndDetails).toHaveBeenCalledWith({
-      tokenAddress: '0x123',
-      networkClientId: 'mainnet',
-    });
-  });
-
   it('handles mixed case token standards', () => {
     mockUseTransactionMetadataRequest.mockReturnValue({
       type: TransactionType.tokenMethodTransferFrom,

--- a/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
+++ b/app/components/Views/confirmations/hooks/useTransferAssetType.test.ts
@@ -1,0 +1,285 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useTransferAssetType } from './useTransferAssetType';
+import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
+import { useAsyncResult } from '../../../hooks/useAsyncResult';
+import { memoizedGetTokenStandardAndDetails } from '../utils/token';
+
+jest.mock('../../../hooks/useAsyncResult');
+jest.mock('../utils/token');
+jest.mock('./transactions/useTransactionMetadataRequest');
+
+const mockUseTransactionMetadataRequest =
+  useTransactionMetadataRequest as jest.MockedFunction<
+    typeof useTransactionMetadataRequest
+  >;
+const mockUseAsyncResult = useAsyncResult as jest.MockedFunction<
+  typeof useAsyncResult
+>;
+const mockMemoizedGetTokenStandardAndDetails =
+  memoizedGetTokenStandardAndDetails as jest.MockedFunction<
+    typeof memoizedGetTokenStandardAndDetails
+  >;
+
+describe('useTransferAssetType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    memoizedGetTokenStandardAndDetails?.cache?.clear?.();
+  });
+
+  it('when transaction type is simpleSend returns native asset type', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: TransactionType.simpleSend,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    } as unknown as TransactionMeta);
+
+    mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+    const { result } = renderHook(() => useTransferAssetType());
+
+    expect(result.current.assetType).toBe('native');
+  });
+
+  it('when transaction type is tokenMethodTransfer returns erc20 asset type', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: TransactionType.tokenMethodTransfer,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    } as unknown as TransactionMeta);
+
+    mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+    const { result } = renderHook(() => useTransferAssetType());
+
+    expect(result.current.assetType).toBe('erc20');
+  });
+
+  describe('when transaction type is tokenMethodTransferFrom', () => {
+    it('returns asset type based on token standard when details are available', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: { standard: 'ERC721' },
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('erc721');
+    });
+
+    it('returns erc1155 when standard is ERC1155', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: { standard: 'ERC1155' },
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('erc1155');
+    });
+
+    it('returns erc20 when standard is ERC20', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: { standard: 'ERC20' },
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('erc20');
+    });
+
+    it('returns unknown when standard is invalid', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: { standard: 'INVALID_STANDARD' },
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('unknown');
+    });
+
+    it('returns unknown when details are not available', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: undefined,
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('unknown');
+    });
+
+    it('returns unknown when standard is not provided', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: TransactionType.tokenMethodTransferFrom,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({
+        value: { standard: undefined },
+        pending: false,
+      });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('unknown');
+    });
+  });
+
+  it('when transaction type is tokenMethodSafeTransferFrom returns asset type based on token standard', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: TransactionType.tokenMethodSafeTransferFrom,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    } as unknown as TransactionMeta);
+
+    mockUseAsyncResult.mockReturnValue({
+      value: { standard: 'ERC721' },
+      pending: false,
+    });
+
+    const { result } = renderHook(() => useTransferAssetType());
+
+    expect(result.current.assetType).toBe('erc721');
+  });
+
+  describe('when transaction type is unknown or undefined', () => {
+    it('returns unknown asset type for undefined transaction type', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: undefined,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('unknown');
+    });
+
+    it('returns unknown asset type for unhandled transaction type', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        type: 'UNKNOWN_TYPE' as TransactionType,
+        txParams: { to: '0x123' },
+        networkClientId: 'mainnet',
+      } as unknown as TransactionMeta);
+
+      mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+      const { result } = renderHook(() => useTransferAssetType());
+
+      expect(result.current.assetType).toBe('unknown');
+    });
+  });
+
+  it('when transaction metadata is not available returns unknown asset type', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+    mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+    const { result } = renderHook(() => useTransferAssetType());
+
+    expect(result.current.assetType).toBe('unknown');
+  });
+
+  it('calls useAsyncResult with correct parameters', () => {
+    const mockTransactionMetadata = {
+      type: TransactionType.simpleSend,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    };
+
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      mockTransactionMetadata as unknown as TransactionMeta,
+    );
+    mockUseAsyncResult.mockReturnValue({ value: undefined, pending: false });
+
+    renderHook(() => useTransferAssetType());
+
+    expect(mockUseAsyncResult).toHaveBeenCalledWith(expect.any(Function), [
+      '0x123',
+      'mainnet',
+    ]);
+  });
+
+  it('calls memoizedGetTokenStandardAndDetails with correct parameters inside async function', async () => {
+    const mockTransactionMetadata = {
+      type: TransactionType.tokenMethodTransferFrom,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    };
+
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      mockTransactionMetadata as unknown as TransactionMeta,
+    );
+
+    let asyncFunction: () => Promise<any>;
+    mockUseAsyncResult.mockImplementation((fn, deps) => {
+      asyncFunction = fn;
+      return { value: undefined, pending: false };
+    });
+
+    renderHook(() => useTransferAssetType());
+
+    await asyncFunction!();
+
+    expect(mockMemoizedGetTokenStandardAndDetails).toHaveBeenCalledWith({
+      tokenAddress: '0x123',
+      networkClientId: 'mainnet',
+    });
+  });
+
+  it('handles mixed case token standards', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      type: TransactionType.tokenMethodTransferFrom,
+      txParams: { to: '0x123' },
+      networkClientId: 'mainnet',
+    } as unknown as TransactionMeta);
+
+    mockUseAsyncResult.mockReturnValue({
+      value: { standard: 'eRc721' },
+      pending: false,
+    });
+
+    const { result } = renderHook(() => useTransferAssetType());
+
+    expect(result.current.assetType).toBe('erc721');
+  });
+});

--- a/app/components/Views/confirmations/hooks/useTransferAssetType.ts
+++ b/app/components/Views/confirmations/hooks/useTransferAssetType.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
+import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
+import { useAsyncResult } from '../../../hooks/useAsyncResult';
+import { memoizedGetTokenStandardAndDetails } from '../utils/token';
+
+const METRICS_ASSET_TYPES = {
+  native: 'native',
+  erc20: 'erc20',
+  erc721: 'erc721',
+  erc1155: 'erc1155',
+  unknown: 'unknown',
+};
+
+export const useTransferAssetType = () => {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const { value: details } = useAsyncResult(async () => await memoizedGetTokenStandardAndDetails({
+      tokenAddress: transactionMetadata?.txParams?.to,
+      networkClientId: transactionMetadata?.networkClientId,
+    }), [transactionMetadata?.txParams?.to, transactionMetadata?.networkClientId]);
+
+  const [assetType, setAssetType] = useState(METRICS_ASSET_TYPES.unknown);
+
+  useEffect(() => {
+    switch (transactionMetadata?.type) {
+      case TransactionType.simpleSend: {
+        setAssetType(METRICS_ASSET_TYPES.native);
+        break;
+      }
+      case TransactionType.contractInteraction:
+      case TransactionType.tokenMethodTransfer: {
+        setAssetType(METRICS_ASSET_TYPES.erc20);
+        break;
+      }
+      case TransactionType.tokenMethodTransferFrom:
+      case TransactionType.tokenMethodSafeTransferFrom: {
+        const standardLower = details?.standard?.toLowerCase();
+        const validAssetType = (standardLower && standardLower in METRICS_ASSET_TYPES)
+          ? standardLower as keyof typeof METRICS_ASSET_TYPES
+          : METRICS_ASSET_TYPES.unknown;
+        setAssetType(validAssetType);
+        break;
+      }
+      default: {
+        setAssetType(METRICS_ASSET_TYPES.unknown);
+        break;
+      }
+    }
+  }, [details, transactionMetadata?.type]);
+
+  return {
+    assetType,
+  };
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aims to add `transaction_transfer_usd_value` and `asset_type` into `transfer` tarnsaction confirmations.

Adding `No QA needed` as these transaction confirmations not live.
Adding `No Smoke e2e needed` as these transactions doesn't affect with no user flow or current e2e tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4969

## **Manual testing steps**

1. Trigger send flow with redesigned enabled to see event metrics.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
