### PR TITLE
chore: cache Intl instances

### DIFF
--- a/app/components/UI/Ramp/Aggregator/utils/index.ts
+++ b/app/components/UI/Ramp/Aggregator/utils/index.ts
@@ -22,6 +22,8 @@ import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
 import { strings } from '../../../../../../locales/i18n';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { QuoteSortBy } from '@consensys/on-ramp-sdk/dist/IOnRampSdk';
+import I18n from '../../../../../locales/i18n';
+import { getIntlNumberFormatter } from '../../../../util/intl';
 
 const isOverAnHour = (minutes: number) => minutes > 59;
 
@@ -119,16 +121,13 @@ export const formatId = (id: string) => {
 
 export function formatAmount(amount: number, useParts = false) {
   try {
-    if (Intl?.NumberFormat) {
-      if (useParts) {
-        return new Intl.NumberFormat()
-          .formatToParts(amount)
-          .map(({ type, value }) => (type === 'integer' ? value : ''))
-          .join(' ');
-      }
-      return new Intl.NumberFormat().format(amount);
+    if (useParts) {
+      return getIntlNumberFormatter(I18n.locale)
+        .formatToParts(amount)
+        .map(({ type, value }) => (type === 'integer' ? value : ''))
+        .join(' ');
     }
-    return String(amount);
+    return getIntlNumberFormatter(I18n.locale).format(amount);
   } catch (e) {
     return String(amount);
   }

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import I18n from '../../../../../locales/i18n';
 import { BigNumber } from 'bignumber.js';
+import { getIntlNumberFormatter } from '../../../../util/intl';
 
 type FiatFormatter = (fiatAmount: BigNumber) => string;
 
@@ -24,7 +25,7 @@ const useFiatFormatter = (): FiatFormatter => {
     const hasDecimals = !fiatAmount.isInteger();
 
     try {
-      return new Intl.NumberFormat(I18n.locale, {
+      return getIntlNumberFormatter(I18n.locale, {
         style: 'currency',
         currency: fiatCurrency,
         minimumFractionDigits: hasDecimals ? 2 : 0,

--- a/app/components/UI/SimulationDetails/formatAmount.ts
+++ b/app/components/UI/SimulationDetails/formatAmount.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js';
+import { getIntlNumberFormatter } from '../../../util/intl';
 
 const MIN_AMOUNT = new BigNumber('0.000001');
 
@@ -20,7 +21,7 @@ export function formatAmountMaxPrecision(
   const formattedValue = bigNumberValue.toFixed(numberOfDecimals ?? 0);
 
   const [integerPart, fractionalPart] = formattedValue.split('.');
-  const formattedIntegerPart = new Intl.NumberFormat(locale).format(
+  const formattedIntegerPart = getIntlNumberFormatter(locale).format(
     integerPart as unknown as number,
   );
 
@@ -75,7 +76,7 @@ export function formatAmount(locale: string, amount: BigNumber): string {
   }
 
   if (amount.abs().isLessThan(1)) {
-    return new Intl.NumberFormat(locale, {
+    return getIntlNumberFormatter(locale, {
       maximumSignificantDigits: MAX_SIGNIFICANT_DECIMAL_PLACES,
     } as Intl.NumberFormatOptions).format(
       amount.dp(DEFAULT_PRECISION ?? 0).toNumber(),
@@ -92,7 +93,7 @@ export function formatAmount(locale: string, amount: BigNumber): string {
     MAX_SIGNIFICANT_DECIMAL_PLACES - digitsLeftOfDecimal + 1,
   );
 
-  return new Intl.NumberFormat(locale, {
+  return getIntlNumberFormatter(locale, {
     maximumFractionDigits,
   } as Intl.NumberFormatOptions).format(
     // string is valid parameter for format function

--- a/app/util/assets/index.ts
+++ b/app/util/assets/index.ts
@@ -1,6 +1,7 @@
 import { Nft, NftControllerState } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
 import { isEqual } from 'lodash';
+import { getIntlNumberFormatter } from '../intl';
 
 export const formatWithThreshold = (
   amount: number | null,
@@ -19,11 +20,11 @@ export const formatWithThreshold = (
   }
 
   if (amount === 0) {
-    return new Intl.NumberFormat(locale, options).format(0);
+    return getIntlNumberFormatter(locale, options).format(0);
   }
   return amount < threshold
-    ? `<${new Intl.NumberFormat(locale, options).format(threshold)}`
-    : new Intl.NumberFormat(locale, options).format(amount);
+    ? `<${getIntlNumberFormatter(locale, options).format(threshold)}`
+    : getIntlNumberFormatter(locale, options).format(amount);
 };
 
 type AccountNfts = NftControllerState['allNfts'][string]; // Type for NFTs of a single account

--- a/app/util/confirm-tx.js
+++ b/app/util/confirm-tx.js
@@ -8,6 +8,7 @@ import {
   conversionGreaterThan,
 } from './conversion';
 import I18n from '../../locales/i18n';
+import { getIntlNumberFormatter } from './intl';
 
 const NON_ISO4217_CRYPTO_CODES = [
   '1ST',
@@ -121,7 +122,7 @@ export function formatCurrency(value, currencyCode) {
     upperCaseCurrencyCode,
   )
     ? `${Number(value)} ${upperCaseCurrencyCode}`
-    : new Intl.NumberFormat(I18n.locale, {
+    : getIntlNumberFormatter(I18n.locale, {
         currency: upperCaseCurrencyCode,
         style: 'currency',
       }).format(Number(value));

--- a/app/util/intl.ts
+++ b/app/util/intl.ts
@@ -1,0 +1,35 @@
+/**
+ * Cache for Intl.NumberFormat instances to avoid expensive recreations
+ * Key is a stringified combination of locale and options
+ * Value is the cached Intl.NumberFormat instance
+ */
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+
+/**
+ * Gets a cached Intl.NumberFormat instance or creates and caches a new one
+ * This allows you to replace `new Intl.NumberFormat(locale, options)` with 
+ * `getIntlNumberFormatter(locale, options)` while keeping the same API
+ * 
+ * @param locale - The locale string (e.g., 'en-US', 'fr-FR')
+ * @param options - Optional NumberFormat options
+ * @returns A cached or new Intl.NumberFormat instance
+ * 
+ * @example
+ * // Before: new Intl.NumberFormat(locale, options).format(amount)
+ * // After:  getIntlNumberFormatter(locale, options).format(amount)
+ */
+export function getIntlNumberFormatter(
+  locale: string,
+  options?: Intl.NumberFormatOptions,
+): Intl.NumberFormat {
+  const cacheKey = `${locale}${options ? JSON.stringify(options) : ''}`;
+  
+  let formatter = numberFormatCache.get(cacheKey);
+  
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    numberFormatCache.set(cacheKey, formatter);
+  }
+  
+  return formatter;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Creating new instances of `Intl` is expensive in Hermes. This PR adds simple cache for it. It improves rendering performance of `TokenList` for about 30% because it makes all `TokenListItem` component faster. This also means that there should be less blank spaces when scrolling quickly.

It could help also in other places in the app as I replaced all usages of `new Intl` with this new cached version.

## **Related issues**

Fixes:

## **Manual testing steps**

Verify that number formatting works across the app.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

~250ms average for render of `TokenList` (measured on high end device)
<img width="888" alt="Screenshot 2025-06-04 at 21 02 19" src="https://github.com/user-attachments/assets/3b316dbd-8010-49f4-874b-92e6c1ff68df" />

### **After**

~170ms average for render of `TokenList` (30% improvement)
<img width="893" alt="Screenshot 2025-06-04 at 20 59 19" src="https://github.com/user-attachments/assets/80cd18de-327f-47d9-ad8f-789a9bcaebb0" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
