### PR TITLE
fix: cp-7.47.0 accounts for scientific notation in amounts

### DIFF
--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -10,6 +10,17 @@ interface UseIsInsufficientBalanceParams {
   token: BridgeToken | undefined;
 }
 
+const normalizeAmount = (value: string, decimals: number): string => {
+  // Check if the value is in scientific notation
+  if (value.includes('e') || value.includes('E')) {
+    // Convert to decimal notation using the token's decimal precision
+    const num = Number(value);
+    const result = num.toFixed(decimals);
+    return result;
+  }
+  return value;
+};
+
 const useIsInsufficientBalance = ({ amount, token }: UseIsInsufficientBalanceParams): boolean => {
   const { quoteRequest } = useSelector(selectBridgeControllerState);
   const latestBalance = useLatestBalance({
@@ -24,7 +35,9 @@ const useIsInsufficientBalance = ({ amount, token }: UseIsInsufficientBalancePar
 
   // Safety check for decimal places before parsing
   const hasValidDecimals = isValidAmount && (() => {
-    const decimalPlaces = amount.includes('.') ? amount.split('.')[1].length : 0;
+    // Convert scientific notation to decimal string if needed
+    const normalizedAmount = normalizeAmount(amount, token.decimals);
+    const decimalPlaces = normalizedAmount.includes('.') ? normalizedAmount.split('.')[1].length : 0;
     return decimalPlaces <= token.decimals;
   })();
 
@@ -32,7 +45,7 @@ const useIsInsufficientBalance = ({ amount, token }: UseIsInsufficientBalancePar
   const isInsufficientBalance = quoteRequest?.insufficientBal ||
     (isValidAmount &&
       hasValidDecimals &&
-      parseUnits(amount, token.decimals).gt(
+      parseUnits(normalizeAmount(amount, token.decimals), token.decimals).gt(
         latestBalance?.atomicBalance ?? BigNumber.from(0),
       ));
 

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -12,11 +12,15 @@ interface UseIsInsufficientBalanceParams {
 
 const normalizeAmount = (value: string, decimals: number): string => {
   // Check if the value is in scientific notation
-  if (value.includes('e') || value.includes('E')) {
+  if (value.toLowerCase().includes('e')) {
     // Convert to decimal notation using the token's decimal precision
     const num = Number(value);
-    const result = num.toFixed(decimals);
-    return result;
+    // Return '0' for invalid numbers
+    if (isNaN(num)) {
+      return '0';
+    }
+    // Remove trailing zeroes after converting from scientific notation
+    return num.toFixed(decimals).replace(/\.?0+$/, '');
   }
   return value;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Hook currently breaks if a token amount is so small that it uses scientific notation. This adds additional checks to normalize those values before passing into parseUnits.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16062

## **Manual testing steps**

1. Go to Solana swap
2. Input source token amount of 0.00001 SOL
3. Select AI16Z as destination token
4. Wait for quote
5. Click "switch tokens" arrow button
6. See no crash

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
