### PR TITLE
fix: WebView keyboard UI glitch

### DIFF
--- a/app/components/UI/UrlAutocomplete/index.tsx
+++ b/app/components/UI/UrlAutocomplete/index.tsx
@@ -14,6 +14,8 @@ import {
   SectionList,
   ActivityIndicator,
   SectionListRenderItem,
+  KeyboardAvoidingView,
+  Platform
 } from 'react-native';
 import dappUrlList from '../../../util/dapp-url-list';
 import Fuse from 'fuse.js';
@@ -253,18 +255,24 @@ const UrlAutocomplete = forwardRef<
 
   return (
     <View ref={resultsRef} style={styles.wrapper}>
-      <SectionList<AutocompleteSearchResult, ResultsWithCategory>
-        contentContainerStyle={styles.contentContainer}
-        sections={resultsByCategory}
-        keyExtractor={(item) =>
-          item.category === UrlAutocompleteCategory.Tokens
-            ? `${item.category}-${item.chainId}-${item.address}`
-            : `${item.category}-${item.url}`
-        }
-        renderSectionHeader={renderSectionHeader}
-        renderItem={renderItem}
-        keyboardShouldPersistTaps="handled"
-      />
+      <KeyboardAvoidingView
+        style={styles.keyboardAvoidingView}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={100}
+      >
+        <SectionList<AutocompleteSearchResult, ResultsWithCategory>
+          contentContainerStyle={styles.contentContainer}
+          sections={resultsByCategory}
+          keyExtractor={(item) =>
+            item.category === UrlAutocompleteCategory.Tokens
+              ? `${item.category}-${item.chainId}-${item.address}`
+              : `${item.category}-${item.url}`
+          }
+          renderSectionHeader={renderSectionHeader}
+          renderItem={renderItem}
+          keyboardShouldPersistTaps="handled"
+        />
+      </KeyboardAvoidingView>
       {networkModal}
     </View>
   );

--- a/app/components/UI/UrlAutocomplete/styles.ts
+++ b/app/components/UI/UrlAutocomplete/styles.ts
@@ -14,6 +14,9 @@ const styleSheet = ({ theme: { colors, typography } }: { theme: Theme }) =>
       display: 'none',
       paddingTop: 8,
     },
+    keyboardAvoidingView: {
+      flex: 1
+    },
     contentContainer: {
       paddingVertical: 15,
     },

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -10,8 +10,6 @@ import {
   Alert,
   BackHandler,
   ImageSourcePropType,
-  KeyboardAvoidingView,
-  Platform,
 } from 'react-native';
 import { isEqual } from 'lodash';
 import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';
@@ -1393,9 +1391,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
    */
   return (
     <ErrorBoundary navigation={navigation} view="BrowserTab">
-      <KeyboardAvoidingView
-        enabled={shouldShowAutocomplete}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      <View
         style={[styles.wrapper, !isTabActive && styles.hide]}
       >
         <View
@@ -1504,7 +1500,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
           {renderBottomBar()}
           {isTabActive && renderOnboardingWizard()}
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </ErrorBoundary>
   );
 });

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -160,6 +160,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const [ipfsBannerVisible, setIpfsBannerVisible] = useState(false);
   const [isResolvedIpfsUrl, setIsResolvedIpfsUrl] = useState(false);
   const [isUrlBarFocused, setIsUrlBarFocused] = useState(false);
+  const [shouldShowAutocomplete, setShouldShowAutocomplete] = useState(false);
   const [connectionType, setConnectionType] = useState(ConnectionType.UNKNOWN);
   const webviewRef = useRef<WebView>(null);
   const blockListType = useRef<string>(''); // TODO: Consider improving this type
