### PR TITLE
fix: cp-7.47.0 Fix alignment on Snap UI links and buttons

### DIFF
--- a/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
+++ b/app/components/Snaps/SnapUIButton/SnapUIButton.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { ButtonType, UserInputEventType } from '@metamask/snaps-sdk';
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
 import AnimatedLottieView from 'lottie-react-native';
 
@@ -12,6 +12,13 @@ export interface SnapUIButtonProps {
   form?: string;
   children: React.ReactNode;
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
 
 export const SnapUIButton: FunctionComponent<SnapUIButtonProps> = ({
   name,
@@ -39,7 +46,12 @@ export const SnapUIButton: FunctionComponent<SnapUIButtonProps> = ({
   };
 
   return (
-    <TouchableOpacity id={name} onPress={handlePress} disabled={disabled}>
+    <TouchableOpacity
+      id={name}
+      onPress={handlePress}
+      disabled={disabled}
+      style={styles.container}
+    >
       {loading ? (
         <AnimatedLottieView
           source={{ uri: './loading.json' }}

--- a/app/components/Snaps/SnapUILink/SnapUILink.tsx
+++ b/app/components/Snaps/SnapUILink/SnapUILink.tsx
@@ -1,6 +1,12 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React from 'react';
-import { Text, StyleSheet, Linking, View } from 'react-native';
+import {
+  Text,
+  StyleSheet,
+  Linking,
+  View,
+  TouchableOpacity,
+} from 'react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -22,6 +28,7 @@ const styles = StyleSheet.create({
 export interface SnapUILinkProps {
   children: React.ReactNode;
   href: string;
+  isInline?: boolean;
 }
 
 const validateUrl = (href: string) => {
@@ -36,18 +43,30 @@ const onPress = (href: string) => {
 };
 
 // TODO: This component should show a modal for links when not using preinstalled Snaps
-export const SnapUILink: React.FC<SnapUILinkProps> = ({ href, children }) => (
-  <Text
-    testID="snaps-ui-link"
-    style={styles.container}
-    onPress={() => onPress(href)}
-    accessibilityRole="link"
-    accessibilityHint={strings('snaps.snap_ui.link.accessibilityHint')}
-  >
-    {children}
-    <View style={styles.spacer} />
-    <Icon name={IconName.Export} color={IconColor.Primary} size={IconSize.Sm} />
-  </Text>
-);
+export const SnapUILink: React.FC<SnapUILinkProps> = ({
+  href,
+  children,
+  isInline,
+}) => {
+  const Component = isInline ? Text : TouchableOpacity;
+
+  return (
+    <Component
+      testID="snaps-ui-link"
+      style={styles.container}
+      onPress={() => onPress(href)}
+      accessibilityRole="link"
+      accessibilityHint={strings('snaps.snap_ui.link.accessibilityHint')}
+    >
+      {children}
+      <View style={styles.spacer} />
+      <Icon
+        name={IconName.Export}
+        color={IconColor.Primary}
+        size={IconSize.Sm}
+      />
+    </Component>
+  );
+};
 
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -1778,6 +1778,12 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                     disabled={false}
                     id="submit"
                     onPress={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                      }
+                    }
                   >
                     <Text
                       accessibilityRole="text"

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -131,6 +131,12 @@ exports[`SnapUIForm will render 1`] = `
               disabled={false}
               id="submit"
               onPress={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
             >
               <Text
                 accessibilityRole="text"
@@ -1209,6 +1215,12 @@ exports[`SnapUIForm will render with fields 1`] = `
               disabled={false}
               id="submit"
               onPress={[Function]}
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
             >
               <Text
                 accessibilityRole="text"

--- a/app/components/Snaps/SnapUIRenderer/components/link.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/link.test.ts
@@ -41,6 +41,7 @@ describe('link component', () => {
       ],
       props: {
         href: 'https://metamask.io',
+        isInline: false,
       },
     });
   });
@@ -94,6 +95,7 @@ describe('link component', () => {
       ],
       props: {
         href: 'https://metamask.io',
+        isInline: false,
       },
     });
   });
@@ -142,6 +144,7 @@ describe('link component', () => {
       ],
       props: {
         href: 'https://metamask.io',
+        isInline: false,
       },
     });
   });

--- a/app/components/Snaps/SnapUIRenderer/components/link.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/link.ts
@@ -36,6 +36,7 @@ export const link: UIComponentFactory<LinkElement> = ({
     ),
     props: {
       href: e.props.href,
+      isInline: params.textVariant !== undefined,
     },
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves alignment of link icons when `SnapUILink` is not used inline by using a different component depending on the context the link is shown in. Also improves alignment when using `SnapUIButton` with more content than just text that needs to be aligned.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img height="500" src="https://github.com/user-attachments/assets/0c174cfa-17f9-4eee-9038-9387b7a8278d" />

### **After**

<img height="500" src="https://github.com/user-attachments/assets/0e8968ec-862b-45eb-a423-c00b5eab682a" />