### PR TITLE
fix: Revert "feat(deposit): adds logout button to settings page (#16110)"

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
@@ -96,23 +96,6 @@ jest.mock('../../sdk', () => ({
   withRampSDK: jest.fn().mockImplementation((Component) => Component),
 }));
 
-const mockClearAuthToken = jest.fn();
-const mockCheckExistingToken = jest.fn();
-
-const mockUseDepositSDKInitialValues = {
-  isInternalBuild: false,
-  clearAuthToken: mockClearAuthToken,
-  isAuthenticated: false,
-  checkExistingToken: mockCheckExistingToken,
-};
-
-let mockUseDepositSDKValues = { ...mockUseDepositSDKInitialValues };
-
-jest.mock('../../../Deposit/sdk', () => ({
-  useDepositSDK: () => mockUseDepositSDKValues,
-  withDepositSDK: jest.fn().mockImplementation((Component) => Component),
-}));
-
 describe('Settings', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -124,9 +107,6 @@ describe('Settings', () => {
     };
     mockUseRampSDKValues = {
       ...mockuseRampSDKInitialValues,
-    };
-    mockUseDepositSDKValues = {
-      ...mockUseDepositSDKInitialValues,
     };
   });
 
@@ -273,52 +253,6 @@ describe('Settings', () => {
       });
       fireEvent.press(removeActivationKeyButton);
       expect(mockRemoveActivationKey).toHaveBeenCalledWith('testKey1');
