### PR TITLE
feat: To make downloading of Blob and Base64 files work on iOS in Browser we need to include these schemes in Info.plist

### DIFF
--- a/ios/MetaMask/Info.plist
+++ b/ios/MetaMask/Info.plist
@@ -43,6 +43,8 @@
 	<array>
 		<string>twitter</string>
 		<string>itms-apps</string>
+		<string>blob</string>
+		<string>data</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
Pull request with downloading support - https://github.com/MetaMask/react-native-webview-mm/pull/50

Problem:
When you try to download a blob file, you receive a URL like **blob:https://google.com/12345**. On iOS it's required to include such URL scheme (blob prefix) into the file Info.plist so the system won't filter out such URLs and client can handle it.

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
