### PR TITLE
fix: regression tests

### DIFF
--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -26,9 +26,9 @@ class CreatePasswordView {
     );
   }
 
-  get iUnderstandCheckboxPlatformSpecific() {
+  get iUnderstandCheckboxNewWallet() {
     return Matchers.getElementByID(
-      ChoosePasswordSelectorsIDs.CREATE_PASSWORD_I_UNDERSTAND_BUTTON_ID,
+      ChoosePasswordSelectorsIDs.CREATE_WALLET_I_UNDERSTAND_BUTTON_ID,
      );
   }
 
@@ -63,7 +63,7 @@ class CreatePasswordView {
       await Gestures.tap(this.iUnderstandCheckbox);
     } catch (error) {
       // Fall back to platform-specific checkbox (used in onboarding flow)
-      await Gestures.tap(this.iUnderstandCheckboxPlatformSpecific);
+      await Gestures.tap(this.iUnderstandCheckboxNewWallet);
     }
   }
 

--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -27,13 +27,9 @@ class CreatePasswordView {
   }
 
   get iUnderstandCheckboxPlatformSpecific() {
-    return device.getPlatform() === 'ios'
-      ? Matchers.getElementByID(
-          ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
-        )
-      : Matchers.getElementByID(
-          ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
-        );
+    return Matchers.getElementByID(
+      ChoosePasswordSelectorsIDs.CREATE_PASSWORD_I_UNDERSTAND_BUTTON_ID,
+     );
   }
 
   get submitButton() {

--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -21,6 +21,12 @@ class CreatePasswordView {
   }
 
   get iUnderstandCheckbox() {
+    return Matchers.getElementByID(
+      ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
+    );
+  }
+
+  get iUnderstandCheckboxPlatformSpecific() {
     return device.getPlatform() === 'ios'
       ? Matchers.getElementByID(
           ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
@@ -56,7 +62,13 @@ class CreatePasswordView {
   }
 
   async tapIUnderstandCheckBox() {
-    await Gestures.waitAndTap(this.iUnderstandCheckbox);
+    try {
+      // Try the generic checkbox first (used in import flow)
+      await Gestures.waitAndTap(this.iUnderstandCheckbox);
+    } catch (error) {
+      // Fall back to platform-specific checkbox (used in onboarding flow)
+      await Gestures.waitAndTap(this.iUnderstandCheckboxPlatformSpecific);
+    }
   }
 
   async tapCreatePasswordButton() {

--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -64,10 +64,10 @@ class CreatePasswordView {
   async tapIUnderstandCheckBox() {
     try {
       // Try the generic checkbox first (used in import flow)
-      await Gestures.waitAndTap(this.iUnderstandCheckbox);
+      await Gestures.tap(this.iUnderstandCheckbox);
     } catch (error) {
       // Fall back to platform-specific checkbox (used in onboarding flow)
-      await Gestures.waitAndTap(this.iUnderstandCheckboxPlatformSpecific);
+      await Gestures.tap(this.iUnderstandCheckboxPlatformSpecific);
     }
   }
 

--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -21,9 +21,13 @@ class CreatePasswordView {
   }
 
   get iUnderstandCheckbox() {
-    return Matchers.getElementByID(
-      ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
-    );
+    return device.getPlatform() === 'ios'
+      ? Matchers.getElementByID(
+          ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
+        )
+      : Matchers.getElementByID(
+          ChoosePasswordSelectorsIDs.ANDROID_I_UNDERSTAND_BUTTON_ID,
+        );
   }
 
   get submitButton() {

--- a/e2e/pages/Onboarding/CreatePasswordView.js
+++ b/e2e/pages/Onboarding/CreatePasswordView.js
@@ -32,7 +32,7 @@ class CreatePasswordView {
           ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
         )
       : Matchers.getElementByID(
-          ChoosePasswordSelectorsIDs.ANDROID_I_UNDERSTAND_BUTTON_ID,
+          ChoosePasswordSelectorsIDs.IOS_I_UNDERSTAND_BUTTON_ID,
         );
   }
 

--- a/e2e/pages/Settings/SecurityAndPrivacy/ChangePasswordView.js
+++ b/e2e/pages/Settings/SecurityAndPrivacy/ChangePasswordView.js
@@ -61,7 +61,9 @@ class ChangePasswordView {
   }
 
   async tapSubmitButton() {
-    await Gestures.waitAndTap(this.submitButton);
+    if (device.getPlatform() === 'android') {
+      await Gestures.waitAndTap(this.submitButton);
+    }
   }
 }
 

--- a/e2e/pages/Settings/SecurityAndPrivacy/ChangePasswordView.js
+++ b/e2e/pages/Settings/SecurityAndPrivacy/ChangePasswordView.js
@@ -36,6 +36,12 @@ class ChangePasswordView {
     );
   }
 
+  get submitButton() {
+    return Matchers.getElementByID(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
+  }
+
   async typeInConfirmPasswordInputBox(PASSWORD) {
     await Gestures.typeTextAndHideKeyboard(this.passwordInput, PASSWORD);
   }
@@ -52,6 +58,10 @@ class ChangePasswordView {
       await TestHelpers.delay(1000);
       await Gestures.waitAndTap(this.androidUnderstandCheck);
     }
+  }
+
+  async tapSubmitButton() {
+    await Gestures.waitAndTap(this.submitButton);
   }
 }
 

--- a/e2e/selectors/Onboarding/ChoosePassword.selectors.js
+++ b/e2e/selectors/Onboarding/ChoosePassword.selectors.js
@@ -5,6 +5,7 @@ export const ChoosePasswordSelectorsIDs = {
   CONFIRM_PASSWORD_INPUT_ID: 'create-password-second-input-field',
   IOS_I_UNDERSTAND_BUTTON_ID: 'password-understand-box',
   ANDROID_I_UNDERSTAND_BUTTON_ID: 'i-understand-text',
+  CREATE_PASSWORD_I_UNDERSTAND_BUTTON_ID: 'password-understand-box',
   I_UNDERSTAND_CHECKBOX_ID: 'i-understand-checkbox',
   SUBMIT_BUTTON_ID: 'submit-button',
 };

--- a/e2e/selectors/Onboarding/ChoosePassword.selectors.js
+++ b/e2e/selectors/Onboarding/ChoosePassword.selectors.js
@@ -5,7 +5,7 @@ export const ChoosePasswordSelectorsIDs = {
   CONFIRM_PASSWORD_INPUT_ID: 'create-password-second-input-field',
   IOS_I_UNDERSTAND_BUTTON_ID: 'password-understand-box',
   ANDROID_I_UNDERSTAND_BUTTON_ID: 'i-understand-text',
-  CREATE_PASSWORD_I_UNDERSTAND_BUTTON_ID: 'password-understand-box',
+  CREATE_WALLET_I_UNDERSTAND_BUTTON_ID: 'password-understand-box',
   I_UNDERSTAND_CHECKBOX_ID: 'i-understand-checkbox',
   SUBMIT_BUTTON_ID: 'submit-button',
 };

--- a/e2e/specs/assets/transaction.spec.js
+++ b/e2e/specs/assets/transaction.spec.js
@@ -16,6 +16,7 @@ import {
 import Assertions from '../../utils/Assertions';
 import WalletView from '../../pages/wallet/WalletView';
 import TokenOverview from '../../pages/wallet/TokenOverview';
+import { mockEvents } from '../../api-mocking/mock-config/mock-events';
 
 describe(Regression('Transaction'), () => {
 
@@ -34,6 +35,9 @@ describe(Regression('Transaction'), () => {
         fixture: new FixtureBuilder().withPopularNetworks().build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
+        testSpecificMock: {
+          GET: [mockEvents.GET.remoteFeatureFlagsOldConfirmations],
+        },
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/assets/transaction.spec.js
+++ b/e2e/specs/assets/transaction.spec.js
@@ -16,7 +16,6 @@ import {
 import Assertions from '../../utils/Assertions';
 import WalletView from '../../pages/wallet/WalletView';
 import TokenOverview from '../../pages/wallet/TokenOverview';
-import { mockEvents } from '../../api-mocking/mock-config/mock-events';
 
 describe(Regression('Transaction'), () => {
 
@@ -35,9 +34,6 @@ describe(Regression('Transaction'), () => {
         fixture: new FixtureBuilder().withPopularNetworks().build(),
         restartDevice: true,
         ganacheOptions: defaultGanacheOptions,
-        testSpecificMock: {
-          GET: [mockEvents.GET.remoteFeatureFlagsOldConfirmations],
-        },
       },
       async () => {
         await loginToApp();

--- a/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
@@ -31,10 +31,10 @@ describe(
 
     it('should be able to opt-in of the onboarding-wizard', async () => {
       await OnboardingCarouselView.tapOnGetStartedButton();
+      await acceptTermOfUse();
       await OnboardingView.tapCreateWallet();
       await Assertions.checkIfVisible(MetaMetricsOptIn.container);
       await MetaMetricsOptIn.tapAgreeButton();
-      await acceptTermOfUse();
       await Assertions.checkIfVisible(CreatePasswordView.container);
     });
 

--- a/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
@@ -72,6 +72,7 @@ describe(
     it('should dismiss the protect your wallet modal', async () => {
       await Assertions.checkIfVisible(
         ProtectYourWalletModal.collapseWalletModal,
+        { timeout: 25000 },
       );
       await TestHelpers.delay(1000);
       await ProtectYourWalletModal.tapRemindMeLaterButton();

--- a/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
@@ -72,7 +72,6 @@ describe(
     it('should dismiss the protect your wallet modal', async () => {
       await Assertions.checkIfVisible(
         ProtectYourWalletModal.collapseWalletModal,
-        25000,
       );
       await TestHelpers.delay(1000);
       await ProtectYourWalletModal.tapRemindMeLaterButton();

--- a/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
+++ b/e2e/specs/onboarding/onboarding-wizard-opt-in.spec.js
@@ -72,7 +72,7 @@ describe(
     it('should dismiss the protect your wallet modal', async () => {
       await Assertions.checkIfVisible(
         ProtectYourWalletModal.collapseWalletModal,
-        { timeout: 25000 },
+        25000,
       );
       await TestHelpers.delay(1000);
       await ProtectYourWalletModal.tapRemindMeLaterButton();

--- a/e2e/specs/onboarding/term-of-use.spec.js
+++ b/e2e/specs/onboarding/term-of-use.spec.js
@@ -17,10 +17,6 @@ describe(Regression('Term of Use Modal'), () => {
     await Assertions.checkIfVisible(OnboardingCarouselView.container);
     await OnboardingCarouselView.tapOnGetStartedButton();
 
-    await Assertions.checkIfVisible(OnboardingView.container);
-    await OnboardingView.tapImportWalletFromSeedPhrase();
-
-    await MetaMetricsOptIn.tapAgreeButton();
     await Assertions.checkIfVisible(TermsOfUseModal.container);
   });
 
@@ -28,8 +24,7 @@ describe(Regression('Term of Use Modal'), () => {
     await TestHelpers.relaunchApp();
     await Assertions.checkIfVisible(OnboardingCarouselView.container);
     await OnboardingCarouselView.tapOnGetStartedButton();
-    await Assertions.checkIfVisible(OnboardingView.container);
-    await OnboardingView.tapImportWalletFromSeedPhrase();
+    
     await Assertions.checkIfVisible(TermsOfUseModal.container);
   });
 
@@ -38,15 +33,16 @@ describe(Regression('Term of Use Modal'), () => {
     await TermsOfUseModal.tapAgreeCheckBox();
     await TermsOfUseModal.tapAcceptButton();
     await Assertions.checkIfNotVisible(TermsOfUseModal.container);
-    await Assertions.checkIfVisible(ImportWalletView.container);
+    
+    await Assertions.checkIfVisible(OnboardingView.container);
   });
 
   it('should restart app after accepting terms', async () => {
     await TestHelpers.relaunchApp();
     await Assertions.checkIfVisible(OnboardingCarouselView.container);
     await OnboardingCarouselView.tapOnGetStartedButton();
-    await Assertions.checkIfVisible(OnboardingView.container);
-    await OnboardingView.tapImportWalletFromSeedPhrase();
+    
     await Assertions.checkIfNotVisible(TermsOfUseModal.container);
+    await Assertions.checkIfVisible(OnboardingView.container);
   });
 });

--- a/e2e/specs/settings/delete-wallet.spec.js
+++ b/e2e/specs/settings/delete-wallet.spec.js
@@ -48,6 +48,7 @@ describe(
         await ChangePasswordView.tapIUnderstandCheckBox();
         await ChangePasswordView.typeInConfirmPasswordInputBox(NEW_PASSWORD);
         await ChangePasswordView.reEnterPassword(NEW_PASSWORD);
+        await ChangePasswordView.tapSubmitButton();
 
         // should lock wallet from Settings
         await CommonView.tapBackButton();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR addresses multiple E2E test failures across the MetaMask mobile app by fixing selector mismatches, UI flow changes, and platform-specific compatibility issues. The fixes ensure tests work reliably across both iOS and Android platforms.
### Root Issues Identified

- Confirmation UI Migration: The app had transitioned to a new confirmation UI by default, but tests were still using selectors from the legacy confirmation interface
- Terms of Use Flow Changes: The Terms of Use modal now appears earlier in the onboarding flow, blocking access to subsequent screens
- Platform-Specific Selector Conflicts: Cross-platform differences in checkbox and button selectors causing test failures
- Feature Flag Conflicts: Tests needed to force specific UI states for consistent behavior

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
