### PR TITLE
fix: cp-7.47.0 Prevent unnecessary re-renders when using Snaps forms

### DIFF
--- a/app/components/Snaps/SnapUIRenderer/utils.ts
+++ b/app/components/Snaps/SnapUIRenderer/utils.ts
@@ -73,6 +73,12 @@ function getChildrenForHash(component: JSXElement) {
     return null;
   }
 
+  // Prevent re-rendering when rendering forms, we don't care what children it contains
+  // since we can identify it by its name. 
+  if (component.type === 'Form') {
+    return null;
+  }
+
   const { children } = component.props;
 
   // Field has special handling to determine the primary child to use for the key


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent unnecessary re-renders when using Snaps forms which fixes some jumping when the keyboard was being toggled from visible to invisible. We don't need to change the React key for the form component when the children update because it can be uniquely identified by its name.

## **Related issues**

Progresses https://github.com/MetaMask/metamask-mobile/issues/15599

## **Manual testing steps**

1. Use the Solana send flow
2. Notice that the keyboard doesn't jump around when the UI updates
