### PR TITLE
feat: Implement Android UI tests for file downloading in Browser

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -315,6 +315,8 @@ dependencies {
          exclude module: "protobuf-lite"
      }
     androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.4.0')
+    androidTestImplementation 'androidx.test.espresso:espresso-web:3.6.1'
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
     // Add these dependencies for androidTest
     androidTestImplementation "com.google.guava:guava:31.1-android"

--- a/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
@@ -1,7 +1,6 @@
 package com.metamask.ui
 
 import android.os.Environment
-import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -15,19 +14,15 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import com.metamask.ui.base.BaseUiTest
+import com.metamask.ui.base.BaseBrowserUiTest
 import com.metamask.ui.base.CustomMatchers
-import io.metamask.TestActivity
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
@@ -36,24 +31,13 @@ import java.io.File
  * You can use Pixel 5 Api 34 Emulator, same as for E2E tests.
  *
  * To run update in [metamask-mobile/app/util/test/utils.js] export const isE2E = true;
- * Then click Run button in Android Studio or call ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.metamask.ui.BrowserDownloadFileTests
+ * Then click Run button in Android Studio or call
+ * ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.metamask.ui.BrowserDownloadFileTests
  *
- * TODO: Automate steps above into Yarn command
+ * Or you can run all UI tests using yarn test:native:android
  */
 @RunWith(AndroidJUnit4::class)