@@ -1246,7 +1247,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
     (item: AutocompleteSearchResult) => {
       // Unfocus the url bar and hide the autocomplete results
       urlBarRef.current?.hide();
-
+      setShouldShowAutocomplete(false);
       if (item.category === 'tokens') {
         navigation.navigate(Routes.BROWSER.ASSET_LOADER, {
           chainId: item.chainId,
@@ -1274,7 +1275,10 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
    * Hide the autocomplete results
    */
   const hideAutocomplete = useCallback(
-    () => autocompleteRef.current?.hide(),
+    () => {
+      autocompleteRef.current?.hide()
+      setShouldShowAutocomplete(false)
+    },
     [],
   );
 
@@ -1289,6 +1293,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const onFocusUrlBar = useCallback(() => {
     // Show the autocomplete results
     autocompleteRef.current?.show();
+    setShouldShowAutocomplete(true)
     urlBarRef.current?.setNativeProps({ text: resolvedUrlRef.current });
   }, []);
 
@@ -1389,6 +1394,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   return (
     <ErrorBoundary navigation={navigation} view="BrowserTab">
       <KeyboardAvoidingView
+        enabled={shouldShowAutocomplete}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={[styles.wrapper, !isTabActive && styles.hide]}
       >

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1388,7 +1388,8 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
    */
   return (
     <ErrorBoundary navigation={navigation} view="BrowserTab">
-      <View
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={[styles.wrapper, !isTabActive && styles.hide]}
       >
         <View
@@ -1497,7 +1498,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
           {renderBottomBar()}
           {isTabActive && renderOnboardingWizard()}
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </ErrorBoundary>
   );
 });

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1388,8 +1388,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
    */
   return (
     <ErrorBoundary navigation={navigation} view="BrowserTab">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      <View
         style={[styles.wrapper, !isTabActive && styles.hide]}
       >
         <View
@@ -1498,7 +1497,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
           {renderBottomBar()}
           {isTabActive && renderOnboardingWizard()}
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </ErrorBoundary>
   );
 });

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -158,7 +158,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const [ipfsBannerVisible, setIpfsBannerVisible] = useState(false);
   const [isResolvedIpfsUrl, setIsResolvedIpfsUrl] = useState(false);
   const [isUrlBarFocused, setIsUrlBarFocused] = useState(false);
-  const [shouldShowAutocomplete, setShouldShowAutocomplete] = useState(false);
   const [connectionType, setConnectionType] = useState(ConnectionType.UNKNOWN);
   const webviewRef = useRef<WebView>(null);
   const blockListType = useRef<string>(''); // TODO: Consider improving this type
@@ -1245,7 +1244,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
     (item: AutocompleteSearchResult) => {
       // Unfocus the url bar and hide the autocomplete results
       urlBarRef.current?.hide();
-      setShouldShowAutocomplete(false);
       if (item.category === 'tokens') {
         navigation.navigate(Routes.BROWSER.ASSET_LOADER, {
           chainId: item.chainId,
@@ -1275,7 +1273,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const hideAutocomplete = useCallback(
     () => {
       autocompleteRef.current?.hide()
-      setShouldShowAutocomplete(false)
     },
     [],
   );
@@ -1291,7 +1288,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const onFocusUrlBar = useCallback(() => {
     // Show the autocomplete results
     autocompleteRef.current?.show();
-    setShouldShowAutocomplete(true)
     urlBarRef.current?.setNativeProps({ text: resolvedUrlRef.current });
   }, []);
 

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1262,7 +1262,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const onDismissAutocomplete = useCallback(() => {
     // Unfocus the url bar and hide the autocomplete results
     urlBarRef.current?.hide();
-
     const hostName =
       new URLParse(resolvedUrlRef.current).hostname || resolvedUrlRef.current;
     urlBarRef.current?.setNativeProps({ text: hostName });

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -10,8 +10,6 @@ import {
   Alert,
   BackHandler,
   ImageSourcePropType,
-  KeyboardAvoidingView,
-  Platform,
 } from 'react-native';
 import { isEqual } from 'lodash';
 import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1262,6 +1262,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
   const onDismissAutocomplete = useCallback(() => {
     // Unfocus the url bar and hide the autocomplete results
     urlBarRef.current?.hide();
+
     const hostName =
       new URLParse(resolvedUrlRef.current).hostname || resolvedUrlRef.current;
     urlBarRef.current?.setNativeProps({ text: hostName });
@@ -1271,9 +1272,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(({
    * Hide the autocomplete results
    */
   const hideAutocomplete = useCallback(
-    () => {
-      autocompleteRef.current?.hide()
-    },
+    () => autocompleteRef.current?.hide(),
     [],
   );
 

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -10,6 +10,8 @@ import {
   Alert,
   BackHandler,
   ImageSourcePropType,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { isEqual } from 'lodash';
 import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';


### PR DESCRIPTION
## **Description**

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13784

**You will notice that this gracefully handles both the `UrlAutocomplete` issue with bottom of results being cut off, and also the WebView input UI glitch.

## **Manual testing steps**

1. Open MM mobile app
2. Go to WebView
3. Go to https://portfolio.metamask.io
4. Click upper-right "hamburger" icon
5. Click "Send"
6. Click on the "to" field to focus it
7. Check UI

## **Screenshots/Recordings**


### **Before**

https://github.com/user-attachments/assets/294561e9-0619-4a24-81b9-2efbf6c5b0ca

### **After**


iOS:


https://github.com/user-attachments/assets/ff07109f-58e6-47db-9dce-bab927d5da90



Android:

https://github.com/user-attachments/assets/5103a521-4239-460d-8cc8-5cd22dd341c9


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
