### PR TITLE
fix: cp-7.47.0 migration order to cherry pick the phishing controller migration in 7.47

### DIFF
--- a/app/store/migrations/078.test.ts
+++ b/app/store/migrations/078.test.ts
@@ -1,13 +1,6 @@
-import { captureException } from '@sentry/react-native';
-import { cloneDeep } from 'lodash';
-import {
-  NetworkConfiguration,
-  RpcEndpointType,
-} from '@metamask/network-controller';
-import { Hex } from '@metamask/utils';
-
-import { ensureValidState } from './util';
 import migrate from './078';
+import { ensureValidState } from './util';
+import { captureException } from '@sentry/react-native';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
@@ -20,243 +13,142 @@ jest.mock('./util', () => ({
 const mockedCaptureException = jest.mocked(captureException);
 const mockedEnsureValidState = jest.mocked(ensureValidState);
 
-const createTestState = () => ({
-  engine: {
-    backgroundState: {
-      NetworkController: {
-        selectedNetworkClientId: 'mainnet',
-        networksMetadata: {},
-        networkConfigurationsByChainId: {
-          '0x1': {
-            chainId: '0x1',
-            rpcEndpoints: [
-              {
-                networkClientId: 'mainnet',
-                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
-                type: 'infura',
-              },
-            ],
-            defaultRpcEndpointIndex: 0,
-            blockExplorerUrls: ['https://etherscan.io'],
-            defaultBlockExplorerUrlIndex: 0,
-            name: 'Ethereum Mainnet',
-            nativeCurrency: 'ETH',
-          },
-          '0xaa36a7': {
-            chainId: '0xaa36a7',
-            rpcEndpoints: [
-              {
-                networkClientId: 'sepolia',
-                url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
-                type: 'infura',
-              },
-            ],
-            defaultRpcEndpointIndex: 0,
-            blockExplorerUrls: ['https://sepolia.etherscan.io'],
-            defaultBlockExplorerUrlIndex: 0,
-            name: 'Sepolia',
-            nativeCurrency: 'SepoliaETH',
-          },
-          '0xe705': {
-            chainId: '0xe705',
-            rpcEndpoints: [
-              {
-                networkClientId: 'linea-sepolia',
-                url: 'https://linea-sepolia.infura.io/v3/{infuraProjectId}',
-                type: 'infura',
-              },
-            ],
-            defaultRpcEndpointIndex: 0,
-            blockExplorerUrls: ['https://sepolia.lineascan.build'],
-            defaultBlockExplorerUrlIndex: 0,
-            name: 'Linea Sepolia',
-            nativeCurrency: 'LineaETH',
-          },
-          '0xe708': {
-            chainId: '0xe708',
-            rpcEndpoints: [
-              {
-                networkClientId: 'linea-mainnet',
-                url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}',
-                type: 'infura',
-              },
-            ],
-            defaultRpcEndpointIndex: 0,
-            blockExplorerUrls: ['https://lineascan.build'],
-            defaultBlockExplorerUrlIndex: 0,
-            name: 'Linea Mainnet',
-            nativeCurrency: 'ETH',
-          },
-          '0x18c6': {
-            chainId: '0x18c6',
-            rpcEndpoints: [
-              {
-                networkClientId: 'megaeth-testnet',
-                url: 'https://carrot.megaeth.com/rpc',
-                type: RpcEndpointType.Custom,
-                failoverUrls: [],
-              },
-            ],
-            defaultRpcEndpointIndex: 0,
-            blockExplorerUrls: ['https://megaexplorer.xyz'],
-            defaultBlockExplorerUrlIndex: 0,
-            name: 'Mega Testnet',
-            nativeCurrency: 'MegaETH',
-          },
-        },
-      },
-    },
-  },
-});
-
-const createMonadTestnetConfiguration = (): NetworkConfiguration => ({
-  chainId: '0x279f',
-  rpcEndpoints: [
-    {
-      networkClientId: 'monad-testnet',
-      url: 'https://testnet-rpc.monad.xyz',
-      type: RpcEndpointType.Custom,
-      failoverUrls: [],
-    },
-  ],
-  defaultRpcEndpointIndex: 0,
-  blockExplorerUrls: ['https://testnet.monadexplorer.com'],
-  defaultBlockExplorerUrlIndex: 0,
-  name: 'Monad Testnet',
-  nativeCurrency: 'MON',
-});
-
-describe('Migration 77: Add `Monad Testnet`', () => {
+describe('Migration 078: Reset PhishingController phishingLists', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('returns state unchanged if ensureValidState fails', () => {
     const state = { some: 'state' };
+
     mockedEnsureValidState.mockReturnValue(false);
 
     const migratedState = migrate(state);
 
-    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(migratedState).toBe(state);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('adds `Monad Testnet` as default network to state', () => {
-    const monadTestnetConfiguration = createMonadTestnetConfiguration();
-    const oldState = createTestState();
-    mockedEnsureValidState.mockReturnValue(true);
+  it('captures exception if engine state is invalid', () => {
+    const state = { invalidState: true };
 
-    const expectedData = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            ...oldState.engine.backgroundState.NetworkController,
-            networkConfigurationsByChainId: {
-              ...oldState.engine.backgroundState.NetworkController
-                .networkConfigurationsByChainId,
-              [monadTestnetConfiguration.chainId]: monadTestnetConfiguration,
-            },
-          },
-        },
-      },
-    };
-
-    const migratedState = migrate(oldState);
-
-    expect(migratedState).toStrictEqual(expectedData);
-    expect(mockedCaptureException).not.toHaveBeenCalled();
-  });
-
-  it('replaces `Monad Testnet` NetworkConfiguration if there is one', () => {
-    const monadTestnetConfiguration = createMonadTestnetConfiguration();
-    const oldState = createTestState();
-    const networkConfigurationsByChainId = oldState.engine.backgroundState
-      .NetworkController.networkConfigurationsByChainId as Record<
-      Hex,
-      NetworkConfiguration
-    >;
-    networkConfigurationsByChainId[monadTestnetConfiguration.chainId] = {
-      ...monadTestnetConfiguration,
-      rpcEndpoints: [
-        {
-          networkClientId: 'some-client-id',
-          url: 'https://some-url.com/rpc',
-          type: RpcEndpointType.Custom,
-        },
-      ],
-    };
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const expectedData = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            ...oldState.engine.backgroundState.NetworkController,
-            networkConfigurationsByChainId: {
-              ...oldState.engine.backgroundState.NetworkController
-                .networkConfigurationsByChainId,
-              [monadTestnetConfiguration.chainId]: monadTestnetConfiguration,
-            },
-          },
-        },
-      },
-    };
-
-    const migratedState = migrate(oldState);
-
-    expect(migratedState).toStrictEqual(expectedData);
-    expect(mockedCaptureException).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    {
-      state: {
-        engine: {},
-      },
-      test: 'empty engine state',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {},
-        },
-      },
-      test: 'empty backgroundState',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {
-            NetworkController: 'invalid',
-          },
-        },
-      },
-      test: 'invalid NetworkController state',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {
-            NetworkController: {
-              networkConfigurationsByChainId: 'invalid',
-            },
-          },
-        },
-      },
-      test: 'invalid networkConfigurationsByChainId state',
-    },
-  ])('does not modify state if the state is invalid - $test', ({ state }) => {
-    const orgState = cloneDeep(state);
     mockedEnsureValidState.mockReturnValue(true);
 
     const migratedState = migrate(state);
 
-    // State should be unchanged
-    expect(migratedState).toStrictEqual(orgState);
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        'Migration 78: NetworkController or networkConfigurationsByChainId not found in state',
-      ),
+    expect(migratedState).toEqual(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
+      'Migration 078: Invalid engine state structure',
     );
   });
