### PR TITLE
fix: unable to scroll through currency in setting on android devices

### DIFF
--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -63,6 +63,7 @@ const createStyles = (colors) =>
       justifyContent: 'center',
       alignItems: 'center',
       borderRadius: 10,
+      maxHeight: Device.getDeviceHeight() - 120, // Subtract top and bottom padding
     },
     list: {
       width: '100%',
@@ -174,7 +175,7 @@ export default class SelectComponent extends PureComponent {
     return (
       <View style={baseStyles.flexGrow}>
         <TouchableOpacity onPress={this.showPicker}
-        testID={this.props.testID}>
+          testID={this.props.testID}>
           <View style={styles.dropdown}>
             <Text style={styles.selectedOption} numberOfLines={1}>
               {this.getSelectedValue()}


### PR DESCRIPTION
## **Description**
There is a bug where users cannot scroll on Android when going into settings -> general -> currency conversion modal select. 

The issue is due to when the list in the SelectComponent gets too long. On Android specifically, the padding bottom does not apply so we end up seeing a modal that overflows to the bottom of the device. This issue does not appear on iOS devices. 

The solution is to set maxHeight for modalView to 120 (60 top, 60 bottom) so that we are sure the padding bottom can always apply since the modal view will not exceed that height.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15830

## **Manual testing steps**

On an Android device
1. Go to Settings -> General 
2. Open the currency conversion modal
3. Select a different currency on the bottom of the list
4. Open the modal again
5. Make sure you can still scroll through the modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

Only applicable on Android 
### **Before**
![Android before](https://github.com/user-attachments/assets/14761433-0ae1-4652-844a-e6a6c831fdc5)


### **After**
![Android after](https://github.com/user-attachments/assets/d8a47cc2-220d-4e0e-b2ba-28a86283fa60)


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
