### PR TITLE
fix: Account modal switch account option should not be hidden is user enable preference to dismiss smart account upgrade

### DIFF
--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -684,24 +684,5 @@ describe('AccountActions', () => {
 
       expect(queryByText('Switch to Smart account')).toBeNull();
     });
-
-    it('option should not be displayed if use has enabled dismissSmartAccountSuggestionEnabled', () => {
-      const { queryByText } = renderWithProvider(<AccountActions />, {
-        state: {
-          ...initialState,
-          engine: {
-            ...initialState.engine,
-            backgroundState: {
-              ...initialState.engine.backgroundState,
-              PreferencesController: {
-                dismissSmartAccountSuggestionEnabled: true,
-              },
-            },
-          },
-        },
-      });
-
-      expect(queryByText('Switch to Smart account')).toBeNull();
-    });
   });
 });

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -50,7 +50,6 @@ import { useTheme } from '../../../util/theme';
 import { useEIP7702Networks } from '../confirmations/hooks/7702/useEIP7702Networks';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
-import { selectDismissSmartAccountSuggestionEnabled } from '../../../selectors/preferencesController';
 
 interface AccountActionsParams {
   selectedAccount: InternalAccount;
@@ -67,9 +66,6 @@ const AccountActions = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { networkSupporting7702Present } = useEIP7702Networks(
     selectedAccount.address,
-  );
-  const dismissSmartAccountSuggestionEnabled = useSelector(
-    selectDismissSmartAccountSuggestionEnabled,
   );
 
   const [blockingModalVisible, setBlockingModalVisible] = useState(false);
@@ -454,14 +450,13 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {networkSupporting7702Present &&
-          !dismissSmartAccountSuggestionEnabled && (
-            <AccountAction
-              actionTitle={strings('account_actions.switch_to_smart_account')}
-              iconName={IconName.SwapHorizontal}
-              onPress={goToSwitchAccountType}
-            />
-          )}
+        {networkSupporting7702Present && (
+          <AccountAction
+            actionTitle={strings('account_actions.switch_to_smart_account')}
+            iconName={IconName.SwapHorizontal}
+            onPress={goToSwitchAccountType}
+          />
+        )}
       </View>
       <BlockingActionModal
         modalVisible={blockingModalVisible}


### PR DESCRIPTION
## **Description**

Account modal switch account option should not be hidden is user enable preference to dismiss smart account upgrade

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5077

## **Manual testing steps**

1. Enable option to dismiss smart account upgrade
2. Open account modal
3. Check that switch account type option works

## **Screenshots/Recordings**
<img width="396" alt="Screenshot 2025-06-03 at 7 10 06 PM" src="https://github.com/user-attachments/assets/0ed5d1db-135e-4e82-a3d9-604a4e817e45" />


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