-    });
-  });
-  describe('Provider Authentication', () => {
-    it('does not show logout button when not authenticated', () => {
-      mockUseDepositSDKValues = {
-        ...mockUseDepositSDKInitialValues,
-        isInternalBuild: true,
-        isAuthenticated: false,
-      };
-      render(Settings);
-      const logoutButton = screen.queryByRole('button', {
-        name: 'Log out of Transak',
-      });
-      expect(logoutButton).toBeNull();
-    });
-
-    it('shows logout button when authenticated', () => {
-      mockUseDepositSDKValues = {
-        ...mockUseDepositSDKInitialValues,
-        isInternalBuild: true,
-        isAuthenticated: true,
-      };
-      render(Settings);
-      const logoutButton = screen.getByRole('button', {
-        name: 'Log out of Transak',
-      });
-      expect(logoutButton).toBeTruthy();
-    });
-
-    it('calls clearAuthToken when pressing logout button', () => {
-      mockUseDepositSDKValues = {
-        ...mockUseDepositSDKInitialValues,
-        isInternalBuild: true,
-        isAuthenticated: true,
-      };
-      render(Settings);
-      const logoutButton = screen.getByRole('button', {
-        name: 'Log out of Transak',
-      });
-      fireEvent.press(logoutButton);
-      expect(mockClearAuthToken).toHaveBeenCalled();
-    });
-
-    it('calls checkExistingToken on component mount', () => {
-      render(Settings);
-      expect(mockCheckExistingToken).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 // Third party dependencies
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -28,20 +28,13 @@ import styles from './Settings.styles';
 
 import ListItem from '../../../../../../component-library/components/List/ListItem';
 import ListItemColumn from '../../../../../../component-library/components/List/ListItemColumn';
-import { useDepositSDK, withDepositSDK } from '../../../Deposit/sdk';
-
-const depositProviderName = 'Transak';
 
 function Settings() {
   const navigation = useNavigation();
   const { selectedRegion, setSelectedRegion, isInternalBuild } = useRampSDK();
-  const { clearAuthToken, isAuthenticated, checkExistingToken } =
-    useDepositSDK();
   const { colors } = useAppTheme();
   const style = styles();
   const trackEvent = useAnalytics();
-
-  const [displayLogoutMessage, setDisplayLogoutMessage] = useState(false);
 
   useEffect(() => {
     navigation.setOptions(
@@ -54,21 +47,12 @@ function Settings() {
     );
   }, [colors, navigation]);
 
-  useEffect(() => {
-    checkExistingToken();
-  }, [checkExistingToken]);
-
   const handleResetRegion = useCallback(() => {
     trackEvent('RAMP_REGION_RESET', {
       location: 'Settings Screen',
     });
     setSelectedRegion(null);
   }, [setSelectedRegion, trackEvent]);
-
-  const handleResetDepositAuth = useCallback(async () => {
-    await clearAuthToken();
-    setDisplayLogoutMessage(true);
-  }, [clearAuthToken]);
 
   return (
     <KeyboardAvoidingView
@@ -110,39 +94,10 @@ function Settings() {
                 <ActivationKeys />
               </Row>
             ) : null}
-
-            {isAuthenticated ? (
-              <Row>
-                <Button
-                  variant={ButtonVariants.Secondary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  onPress={handleResetDepositAuth}
-                  label={strings(
-                    'app_settings.fiat_on_ramp.deposit_provider_logout_button',
-                    {
-                      depositProviderName,
-                    },
-                  )}
-                />
-              </Row>
-            ) : null}
-            {displayLogoutMessage ? (
-              <Row>
-                <Text>
-                  {strings(
-                    'app_settings.fiat_on_ramp.deposit_provider_logged_out',
-                    {
-                      depositProviderName,
-                    },
-                  )}
-                </Text>
-              </Row>
-            ) : null}
           </ScreenLayout.Content>
         </ScreenLayout.Body>
       </ScreenLayout>
     </KeyboardAvoidingView>
   );
 }
-export default withDepositSDK(withRampSDK(Settings));
+export default withRampSDK(Settings);

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.test.tsx
@@ -133,7 +133,6 @@ describe('OtpCode Component', () => {
       setAuthToken: mockSetAuthToken,
       isAuthenticated: false,
       checkExistingToken: jest.fn(),
-      clearAuthToken: jest.fn(),
     });
 
     const { getByTestId } = render(OtpCode);

--- a/app/components/UI/Ramp/Deposit/sdk/index.test.tsx
+++ b/app/components/UI/Ramp/Deposit/sdk/index.test.tsx
@@ -396,53 +396,5 @@ describe('Deposit SDK Context', () => {
       jest.requireMock('../utils/ProviderTokenVault').getProviderToken =
         originalMock;
     });
-    it('clears authentication state when calling clearAuthToken', async () => {
-      const resetProviderTokenMock = jest.fn().mockResolvedValue(undefined);
-      jest.requireMock('../utils/ProviderTokenVault').resetProviderToken =
-        resetProviderTokenMock;
-
-      const clearAccessTokenMock = jest.fn();
-      (NativeRampsSdk as jest.Mock).mockImplementationOnce(() => ({
-        setAccessToken: jest.fn(),
-        clearAccessToken: clearAccessTokenMock,
-      }));
-
-      let contextValue: ReturnType<typeof useDepositSDK> | undefined;
-      const TestComponent = () => {
-        contextValue = useDepositSDK();
-        return <Text>Test Component</Text>;
-      };
-
-      renderWithProvider(
-        <DepositSDKProvider>
-          <TestComponent />
-        </DepositSDKProvider>,
-        { state: mockedState },
-      );
-
-      const mockToken = {
-        id: 'test-token-id',
-        accessToken: 'test-token',
-        ttl: 3600,
-        created: new Date(),
-        userId: 'test-user-id',
-      };
-
-      await act(async () => {
-        await contextValue?.setAuthToken(mockToken);
-      });
-
-      expect(contextValue?.isAuthenticated).toBe(true);
-      expect(contextValue?.authToken).toEqual(mockToken);
-
-      await act(async () => {
-        contextValue?.clearAuthToken();
-      });
-
-      expect(resetProviderTokenMock).toHaveBeenCalled();
-      expect(clearAccessTokenMock).toHaveBeenCalled();
-      expect(contextValue?.isAuthenticated).toBe(false);
-      expect(contextValue?.authToken).toBeUndefined();
-    });
   });
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1231,9 +1231,7 @@
       "key": "Key",
       "add": "Add",
       "update": "Update",
-      "cancel": "Cancel",
-      "deposit_provider_logout_button": "Log out of {{depositProviderName}}",
-      "deposit_provider_logged_out": "Logged out of {{depositProviderName}}"
+      "cancel": "Cancel"
     },
     "request_feature": "Request a feature",
     "contact_support": "Contact support",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The e2e pipeline is currently broken on main because of https://github.com/MetaMask/metamask-mobile/pull/16110. The purpose of this PR is to revert commit `dc87d4f4fbe8358517a642e77dab2fa0704010c4` so that we have a stable pipeline once again. 


The passing e2e is here: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/c832b5b8-9db1-49f6-8a6e-0cbadde3a222

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
