### PR TITLE
fix: SelectComponent scrollview does not scroll to item automatically

### DIFF
--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -74,7 +74,7 @@ const createStyles = (colors) =>
       flexDirection: 'row',
       justifyContent: 'center',
       alignItems: 'center',
-      height: Device.isIos() ? ROW_HEIGHT : undefined,
+      height: ROW_HEIGHT,
     },
     optionLabel: {
       flex: 1,
@@ -120,7 +120,7 @@ export default class SelectComponent extends PureComponent {
     pickerVisible: false,
   };
 
-  scrollView = Device.isIos() ? React.createRef() : null;
+  scrollView = React.createRef();
 
   onValueChange = (val) => {
     this.props.onValueChange(val);
@@ -136,11 +136,10 @@ export default class SelectComponent extends PureComponent {
   showPicker = () => {
     dismissKeyboard();
     this.setState({ pickerVisible: true });
-    Device.isIos() &&
-      // If there are more options than 13 (number of items
-      // that should fit in a normal screen)
-      // then let's scroll to the selected item
-      this.props.options.length > 13 &&
+    // If there are more options than 13 (number of items
+    // that should fit in a normal screen)
+    // then let's scroll to the selected item
+    this.props.options.length > 13 &&
       this.props.options.forEach((item, i) => {
         if (item.value === this.props.selectedValue) {
           setTimeout(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
On Android, SelectComponent scrollview does not scroll to the selected item automatically when the modal opens. This PR is copying the behaviour on iOS

## **Related issues**

Fixes: #15942 

## **Manual testing steps**

1. On Android, go to settings -> general -> currency conversion
2. Open the dropdown 
3. Select a currency that's lower down the list, the modal should close after selected
4. Re-open the modal 
5. should see the selected currency in view

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![Android before](https://github.com/user-attachments/assets/b7176291-69fc-41b4-b0a4-78495ce03d29)



### **After**
![Android after](https://github.com/user-attachments/assets/e9e6ce35-1cdc-4746-990f-ffc4830c41b2)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
