### PR TITLE
chore: add e2e test utils for user storage

### DIFF
--- a/e2e/specs/identity/utils/helpers.js
+++ b/e2e/specs/identity/utils/helpers.js
@@ -1,3 +1,5 @@
+import { USER_STORAGE_FEATURE_NAMES } from '@metamask/profile-sync-controller/sdk';
+
 export const determineIfFeatureEntryFromURL = (url) => {
   const decodedUrl = decodeURIComponent(url);
   return (
@@ -8,3 +10,101 @@ export const determineIfFeatureEntryFromURL = (url) => {
 
 export const getDecodedProxiedURL = (url) =>
   decodeURIComponent(String(new URL(url).searchParams.get('url')));
+
+export const arrangeTestUtils = (userStorageMockttpController) => {
+  const BASE_TIMEOUT = 30000;
+  const BASE_INTERVAL = 1000;
+
+  /**
+   * Creates a counter for events and provides a way to wait until a specific number of events have been emitted
+   * @param {string} event - The event to track
+   * @returns {Object} Object containing waitUntilEventsEmittedNumberEquals function
+   */
+  const prepareEventsEmittedCounter = (event) => {
+    let counter = 0;
+    userStorageMockttpController.eventEmitter.on(event, () => {
+      counter += 1;
+    });
+
+    const waitUntilEventsEmittedNumberEquals = (expectedNumber) =>
+      new Promise((resolve, reject) => {
+        if (counter >= expectedNumber) {
+          resolve();
+          return;
+        }
+
+        const timerIds = (() => {
+          const ids = {};
+
+          ids.interval = setInterval(() => {
+            if (counter >= expectedNumber) {
+              clearInterval(ids.interval);
+              clearTimeout(ids.timeout);
+              resolve();
+            }
+          }, BASE_INTERVAL);
+
+          ids.timeout = setTimeout(() => {
+            clearInterval(ids.interval);
+            reject(
+              new Error(
+                `Timeout waiting for event ${event} to be emitted ${expectedNumber} times`,
+              ),
+            );
+          }, BASE_TIMEOUT);
+
+          return ids;
+        })();
+      });
+
+    return { waitUntilEventsEmittedNumberEquals };
+  };
+
+  /**
+   * Waits until the number of synced accounts equals the expected number
+   * @param {number} expectedNumber - The expected number of accounts
+   * @returns {Promise} Resolves when the condition is met, rejects on timeout
+   */
+  const waitUntilSyncedAccountsNumberEquals = (expectedNumber) =>
+    new Promise((resolve, reject) => {
+      const checkAccounts = () => {
+        const accounts = userStorageMockttpController.paths.get(
+          USER_STORAGE_FEATURE_NAMES.accounts,
+        )?.response;
+        return accounts?.length === expectedNumber;
+      };
+
+      if (checkAccounts()) {
+        resolve();
+        return;
+      }
+
+      const timerIds = (() => {
+        const ids = {};
+
+        ids.interval = setInterval(() => {
+          if (checkAccounts()) {
+            clearInterval(ids.interval);
+            clearTimeout(ids.timeout);
+            resolve();
+          }
+        }, BASE_INTERVAL);
+
+        ids.timeout = setTimeout(() => {
+          clearInterval(ids.interval);
+          reject(
+            new Error(
+              `Timeout waiting for synced accounts number to be ${expectedNumber}`,
+            ),
+          );
+        }, BASE_TIMEOUT);
+
+        return ids;
+      })();
+    });
+
+  return {
+    prepareEventsEmittedCounter,
+    waitUntilSyncedAccountsNumberEquals,
+  };
+};

--- a/e2e/specs/identity/utils/user-storage/userStorageMockttpController.js
+++ b/e2e/specs/identity/utils/user-storage/userStorageMockttpController.js
@@ -24,6 +24,19 @@ export const pathRegexps = {
   ),
 };
 
+export const UserStorageMockttpControllerEvents = {
+  GET_NOT_FOUND: 'GET_NOT_FOUND',
+  GET_SINGLE: 'GET_SINGLE',
+  GET_ALL: 'GET_ALL',
+  PUT_SINGLE: 'PUT_SINGLE',
+  PUT_BATCH: 'PUT_BATCH',
+  DELETE_NOT_FOUND: 'DELETE_NOT_FOUND',
+  DELETE_SINGLE: 'DELETE_SINGLE',
+  DELETE_ALL: 'DELETE_ALL',
+  DELETE_BATCH_NOT_FOUND: 'DELETE_BATCH_NOT_FOUND',
+  DELETE_BATCH: 'DELETE_BATCH',
+};
+
 export class UserStorageMockttpController {
   paths = new Map();
 
@@ -33,7 +46,7 @@ export class UserStorageMockttpController {
     const internalPathData = this.paths.get(path);
 
     if (!internalPathData) {
-      this.eventEmitter.emit('GET_NOT_FOUND', {
+      this.eventEmitter.emit(UserStorageMockttpControllerEvents.GET_NOT_FOUND, {
         path,
         statusCode,
       });
@@ -53,7 +66,7 @@ export class UserStorageMockttpController {
             getDecodedProxiedURL(request.url).split('/').pop(),
         ) || null;
 
-      this.eventEmitter.emit('GET_SINGLE', {
+      this.eventEmitter.emit(UserStorageMockttpControllerEvents.GET_SINGLE, {
         path,
         statusCode,
       });
@@ -68,7 +81,7 @@ export class UserStorageMockttpController {
       ? internalPathData.response
       : null;
 
-    this.eventEmitter.emit('GET_ALL', {
+    this.eventEmitter.emit(UserStorageMockttpControllerEvents.GET_ALL, {
       path,
       statusCode,
     });
@@ -91,10 +104,13 @@ export class UserStorageMockttpController {
       const internalPathData = this.paths.get(path);
 
       if (!internalPathData) {
-        this.eventEmitter.emit('DELETE_BATCH_NOT_FOUND', {
-          path,
-          statusCode,
-        });
+        this.eventEmitter.emit(
+          UserStorageMockttpControllerEvents.DELETE_BATCH_NOT_FOUND,
+          {
+            path,
+            statusCode,
+          },
+        );
         return {
           statusCode,
         };
@@ -107,7 +123,7 @@ export class UserStorageMockttpController {
         ),
       });
 
-      this.eventEmitter.emit('DELETE_BATCH', {
+      this.eventEmitter.emit(UserStorageMockttpControllerEvents.DELETE_BATCH, {
         path,
         statusCode,
       });
@@ -155,12 +171,15 @@ export class UserStorageMockttpController {
         }
 
         if (newOrUpdatedSingleOrBatchEntries.length === 1) {
-          this.eventEmitter.emit('PUT_SINGLE', {
-            path,
-            statusCode,
-          });
+          this.eventEmitter.emit(
+            UserStorageMockttpControllerEvents.PUT_SINGLE,
+            {
+              path,
+              statusCode,
+            },
+          );
         } else {
-          this.eventEmitter.emit('PUT_BATCH', {
+          this.eventEmitter.emit(UserStorageMockttpControllerEvents.PUT_BATCH, {
             path,
             statusCode,
           });
@@ -177,10 +196,13 @@ export class UserStorageMockttpController {
     const internalPathData = this.paths.get(path);
 
     if (!internalPathData) {
-      this.eventEmitter.emit('DELETE_NOT_FOUND', {
-        path,
-        statusCode,
-      });
+      this.eventEmitter.emit(
+        UserStorageMockttpControllerEvents.DELETE_NOT_FOUND,
+        {
+          path,
+          statusCode,
+        },
+      );
 
       return {
         statusCode,
@@ -199,7 +221,7 @@ export class UserStorageMockttpController {
         ),
       });
 
-      this.eventEmitter.emit('DELETE_SINGLE', {
+      this.eventEmitter.emit(UserStorageMockttpControllerEvents.DELETE_SINGLE, {
         path,
         statusCode,
       });
@@ -209,7 +231,7 @@ export class UserStorageMockttpController {
         response: [],
       });
 
-      this.eventEmitter.emit('DELETE_ALL', {
+      this.eventEmitter.emit(UserStorageMockttpControllerEvents.DELETE_ALL, {
         path,
         statusCode,
       });


### PR DESCRIPTION
## **Description**

This PR adds the same user-storage E2E helpers we have in extension.
Those improves user-storage related tests so that we can really on actual events instead of waiting a random delay for syncing actions to complete.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-120

## **Manual testing steps**

1. No manual testing steps as it impacts only E2E tests.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
