### PR TITLE
fix: Fix PDSN unit tests

### DIFF
--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -60,7 +60,7 @@ const useAddressBalance = (
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
   if (isPerDappSelectedNetworkEnabled() && chainId) {
     // If chainId is provided, use the accounts and ticker for that chain
-    accounts = accountsByChainId[chainId];
+    accounts = accountsByChainId[chainId] || {};
     ticker = networkConfigurationByChainId?.nativeCurrency;
   }
 


### PR DESCRIPTION
Fix `accounts` to be an object instead of `undefined` to pass tests using `useAddressBalance` hook.