-});
+
+  it('captures exception if PhishingController state is invalid', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          // PhishingController is missing
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toEqual(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
+      'Migration 078: Invalid PhishingController state',
+    );
+  });
+
+  it('resets PhishingController phishingLists to empty array and stalelistLastFetched to 0 while preserving other fields', () => {
+    interface TestState {
+      engine: {
+        backgroundState: {
+          PhishingController: {
+            c2DomainBlocklistLastFetched: number;
+            phishingLists: string[];
+            whitelist: string[];
+            hotlistLastFetched: number;
+            stalelistLastFetched: number;
+            extraProperty?: string;
+          };
+          OtherController: {
+            shouldStayUntouched: boolean;
+          };
+        };
+      };
+    }
+
+    const state: TestState = {
+      engine: {
+        backgroundState: {
+          PhishingController: {
+            c2DomainBlocklistLastFetched: 123456789,
+            phishingLists: ['list1', 'list2'],
+            whitelist: ['site1', 'site2'],
+            hotlistLastFetched: 987654321,
+            stalelistLastFetched: 123123123,
+            extraProperty: 'should remain',
+          },
+          OtherController: {
+            shouldStayUntouched: true,
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state) as typeof state;
+
+    // PhishingLists should be reset to empty array and stalelistLastFetched to 0
+    expect(migratedState.engine.backgroundState.PhishingController.phishingLists).toEqual([]);
+    expect(migratedState.engine.backgroundState.PhishingController.stalelistLastFetched).toBe(0);
+
+    // Other fields should remain unchanged
+    expect(migratedState.engine.backgroundState.PhishingController.c2DomainBlocklistLastFetched).toBe(123456789);
+    expect(migratedState.engine.backgroundState.PhishingController.whitelist).toEqual(['site1', 'site2']);
+    expect(migratedState.engine.backgroundState.PhishingController.hotlistLastFetched).toBe(987654321);
+    expect(migratedState.engine.backgroundState.PhishingController.extraProperty).toBe('should remain');
+
+    // Other controllers should remain untouched
+    expect(migratedState.engine.backgroundState.OtherController).toEqual({
+      shouldStayUntouched: true,
+    });
+
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('handles error during migration', () => {
+    // Create state with a PhishingController that throws when phishingLists is accessed
+    const state = {
+      engine: {
+        backgroundState: {
+          PhishingController: Object.defineProperty({}, 'phishingLists', {
+            get: () => {
+              throw new Error('Test error');
+            },
+            set: () => {
+              throw new Error('Test error');
+            },
+            configurable: true,
+            enumerable: true,
+          }),
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toEqual(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
+      'Migration 078: cleaning PhishingController state failed with error',
+    );
+  });
+}); 

--- a/app/store/migrations/078.test.ts
+++ b/app/store/migrations/078.test.ts
@@ -29,20 +29,6 @@ describe('Migration 078: Reset PhishingController phishingLists', () => {
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('captures exception if engine state is invalid', () => {
-    const state = { invalidState: true };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = migrate(state);
-
-    expect(migratedState).toEqual(state);
-    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
-      'Migration 078: Invalid engine state structure',
-    );
-  });
-
   it('captures exception if PhishingController state is invalid', () => {
     const state = {
       engine: {

--- a/app/store/migrations/078.ts
+++ b/app/store/migrations/078.ts
@@ -3,14 +3,14 @@ import { ensureValidState } from './util';
 import { captureException } from '@sentry/react-native';
 
 /**
- * Migration 82: Reset PhishingController phishingLists
+ * Migration 78: Reset PhishingController phishingLists
  *
  * This migration resets only the phishingLists array in the PhishingController state
  * while preserving all other state properties. This allows the app to rebuild the lists
  * while maintaining user preferences and configuration.
  */
 const migration = (state: unknown): unknown => {
-  const migrationVersion = 82;
+  const migrationVersion = 78;
 
   if (!ensureValidState(state, migrationVersion)) {
     return state;
@@ -25,7 +25,7 @@ const migration = (state: unknown): unknown => {
     ) {
       captureException(
         new Error(
-          `Migration 082: Invalid engine state structure`,
+          `Migration 078: Invalid engine state structure`,
         ),
       );
       return state;
@@ -37,7 +37,7 @@ const migration = (state: unknown): unknown => {
     ) {
       captureException(
         new Error(
-          `Migration 082: Invalid PhishingController state: '${JSON.stringify(
+          `Migration 078: Invalid PhishingController state: '${JSON.stringify(
             state.engine.backgroundState.PhishingController,
           )}'`,
         ),
@@ -54,7 +54,7 @@ const migration = (state: unknown): unknown => {
   } catch (error) {
     captureException(
       new Error(
-        `Migration 082: cleaning PhishingController state failed with error: ${error}`,
+        `Migration 078: cleaning PhishingController state failed with error: ${error}`,
       ),
     );
     return state;

--- a/app/store/migrations/078.ts
+++ b/app/store/migrations/078.ts
@@ -1,87 +1,64 @@
-import { captureException } from '@sentry/react-native';
 import { hasProperty, isObject } from '@metamask/utils';
-import {
-  type NetworkConfiguration,
-  RpcEndpointType,
-} from '@metamask/network-controller';
-import {
-  ChainId,
-  BuiltInNetworkName,
-  NetworkNickname,
-  BUILT_IN_CUSTOM_NETWORKS_RPC,
-  NetworksTicker,
-  BlockExplorerUrl,
-} from '@metamask/controller-utils';
-
 import { ensureValidState } from './util';
+import { captureException } from '@sentry/react-native';
 
 /**
- * Migration 78: Add 'Monad Testnet'
+ * Migration 82: Reset PhishingController phishingLists
  *
- * This migration add Monad Testnet to the network controller
- * as a default Testnet.
+ * This migration resets only the phishingLists array in the PhishingController state
+ * while preserving all other state properties. This allows the app to rebuild the lists
+ * while maintaining user preferences and configuration.
  */
 const migration = (state: unknown): unknown => {
-  const migrationVersion = 78;
+  const migrationVersion = 82;
 
-  // Ensure the state is valid for migration
   if (!ensureValidState(state, migrationVersion)) {
     return state;
   }
 
   try {
     if (
-      hasProperty(state, 'engine') &&
-      hasProperty(state.engine, 'backgroundState') &&
-      hasProperty(state.engine.backgroundState, 'NetworkController') &&
-      isObject(state.engine.backgroundState.NetworkController) &&
-      isObject(
-        state.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId,
-      )
+      !hasProperty(state, 'engine') ||
+      !isObject(state.engine) ||
+      !hasProperty(state.engine, 'backgroundState') ||
+      !isObject(state.engine.backgroundState)
     ) {
-      // It is possible to get the Monad Network configuration by `getDefaultNetworkConfigurationsByChainId()`,
-      // But we choose to re-define it here to prevent the need to change this file,
-      // when `getDefaultNetworkConfigurationsByChainId()` has some breaking changes in the future.
-      const networkClientId = BuiltInNetworkName.MonadTestnet;
-      const chainId = ChainId[networkClientId];
-      const monadTestnetConfiguration: NetworkConfiguration = {
-        blockExplorerUrls: [BlockExplorerUrl[networkClientId]],
-        chainId,
-        defaultRpcEndpointIndex: 0,
-        defaultBlockExplorerUrlIndex: 0,
-        name: NetworkNickname[networkClientId],
-        nativeCurrency: NetworksTicker[networkClientId],
-        rpcEndpoints: [
-          {
-            failoverUrls: [],
-            networkClientId,
-            type: RpcEndpointType.Custom,
-            url: BUILT_IN_CUSTOM_NETWORKS_RPC['monad-testnet'],
-          },
-        ],
-      };
-
-      // Regardless if the network already exists, we will overwrite it with the default configuration.
-      state.engine.backgroundState.NetworkController.networkConfigurationsByChainId[
-        chainId
-      ] = monadTestnetConfiguration;
-    } else {
       captureException(
         new Error(
-          `Migration ${migrationVersion}: NetworkController or networkConfigurationsByChainId not found in state`,
+          `Migration 082: Invalid engine state structure`,
         ),
       );
+      return state;
     }
+
+    if (
+      !hasProperty(state.engine.backgroundState, 'PhishingController') ||
+      !isObject(state.engine.backgroundState.PhishingController)
+    ) {
+      captureException(
+        new Error(
+          `Migration 082: Invalid PhishingController state: '${JSON.stringify(
+            state.engine.backgroundState.PhishingController,
+          )}'`,
+        ),
+      );
+      return state;
+    }
+
+    // Only reset the phishingLists field to an empty array
+    // while preserving all other fields
+    state.engine.backgroundState.PhishingController.phishingLists = [];
+    state.engine.backgroundState.PhishingController.stalelistLastFetched = 0;
+
     return state;
   } catch (error) {
     captureException(
       new Error(
-        `Migration ${migrationVersion}: Adding Monad Testnet failed with error: ${error}`,
+        `Migration 082: cleaning PhishingController state failed with error: ${error}`,
       ),
     );
     return state;
   }
 };
 
-export default migration;
+export default migration; 

--- a/app/store/migrations/078.ts
+++ b/app/store/migrations/078.ts
@@ -18,20 +18,6 @@ const migration = (state: unknown): unknown => {
 
   try {
     if (
-      !hasProperty(state, 'engine') ||
-      !isObject(state.engine) ||
-      !hasProperty(state.engine, 'backgroundState') ||
-      !isObject(state.engine.backgroundState)
-    ) {
-      captureException(
-        new Error(
-          `Migration 078: Invalid engine state structure`,
-        ),
-      );
-      return state;
-    }
-
-    if (
       !hasProperty(state.engine.backgroundState, 'PhishingController') ||
       !isObject(state.engine.backgroundState.PhishingController)
     ) {
@@ -61,4 +47,4 @@ const migration = (state: unknown): unknown => {
   }
 };
 
-export default migration; 
+export default migration;

--- a/app/store/migrations/082.test.ts
+++ b/app/store/migrations/082.test.ts
@@ -1,6 +1,13 @@
-import migrate from './082';
-import { ensureValidState } from './util';
 import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+import {
+  NetworkConfiguration,
+  RpcEndpointType,
+} from '@metamask/network-controller';
+import { Hex } from '@metamask/utils';
+
+import { ensureValidState } from './util';
+import migrate from './082';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
@@ -13,142 +20,243 @@ jest.mock('./util', () => ({
 const mockedCaptureException = jest.mocked(captureException);
 const mockedEnsureValidState = jest.mocked(ensureValidState);
 
-describe('Migration 082: Reset PhishingController phishingLists', () => {
+const createTestState = () => ({
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        selectedNetworkClientId: 'mainnet',
+        networksMetadata: {},
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+          },
+          '0xaa36a7': {
+            chainId: '0xaa36a7',
+            rpcEndpoints: [
+              {
+                networkClientId: 'sepolia',
+                url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://sepolia.etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Sepolia',
+            nativeCurrency: 'SepoliaETH',
+          },
+          '0xe705': {
+            chainId: '0xe705',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-sepolia',
+                url: 'https://linea-sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://sepolia.lineascan.build'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Sepolia',
+            nativeCurrency: 'LineaETH',
+          },
+          '0xe708': {
+            chainId: '0xe708',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-mainnet',
+                url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://lineascan.build'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Mainnet',
+            nativeCurrency: 'ETH',
+          },
+          '0x18c6': {
+            chainId: '0x18c6',
+            rpcEndpoints: [
+              {
+                networkClientId: 'megaeth-testnet',
+                url: 'https://carrot.megaeth.com/rpc',
+                type: RpcEndpointType.Custom,
+                failoverUrls: [],
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://megaexplorer.xyz'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Mega Testnet',
+            nativeCurrency: 'MegaETH',
+          },
+        },
+      },
+    },
+  },
+});
+
+const createMonadTestnetConfiguration = (): NetworkConfiguration => ({
+  chainId: '0x279f',
+  rpcEndpoints: [
+    {
+      networkClientId: 'monad-testnet',
+      url: 'https://testnet-rpc.monad.xyz',
+      type: RpcEndpointType.Custom,
+      failoverUrls: [],
+    },
+  ],
+  defaultRpcEndpointIndex: 0,
+  blockExplorerUrls: ['https://testnet.monadexplorer.com'],
+  defaultBlockExplorerUrlIndex: 0,
+  name: 'Monad Testnet',
+  nativeCurrency: 'MON',
+});
+
+describe('Migration 77: Add `Monad Testnet`', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('returns state unchanged if ensureValidState fails', () => {
     const state = { some: 'state' };
-
     mockedEnsureValidState.mockReturnValue(false);
 
     const migratedState = migrate(state);
 
-    expect(migratedState).toBe(state);
+    expect(migratedState).toStrictEqual({ some: 'state' });
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('captures exception if engine state is invalid', () => {
-    const state = { invalidState: true };
-
+  it('adds `Monad Testnet` as default network to state', () => {
+    const monadTestnetConfiguration = createMonadTestnetConfiguration();
+    const oldState = createTestState();
     mockedEnsureValidState.mockReturnValue(true);
 
-    const migratedState = migrate(state);
-
-    expect(migratedState).toEqual(state);
-    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
-      'Migration 082: Invalid engine state structure',
-    );
-  });
-
-  it('captures exception if PhishingController state is invalid', () => {
-    const state = {
+    const expectedData = {
       engine: {
         backgroundState: {
-          // PhishingController is missing
-        },
-      },
-    };
-
-    mockedEnsureValidState.mockReturnValue(true);
-
-    const migratedState = migrate(state);
-
-    expect(migratedState).toEqual(state);
-    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
-      'Migration 082: Invalid PhishingController state',
-    );
-  });
-
-  it('resets PhishingController phishingLists to empty array and stalelistLastFetched to 0 while preserving other fields', () => {
-    interface TestState {
-      engine: {
-        backgroundState: {
-          PhishingController: {
-            c2DomainBlocklistLastFetched: number;
-            phishingLists: string[];
-            whitelist: string[];
-            hotlistLastFetched: number;
-            stalelistLastFetched: number;
-            extraProperty?: string;
-          };
-          OtherController: {
-            shouldStayUntouched: boolean;
-          };
-        };
-      };
-    }
-
-    const state: TestState = {
-      engine: {
-        backgroundState: {
-          PhishingController: {
-            c2DomainBlocklistLastFetched: 123456789,
-            phishingLists: ['list1', 'list2'],
-            whitelist: ['site1', 'site2'],
-            hotlistLastFetched: 987654321,
-            stalelistLastFetched: 123123123,
-            extraProperty: 'should remain',
-          },
-          OtherController: {
-            shouldStayUntouched: true,
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              [monadTestnetConfiguration.chainId]: monadTestnetConfiguration,
+            },
           },
         },
       },
     };
 
-    mockedEnsureValidState.mockReturnValue(true);
+    const migratedState = migrate(oldState);
 
-    const migratedState = migrate(state) as typeof state;
-
-    // PhishingLists should be reset to empty array and stalelistLastFetched to 0
-    expect(migratedState.engine.backgroundState.PhishingController.phishingLists).toEqual([]);
-    expect(migratedState.engine.backgroundState.PhishingController.stalelistLastFetched).toBe(0);
-
-    // Other fields should remain unchanged
-    expect(migratedState.engine.backgroundState.PhishingController.c2DomainBlocklistLastFetched).toBe(123456789);
-    expect(migratedState.engine.backgroundState.PhishingController.whitelist).toEqual(['site1', 'site2']);
-    expect(migratedState.engine.backgroundState.PhishingController.hotlistLastFetched).toBe(987654321);
-    expect(migratedState.engine.backgroundState.PhishingController.extraProperty).toBe('should remain');
-
-    // Other controllers should remain untouched
-    expect(migratedState.engine.backgroundState.OtherController).toEqual({
-      shouldStayUntouched: true,
-    });
-
+    expect(migratedState).toStrictEqual(expectedData);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('handles error during migration', () => {
-    // Create state with a PhishingController that throws when phishingLists is accessed
-    const state = {
+  it('replaces `Monad Testnet` NetworkConfiguration if there is one', () => {
+    const monadTestnetConfiguration = createMonadTestnetConfiguration();
+    const oldState = createTestState();
+    const networkConfigurationsByChainId = oldState.engine.backgroundState
+      .NetworkController.networkConfigurationsByChainId as Record<
+      Hex,
+      NetworkConfiguration
+    >;
+    networkConfigurationsByChainId[monadTestnetConfiguration.chainId] = {
+      ...monadTestnetConfiguration,
+      rpcEndpoints: [
+        {
+          networkClientId: 'some-client-id',
+          url: 'https://some-url.com/rpc',
+          type: RpcEndpointType.Custom,
+        },
+      ],
+    };
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedData = {
       engine: {
         backgroundState: {
-          PhishingController: Object.defineProperty({}, 'phishingLists', {
-            get: () => {
-              throw new Error('Test error');
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              [monadTestnetConfiguration.chainId]: monadTestnetConfiguration,
             },
-            set: () => {
-              throw new Error('Test error');
-            },
-            configurable: true,
-            enumerable: true,
-          }),
+          },
         },
       },
     };
 
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      state: {
+        engine: {},
+      },
+      test: 'empty engine state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      test: 'empty backgroundState',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      test: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      test: 'invalid networkConfigurationsByChainId state',
+    },
+  ])('does not modify state if the state is invalid - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
     mockedEnsureValidState.mockReturnValue(true);
 
     const migratedState = migrate(state);
 
-    expect(migratedState).toEqual(state);
-    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockedCaptureException.mock.calls[0][0].message).toContain(
-      'Migration 082: cleaning PhishingController state failed with error',
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        'Migration 82: NetworkController or networkConfigurationsByChainId not found in state',
+      ),
     );
   });
-}); 
+});

--- a/app/store/migrations/082.ts
+++ b/app/store/migrations/082.ts
@@ -1,64 +1,87 @@
-import { hasProperty, isObject } from '@metamask/utils';
-import { ensureValidState } from './util';
 import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import {
+  type NetworkConfiguration,
+  RpcEndpointType,
+} from '@metamask/network-controller';
+import {
+  ChainId,
+  BuiltInNetworkName,
+  NetworkNickname,
+  BUILT_IN_CUSTOM_NETWORKS_RPC,
+  NetworksTicker,
+  BlockExplorerUrl,
+} from '@metamask/controller-utils';
+
+import { ensureValidState } from './util';
 
 /**
- * Migration 82: Reset PhishingController phishingLists
+ * Migration 82: Add 'Monad Testnet'
  *
- * This migration resets only the phishingLists array in the PhishingController state
- * while preserving all other state properties. This allows the app to rebuild the lists
- * while maintaining user preferences and configuration.
+ * This migration add Monad Testnet to the network controller
+ * as a default Testnet.
  */
 const migration = (state: unknown): unknown => {
   const migrationVersion = 82;
 
+  // Ensure the state is valid for migration
   if (!ensureValidState(state, migrationVersion)) {
     return state;
   }
 
   try {
     if (
-      !hasProperty(state, 'engine') ||
-      !isObject(state.engine) ||
-      !hasProperty(state.engine, 'backgroundState') ||
-      !isObject(state.engine.backgroundState)
+      hasProperty(state, 'engine') &&
+      hasProperty(state.engine, 'backgroundState') &&
+      hasProperty(state.engine.backgroundState, 'NetworkController') &&
+      isObject(state.engine.backgroundState.NetworkController) &&
+      isObject(
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId,
+      )
     ) {
+      // It is possible to get the Monad Network configuration by `getDefaultNetworkConfigurationsByChainId()`,
+      // But we choose to re-define it here to prevent the need to change this file,
+      // when `getDefaultNetworkConfigurationsByChainId()` has some breaking changes in the future.
+      const networkClientId = BuiltInNetworkName.MonadTestnet;
+      const chainId = ChainId[networkClientId];
+      const monadTestnetConfiguration: NetworkConfiguration = {
+        blockExplorerUrls: [BlockExplorerUrl[networkClientId]],
+        chainId,
+        defaultRpcEndpointIndex: 0,
+        defaultBlockExplorerUrlIndex: 0,
+        name: NetworkNickname[networkClientId],
+        nativeCurrency: NetworksTicker[networkClientId],
+        rpcEndpoints: [
+          {
+            failoverUrls: [],
+            networkClientId,
+            type: RpcEndpointType.Custom,
+            url: BUILT_IN_CUSTOM_NETWORKS_RPC['monad-testnet'],
+          },
+        ],
+      };
+
+      // Regardless if the network already exists, we will overwrite it with the default configuration.
+      state.engine.backgroundState.NetworkController.networkConfigurationsByChainId[
+        chainId
+      ] = monadTestnetConfiguration;
+    } else {
       captureException(
         new Error(
-          `Migration 082: Invalid engine state structure`,
+          `Migration ${migrationVersion}: NetworkController or networkConfigurationsByChainId not found in state`,
         ),
       );
-      return state;
     }
-
-    if (
-      !hasProperty(state.engine.backgroundState, 'PhishingController') ||
-      !isObject(state.engine.backgroundState.PhishingController)
-    ) {
-      captureException(
-        new Error(
-          `Migration 082: Invalid PhishingController state: '${JSON.stringify(
-            state.engine.backgroundState.PhishingController,
-          )}'`,
-        ),
-      );
-      return state;
-    }
-
-    // Only reset the phishingLists field to an empty array
-    // while preserving all other fields
-    state.engine.backgroundState.PhishingController.phishingLists = [];
-    state.engine.backgroundState.PhishingController.stalelistLastFetched = 0;
-
     return state;
   } catch (error) {
     captureException(
       new Error(
-        `Migration 082: cleaning PhishingController state failed with error: ${error}`,
+        `Migration ${migrationVersion}: Adding Monad Testnet failed with error: ${error}`,
       ),
     );
     return state;
   }
 };
 
-export default migration; 
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -78,11 +78,11 @@ import migration74 from './074';
 import migration75 from './075';
 import migration76 from './076';
 import migration77 from './077';
-import migration78 from './078';
+import migration78 from './082';
 import migration79 from './079';
 import migration80 from './080';
 import migration81 from './081';
-import migration82 from './082';
+import migration82 from './078';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -78,11 +78,11 @@ import migration74 from './074';
 import migration75 from './075';
 import migration76 from './076';
 import migration77 from './077';
-import migration78 from './082';
+import migration78 from './078';
 import migration79 from './079';
 import migration80 from './080';
 import migration81 from './081';
-import migration82 from './078';
+import migration82 from './082';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';


### PR DESCRIPTION
This PR is only changing the order of the migrations 78 and 82 in order to be able to cherry pick the phishing controller migration in 7-37 without causing breaking changes to the migration order. No code functionality has been changed. Only the migration number and its references. 

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
