### PR TITLE
Fix/cherry pick b4e508f

### DIFF
--- a/app/components/Views/AccountPermissions/AccountPermissions.tsx
+++ b/app/components/Views/AccountPermissions/AccountPermissions.tsx
@@ -67,6 +67,7 @@ import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import { getPermittedEthChainIds } from '@metamask/chain-agnostic-permission';
 import { Hex } from '@metamask/utils';
 import Routes from '../../../constants/navigation/Routes';
+import { areAddressesEqual } from '../../../util/address';
 
 const AccountPermissions = (props: AccountPermissionsProps) => {
   const { navigate } = useNavigation();
@@ -218,8 +219,11 @@ const AccountPermissions = (props: AccountPermissionsProps) => {
     };
 
     accounts.forEach((account) => {
-      const lowercasedAccount = account.address.toLowerCase();
-      if (permittedAccounts.includes(lowercasedAccount)) {
+      const isPermitted = permittedAccounts.some((permittedAccount) =>
+        areAddressesEqual(account.address, permittedAccount),
+      );
+
+      if (isPermitted) {
         accountsByPermittedStatus.permitted.push(account);
       } else {
         accountsByPermittedStatus.unpermitted.push(account);

--- a/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
@@ -193,7 +193,23 @@ exports[`AccountPermissions renders correctly 1`] = `
       </View>
       <RCTScrollView
         collapsable={false}
-        data={[]}
+        data={
+          [
+            {
+              "address": "0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272",
+              "assets": {
+                "fiatBalance": "$3200.00
+1 ETH",
+                "tokens": [],
+              },
+              "balanceError": undefined,
+              "isSelected": true,
+              "name": "Account 1",
+              "type": "HD Key Tree",
+              "yOffset": 0,
+            },
+          ]
+        }
         getItem={[Function]}
         getItemCount={[Function]}
         initialNumToRender={999}
@@ -215,7 +231,417 @@ exports[`AccountPermissions renders correctly 1`] = `
         testID="account-selector-list"
         viewabilityConfigCallbackPairs={[]}
       >
-        <View />
+        <View>
+          <View
+            onFocusCapture={[Function]}
+            onLayout={[Function]}
+            style={null}
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#4459ff1a",
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <TouchableOpacity
+                onLongPress={[Function]}
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "opacity": 1,
+                    "padding": 16,
+                    "position": "relative",
+                    "zIndex": 1,
+                  }
+                }
+                testID="select-with-menu"
+              >
+                <View
+                  accessibilityRole="none"
+                  accessible={true}
+                  style={
+                    {
+                      "alignItems": "flex-start",
+                      "flexDirection": "column",
+                      "padding": 16,
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                      "zIndex": 2,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          {
+                            "backgroundColor": "#ffffff",
+                            "borderRadius": 16,
+                            "height": 32,
+                            "marginRight": 16,
+                            "overflow": "hidden",
+                            "width": 32,
+                          }
+                        }
+                        testID="cellbase-avatar"
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "overflow": "hidden",
+                              },
+                              {
+                                "backgroundColor": "#C7144F",
+                                "borderRadius": 16,
+                                "height": 32,
+                                "width": 32,
+                              },
+                              undefined,
+                            ]
+                          }
+                        >
+                          <RNSVGSvgView
+                            bbHeight={32}
+                            bbWidth={32}
+                            focusable={false}
+                            height={32}
+                            style={
+                              [
+                                {
+                                  "backgroundColor": "transparent",
+                                  "borderWidth": 0,
+                                },
+                                {
+                                  "flex": 0,
+                                  "height": 32,
+                                  "width": 32,
+                                },
+                              ]
+                            }
+                            width={32}
+                          >
+                            <RNSVGGroup
+                              fill={
+                                {
+                                  "payload": 4278190080,
+                                  "type": 0,
+                                }
+                              }
+                            >
+                              <RNSVGRect
+                                fill={
+                                  {
+                                    "payload": 4294711651,
+                                    "type": 0,
+                                  }
+                                }
+                                height={32}
+                                matrix={
+                                  [
+                                    0.46329603511986217,
+                                    0.8862035792312145,
+                                    -0.8862035792312145,
+                                    0.46329603511986217,
+                                    29.06767649409735,
+                                    -8.290603334655817,
+                                  ]
+                                }
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                                width={32}
+                                x={0}
+                                y={0}
+                              />
+                              <RNSVGRect
+                                fill={
+                                  {
+                                    "payload": 4280576225,
+                                    "type": 0,
+                                  }
+                                }
+                                height={32}
+                                matrix={
+                                  [
+                                    -0.5778576243835052,
+                                    0.8161375900801603,
+                                    -0.8161375900801603,
+                                    -0.5778576243835052,
+                                    51.62016714634118,
+                                    17.239003094412087,
+                                  ]
+                                }
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                                width={32}
+                                x={0}
+                                y={0}
+                              />
+                              <RNSVGRect
+                                fill={
+                                  {
+                                    "payload": 4278407261,
+                                    "type": 0,
+                                  }
+                                }
+                                height={32}
+                                matrix={
+                                  [
+                                    0.7046342099635947,
+                                    -0.7095707365365209,
+                                    0.7095707365365209,
+                                    0.7046342099635947,
+                                    -25.225718686778755,
+                                    -4.611026307883787,
+                                  ]
+                                }
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                                width={32}
+                                x={0}
+                                y={0}
+                              />
+                            </RNSVGGroup>
+                          </RNSVGSvgView>
+                        </View>
+                      </View>
+                      <View
+                        style={
+                          {
+                            "alignItems": "flex-start",
+                            "flex": 1,
+                          }
+                        }
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          numberOfLines={1}
+                          style={
+                            {
+                              "color": "#121314",
+                              "fontFamily": "CentraNo1-Book",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            }
+                          }
+                          testID="cellbase-avatar-title"
+                        >
+                          Account 1
+                        </Text>
+                        <TouchableOpacity
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessible={true}
+                          focusable={false}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "flex-start",
+                              "flexDirection": "row",
+                              "marginBottom": 0,
+                              "zIndex": 1,
+                            }
+                          }
+                        >
+                          <Text
+                            accessibilityRole="text"
+                            numberOfLines={1}
+                            style={
+                              {
+                                "color": "#686e7d",
+                                "fontFamily": "CentraNo1-Book",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                              }
+                            }
+                          >
+                            0xC4955...4D272
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+                      <View
+                        style={
+                          {
+                            "marginLeft": 16,
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "alignItems": "flex-end",
+                              "flexDirection": "column",
+                            }
+                          }
+                          testID="account-balance-by-address-0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272"
+                        >
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              {
+                                "color": "#121314",
+                                "fontFamily": "CentraNo1-Book",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "right",
+                              }
+                            }
+                          >
+                            $3200.00
+                          </Text>
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              {
+                                "color": "#121314",
+                                "fontFamily": "CentraNo1-Book",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "right",
+                              }
+                            }
+                          >
+                            1 ETH
+                          </Text>
+                          <View
+                            style={
+                              {
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                              }
+                            }
+                          />
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  accessibilityRole="checkbox"
+                  accessible={true}
+                  style={
+                    {
+                      "backgroundColor": "#4459ff1a",
+                      "bottom": 0,
+                      "flexDirection": "row",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": 4,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "backgroundColor": "#4459ff",
+                        "borderRadius": 2,
+                        "marginLeft": 4,
+                        "marginVertical": 4,
+                        "width": 4,
+                      }
+                    }
+                  />
+                </View>
+              </TouchableOpacity>
+              <View
+                style={
+                  {
+                    "paddingRight": 20,
+                  }
+                }
+              >
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  disabled={false}
+                  onPress={[Function]}
+                  onPressIn={[Function]}
+                  onPressOut={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "borderRadius": 8,
+                      "height": 24,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "width": 24,
+                    }
+                  }
+                  testID="main-wallet-account-actions-0"
+                >
+                  <SvgMock
+                    color="#121314"
+                    fill="currentColor"
+                    height={16}
+                    name="MoreVertical"
+                    style={
+                      {
+                        "height": 16,
+                        "width": 16,
+                      }
+                    }
+                    width={16}
+                  />
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </View>
       </RCTScrollView>
       <View
         style={


### PR DESCRIPTION
This fix corrects a [mistake that was made in the cherry-pick-b4e508f PR](https://github.com/MetaMask/metamask-mobile/pull/16167/files#diff-aff760bbb7dc29d07e6efd6c3e9b9bcde7f9c7cbed2fb2981a0f806ac075c8e7L196).

>[!NOTE]
> DO NOT INCLUDE IN CHANGELOG

- A bug was introduced in the [`cherry-pick-b4e508f` PR](https://github.com/MetaMask/metamask-mobile/pull/16167/files#diff-aff760bbb7dc29d07e6efd6c3e9b9bcde7f9c7cbed2fb2981a0f806ac075c8e7L196) due to a stale release branch.  
- An important logic update in the `AccountsPermission` component was missed during the cherry-pick.  
- I prematurely updated the snapshot, unaware that it relied on outdated logic.  
- The new snapshot was incorrect, missing accounts data because of a format mismatch.  
- The component now uses the `areAddressesEqual` function to properly compare addresses:  
  - Ethereum addresses: case-insensitive comparison  
  - Non-Ethereum addresses: case-sensitive comparison  
- The snapshot now correctly matches what it was in `release/7.47.0` before the faulty cherry-pick.