### PR TITLE
feat: Enable `transfer` and `contractInteraction` redesigned confirmations

### DIFF
--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
   process.env.FEATURE_FLAG_REDESIGNED_SIGNATURES = undefined;
   process.env.FEATURE_FLAG_REDESIGNED_STAKING_TRANSACTIONS = undefined;
   process.env.FEATURE_FLAG_REDESIGNED_CONTRACT_INTERACTION = undefined;
+  process.env.FEATURE_FLAG_REDESIGNED_TRANSFER = undefined;
 });
 
 afterEach(() => {
@@ -67,17 +68,20 @@ describe('confirmationRedesign Feature flag: selectConfirmationRedesignFlags sel
       signatures,
       staking_confirmations,
       contract_interaction,
+      transfer,
     } = result as ConfirmationRedesignRemoteFlags;
 
     const {
       signatures: expectedSignatures,
       staking_confirmations: expectedStakingConfirmations,
       contract_interaction: expectedContractInteraction,
+      transfer: expectedTransfer,
     } = expected;
 
     expect(signatures).toEqual(expectedSignatures);
     expect(staking_confirmations).toEqual(expectedStakingConfirmations);
     expect(contract_interaction).toEqual(expectedContractInteraction);
+    expect(transfer).toEqual(expectedTransfer);
   };
 
   it('returns default values when empty feature flag state', () => {

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -18,7 +18,8 @@ const isRemoteFeatureFlagValuesValid = (
   isObject(obj) &&
   hasProperty(obj, 'signatures') &&
   hasProperty(obj, 'staking_confirmations') &&
-  hasProperty(obj, 'contract_interaction');
+  hasProperty(obj, 'contract_interaction') &&
+  hasProperty(obj, 'transfer');
 
 const confirmationRedesignFlagsDefaultValues: ConfirmationRedesignRemoteFlags =
   {
@@ -51,14 +52,13 @@ export const selectConfirmationRedesignFlagsFromRemoteFeatureFlags = (
 
   const isContractInteractionEnabled = getFeatureFlagValue(
     process.env.FEATURE_FLAG_REDESIGNED_CONTRACT_INTERACTION,
-    // TODO: This will be pick up values from the remote feature flag once the
-    // feature is ready to be rolled out
-    false,
+    confirmationRedesignFlags.contract_interaction,
   );
 
-  // TODO: This will be pick up values from the remote feature flag once the feature is ready
-  // Task is created but still in draft
-  const isTransferEnabled = process.env.FEATURE_FLAG_REDESIGNED_TRANSFER === 'true';
+  const isTransferEnabled = getFeatureFlagValue(
+    process.env.FEATURE_FLAG_REDESIGNED_TRANSFER,
+    confirmationRedesignFlags.transfer,
+  );
 
   return {
     signatures: isSignaturesEnabled,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to enable redesigned `transfer` and `contractInteraction` confirmations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5003

## **Manual testing steps**

1. Go to send flow
2. Initiate any transfer 
3. Redesigned transfer confirmations will appear

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
