### PR TITLE
fix: cherry-pick 7.47.0 include gas and gas price in PPOM requests (#15836)

### DIFF
--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -559,7 +559,9 @@ class Confirm extends PureComponent {
       ],
     };
 
-    ppomUtil.validateRequest(reqObject, id);
+    ppomUtil.validateRequest(reqObject, {
+      transactionMeta,
+    });
   };
 
   componentDidUpdate = (prevProps, prevState) => {

--- a/app/core/RPCMethods/eth_sendTransaction.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.ts
@@ -114,7 +114,9 @@ async function eth_sendTransaction({
     origin: hostname,
   });
 
-  ppomUtil.validateRequest(req as PPOMRequest, transactionMeta?.id);
+  ppomUtil.validateRequest(req as PPOMRequest, {
+    transactionMeta,
+  });
 
   res.result = await result;
 }

--- a/app/core/WalletConnect/WalletConnect.js
+++ b/app/core/WalletConnect/WalletConnect.js
@@ -213,7 +213,9 @@ class WalletConnect {
                 ],
               };
 
-              ppomUtil.validateRequest(reqObject, id);
+              ppomUtil.validateRequest(reqObject, {
+                transactionMeta: trx.transactionMeta,
+              });
 
               const hash = await trx.result;
               this.approveRequest({

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -570,7 +570,6 @@ class WalletConnect2Session {
         securityAlertResponse: undefined,
       });
 
-      const id = trx.transactionMeta.id;
       const reqObject = {
         id: requestEvent.id,
         jsonrpc: '2.0',
@@ -586,7 +585,9 @@ class WalletConnect2Session {
         ],
       };
 
-      ppomUtil.validateRequest(reqObject, id);
+      ppomUtil.validateRequest(reqObject, {
+        transactionMeta: trx.transactionMeta,
+      });
       const hash = await trx.result;
 
       await this.approveRequest({ id: requestEvent.id + '', result: hash });

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -1,4 +1,7 @@
-import { normalizeTransactionParams } from '@metamask/transaction-controller';
+import {
+  normalizeTransactionParams,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import * as SignatureRequestActions from '../../actions/signatureRequest'; // eslint-disable-line import/no-namespace
 import * as TransactionActions from '../../actions/transaction'; // eslint-disable-line import/no-namespace
 import * as NetworkControllerSelectors from '../../selectors/networkController'; // eslint-disable-line import/no-namespace

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -24,6 +24,7 @@ import {
 import Logger from '../../util/Logger';
 
 const CHAIN_ID_MOCK = '0x1';
+const TRANSACTION_ID_MOCK = '111-222-333';
 
 const SIGN_TYPED_DATA_PARAMS_MOCK_1 = '0x123';
 const SIGN_TYPED_DATA_PARAMS_MOCK_2 =
@@ -99,6 +100,33 @@ const mockRequest = {
   ],
   toNative: true,
 };
+
+/** Disclaimer: the gas and gasPrice are derived from the transactionMeta.txParams */
+const mockTransactionNormalized = {
+  ...mockRequest,
+  params: [
+    {
+      from: '0x8eeee1781fd885ff5ddef7789486676961873d12',
+      to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+      value: '0x0',
+      gas: undefined,
+      gasPrice: undefined,
+    },
+  ],
+};
+
+const mockTransactionNormalizedWithGasAndGasPrice = {
+  ...mockTransactionNormalized,
+  params: [
+    {
+      ...mockTransactionNormalized.params[0],
+      gas: '0x5028',
+      gasPrice: '0x2540be400',
+    },
+  ],
+};
+
+const mockTransactionMeta = { id: CHAIN_ID_MOCK, txParams: { gas: '0x5028', gasPrice: '0x2540be400' } } as TransactionMeta;
 
 const mockSignatureRequest = {
   method: 'personal_sign',
@@ -185,7 +213,7 @@ describe('PPOM Utils', () => {
       );
       MockEngine.context.PreferencesController.state.securityAlertsEnabled =
         false;
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         0,
       );
@@ -204,7 +232,7 @@ describe('PPOM Utils', () => {
             address: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
           },
         ]);
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         0,
       );
@@ -223,7 +251,7 @@ describe('PPOM Utils', () => {
       jest
         .spyOn(NetworkControllerSelectors, 'selectChainId')
         .mockReturnValue('0xfa');
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         0,
       );
@@ -242,7 +270,7 @@ describe('PPOM Utils', () => {
           ...mockRequest,
           method: 'eth_someMethod',
         },
-        CHAIN_ID_MOCK,
+        { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta },
       );
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         0,
@@ -263,7 +291,7 @@ describe('PPOM Utils', () => {
     });
 
     it('should invoke PPOMController usePPOM if securityAlertsEnabled is true', async () => {
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         1,
       );
@@ -274,7 +302,7 @@ describe('PPOM Utils', () => {
         TransactionActions,
         'setTransactionSecurityAlertResponse',
       );
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
@@ -285,11 +313,6 @@ describe('PPOM Utils', () => {
     });
 
     it('normalizes transaction requests before validation', async () => {
-      const normalizedTransactionParamsMock = {
-        ...mockRequest.params[0],
-        data: '0xabcd',
-      };
-
       const validateMock = jest.fn();
 
       const ppomMock = {
@@ -301,21 +324,17 @@ describe('PPOM Utils', () => {
         (callback: any) => callback(ppomMock),
       );
 
-      normalizeTransactionParamsMock.mockReturnValue(
-        normalizedTransactionParamsMock,
-      );
-
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
 
       expect(normalizeTransactionParamsMock).toHaveBeenCalledTimes(1);
       expect(normalizeTransactionParamsMock).toHaveBeenCalledWith(
-        mockRequest.params[0],
+        mockTransactionNormalized.params[0],
       );
 
       expect(validateMock).toHaveBeenCalledTimes(1);
       expect(validateMock).toHaveBeenCalledWith({
         ...mockRequest,
-        params: [normalizedTransactionParamsMock],
+        params: [mockTransactionNormalized.params[0]],
       });
     });
 
@@ -327,7 +346,7 @@ describe('PPOM Utils', () => {
 
       const spyLogger = jest.spyOn(Logger, 'log');
 
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
 
       expect(spyLogger).toHaveBeenCalledTimes(1);
       expect(spyLogger).toHaveBeenCalledWith(
@@ -352,31 +371,29 @@ describe('PPOM Utils', () => {
           ...mockRequest,
           origin: 'wc::metamask.github.io',
         },
-        CHAIN_ID_MOCK,
+        { transactionMeta: mockTransactionMeta },
       );
 
       expect(normalizeTransactionParamsMock).toHaveBeenCalledTimes(1);
       expect(normalizeTransactionParamsMock).toHaveBeenCalledWith(
-        mockRequest.params[0],
+        mockTransactionNormalizedWithGasAndGasPrice.params[0],
       );
 
       expect(validateMock).toHaveBeenCalledTimes(1);
-      expect(validateMock).toHaveBeenCalledWith({
-        ...mockRequest,
-      });
+      expect(validateMock).toHaveBeenCalledWith(mockTransactionNormalizedWithGasAndGasPrice);
     });
 
     it('uses security alerts API if enabled', async () => {
       isSecurityAlertsEnabledMock.mockReturnValue(true);
 
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
 
       expect(MockEngine.context.PPOMController?.usePPOM).not.toHaveBeenCalled();
 
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
         CHAIN_ID_MOCK,
-        mockRequest,
+        mockTransactionNormalized,
       );
     });
 
@@ -387,7 +404,7 @@ describe('PPOM Utils', () => {
         new Error('Test Error'),
       );
 
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: mockTransactionMeta });
 
       expect(MockEngine.context.PPOMController?.usePPOM).toHaveBeenCalledTimes(
         1,
@@ -396,7 +413,7 @@ describe('PPOM Utils', () => {
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
         CHAIN_ID_MOCK,
-        mockRequest,
+        mockTransactionNormalizedWithGasAndGasPrice,
       );
     });
 
@@ -405,7 +422,7 @@ describe('PPOM Utils', () => {
         TransactionActions,
         'setTransactionSecurityAlertResponse',
       );
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
@@ -426,7 +443,8 @@ describe('PPOM Utils', () => {
         (callback: any) => callback(ppomMock),
       );
 
-      await PPOMUtil.validateRequest(mockRequest, CHAIN_ID_MOCK);
+      await PPOMUtil.validateRequest(mockRequest, { transactionMeta: mockTransactionMeta });
+
       expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
         chainId: CHAIN_ID_MOCK,
@@ -457,7 +475,7 @@ describe('PPOM Utils', () => {
           method,
           params,
         };
-        await PPOMUtil.validateRequest(request, CHAIN_ID_MOCK);
+        await PPOMUtil.validateRequest(request, { transactionMeta: { id: TRANSACTION_ID_MOCK } as TransactionMeta });
 
         expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
         expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -1,3 +1,4 @@
+import { createProjectLogger } from '@metamask/utils';
 import setSignatureRequestSecurityAlertResponse from '../../actions/signatureRequest';
 import { setTransactionSecurityAlertResponse } from '../../actions/transaction';
 import {
@@ -12,6 +13,8 @@ import { isBlockaidFeatureEnabled } from '../../util/blockaid';
 import Logger from '../../util/Logger';
 import { updateSecurityAlertResponse } from '../../util/transaction-controller';
 import {
+  TransactionControllerUnapprovedTransactionAddedEvent,
+  TransactionMeta,
   TransactionParams,
   normalizeTransactionParams,
 } from '@metamask/transaction-controller';
@@ -22,21 +25,35 @@ import {
   validateWithSecurityAlertsAPI,
 } from './security-alerts-api';
 import { PPOMController } from '@metamask/ppom-validator';
+import { Messenger } from '@metamask/base-controller';
+import { SignatureStateChange } from '@metamask/signature-controller';
+import cloneDeep from 'lodash/cloneDeep';
 
 export interface PPOMRequest {
   method: string;
   params: unknown[];
+
+  // Optional
+  id?: number | string;
+  jsonrpc?: string;
   origin?: string;
 }
 
-const TRANSACTION_METHOD = 'eth_sendTransaction';
-const TRANSACTION_METHODS = [TRANSACTION_METHOD, 'eth_sendRawTransaction'];
+export type PPOMMessenger = Messenger<
+  never,
+  SignatureStateChange | TransactionControllerUnapprovedTransactionAddedEvent
+>;
+
+const log = createProjectLogger('ppom-util');
+
+const METHOD_SEND_TRANSACTION = 'eth_sendTransaction';
+const TRANSACTION_METHODS = [METHOD_SEND_TRANSACTION, 'eth_sendRawTransaction'];
 export const METHOD_SIGN_TYPED_DATA_V3 = 'eth_signTypedData_v3';
 export const METHOD_SIGN_TYPED_DATA_V4 = 'eth_signTypedData_v4';
 
 const CONFIRMATION_METHODS = Object.freeze([
   'eth_sendRawTransaction',
-  TRANSACTION_METHOD,
+  METHOD_SEND_TRANSACTION,
   'eth_signTypedData',
   'eth_signTypedData_v1',
   'eth_signTypedData_v3',
@@ -58,8 +75,13 @@ const SECURITY_ALERT_RESPONSE_IN_PROGRESS = {
 
 async function validateRequest(
   req: PPOMRequest,
-  transactionId?: string,
-  securityAlertId?: string,
+  {
+    transactionMeta = {} as TransactionMeta,
+    securityAlertId,
+  }: {
+    transactionMeta?: TransactionMeta;
+    securityAlertId?: string;
+  } = {},
 ) {
   const {
     AccountsController,
@@ -74,11 +96,12 @@ async function validateRequest(
   );
   const isConfirmationMethod = CONFIRMATION_METHODS.includes(req.method);
   const isBlockaidFeatEnabled = await isBlockaidFeatureEnabled();
+
   if (!ppomController || !isBlockaidFeatEnabled || !isConfirmationMethod) {
     return;
   }
 
-  if (req.method === 'eth_sendTransaction') {
+  if (req.method === METHOD_SEND_TRANSACTION) {
     const internalAccounts = AccountsController.listAccounts();
     const { from: fromAddress, to: toAddress } = req
       ?.params?.[0] as Partial<TransactionParams>;
@@ -95,6 +118,7 @@ async function validateRequest(
   }
 
   const isTransaction = isTransactionRequest(req);
+  const transactionId = transactionMeta?.id;
   let securityAlertResponse: SecurityAlertResponse | undefined;
 
   try {
@@ -110,7 +134,9 @@ async function validateRequest(
       { securityAlertId },
     );
 
-    const normalizedRequest = normalizeRequest(req);
+    const normalizedRequest = normalizeRequest(req, transactionMeta);
+
+    log('Normalized request', normalizedRequest);
 
     securityAlertResponse = isSecurityAlertsAPIEnabled()
       ? await validateWithAPI(ppomController, chainId, normalizedRequest)
@@ -205,33 +231,68 @@ function isTransactionRequest(request: PPOMRequest) {
   return TRANSACTION_METHODS.includes(request.method);
 }
 
-function sanitizeRequest(request: PPOMRequest): PPOMRequest {
+function normalizeSignatureRequest(request: PPOMRequest): PPOMRequest {
   // This is a temporary fix to prevent a PPOM bypass
   if (
-    request.method === METHOD_SIGN_TYPED_DATA_V4 ||
-    request.method === METHOD_SIGN_TYPED_DATA_V3
+    request.method !== METHOD_SIGN_TYPED_DATA_V4 &&
+    request.method !== METHOD_SIGN_TYPED_DATA_V3
   ) {
-    if (Array.isArray(request.params)) {
-      return {
-        ...request,
-        params: request.params.slice(0, 2),
-      };
-    }
+    return request;
   }
-  return request;
+
+  if (!Array.isArray(request.params)) {
+    return request;
+  }
+
+  return {
+    ...request,
+    params: request.params.slice(0, 2),
+  };
 }
 
-function normalizeRequest(request: PPOMRequest): PPOMRequest {
-  if (request.method !== TRANSACTION_METHOD) {
-    return sanitizeRequest(request);
+function normalizeRequest(
+  request: PPOMRequest,
+  transactionMeta?: TransactionMeta
+): PPOMRequest {
+  let normalizedRequest = cloneDeep(request);
+
+  normalizedRequest = normalizeSignatureRequest(normalizedRequest);
+
+  normalizedRequest = normalizeTransactionRequest(
+    normalizedRequest,
+    transactionMeta,
+  );
+
+  return normalizedRequest;
+}
+
+function normalizeTransactionRequest(
+  request: PPOMRequest,
+  transactionMeta?: TransactionMeta,
+): PPOMRequest {
+  if (request.method !== METHOD_SEND_TRANSACTION) {
+    return request;
   }
 
   request.origin = request.origin
     ?.replace(WALLET_CONNECT_ORIGIN, '')
     ?.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, '');
 
-  const transactionParams = (request.params?.[0] || {}) as TransactionParams;
-  const normalizedParams = normalizeTransactionParams(transactionParams);
+  const txParams = (Array.isArray(request.params) ? request.params[0] : {}) as TransactionParams;
+
+  // Provide the estimated gas to PPOM rather than relying on PPOM to estimate the gas values
+  txParams.gas = transactionMeta?.txParams?.gas;
+  txParams.gasPrice = transactionMeta?.txParams?.maxFeePerGas ?? transactionMeta?.txParams?.gasPrice;
+
+  // Remove unused request params for PPOM
+  delete txParams.gasLimit;
+  delete txParams.maxFeePerGas;
+  delete txParams.maxPriorityFeePerGas;
+  delete txParams.type;
+
+  const normalizedParams = normalizeTransactionParams(txParams);
+
+  log('Normalized transaction params', normalizedParams);
 
   return {
     ...request,
@@ -244,8 +305,7 @@ function clearSignatureSecurityAlertResponse() {
 }
 
 function createValidatorForSecurityAlertId(securityAlertId: string) {
-  return (req: PPOMRequest, transactionId?: string) =>
-    validateRequest(req, transactionId, securityAlertId);
+  return (req: PPOMRequest) => validateRequest(req, { securityAlertId });
 }
 
 export default {


### PR DESCRIPTION
Cherry-picks https://github.com/MetaMask/metamask-mobile/pull/15836

Delta: 
- app/components/Views/confirmations/utils/transaction.ts does not have addMMOriginatedTransaction method yet. missing +1 -1 from this
- app/lib/ppom/ppom-util.test.ts 
  - add TransactionMeta import
  - multiple line diffs using former ppomUtil.validateRequest params
- app/lib/ppom/ppom-util.ts 1 line delta which was a line with 1 bracket
   ```
      }
   ```

----

> Similar to https://github.com/MetaMask/metamask-extension/pull/33180 with variations
> 
> - Extract gas properties from TransactionMeta.
> - Continue to pass all request properties to PPOM (Tests are expecting these, and I don't see how this would block the work in this PR)
> - Use constant names > magic names

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5005

