### PR TITLE
fix: cp-7.47.0 check for valid decimals before parsing in isInsufficientBalance

### DIFF
--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -22,9 +22,16 @@ const useIsInsufficientBalance = ({ amount, token }: UseIsInsufficientBalancePar
   const isValidAmount =
     amount !== undefined && amount !== '.' && token?.decimals;
 
+  // Safety check for decimal places before parsing
+  const hasValidDecimals = isValidAmount && (() => {
+    const decimalPlaces = amount.includes('.') ? amount.split('.')[1].length : 0;
+    return decimalPlaces <= token.decimals;
+  })();
+
   // quoteRequest.insufficientBal is undefined for Solana quotes, so we need to manually check if the source amount is greater than the balance
   const isInsufficientBalance = quoteRequest?.insufficientBal ||
     (isValidAmount &&
+      hasValidDecimals &&
       parseUnits(amount, token.decimals).gt(
         latestBalance?.atomicBalance ?? BigNumber.from(0),
       ));


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The useIsInsufficientBalance hook currently breaks when attempting to parse an amount with more decimals than the decimals of the token. This PR adds a safety check to validate decimals before parsing.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16062

## **Manual testing steps**

1. Select a Solana account
2. Go to swaps
3. While SOL token is selected as source input the amount "0.123123123"
4. Switch the source token to USDC or PONK

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
