### PR TITLE
fix: No selected account or hd keyrings when device is locked during create account flow cp-7.47.0

### DIFF
--- a/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
@@ -5,7 +5,6 @@ import { strings } from '../../../../locales/i18n';
 import AddNewAccount from './AddNewAccount';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import {
-  MOCK_ACCOUNTS_CONTROLLER_STATE,
   internalAccount1,
   internalAccount2,
 } from '../../../util/test/accountsControllerTestUtils';
@@ -77,9 +76,18 @@ jest.mock('../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
+const mockAccount1 = {
+  ...internalAccount1,
+  options: { entropySource: '01JKZ55Y6KPCYH08M6B9VSZWKW' },
+};
+const mockAccount2 = {
+  ...internalAccount2,
+  options: { entropySource: '01JKZ56KRVYEEHC601HSNW28T2' },
+};
+
 const mockKeyring1 = {
   type: ExtendedKeyringTypes.hd,
-  accounts: [internalAccount1.address],
+  accounts: [mockAccount1.address],
   metadata: {
     id: '01JKZ55Y6KPCYH08M6B9VSZWKW',
     name: '',
@@ -88,7 +96,7 @@ const mockKeyring1 = {
 
 const mockKeyring2 = {
   type: ExtendedKeyringTypes.hd,
-  accounts: [internalAccount2.address],
+  accounts: [mockAccount2.address],
   metadata: {
     id: '01JKZ56KRVYEEHC601HSNW28T2',
     name: '',
@@ -101,7 +109,15 @@ const initialState = {
   engine: {
     backgroundState: {
       ...backgroundState,
-      AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
+      AccountsController: {
+        internalAccounts: {
+          accounts: {
+            [mockAccount1.id]: mockAccount1,
+            [mockAccount2.id]: mockAccount2,
+          },
+          selectedAccount: mockAccount2.id,
+        },
+      },
       KeyringController: {
         keyrings: [mockKeyring1, mockKeyring2],
       },

--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -61,14 +61,15 @@ const AddNewAccount = ({ route }: AddNewAccountProps) => {
   const internalAccounts = useSelector(selectInternalAccounts);
   const hdKeyrings = useSelector(selectHDKeyrings);
   const [primaryKeyringId] = hdKeyrings;
-  const initialKeyringIdToUse = useMemo(() => {
-    // The accounts controller now adds the entropySource to to hd accounts since 29.0.1
-    // if it is not a hd account, we use the primary keyring id
-    return (
-      (selectedInternalAccount!.options.entropySource as string) ??
-      primaryKeyringId.metadata.id
-    );
-  }, [selectedInternalAccount, primaryKeyringId]);
+  const initialKeyringIdToUse = useMemo(
+    () =>
+      // For HD accounts (since v29.0.1), use the entropySource if available.
+      // Cast to string since it's typed as Json in the keyring API.
+      // Fall back to primary keyring ID for non-HD accounts.
+      (selectedInternalAccount?.options.entropySource as string) ??
+      primaryKeyringId.metadata.id,
+    [selectedInternalAccount, primaryKeyringId],
+  );
   const [keyringId, setKeyringId] = useState<string>(initialKeyringIdToUse);
   const hasMultipleSRPs = hdKeyrings.length > 1;
   const [showSRPList, setShowSRPList] = useState(false);

--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -59,11 +59,17 @@ const AddNewAccount = ({ route }: AddNewAccountProps) => {
   const [accountName, setAccountName] = useState<string | undefined>(undefined);
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const internalAccounts = useSelector(selectInternalAccounts);
-  const [keyringId, setKeyringId] = useState<string>(
-    // This is safe because it is added by the accounts controller now since 29.0.1
-    selectedInternalAccount!.options.entropySource as string,
-  );
   const hdKeyrings = useSelector(selectHDKeyrings);
+  const [primaryKeyringId] = hdKeyrings;
+  const initialKeyringIdToUse = useMemo(() => {
+    // The accounts controller now adds the entropySource to to hd accounts since 29.0.1
+    // if it is not a hd account, we use the primary keyring id
+    return (
+      (selectedInternalAccount!.options.entropySource as string) ??
+      primaryKeyringId.metadata.id
+    );
+  }, [selectedInternalAccount, primaryKeyringId]);
+  const [keyringId, setKeyringId] = useState<string>(initialKeyringIdToUse);
   const hasMultipleSRPs = hdKeyrings.length > 1;
   const [showSRPList, setShowSRPList] = useState(false);
   const [error, setError] = useState<string>('');

--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -31,7 +31,6 @@ import Button, {
 } from '../../../component-library/components/Buttons/Button';
 import SRPList from '../../UI/SRPList';
 import Logger from '../../../util/Logger';
-import { getHdKeyringOfSelectedAccountOrPrimaryKeyring } from '../../../selectors/multisrp';
 import {
   MultichainWalletSnapFactory,
   WalletClientType,
@@ -41,7 +40,10 @@ import BottomSheet, {
 } from '../../../component-library/components/BottomSheets/BottomSheet';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../constants/navigation/Routes';
-import { selectInternalAccounts } from '../../../selectors/accountsController';
+import {
+  selectInternalAccounts,
+  selectSelectedInternalAccount,
+} from '../../../selectors/accountsController';
 import SRPListItem from '../../UI/SRPListItem';
 import { getMultichainAccountName } from '../../../core/SnapKeyring/utils/getMultichainAccountName';
 import { MetaMetricsEvents } from '../../../core/Analytics/MetaMetrics.events';
@@ -55,12 +57,11 @@ const AddNewAccount = ({ route }: AddNewAccountProps) => {
   const { colors } = theme;
   const [isLoading, setIsLoading] = useState(false);
   const [accountName, setAccountName] = useState<string | undefined>(undefined);
+  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const internalAccounts = useSelector(selectInternalAccounts);
-  const keyringOfSelectedAccount = useSelector(
-    getHdKeyringOfSelectedAccountOrPrimaryKeyring,
-  );
   const [keyringId, setKeyringId] = useState<string>(
-    keyringOfSelectedAccount.metadata.id,
+    // This is safe because it is added by the accounts controller now since 29.0.1
+    selectedInternalAccount!.options.entropySource as string,
   );
   const hdKeyrings = useSelector(selectHDKeyrings);
   const hasMultipleSRPs = hdKeyrings.length > 1;

--- a/app/selectors/multisrp/index.test.ts
+++ b/app/selectors/multisrp/index.test.ts
@@ -125,26 +125,6 @@ const mockState = (selectedAccount: InternalAccount = mockAccount1) =>
     },
   } as unknown as RootState);
 
-const mockStateWithNoSelectedAccount = {
-  engine: {
-    backgroundState: {
-      KeyringController: {
-        keyrings: [mockHDKeyring, mockHDKeyring2, mockSimpleKeyring],
-      },
-      AccountsController: {
-        internalAccounts: {
-          accounts: {
-            [mockAccount1.id]: mockAccount1,
-            [mockAccount2.id]: mockAccount2,
-            [mockAccount3.id]: mockAccount3,
-          },
-          selectedAccount: undefined,
-        },
-      },
-    },
-  },
-} as unknown as RootState;
-
 describe('multisrp selectors', () => {
   describe('selectHdKeyringIndexByIdOrDefault', () => {
     it('returns 0 when no keyringId is provided', () => {

--- a/app/selectors/multisrp/index.test.ts
+++ b/app/selectors/multisrp/index.test.ts
@@ -1,6 +1,5 @@
 import {
   selectHdKeyringIndexByIdOrDefault,
-  getHdKeyringOfSelectedAccountOrPrimaryKeyring,
   getSnapAccountsByKeyringId,
 } from './index';
 import { RootState } from '../../reducers';
@@ -167,35 +166,6 @@ describe('multisrp selectors', () => {
         mockHDKeyring.metadata.id,
       );
       expect(result).toBe(0);
-    });
-  });
-
-  describe('getHdKeyringOfSelectedAccountOrPrimaryKeyring', () => {
-    it('returns first HD keyring when no account is selected', () => {
-      expect(() =>
-        getHdKeyringOfSelectedAccountOrPrimaryKeyring(
-          mockStateWithNoSelectedAccount,
-        ),
-      ).toThrow('No selected account or hd keyrings');
-    });
-
-    it('returns correct HD keyring when the selected account is from the second HD keyring', () => {
-      const result = getHdKeyringOfSelectedAccountOrPrimaryKeyring(
-        mockState(mockAccount2),
-      );
-      expect(result).toStrictEqual(mockHDKeyring2);
-    });
-
-    it('returns selected account keyring when it is HD type', () => {
-      const result = getHdKeyringOfSelectedAccountOrPrimaryKeyring(mockState());
-      expect(result).toStrictEqual(mockHDKeyring);
-    });
-
-    it('returns first HD keyring when selected account keyring is not HD type', () => {
-      const result = getHdKeyringOfSelectedAccountOrPrimaryKeyring(
-        mockState(mockAccount3),
-      );
-      expect(result).toStrictEqual(mockHDKeyring);
     });
   });
 

--- a/app/selectors/multisrp/index.ts
+++ b/app/selectors/multisrp/index.ts
@@ -1,10 +1,6 @@
-import { isEqualCaseInsensitive } from '@metamask/controller-utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { RootState } from '../../reducers';
-import {
-  selectInternalAccounts,
-  selectSelectedInternalAccount,
-} from '../accountsController';
+import { selectInternalAccounts } from '../accountsController';
 import { selectHDKeyrings } from '../keyringController';
 import { createDeepEqualSelector } from '../util';
 import { KeyringObject } from '@metamask/keyring-controller';

--- a/app/selectors/multisrp/index.ts
+++ b/app/selectors/multisrp/index.ts
@@ -34,40 +34,6 @@ export const selectHdKeyringIndexByIdOrDefault = createDeepEqualSelector(
 );
 
 /**
- * !! Only use this selector after onboarding
- * Selects the HD keyring of the currently selected account, or falls back to the primary HD keyring
- * @param state - The Redux state
- * @returns The HD keyring containing the selected account if it's an HD keyring, otherwise returns the primary HD keyring
- */
-export const getHdKeyringOfSelectedAccountOrPrimaryKeyring =
-  createDeepEqualSelector(
-    selectSelectedInternalAccount,
-    selectHDKeyrings,
-    (
-      selectedAccount: InternalAccount | undefined,
-      hdKeyrings: KeyringObject[],
-    ) => {
-      if (!selectedAccount || hdKeyrings.length === 0) {
-        // Should never reach this point. This selector is only used after onboarding.
-        throw new Error('No selected account or hd keyrings');
-      }
-
-      const selectedKeyring = hdKeyrings.find(
-        (keyring) =>
-          keyring.accounts.some((account) =>
-            isEqualCaseInsensitive(account, selectedAccount.address),
-          ) && keyring.type === selectedAccount.metadata.keyring.type,
-      );
-
-      if (!selectedKeyring) {
-        return hdKeyrings[0];
-      }
-
-      return selectedKeyring;
-    },
-  );
-
-/**
  * Selector that filters internal accounts by their associated keyring ID.
  * This is used to get all accounts that were created by a specific Snap keyring.
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR removes the usage of `getHdKeyringOfSelectedAccountOrPrimaryKeyring`. It would throw if the selectedAccount is undefined or if there aren't any hd keyrings. This causes an error when the wallet is locked during the add account screen. The state of the keyrings are cleared when the wallet is locked thus causing the error. 

The accounts controller now provides the entropySource for hd accounts and this is now used instead. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15982#event-17933966386

## **Manual testing steps**

1. Create a new wallet
2. Import a srp
3. Go to wallet view and add account
4. Click Add account
5. click Create Ethereum account (but only if you have multiple SRPs imported) or click Create Solana Account
6. Lock the device or wait for the device to auto-lock on the Create account screen
7. Unlock device
8. See that no error is thrown. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
