### PR TITLE
fix: use shortened i18n currency format

### DIFF
--- a/app/util/assets/index.test.ts
+++ b/app/util/assets/index.test.ts
@@ -7,9 +7,9 @@ import {
 import { Hex } from '@metamask/utils';
 
 describe('formatWithThreshold', () => {
-  const enUSCurrencyOptions = { style: 'currency', currency: 'USD' };
-  const enEUCurrencyOptions = { style: 'currency', currency: 'EUR' };
-  const jpYenCurrencyOptions = { style: 'currency', currency: 'JPY' };
+  const enUSCurrencyOptions = { style: 'currency', currency: 'USD' } as const;
+  const enEUCurrencyOptions = { style: 'currency', currency: 'EUR' } as const;
+  const jpYenCurrencyOptions = { style: 'currency', currency: 'JPY' } as const;
   const numberOptions = { maximumFractionDigits: 2 };
 
   const cryptoOptions = {

--- a/app/util/assets/index.ts
+++ b/app/util/assets/index.ts
@@ -11,6 +11,13 @@ export const formatWithThreshold = (
   if (amount === null) {
     return '';
   }
+
+  // Ensures that if we are using currency, we are using the narrow symbol to match existing currencies.
+  // E.g. instead of US$xx.yy we show $xx.yy
+  if (options.currency && !options.currencyDisplay) {
+    options.currencyDisplay = 'narrowSymbol';
+  }
+
   if (amount === 0) {
     return new Intl.NumberFormat(locale, options).format(0);
   }


### PR DESCRIPTION
## **Description**

Uses the shortened currency symbol to provide consistency throughout the app. This was only visible since I am testing under an `en-GB` locale.

## **Related issues**

Fixes:

## **Manual testing steps**


1. force change the device locale (or move to the UK)
2. Open app 
3. Expected - we are using `$xx.yy` and not `UX$xx.yy` throughout the app. There should be currency consistency.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-06-04 at 17 03 00](https://github.com/user-attachments/assets/21caee08-a96d-4b66-b5cc-a64ec2bd21bc)

### **After**

![Screenshot 2025-06-04 at 17 05 35](https://github.com/user-attachments/assets/76b62bce-b331-4b7c-a610-6ea6e5a2d839)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
