### PR TITLE
fix: cp-7.47.0 set destination chain ID when token switch button is clicked

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
@@ -11,6 +11,7 @@ import { isSolanaChainId } from '@metamask/bridge-controller';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import Engine from '../../../../../core/Engine';
+import { setSelectedDestChainId } from '../../../../../core/redux/slices/bridge';
 
 export const useSwitchTokens = () => {
   const dispatch = useDispatch();
@@ -48,6 +49,8 @@ export const useSwitchTokens = () => {
       dispatch(setDestToken(sourceToken));
 
       if (sourceToken.chainId !== destToken.chainId) {
+        dispatch(setSelectedDestChainId(sourceToken.chainId));
+
         if (isSolanaChainId(destToken.chainId)) {
           await onNonEvmNetworkChange(destToken.chainId as CaipChainId);
         } else {

--- a/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
@@ -4,6 +4,7 @@ import {
   setDestToken,
   selectDestToken,
   selectSourceToken,
+  setSelectedDestChainId
 } from '../../../../../core/redux/slices/bridge';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
@@ -11,7 +12,6 @@ import { isSolanaChainId } from '@metamask/bridge-controller';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import Engine from '../../../../../core/Engine';
-import { setSelectedDestChainId } from '../../../../../core/redux/slices/bridge';
 
 export const useSwitchTokens = () => {
   const dispatch = useDispatch();


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently clicking the "switch" button when bridging will break the quotes. This fixes that by ensuring the destination chain ID is properly set.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this bridge
2. Get quote
3. Switch tokens
4. Get quote

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/322c17ed-6a13-4b67-bd31-d517f3495ab0


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/f2968aab-ade1-4dbd-a0b2-cdadc4d588ab


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
