### PR TITLE
chore: prevent TokenList rerenders

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/index.tsx
@@ -452,3 +452,5 @@ export const TokenListItem = React.memo(
     );
   },
 );
+
+TokenListItem.displayName = 'TokenListItem';

--- a/app/components/UI/Tokens/util/refreshTokens.test.ts
+++ b/app/components/UI/Tokens/util/refreshTokens.test.ts
@@ -2,7 +2,6 @@ import { refreshTokens } from './refreshTokens';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { Hex } from '@metamask/utils';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -118,13 +117,11 @@ describe('refreshTokens', () => {
   });
 
   it('should call updateBalance with selectedAccount ID when EVM is not selected', async () => {
-    const selectedAccount = { id: 'test-account-id' } as InternalAccount;
-
     await refreshTokens({
       isEvmSelected: false,
       evmNetworkConfigurationsByChainId: {},
       nativeCurrencies: [],
-      selectedAccount,
+      selectedAccountId: 'test-account-id',
     });
 
     expect(
@@ -137,7 +134,7 @@ describe('refreshTokens', () => {
       isEvmSelected: false,
       evmNetworkConfigurationsByChainId: {},
       nativeCurrencies: [],
-      selectedAccount: undefined,
+      selectedAccountId: undefined,
     });
 
     expect(

--- a/app/components/UI/Tokens/util/refreshTokens.ts
+++ b/app/components/UI/Tokens/util/refreshTokens.ts
@@ -11,20 +11,20 @@ interface RefreshTokensProps {
     { chainId: Hex; nativeCurrency: string }
   >;
   nativeCurrencies: string[];
-  selectedAccount?: InternalAccount;
+  selectedAccountId?: InternalAccount['id'];
 }
 
 export const refreshTokens = async ({
   isEvmSelected,
   evmNetworkConfigurationsByChainId,
   nativeCurrencies,
-  selectedAccount,
+  selectedAccountId,
 }: RefreshTokensProps) => {
   if (!isEvmSelected) {
     const { MultichainBalancesController } = Engine.context;
-    if (selectedAccount) {
+    if (selectedAccountId) {
       try {
-        await MultichainBalancesController.updateBalance(selectedAccount.id);
+        await MultichainBalancesController.updateBalance(selectedAccountId);
       } catch (error) {
         Logger.error(error as Error, 'Error while refreshing NonEvm tokens');
       }

--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -22,6 +22,7 @@ import {
   selectSolanaAccountAddress,
   selectSolanaAccount,
   selectPreviouslySelectedEvmAccount,
+  selectSelectedInternalAccountId,
 } from './accountsController';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -744,5 +745,31 @@ describe('selectPreviouslySelectedEvmAccount', () => {
 
     // Should return undefined as there are no EVM accounts
     expect(selectPreviouslySelectedEvmAccount(state)).toBeUndefined();
+  });
+});
+
+describe('selectSelectedInternalAccountId', () => {
+  const arrangeAccount = () =>
+    createMockInternalAccount(
+      '0xAddr1',
+      'Mock Account',
+      KeyringTypes.hd,
+      EthAccountType.Eoa,
+    );
+
+  it('returns the selected accountId from state', () => {
+    const internalAccount = arrangeAccount();
+    const state = getStateWithAccount(internalAccount);
+    const result = selectSelectedInternalAccountId(state);
+    expect(result).toBe(internalAccount.id);
+  });
+
+  it('returns the same result on subsequent calls, does not recompute', () => {
+    const internalAccount = arrangeAccount();
+    const state = getStateWithAccount(internalAccount);
+    const result1 = selectSelectedInternalAccountId(state);
+    const result2 = selectSelectedInternalAccountId(state);
+    expect(result1).toBe(result2);
+    expect(selectSelectedInternalAccountId.recomputations()).toBe(1);
   });
 });

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -25,7 +25,7 @@ import { isEqualCaseInsensitive } from '@metamask/controller-utils';
 
 export type InternalAccountWithCaipAccountId = InternalAccount & {
   caipAccountId: CaipAccountId;
-}
+};
 
 /**
  *
@@ -100,6 +100,14 @@ export const selectSelectedInternalAccount = createDeepEqualSelector(
 );
 
 /**
+ * A memoized selector that returns the selected internal account id
+ */
+export const selectSelectedInternalAccountId = createSelector(
+  selectSelectedInternalAccount,
+  (account): string | undefined => account?.id,
+);
+
+/**
  * A memoized selector that returns the internal accounts sorted by the last selected timestamp
  */
 export const selectOrderedInternalAccountsByLastSelected = createSelector(
@@ -120,7 +128,8 @@ export const selectOrderedInternalAccountsByLastSelected = createSelector(
 
 export const getMemoizedInternalAccountByAddress = createDeepEqualSelector(
   [selectInternalAccounts, (_state, address) => address],
-  (internalAccounts, address) => internalAccounts.find((account) =>
+  (internalAccounts, address) =>
+    internalAccounts.find((account) =>
       isEqualCaseInsensitive(account.address, address),
     ),
 );

--- a/app/selectors/tokenList.test.ts
+++ b/app/selectors/tokenList.test.ts
@@ -1,0 +1,175 @@
+import { selectSortedTokenKeys } from './tokenList';
+import { selectTokenSortConfig } from './preferencesController';
+import { selectIsEvmNetworkSelected } from './multichainNetworkController';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { selectSelectedInternalAccount } from './accountsController';
+///: END:ONLY_INCLUDE_IF
+
+import {
+  selectEvmTokens,
+  selectEvmTokenFiatBalances,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  selectMultichainTokenListForAccountId,
+  ///: END:ONLY_INCLUDE_IF
+} from './multichain';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { TokenI } from '../components/UI/Tokens/types';
+import { RootState } from '../reducers';
+
+jest.mock('./preferencesController');
+jest.mock('./multichainNetworkController');
+jest.mock('./accountsController');
+jest.mock('./multichain');
+jest.mock('../store', () => ({
+  store: { getState: jest.fn() },
+}));
+
+// This selector consumes many selectors and is very hard to create exact state
+// So instead uses mocks to simulate the internal selector changes
+describe('selectSortedTokenKeys', () => {
+  const mockState = () => ({} as unknown as RootState);
+
+  const createEvmTokens = (tokenAddrs: string[]) =>
+    tokenAddrs.map(
+      (address) =>
+        ({
+          address,
+          chainId: '0x1',
+          isStaked: false,
+        } as TokenI),
+    );
+
+  const createNonEvmTokens = (tokenAddrs: string[]) =>
+    tokenAddrs.map(
+      (address, idx) =>
+        ({
+          address,
+          chainId: '0x1337',
+          isStaked: undefined,
+          balanceFiat: idx + 10,
+        } as unknown as ReturnType<
+          typeof selectMultichainTokenListForAccountId
+        >[number]),
+    );
+
+  const arrangeMocks = () => {
+    const mockSelectTokenSortConfig = jest
+      .mocked(selectTokenSortConfig)
+      .mockReturnValue({
+        key: 'tokenFiatAmount',
+        order: 'dsc',
+        sortCallback: 'stringNumeric',
+      });
+
+    const mockSelectIsEvmNetworkSelected = jest
+      .mocked(selectIsEvmNetworkSelected)
+      .mockReturnValue(true);
+
+    const mockEvmTokens = createEvmTokens([
+      'tokenAddr1',
+      'tokenAddr2',
+      'tokenAddr3',
+    ]);
+    const mockSelectEvmTokens = jest
+      .mocked(selectEvmTokens)
+      .mockReturnValue(mockEvmTokens);
+
+    const mockEvmTotalFiatBalance = mockEvmTokens.map((_, idx) => idx + 1);
+
+    const mockSelectEvmTokenFiatBalances = jest
+      .mocked(selectEvmTokenFiatBalances)
+      .mockReturnValue(mockEvmTotalFiatBalance);
+
+    const mockSelectSelectedInternalAccount = jest
+      .mocked(selectSelectedInternalAccount)
+      .mockReturnValue({ id: 'account1' } as InternalAccount);
+
+    const mockNonEvmTokens = createNonEvmTokens([
+      'tokenAddrA',
+      'tokenAddrB',
+      'tokenAddrC',
+    ]);
+    const mockSelectMultichainTokenListForAccountId = jest
+      .mocked(selectMultichainTokenListForAccountId)
+      .mockReturnValue(mockNonEvmTokens);
+
+    return {
+      mockSelectTokenSortConfig,
+      mockSelectIsEvmNetworkSelected,
+      mockSelectEvmTokens,
+      mockSelectEvmTokenFiatBalances,
+      mockSelectSelectedInternalAccount,
+      mockSelectMultichainTokenListForAccountId,
+    };
+  };
+
+  // Setup mocks
+  beforeEach(() => {
+    jest.clearAllMocks();
+    selectSortedTokenKeys.resetRecomputations();
+  });
+
+  it('returns an array of ordered evm token keys', () => {
+    const { mockSelectEvmTokens, mockSelectEvmTokenFiatBalances } =
+      arrangeMocks();
+
+    // Arrange - setup tokens
+    mockSelectEvmTokens.mockReturnValue(createEvmTokens(['0x1', '0x2', '0x3']));
+    mockSelectEvmTokenFiatBalances.mockReturnValue([1, 2, 3]);
+
+    const result = selectSortedTokenKeys(mockState());
+    expect(result.map((r) => r.address)).toStrictEqual(['0x3', '0x2', '0x1']);
+  });
+
+  it('returns an array of ordered non-evm token keys', () => {
+    const {
+      mockSelectIsEvmNetworkSelected,
+      mockSelectMultichainTokenListForAccountId,
+    } = arrangeMocks();
+
+    mockSelectIsEvmNetworkSelected.mockReturnValueOnce(false);
+
+    // Arrange - setup tokens
+    const nonEvmTokens = createNonEvmTokens(['0x4', '0x5', '0x6']);
+    nonEvmTokens[0].balanceFiat = '4';
+    nonEvmTokens[1].balanceFiat = '5';
+    nonEvmTokens[2].balanceFiat = '6';
+    mockSelectMultichainTokenListForAccountId.mockReturnValue(nonEvmTokens);
+
+    const result = selectSortedTokenKeys(mockState());
+    expect(result.map((r) => r.address)).toStrictEqual(['0x6', '0x5', '0x4']);
+  });
+
+  it('returns the exact same result when input values/selectors are the same', () => {
+    arrangeMocks();
+    const result1 = selectSortedTokenKeys(mockState());
+    const result2 = selectSortedTokenKeys(mockState());
+    expect(result1).toBe(result2);
+  });
+
+  it('returns the exact same result when evm fiat fluctuates a tiny bit', () => {
+    const { mockSelectEvmTokenFiatBalances } = arrangeMocks();
+
+    mockSelectEvmTokenFiatBalances.mockReturnValue([1, 2, 3]);
+    const result1 = selectSortedTokenKeys(mockState());
+
+    // fiat values changed, but order remains the same
+    mockSelectEvmTokenFiatBalances.mockReturnValue([1.1, 2.2, 3.3]);
+    const result2 = selectSortedTokenKeys(mockState());
+
+    expect(result1).toBe(result2);
+  });
+
+  it('returns a new list or sorted keys when evm fiat changes order', () => {
+    const { mockSelectEvmTokenFiatBalances } = arrangeMocks();
+
+    mockSelectEvmTokenFiatBalances.mockReturnValue([1, 2, 3]);
+    const result1 = selectSortedTokenKeys(mockState());
+
+    // fiat values changed drastically, order has changed
+    mockSelectEvmTokenFiatBalances.mockReturnValue([3, 2, 1]);
+    const result2 = selectSortedTokenKeys(mockState());
+
+    expect(result1).not.toBe(result2);
+  });
+});

--- a/app/selectors/tokenList.ts
+++ b/app/selectors/tokenList.ts
@@ -1,0 +1,74 @@
+import { createSelector } from 'reselect';
+import { selectTokenSortConfig } from './preferencesController';
+import { selectIsEvmNetworkSelected } from './multichainNetworkController';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { selectSelectedInternalAccount } from './accountsController';
+///: END:ONLY_INCLUDE_IF
+
+import {
+  selectEvmTokens,
+  selectEvmTokenFiatBalances,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  selectMultichainTokenListForAccountId,
+  ///: END:ONLY_INCLUDE_IF
+} from './multichain';
+import { RootState } from '../reducers';
+import { TokenI } from '../components/UI/Tokens/types';
+import { sortAssets } from '../components/UI/Tokens/util';
+import { TraceName, endTrace, trace } from '../util/trace';
+import { getTraceTags } from '../util/sentry/tags';
+import { store } from '../store';
+import { createDeepEqualSelector } from './util';
+
+const _selectSortedTokenKeys = createSelector(
+  [
+    selectEvmTokens,
+    selectEvmTokenFiatBalances,
+    selectIsEvmNetworkSelected,
+    selectTokenSortConfig,
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    (state: RootState) => {
+      const selectedAccount = selectSelectedInternalAccount(state);
+      return selectMultichainTokenListForAccountId(state, selectedAccount?.id);
+    },
+    ///: END:ONLY_INCLUDE_IF
+  ],
+  (
+    evmTokens,
+    tokenFiatBalances,
+    isEvmSelected,
+    tokenSortConfig,
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    nonEvmTokens,
+    ///: END:ONLY_INCLUDE_IF
+  ) => {
+    trace({
+      name: TraceName.Tokens,
+      tags: getTraceTags(store.getState()),
+    });
+
+    const tokenListData = isEvmSelected ? evmTokens : nonEvmTokens;
+
+    const tokensWithBalances: TokenI[] = tokenListData.map((token, i) => ({
+      ...token,
+      tokenFiatAmount: isEvmSelected ? tokenFiatBalances[i] : token.balanceFiat,
+    }));
+
+    const tokensSorted = sortAssets(tokensWithBalances, tokenSortConfig);
+
+    endTrace({ name: TraceName.Tokens });
+
+    return tokensSorted.map(({ address, chainId, isStaked }) => ({
+      address,
+      chainId,
+      isStaked,
+    }));
+  },
+);
+
+// Deep equal selector is necessary, because prices can change little bit but order of tokens stays the same.
+// So if the previous keys are still valid (deep eq the current list), then we can use the memoized result
+export const selectSortedTokenKeys = createDeepEqualSelector(
+  _selectSortedTokenKeys,
+  (keys) => keys.filter(({ address, chainId }) => address && chainId),
+);


### PR DESCRIPTION
## **Description**

This migrates this external contribution internally so we can run the full CI test suite.
External PR: https://github.com/MetaMask/metamask-mobile/pull/15692

-----

When user switched to Popular Networks there were 2 extra rerenders because switching between networks will trigger refetch of TokenRatesController and TokenListController. These refetches caused some selectors to update, specifically ones used to generate sortedTokenKeys, but difference by update is usually so small, that order of sortedTokenKeys stays same anyway so it's unecessary to rerender to component.

We also agreed with @sahar-fehri that these updates are happening correctly (more info in Slack https://margelo.slack.com/archives/C08P7RJQU04/p1748003584532309?thread_ts=1747998202.840729&cid=C08P7RJQU04)

I moved generating sortedTokenKeys to separate selector which simplified component and thanks to deep equality it prevents rerenders unless order is really changed. I also added some displayNames and some missing useCallback.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMASSETS-884

## **Manual testing steps**

Interact with the token list and ensure no bugs are due to these perf changes.

1. View popular networks, single network
2. Switch networks and accounts, view token list.
3. Interact with a token list item.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