-class BrowserDownloadFileTests : BaseUiTest() {
-
-  private val device by lazy(LazyThreadSafetyMode.NONE) {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-  }
-
-  @Before
-  fun loginAndOpenBrowser() {
-    launchActivity<TestActivity>()
-    device.findObject(UiSelector().resourceId("login-password-input")).setText("123123123")
-    device.findObject(UiSelector().description("UNLOCK")).click()
-    device.findObject(UiSelector().resourceId("tab-bar-item-Browser")).click()
-  }
+class BrowserDownloadFileTests : BaseBrowserUiTest() {
 
   @After
   fun deleteDownloadedFiles() {
@@ -91,6 +75,7 @@ class BrowserDownloadFileTests : BaseUiTest() {
     Thread.sleep(1_000) // Wait for the file to download
 
     Assert.assertTrue(device.findObject(UiSelector().textContains("Download complete.")).exists())
+    device.pressBack() // Close notifications screen
     val downloadedFile = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.php")
     Assert.assertTrue(downloadedFile.exists())
     Assert.assertTrue(downloadedFile.length() > 1) // Verify that file doesn't weight 0 bytes

--- a/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
@@ -1,0 +1,162 @@
+package com.metamask.ui
+
+import android.os.Environment
+import androidx.test.core.app.launchActivity
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isClickable
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.isJavascriptEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.Until
+import com.metamask.ui.base.BaseUiTest
+import com.metamask.ui.base.CustomMatchers
+import io.metamask.TestActivity
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * You can use Pixel 5 Api 34 Emulator, same as for E2E tests.
+ *
+ * To run update in [metamask-mobile/app/util/test/utils.js] export const isE2E = true;
+ * Then click Run button in Android Studio or call ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.metamask.ui.BrowserDownloadFileTests
+ *
+ * TODO: Automate steps above into Yarn command
+ */
+@RunWith(AndroidJUnit4::class)
+class BrowserDownloadFileTests : BaseUiTest() {
+
+  private val device by lazy(LazyThreadSafetyMode.NONE) {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+  }
+
+  @Before
+  fun loginAndOpenBrowser() {
+    launchActivity<TestActivity>()
+    device.findObject(UiSelector().resourceId("login-password-input")).setText("123123123")
+    device.findObject(UiSelector().description("UNLOCK")).click()
+    device.findObject(UiSelector().resourceId("tab-bar-item-Browser")).click()
+  }
+
+  @After
+  fun deleteDownloadedFiles() {
+    File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.php").delete()
+    File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.txt").delete()
+  }
+
+  @Test
+  fun downloadFile() {
+    device.findObject(UiSelector().resourceId("url-input")).click()
+    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
+      .setText("https://tyschenko.github.io/download_file.html")
+    device.pressEnter()
+
+    onWebView(
+      allOf(
+        isJavascriptEnabled(),
+        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
+      )
+    )
+      .withElement(findElement(Locator.ID, "download_button"))
+      .perform(webClick())
+
+    val downloadButtonInDialog = onView(withText("Download")).inRoot(RootMatchers.isDialog())
+
+    downloadButtonInDialog.check(matches(not(isEnabled()))) // Verify button is disabled to prevent tap jacking
+
+    Thread.sleep(500) // Wait because of tap jacking rule
+
+    downloadButtonInDialog
+      .check(matches(isClickable()))
+      .perform(ViewActions.click())
+
+    device.openNotification()
+    Thread.sleep(1_000) // Wait for the file to download
+
+    Assert.assertTrue(device.findObject(UiSelector().textContains("Download complete.")).exists())
+    val downloadedFile = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.php")
+    Assert.assertTrue(downloadedFile.exists())
+    Assert.assertTrue(downloadedFile.length() > 1) // Verify that file doesn't weight 0 bytes
+  }
+
+  @Test
+  fun downloadBlobFile() {
+    device.findObject(UiSelector().resourceId("url-input")).click()
+    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
+      .setText("https://tyschenko.github.io/download_blob_file.html")
+    device.pressEnter()
+
+    onWebView(
+      allOf(
+        isJavascriptEnabled(),
+        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
+      )
+    )
+      .withElement(findElement(Locator.ID, "download_button"))
+      .perform(webClick())
+
+    val downloadButtonInDialog = onView(withText("Download")).inRoot(RootMatchers.isDialog())
+
+    downloadButtonInDialog.check(matches(not(isEnabled()))) // Verify button is disabled to prevent tap jacking
+
+    Thread.sleep(500) // Wait because of tap jacking rule
+
+    onView(withText("Download"))
+      .inRoot(RootMatchers.isDialog())
+      .perform(ViewActions.click())
+
+    Thread.sleep(1_000) // Wait for the file to download
+
+    device.wait(Until.hasObject(By.text("Downloaded successfully")), 5_000) // Verify Toast is displayed
+    val downloadedFile = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.txt")
+    Assert.assertTrue(downloadedFile.exists())
+    Assert.assertTrue(downloadedFile.length() > 1) // Verify that file doesn't weight 0 bytes
+  }
+
+  @Test
+  fun downloadBase64File() {
+    device.findObject(UiSelector().resourceId("url-input")).click()
+    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
+      .setText("https://tyschenko.github.io/download_base64_file.html")
+    device.pressEnter()
+
+    onWebView(
+      allOf(
+        isJavascriptEnabled(),
+        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
+      )
+    )
+      .withElement(findElement(Locator.ID, "download_button"))
+      .perform(webClick())
+
+    Thread.sleep(500) // Wait because of tap jacking rule
+
+    onView(withText("Download"))
+      .inRoot(RootMatchers.isDialog())
+      .perform(ViewActions.click())
+
+    Thread.sleep(1_000) // Wait for the file to download
+
+    device.wait(Until.hasObject(By.text("Downloaded successfully")), 5_000) // Verify Toast is displayed
+    val downloadedFile = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "file.txt")
+    Assert.assertTrue(downloadedFile.exists())
+    Assert.assertTrue(downloadedFile.length() > 1) // Verify that file doesn't weight 0 bytes
+  }
+}

--- a/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/BrowserDownloadFileTests.kt
@@ -7,9 +7,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
-import androidx.test.espresso.matcher.ViewMatchers.isJavascriptEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
@@ -18,8 +16,6 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.metamask.ui.base.BaseBrowserUiTest
-import com.metamask.ui.base.CustomMatchers
-import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Assert
@@ -47,17 +43,9 @@ class BrowserDownloadFileTests : BaseBrowserUiTest() {
 
   @Test
   fun downloadFile() {
-    device.findObject(UiSelector().resourceId("url-input")).click()
-    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
-      .setText("https://tyschenko.github.io/download_file.html")
-    device.pressEnter()
+    openUrl("https://tyschenko.github.io/download_file.html")
 
-    onWebView(
-      allOf(
-        isJavascriptEnabled(),
-        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
-      )
-    )
+    onMetaMaskWebView()
       .withElement(findElement(Locator.ID, "download_button"))
       .perform(webClick())
 
@@ -83,17 +71,9 @@ class BrowserDownloadFileTests : BaseBrowserUiTest() {
 
   @Test
   fun downloadBlobFile() {
-    device.findObject(UiSelector().resourceId("url-input")).click()
-    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
-      .setText("https://tyschenko.github.io/download_blob_file.html")
-    device.pressEnter()
+    openUrl("https://tyschenko.github.io/download_blob_file.html")
 
-    onWebView(
-      allOf(
-        isJavascriptEnabled(),
-        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
-      )
-    )
+    onMetaMaskWebView()
       .withElement(findElement(Locator.ID, "download_button"))
       .perform(webClick())
 
@@ -117,17 +97,9 @@ class BrowserDownloadFileTests : BaseBrowserUiTest() {
 
   @Test
   fun downloadBase64File() {
-    device.findObject(UiSelector().resourceId("url-input")).click()
-    device.findObject(UiSelector().resourceId("browser-modal-url-input"))
-      .setText("https://tyschenko.github.io/download_base64_file.html")
-    device.pressEnter()
+    openUrl("https://tyschenko.github.io/download_base64_file.html")
 
-    onWebView(
-      allOf(
-        isJavascriptEnabled(),
-        CustomMatchers.withMinimumWidth(1), // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
-      )
-    )
+    onMetaMaskWebView()
       .withElement(findElement(Locator.ID, "download_button"))
       .perform(webClick())
 

--- a/android/app/src/androidTest/java/com/metamask/ui/base/BaseBrowserUiTest.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/BaseBrowserUiTest.kt
@@ -1,8 +1,13 @@
 package com.metamask.ui.base
 
 import androidx.test.core.app.launchActivity
+import androidx.test.espresso.matcher.ViewMatchers.isJavascriptEnabled
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.sugar.Web.WebInteraction
 import androidx.test.uiautomator.UiSelector
 import io.metamask.TestActivity
+import org.hamcrest.Matchers.allOf
+import java.util.concurrent.TimeUnit
 import org.junit.Before
 
 abstract class BaseBrowserUiTest : BaseUiTest() {
@@ -14,4 +19,17 @@ abstract class BaseBrowserUiTest : BaseUiTest() {
     device.findObject(UiSelector().description("Unlock")).click()
     device.findObject(UiSelector().resourceId("tab-bar-item-Browser")).click()
   }
+
+  fun openUrl(url: String) {
+    device.findObject(UiSelector().resourceId("url-input")).click()
+    device.findObject(UiSelector().resourceId("browser-modal-url-input")).setText(url)
+    device.pressEnter()
+  }
+
+  fun onMetaMaskWebView() = onWebView(
+    allOf(
+      isJavascriptEnabled(),
+      CustomMatchers.withMinimumWidth(1) // There are multiple webviews in the layout, we choose one that has width and height not equal to 0
+    )
+  ).withTimeout(10, TimeUnit.SECONDS)
 }

--- a/android/app/src/androidTest/java/com/metamask/ui/base/BaseBrowserUiTest.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/BaseBrowserUiTest.kt
@@ -1,0 +1,17 @@
+package com.metamask.ui.base
+
+import androidx.test.core.app.launchActivity
+import androidx.test.uiautomator.UiSelector
+import io.metamask.TestActivity
+import org.junit.Before
+
+abstract class BaseBrowserUiTest : BaseUiTest() {
+
+  @Before
+  fun loginAndOpenBrowser() {
+    launchActivity<TestActivity>()
+    device.findObject(UiSelector().resourceId("login-password-input")).setText("123123123")
+    device.findObject(UiSelector().description("Unlock")).click()
+    device.findObject(UiSelector().resourceId("tab-bar-item-Browser")).click()
+  }
+}

--- a/android/app/src/androidTest/java/com/metamask/ui/base/BaseUiTest.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/BaseUiTest.kt
@@ -1,0 +1,31 @@
+package com.metamask.ui.base
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+
+abstract class BaseUiTest {
+
+  private lateinit var mockWebServer: MockWebServer
+
+  @Before
+  fun mockAccount() {
+    mockWebServer = MockWebServer()
+    mockWebServer.start(12345)
+    mockWebServer.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/json")
+        .setBody(Fixtures.DEFAULT_FIXTURES_JSON)
+        .addHeader("Access-Control-Allow-Origin", "*")
+        .addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+        .addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+    )
+  }
+
+  @After
+  fun shutdown() {
+    mockWebServer.shutdown()
+  }
+}

--- a/android/app/src/androidTest/java/com/metamask/ui/base/BaseUiTest.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/BaseUiTest.kt
@@ -1,11 +1,20 @@
 package com.metamask.ui.base
 
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 
+/**
+ * To run all UI tests call yarn test:native:android
+ */
 abstract class BaseUiTest {
+
+  val device: UiDevice by lazy(LazyThreadSafetyMode.NONE) {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+  }
 
   private lateinit var mockWebServer: MockWebServer
 

--- a/android/app/src/androidTest/java/com/metamask/ui/base/CustomMatchers.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/CustomMatchers.kt
@@ -1,0 +1,20 @@
+package com.metamask.ui.base
+
+import android.view.View
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+object CustomMatchers {
+  fun withMinimumWidth(minWidth: Int): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun describeTo(description: Description) {
+        description.appendText("View with minimum width of $minWidth")
+      }
+
+      override fun matchesSafely(view: View): Boolean {
+        return view.width >= minWidth
+      }
+    }
+  }
+}

--- a/android/app/src/androidTest/java/com/metamask/ui/base/Fixtures.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/Fixtures.kt
@@ -409,7 +409,8 @@ object Fixtures {
           "userLoggedIn": true,
           "isAuthChecked": false,
           "initialScreen": "",
-          "appTheme": "os"
+          "appTheme": "os",
+          "existingUser": true
         },
         "wizard": {
           "step": 0
@@ -585,10 +586,11 @@ object Fixtures {
       },
       "asyncState": {
         "@MetaMask:existingUser": "true",
+        "@MetaMask:OptinMetaMetricsUISeen": "true",
         "@MetaMask:onboardingWizard": "explored",
         "@MetaMask:UserTermsAcceptedv1.0": "true",
         "@MetaMask:WhatsNewAppVersionSeen": "7.24.3",
-        "@MetaMask:solanaFeatureModalShown": "true"
+        "@MetaMask:solanaFeatureModalShownV2": "true"
       }
     }
     """.trimIndent()

--- a/android/app/src/androidTest/java/com/metamask/ui/base/Fixtures.kt
+++ b/android/app/src/androidTest/java/com/metamask/ui/base/Fixtures.kt
@@ -1,0 +1,595 @@
+package com.metamask.ui.base
+
+object Fixtures {
+  val DEFAULT_FIXTURES_JSON = """
+    {
+      "state": {
+        "legalNotices": {
+          "newPrivacyPolicyToastClickedOrClosed": true,
+          "newPrivacyPolicyToastShownDate": 1684232000456
+        },
+        "collectibles": {
+          "favorites": {}
+        },
+        "engine": {
+          "backgroundState": {
+            "AccountTrackerController": {
+              "accountsByChainId": {
+                "64": {
+                  "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3": {
+                    "balance": "0x0"
+                  }
+                },
+                "1": {
+                  "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3": {
+                    "balance": "0x0"
+                  }
+                }
+              }
+            },
+            "AddressBookController": {
+              "addressBook": {}
+            },
+            "NftController": {
+              "allNftContracts": {},
+              "allNfts": {},
+              "ignoredNfts": []
+            },
+            "TokenListController": {
+              "tokensChainsCache": {
+                "0x1": {
+                  "data": [
+                    {
+                      "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f": {
+                        "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                        "symbol": "SNX",
+                        "decimals": 18,
+                        "name": "Synthetix Network Token",
+                        "iconUrl": "https://static.cx.metamask.io/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png",
+                        "type": "erc20",
+                        "aggregators": [
+                          "Aave",
+                          "Bancor",
+                          "CMC",
+                          "Crypto.com",
+                          "CoinGecko",
+                          "1inch",
+                          "PMM",
+                          "Synthetix",
+                          "Zerion",
+                          "Lifi"
+                        ],
+                        "occurrences": 10,
+                        "fees": {
+                          "0x5fd79d46eba7f351fe49bff9e87cdea6c821ef9f": 0,
+                          "0xda4ef8520b1a57d7d63f1e249606d1a459698876": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "preventPollingOnNetworkRestart": false
+            },
+            "CurrencyRateController": {
+              "currentCurrency": "usd",
+              "currencyRates": {
+                "ETH": {
+                  "conversionDate": 1684232383.997,
+                  "conversionRate": 1815.41,
+                  "usdConversionRate": 1815.41
+                }
+              }
+            },
+            "KeyringController": {
+              "vault": "{\"cipher\":\"T+MXWPPwXOh8RLxpryUuoFCObwXqNQdwak7FafAoVeXOehhpuuUDbjWiHkeVs9slsy/uzG8z+4Va+qyz4dlRnd/Gvc/2RbHTAb/LG1ECk1rvLZW23JPGkBBVAu36FNGCTtT+xrF4gRzXPfIBVAAgg40YuLJWkcfVty6vGcHr3R3/9gpsqs3etrF5tF4tHYWPEhzhhx6HN6Tr4ts3G9sqgyEhyxTLCboAYWp4lsq2iTEl1vQ6T/UyBRNhfDj8RyQMF6hwkJ0TIq2V+aAYkr5NJguBBSi0YKPFI/SGLrin9/+d66gcOSFhIH0GhUbez3Yf54852mMtvOH8Vj7JZc664ukOvEdJIpvCw1CbtA9TItyVApkjQypLtE+IdV3sT5sy+v0mK7Xc054p6+YGiV8kTiTG5CdlI4HkKvCOlP9axwXP0aRwc4ffsvp5fKbnAVMf9+otqmOmlA5nCKdx4FOefTkr/jjhMlTGV8qUAJ2c6Soi5X02fMcrhAfdUtFxtUqHovOh3KzOe25XhjxZ6KCuix8OZZiGtbNDu3xJezPc3vzkTFwF75ubYozLDvw8HzwI+D5Ifn0S3q4/hiequ6NGiR3Dd0BIhWODSvFzbaD7BKdbgXhbJ9+3FXFF9Xkp74msFp6o7nLsx02ywv/pmUNqQhwtVBfoYhcFwqZZQlOPKcH8otguhSvZ7dPgt7VtUuf8gR23eAV4ffVsYK0Hll+5n0nZztpLX4jyFZiV/kSaBp+D2NZM2dnQbsWULKOkjo/1EpNBIjlzjXRBg5Ui3GgT3JXUDx/2GmJXceacrbMcos3HC2yfxwUTXC+yda4IrBx/81eYb7sIjEVNxDuoBxNdRLKoxwmAJztxoQLF3gRexS45QKoFZZ0kuQ9MqLyY6HDK\",\"iv\":\"3271713c2b35a7c246a2a9b263365c3d\",\"keyMetadata\":{\"algorithm\":\"PBKDF2\",\"params\":{\"iterations\":5000}},\"lib\":\"original\",\"salt\":\"l4e+sn/jdsaofDWIB/cuGQ==\"}",
+              "keyrings": [
+                {
+                  "accounts": ["0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3"],
+                  "type": "HD Key Tree"
+                },
+                {
+                  "type": "QR Hardware Wallet Device",
+                  "accounts": []
+                }
+              ]
+            },
+            "NetworkController": {
+              "selectedNetworkClientId": "mainnet",
+              "networksMetadata": {
+                "mainnet": {
+                  "status": "available",
+                  "EIPS": {
+                    "1559": true
+                  }
+                },
+                "networkId1": {
+                  "status": "available",
+                  "EIPS": {
+                    "1559": true
+                  }
+                }
+              },
+              "networkConfigurationsByChainId": {
+                "0x1": {
+                  "chainId": "0x1",
+                  "rpcEndpoints": [
+                    {
+                      "networkClientId": "mainnet",
+                      "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
+                      "type": "infura",
+                      "name": "Ethereum Network default RPC"
+                    }
+                  ],
+                  "defaultRpcEndpointIndex": 0,
+                  "blockExplorerUrls": ["https://etherscan.io"],
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "name": "Ethereum Main Network",
+                  "nativeCurrency": "ETH"
+                },
+                "0x539": {
+                  "chainId": "0x539",
+                  "rpcEndpoints": [
+                    {
+                      "networkClientId": "networkId1",
+                      "url": "http://localhost:8545",
+                      "type": "custom",
+                      "name": "Local RPC"
+                    }
+                  ],
+                  "defaultRpcEndpointIndex": 0,
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "blockExplorerUrls": ["https://test.io"],
+                  "name": "Localhost",
+                  "nativeCurrency": "ETH"
+                },
+                "0xaa36a7": {
+                  "blockExplorerUrls": [],
+                  "chainId": "0xaa36a7",
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
+                  "rpcEndpoints": [
+                    {
+                      "networkClientId": "sepolia",
+                      "type": "infura",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}"
+                    }
+                  ]
+                },
+                "0xe705": {
+                  "blockExplorerUrls": [],
+                  "chainId": "0xe705",
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea Sepolia",
+                  "nativeCurrency": "LineaETH",
+                  "rpcEndpoints": [
+                    {
+                      "networkClientId": "linea-sepolia",
+                      "type": "infura",
+                      "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}"
+                    }
+                  ]
+                }
+              }
+            },
+            "PhishingController": {
+              "listState": {
+                "allowlist": [],
+                "fuzzylist": [
+                  "cryptokitties.co",
+                  "launchpad.ethereum.org",
+                  "etherscan.io",
+                  "makerfoundation.com",
+                  "metamask.io",
+                  "myetherwallet.com",
+                  "opensea.io",
+                  "satoshilabs.com"
+                ],
+                "version": 2,
+                "name": "MetaMask",
+                "tolerance": 1,
+                "lastUpdated": 1684231917
+              },
+              "whitelist": [],
+              "hotlistLastFetched": 1684231917,
+              "stalelistLastFetched": 1684231917
+            },
+            "AccountsController": {
+              "internalAccounts": {
+                "accounts": {
+                  "4d7a5e0b-b261-4aed-8126-43972b0fa0a1": {
+                    "address": "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3",
+                    "id": "4d7a5e0b-b261-4aed-8126-43972b0fa0a1",
+                    "metadata": {
+                      "name": "Account 1",
+                      "importTime": 1684232000456,
+                      "keyring": {
+                        "type": "HD Key Tree"
+                      }
+                    },
+                    "options": {},
+                    "methods": [
+                      "personal_sign",
+                      "eth_signTransaction",
+                      "eth_signTypedData_v1",
+                      "eth_signTypedData_v3",
+                      "eth_signTypedData_v4"
+                    ],
+                    "type": "eip155:eoa",
+                    "scopes": ["eip155:0"]
+                  }
+                },
+                "selectedAccount": "4d7a5e0b-b261-4aed-8126-43972b0fa0a1"
+              }
+            },
+            "PreferencesController": {
+              "featureFlags": {},
+              "identities": {
+                "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3": {
+                  "address": "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3",
+                  "name": "Account 1",
+                  "importTime": 1684232000456
+                }
+              },
+              "ipfsGateway": "https://dweb.link/ipfs/",
+              "lostIdentities": {},
+              "selectedAddress": "0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3",
+              "useTokenDetection": true,
+              "useNftDetection": true,
+              "displayNftMedia": true,
+              "useSafeChainsListValidation": false,
+              "isMultiAccountBalancesEnabled": true,
+              "showTestNetworks": true
+            },
+            "TokenBalancesController": {
+              "tokenBalances": {}
+            },
+            "TokenRatesController": {
+              "marketData": {}
+            },
+            "TokensController": {
+              "allTokens": {},
+              "allIgnoredTokens": {},
+              "allDetectedTokens": {}
+            },
+            "TransactionController": {
+              "methodData": {},
+              "transactions": [],
+              "swapsTransactions": {}
+            },
+            "SwapsController": {
+              "quotes": {},
+              "quoteValues": {},
+              "fetchParams": {
+                "slippage": 0,
+                "sourceToken": "",
+                "sourceAmount": 0,
+                "destinationToken": "",
+                "walletAddress": ""
+              },
+              "fetchParamsMetaData": {
+                "sourceTokenInfo": {
+                  "decimals": 0,
+                  "address": "",
+                  "symbol": ""
+                },
+                "destinationTokenInfo": {
+                  "decimals": 0,
+                  "address": "",
+                  "symbol": ""
+                }
+              },
+              "topAggSavings": null,
+              "aggregatorMetadata": null,
+              "tokens": null,
+              "topAssets": null,
+              "approvalTransaction": null,
+              "aggregatorMetadataLastFetched": 0,
+              "quotesLastFetched": 0,
+              "error": {
+                "key": null,
+                "description": null
+              },
+              "topAggId": null,
+              "tokensLastFetched": 0,
+              "isInPolling": false,
+              "pollingCyclesLeft": 4,
+              "quoteRefreshSeconds": null,
+              "usedGasEstimate": null,
+              "usedCustomGas": null,
+              "chainCache": {
+                "0x1": {
+                  "aggregatorMetadata": null,
+                  "tokens": null,
+                  "topAssets": null,
+                  "aggregatorMetadataLastFetched": 0,
+                  "topAssetsLastFetched": 0,
+                  "tokensLastFetched": 0
+                }
+              }
+            },
+            "GasFeeController": {
+              "gasFeeEstimates": {},
+              "estimatedGasFeeTimeBounds": {},
+              "gasEstimateType": "none",
+              "gasFeeEstimatesByChainId": {},
+              "nonRPCGasFeeApisDisabled": false
+            },
+            "PermissionController": {
+              "subjects": {}
+            },
+            "ApprovalController": {
+              "pendingApprovals": {},
+              "pendingApprovalCount": 0,
+              "approvalFlows": []
+            },
+            "UserStorageController": {},
+            "NotificationServicesController": {
+              "subscriptionAccountsSeen": [],
+              "isMetamaskNotificationsFeatureSeen": false,
+              "isNotificationServicesEnabled": false,
+              "isFeatureAnnouncementsEnabled": false,
+              "metamaskNotificationsList": [],
+              "metamaskNotificationsReadList": [],
+              "isUpdatingMetamaskNotifications": false,
+              "isFetchingMetamaskNotifications": false,
+              "isUpdatingMetamaskNotificationsAccount": [],
+              "isCheckingAccountsPresence": false
+            },
+            "MultichainNetworkController": {
+              "selectedMultichainNetworkChainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+              "multichainNetworkConfigurationsByChainId": {},
+              "isEvmSelected": true
+            },
+            "MultichainAssetsController": {
+              "accountsAssets": {},
+              "assetsMetadata": {}
+            },
+            "MultichainAssetsRatesController": {
+              "conversionRates": {}
+            },
+            "CronJobController": {
+              "jobs": {},
+              "events": {}
+            }
+          }
+        },
+        "privacy": {
+          "approvedHosts": {},
+          "revealSRPTimestamps": []
+        },
+        "bookmarks": [],
+        "browser": {
+          "history": [],
+          "whitelist": [],
+          "tabs": [
+            {
+              "url": "https://google.com",
+              "id": 1692550481062
+            }
+          ],
+          "activeTab": 1692550481062,
+          "favicons": []
+        },
+        "modals": {
+          "networkModalVisible": false,
+          "shouldNetworkSwitchPopToWallet": true,
+          "collectibleContractModalVisible": false,
+          "receiveModalVisible": false,
+          "dappTransactionModalVisible": false,
+          "signMessageModalVisible": true
+        },
+        "settings": {
+          "searchEngine": "Google",
+          "primaryCurrency": "ETH",
+          "lockTime": 30000,
+          "useBlockieIcon": true,
+          "hideZeroBalanceTokens": false,
+          "basicFunctionalityEnabled": true
+        },
+        "alert": {
+          "isVisible": false,
+          "autodismiss": null,
+          "content": null,
+          "data": null
+        },
+        "transaction": {
+          "selectedAsset": {},
+          "transaction": {}
+        },
+        "user": {
+          "loadingMsg": "",
+          "loadingSet": false,
+          "passwordSet": true,
+          "seedphraseBackedUp": true,
+          "backUpSeedphraseVisible": false,
+          "protectWalletModalVisible": false,
+          "gasEducationCarouselSeen": false,
+          "userLoggedIn": true,
+          "isAuthChecked": false,
+          "initialScreen": "",
+          "appTheme": "os"
+        },
+        "wizard": {
+          "step": 0
+        },
+        "onboarding": {
+          "events": []
+        },
+        "notification": {
+          "notifications": []
+        },
+        "swaps": {
+          "0x1": {
+            "isLive": true
+          },
+          "isLive": true,
+          "hasOnboarded": false
+        },
+        "fiatOrders": {
+          "orders": [],
+          "customOrderIds": [],
+          "networks": [
+            {
+              "active": true,
+              "chainId": 1,
+              "chainName": "Ethereum Mainnet",
+              "shortName": "Ethereum",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 10,
+              "chainName": "Optimism Mainnet",
+              "shortName": "Optimism",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 25,
+              "chainName": "Cronos Mainnet",
+              "shortName": "Cronos",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 56,
+              "chainName": "BNB Chain Mainnet",
+              "shortName": "BNB Chain",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 137,
+              "chainName": "Polygon Mainnet",
+              "shortName": "Polygon",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 250,
+              "chainName": "Fantom Mainnet",
+              "shortName": "Fantom",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 1284,
+              "chainName": "Moonbeam Mainnet",
+              "shortName": "Moonbeam",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 1285,
+              "chainName": "Moonriver Mainnet",
+              "shortName": "Moonriver",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 42161,
+              "chainName": "Arbitrum Mainnet",
+              "shortName": "Arbitrum",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 42220,
+              "chainName": "Celo Mainnet",
+              "shortName": "Celo",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 43114,
+              "chainName": "Avalanche C-Chain Mainnet",
+              "shortName": "Avalanche C-Chain",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 1313161554,
+              "chainName": "Aurora Mainnet",
+              "shortName": "Aurora",
+              "nativeTokenSupported": false
+            },
+            {
+              "active": true,
+              "chainId": 1666600000,
+              "chainName": "Harmony Mainnet (Shard 0)",
+              "shortName": "Harmony  (Shard 0)",
+              "nativeTokenSupported": true
+            },
+            {
+              "active": true,
+              "chainId": 11297108109,
+              "chainName": "Palm Mainnet",
+              "shortName": "Palm",
+              "nativeTokenSupported": false
+            },
+            {
+              "active": true,
+              "chainId": 1337,
+              "chainName": "Localhost",
+              "shortName": "Localhost",
+              "nativeTokenSupported": true
+            },
+            {
+              "chainId": 1,
+              "chainName": "Tenderly",
+              "shortName": "Tenderly",
+              "nativeTokenSupported": true
+            }
+          ],
+          "selectedRegionAgg": null,
+          "selectedPaymentMethodAgg": null,
+          "getStartedAgg": false,
+          "getStartedSell": false,
+          "authenticationUrls": [],
+          "activationKeys": []
+        },
+        "infuraAvailability": {
+          "isBlocked": false
+        },
+        "navigation": {
+          "currentRoute": "AdvancedSettings",
+          "currentBottomNavRoute": "Wallet"
+        },
+        "networkOnboarded": {
+          "networkOnboardedState": {},
+          "networkState": {
+            "showNetworkOnboarding": false,
+            "nativeToken": "",
+            "networkType": "",
+            "networkUrl": ""
+          },
+          "switchedNetwork": {
+            "networkUrl": "",
+            "networkStatus": false
+          }
+        },
+        "security": {
+          "allowLoginWithRememberMe": false,
+          "automaticSecurityChecksEnabled": false,
+          "hasUserSelectedAutomaticSecurityCheckOption": true,
+          "isAutomaticSecurityChecksModalOpen": false
+        },
+        "experimentalSettings": {
+          "securityAlertsEnabled": true
+        },
+        "inpageProvider": {
+          "networkId": "1"
+        }
+      },
+      "asyncState": {
+        "@MetaMask:existingUser": "true",
+        "@MetaMask:onboardingWizard": "explored",
+        "@MetaMask:UserTermsAcceptedv1.0": "true",
+        "@MetaMask:WhatsNewAppVersionSeen": "7.24.3",
+        "@MetaMask:solanaFeatureModalShown": "true"
+      }
+    }
+    """.trimIndent()
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -155,6 +155,7 @@
 				<category android:name="android.intent.category.BROWSABLE" />
 			</intent-filter>
 		</activity>
+    <activity android:name=".TestActivity" android:exported="false" />
 		<!-- Explicitly opt-in to safe browsing -->
 		<meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="true" />
 		<!-- Branch keys -->

--- a/android/app/src/main/java/io/metamask/TestActivity.kt
+++ b/android/app/src/main/java/io/metamask/TestActivity.kt
@@ -1,0 +1,12 @@
+package io.metamask
+
+import com.facebook.react.ReactActivity
+
+/**
+ * Used for Android UI tests
+ * 
+ * TODO: Move into androidTest folder to be available only in tests
+ */
+class TestActivity : ReactActivity() {
+  override fun getMainComponentName(): String = "MetaMask"
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2808,15 +2808,21 @@ workflows:
             - deploy_path: browserstack_uploaded_flask_apps.json
           title: Bitrise Deploy Browserstack Uploaded Flask Apps
   run_native_android_tests:
+    before_run:
+      - code_setup
     steps:
       - script@1:
           inputs:
             - content: |-
                 #!/usr/bin/env bash
                 node -v
-                GIT_BRANCH=$BITRISE_GIT_BRANCH yarn test:native:android
+                yarn test:native:android
           title: Build and run Android native UI tests
           is_always_run: true
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
 
 app:
   envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2810,6 +2810,7 @@ workflows:
   run_native_android_tests:
     before_run:
       - code_setup
+      - build_android_devbuild
     steps:
       - script@1:
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -370,6 +370,9 @@ stages:
           envs:
             - MM_ANDROID_PACKAGE_NAME: 'io.metamask.flask'
       - deploy_ios_to_store:
+  run_native_tests:
+    workflows:
+      - run_native_android_tests: {}
 
 workflows:
   # Code Setups
@@ -1060,13 +1063,13 @@ workflows:
             - content: |-
                 #!/usr/bin/env bash
                 echo "Copying Android build from cache..."
-                
+
                 if [ -d "/tmp/android-cache/build/outputs" ]; then
                     echo "Restoring Android build outputs from cache..."
                     mkdir -p android/app/build/outputs
                     cp -r /tmp/android-cache/build/outputs/* android/app/build/outputs/
                     echo "✅ Android build artifacts restored from cache"
-                    
+
                     echo "Restored files:"
                     find android/app/build/outputs -type f -name "*.apk" -o -name "*.aab" | head -5
                 else
@@ -1178,7 +1181,7 @@ workflows:
             - content: |-
                 #!/usr/bin/env bash
                 echo "Copying iOS build from cache..."
-                
+
                 # Check if cached build products exist
                 if [ -d "ios/build/Build/Products/Release-iphonesimulator" ]; then
                     echo "✅ iOS build artifacts found in cache"
@@ -1188,7 +1191,7 @@ workflows:
                     echo "❌ iOS build products not found in cache"
                     mkdir -p ios/build/Build/Products/Release-iphonesimulator
                 fi
-                
+
                 # Check if cached Detox artifacts exist
                 if [ -d "../Library/Detox/ios" ]; then
                     echo "✅ Detox iOS artifacts found in cache"
@@ -1198,7 +1201,7 @@ workflows:
                     echo "❌ Detox iOS artifacts not found in cache"
                     mkdir -p ../Library/Detox/ios
                 fi
-                
+
                 echo "iOS build artifacts restored from cache"
       - pull-intermediate-files@1:
           inputs:
@@ -1314,18 +1317,18 @@ workflows:
           inputs:
             - content: |-
                 #!/usr/bin/env bash
-                
+
                 # Initialize local variables with current state
                 LOCAL_SKIP_IOS="$SKIP_IOS_BUILD"
                 LOCAL_SKIP_ANDROID="$SKIP_ANDROID_BUILD"
-                
+
                 # Ensure iOS value is set if cache check was skipped
                 if [[ -z "$IOS_PR_BUILD_CACHE_KEY" ]]; then
                     echo "No iOS cache key available - build will proceed"
                     LOCAL_SKIP_IOS="false"
                     envman add --key SKIP_IOS_BUILD --value "false"
                 fi
-                
+
                 # Only process Android cache if we have cache keys
                 if [[ -n "$ANDROID_PR_BUILD_CACHE_KEY" ]]; then
                     if [[ "$BITRISE_CACHE_HIT" == "exact" ]]; then
@@ -1342,7 +1345,7 @@ workflows:
                     LOCAL_SKIP_ANDROID="false"
                     envman add --key SKIP_ANDROID_BUILD --value "false"
                 fi
-                
+
                 echo ""
                 echo "=== Final Build Decisions ==="
                 echo "iOS build:     $([ "$LOCAL_SKIP_IOS" == "true" ] && echo "SKIP" || echo "BUILD")"
@@ -1480,7 +1483,7 @@ workflows:
             - content: |-
                 #!/usr/bin/env bash
                 echo "Copying iOS build from cache..."
-                
+
                 # Check if cached build products exist
                 if [ -d "ios/build/Build/Products/Release-iphonesimulator" ]; then
                     echo "✅ iOS build artifacts found in cache"
@@ -1490,7 +1493,7 @@ workflows:
                     echo "❌ iOS build products not found in cache"
                     mkdir -p ios/build/Build/Products/Release-iphonesimulator
                 fi
-                
+
                 # Check if cached Detox artifacts exist
                 if [ -d "../Library/Detox/ios" ]; then
                     echo "✅ Detox iOS artifacts found in cache"
@@ -1500,7 +1503,7 @@ workflows:
                     echo "❌ Detox iOS artifacts not found in cache"
                     mkdir -p ../Library/Detox/ios
                 fi
-                
+
                 echo "iOS build artifacts restored from cache"
       - pull-intermediate-files@1:
           inputs:
@@ -1815,7 +1818,7 @@ workflows:
                 #!/usr/bin/env bash
                 echo "=== Android Build Output Debug ==="
                 echo "Checking for Android build outputs to cache..."
-                
+
                 if [ -d "android/app/build/outputs" ]; then
                     echo "✅ android/app/build/outputs directory exists"
                     echo "Directory size: $(du -sh android/app/build/outputs 2>/dev/null || echo 'Could not calculate')"
@@ -1826,7 +1829,7 @@ workflows:
                     echo "❌ android/app/build/outputs directory does not exist!"
                     echo "This means the Android build failed or output path is incorrect"
                 fi
-                
+
                 echo "Current working directory: $(pwd)"
                 echo "Listing android/app/build directory:"
                 ls -la android/app/build/ 2>/dev/null || echo "android/app/build does not exist"
@@ -1837,15 +1840,15 @@ workflows:
                 #!/usr/bin/env bash
                 echo "=== Preparing Android cache with proper paths ==="
                 echo "Current working directory: $(pwd)"
-                
+
                 # Create a clean cache directory structure
                 mkdir -p /tmp/android-cache/build/outputs
-                
+
                 if [ -d "android/app/build/outputs" ]; then
                     echo "Copying Android build outputs to cache staging area..."
                     cp -r android/app/build/outputs/* /tmp/android-cache/build/outputs/
                     echo "Cache staging completed"
-                    
+
                     echo "Cache contents:"
                     find /tmp/android-cache -type f | head -10
                     echo "Total cache size: $(du -sh /tmp/android-cache 2>/dev/null || echo 'Unknown')"
@@ -2804,7 +2807,16 @@ workflows:
           inputs:
             - deploy_path: browserstack_uploaded_flask_apps.json
           title: Bitrise Deploy Browserstack Uploaded Flask Apps
-
+  run_native_android_tests:
+    steps:
+      - script@1:
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                node -v
+                GIT_BRANCH=$BITRISE_GIT_BRANCH yarn test:native:android
+          title: Build and run Android native UI tests
+          is_always_run: true
 
 app:
   envs:

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:wdio:android": "yarn wdio ./wdio/config/android.config.debug.js",
     "test:wdio:android:browserstack": "yarn wdio ./wdio/config/android.config.browserstack.js",
     "test:wdio:android:browserstack:local": "yarn wdio ./wdio/config/android.config.browserstack.local.js",
+    "test:native:android": "node runNativeAndroidTests.js",
     "test:depcheck": "yarn depcheck",
     "test:tgz-check": "./scripts/tgz-check.sh",
     "test:attribution-check": "./scripts/attributions-check.sh",

--- a/runNativeAndroidTests.js
+++ b/runNativeAndroidTests.js
@@ -1,0 +1,12 @@
+require('dotenv').config({path: '.e2e.env'});
+const {exec} = require('child_process');
+exec('cd android && ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=com.metamask.ui', (error, stdout, stderr) => {
+  if (error) {
+    console.error(`Gradle Error: ${error.message}`);
+    return;
+  }
+  if (stderr) {
+    console.error(`Gradle stderr: ${stderr}`);
+  }
+  console.log(`Gradle output:\n${stdout}`);
+});

--- a/runNativeAndroidTests.js
+++ b/runNativeAndroidTests.js
@@ -1,4 +1,6 @@
+// eslint-disable-next-line import/no-commonjs
 require('dotenv').config({path: '.e2e.env'});
+// eslint-disable-next-line import/no-nodejs-modules,import/no-commonjs
 const {exec} = require('child_process');
 exec('cd android && ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=com.metamask.ui', (error, stdout, stderr) => {
   if (error) {
@@ -8,5 +10,6 @@ exec('cd android && ./gradlew connectedFlaskDebugAndroidTest -Pandroid.testInstr
   if (stderr) {
     console.error(`Gradle stderr: ${stderr}`);
   }
+  // eslint-disable-next-line no-console
   console.log(`Gradle output:\n${stdout}`);
 });


### PR DESCRIPTION
Our current E2E test framework doesn't support interactions inside the WebView. To overcome this issue I wrote native Android UI tests. Currently, there are 3 tests:
1) Download regular file
2) Download base64 file
3) Download blob file

It covers changes from this PR: https://github.com/MetaMask/react-native-webview-mm/pull/51

To run tests you can execute **yarn test:native:android**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
