### PR TITLE
feat: added e2e for two connected dapps

### DIFF
--- a/app/components/UI/Tabs/TabThumbnail/TabThumbnail.tsx
+++ b/app/components/UI/Tabs/TabThumbnail/TabThumbnail.tsx
@@ -71,6 +71,7 @@ const TabThumbnail = ({
         accessibilityLabel={strings('browser.switch_tab')}
         onPress={() => onSwitch(tab)}
         style={[styles.tabWrapper, isActiveTab && styles.activeTab]}
+        testID={`browser-tab-${tab.id}`}
       >
         <View style={styles.tabHeader}>
           <View style={styles.titleButton}>
@@ -89,6 +90,7 @@ const TabThumbnail = ({
             accessibilityLabel={strings('browser.close_tab')}
             onPress={() => onClose(tab)}
             hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
+            testID={`tab-close-button-${tab.id}`}
           >
             <Icon
               name={IconName.Close}

--- a/app/components/UI/Tabs/TabThumbnail/__snapshots__/TabThumbnail.test.tsx.snap
+++ b/app/components/UI/Tabs/TabThumbnail/__snapshots__/TabThumbnail.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`TabThumbnail should render correctly 1`] = `
         },
       ]
     }
+    testID="browser-tab-123"
   >
     <View
       style={
@@ -122,6 +123,7 @@ exports[`TabThumbnail should render correctly 1`] = `
           }
         }
         onPress={[Function]}
+        testID="tab-close-button-123"
       >
         <SvgMock
           color="#121314"

--- a/app/components/UI/Tabs/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Tabs/__snapshots__/index.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`Tabs should render correctly 1`] = `
               false,
             ]
           }
+          testID="browser-tab-1"
         >
           <View
             style={
@@ -149,6 +150,7 @@ exports[`Tabs should render correctly 1`] = `
                 }
               }
               onPress={[Function]}
+              testID="tab-close-button-1"
             >
               <SvgMock
                 color="#121314"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,7 +214,7 @@ stages:
   #     - run_tag_multichain_permissions_android: {}
   run_smoke_e2e_ios_android_stage:
     workflows:
-      - run_ios_api_specs: {}
+      # - run_ios_api_specs: {}
       - run_trade_swimlane_ios_smoke: {}
       - run_trade_swimlane_android_smoke: {}
       - run_network_abstraction_swimlane_ios_smoke: {}
@@ -238,7 +238,7 @@ stages:
     workflows:
       - ios_run_regression_tests: {}
       - android_run_regression_tests: {}
-      - run_ios_api_specs: {}
+      # - run_ios_api_specs: {}
       - run_trade_swimlane_ios_smoke: {}
       - run_trade_swimlane_android_smoke: {}
       - run_network_expansion_swimlane_ios_smoke: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,7 +214,7 @@ stages:
   #     - run_tag_multichain_permissions_android: {}
   run_smoke_e2e_ios_android_stage:
     workflows:
-      # - run_ios_api_specs: {}
+      - run_ios_api_specs: {}
       - run_trade_swimlane_ios_smoke: {}
       - run_trade_swimlane_android_smoke: {}
       - run_network_abstraction_swimlane_ios_smoke: {}
@@ -238,7 +238,7 @@ stages:
     workflows:
       - ios_run_regression_tests: {}
       - android_run_regression_tests: {}
-      # - run_ios_api_specs: {}
+      - run_ios_api_specs: {}
       - run_trade_swimlane_ios_smoke: {}
       - run_trade_swimlane_android_smoke: {}
       - run_network_expansion_swimlane_ios_smoke: {}

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -258,6 +258,20 @@ class FixtureBuilder {
                     },
                   ],
                 },
+                '0xe708': {
+                  blockExplorerUrls: [],
+                  chainId: '0xe708',
+                  defaultRpcEndpointIndex: 0,
+                  name: 'Linea Main Network',
+                  nativeCurrency: 'LineaETH',
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'linea-mainnet',
+                      type: 'infura',
+                      url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}',
+                    },
+                  ],
+                },
               },
             },
             PhishingController: {
@@ -455,11 +469,6 @@ class FixtureBuilder {
             {
               url: 'https://google.com',
               id: 1692550481062,
-            },
-            {
-              url: `http://localhost:${getSecondTestDappPort()}`,
-              id: 1749234797566,
-              isArchived: false,
             },
           ],
           activeTab: 1692550481062,

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { device } from 'detox';
-import { getGanachePort, getSecondTestDappPort } from './utils';
+import { getGanachePort, getSecondTestDappLocalUrl } from './utils';
 import { merge } from 'lodash';
 import { CustomNetworks, PopularNetworksList } from '../resources/networks.e2e';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -471,7 +471,7 @@ class FixtureBuilder {
               id: 1692550481062,
             },
             {
-              url: `http://${device.getPlatform() === 'android' ? '10.0.2.2' : '127.0.0.1'}:${getSecondTestDappPort()}`,
+              url: getSecondTestDappLocalUrl(),
               id: 1749234797566,
               isArchived: false,
             },

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -470,6 +470,11 @@ class FixtureBuilder {
               url: 'https://google.com',
               id: 1692550481062,
             },
+            {
+              url: `http://localhost:${getSecondTestDappPort()}`,
+              id: 1749234797566,
+              isArchived: false,
+            },
           ],
           activeTab: 1692550481062,
         },

--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-import { getGanachePort } from './utils';
+import { getGanachePort, getSecondTestDappPort } from './utils';
 import { merge } from 'lodash';
 import { CustomNetworks, PopularNetworksList } from '../resources/networks.e2e';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -304,7 +304,7 @@ class FixtureBuilder {
                       'eth_signTypedData_v4',
                     ],
                     type: 'eip155:eoa',
-                    scopes: ['eip155:0']
+                    scopes: ['eip155:0'],
                   },
                 },
                 selectedAccount: '4d7a5e0b-b261-4aed-8126-43972b0fa0a1',
@@ -455,6 +455,11 @@ class FixtureBuilder {
             {
               url: 'https://google.com',
               id: 1692550481062,
+            },
+            {
+              url: `http://localhost:${getSecondTestDappPort()}`,
+              id: 1749234797566,
+              isArchived: false,
             },
           ],
           activeTab: 1692550481062,

--- a/e2e/fixtures/utils.js
+++ b/e2e/fixtures/utils.js
@@ -41,6 +41,11 @@ export function getMockServerPort() {
   return getServerPort(DEFAULT_MOCKSERVER_PORT);
 }
 
+export function getSecondTestDappPort() {
+  // Use a different base port for the second dapp
+  return getServerPort(DEFAULT_DAPP_SERVER_PORT + 1);
+}
+
 export function buildPermissions(chainIds) {
   // default mainnet
   const optionalScopes = { 'eip155:1': { accounts: [] } };

--- a/e2e/fixtures/utils.js
+++ b/e2e/fixtures/utils.js
@@ -3,7 +3,7 @@ import {
   Caip25EndowmentPermissionName,
 } from '@metamask/chain-agnostic-permission';
 import { DEFAULT_GANACHE_PORT } from '../../app/util/test/ganache';
-import {DEFAULT_ANVIL_PORT} from '../../e2e/seeder/anvil-manager';
+import { DEFAULT_ANVIL_PORT } from '../../e2e/seeder/anvil-manager';
 import { DEFAULT_FIXTURE_SERVER_PORT } from './fixture-server';
 import { DEFAULT_DAPP_SERVER_PORT } from './fixture-helper';
 export const DEFAULT_MOCKSERVER_PORT = 8000;
@@ -22,6 +22,20 @@ function getServerPort(defaultPort) {
   }
   return defaultPort;
 }
+
+/**
+ * Gets the URL for the second test dapp.
+ * This function is used instead of a constant to ensure device.getPlatform() is called
+ * after Detox is properly initialized, preventing initialization errors in the apiSpecs tests.
+ *
+ * @returns {string} The URL for the second test dapp
+ */
+export function getSecondTestDappLocalUrl() {
+  const host = device.getPlatform() === 'android' ? '10.0.2.2' : '127.0.0.1';
+  return `http://${host}:${getSecondTestDappPort()}`;
+}
+
+export const TEST_DAPP_LOCAL_URL = `http://localhost:${getLocalTestDappPort()}`;
 
 export function getGanachePort() {
   return getServerPort(DEFAULT_GANACHE_PORT);

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -4,6 +4,7 @@ import {
   getGanachePort,
   getLocalTestDappPort,
   getMockServerPort,
+  getSecondTestDappPort,
 } from './fixtures/utils';
 import Utilities from './utils/Utilities';
 import { resolveConfig } from 'detox/internals';
@@ -378,6 +379,7 @@ export default class TestHelpers {
       await device.reverseTcpPort(getGanachePort());
       await device.reverseTcpPort(getFixturesServerPort());
       await device.reverseTcpPort(getLocalTestDappPort());
+      await device.reverseTcpPort(getSecondTestDappPort());
       await device.reverseTcpPort(getMockServerPort());
     }
   }

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../helpers';
-import { TEST_DAPP_LOCAL_URL,SECOND_TEST_DAPP_LOCAL_URL } from './TestDApp';
+import { TEST_DAPP_LOCAL_URL, SECOND_TEST_DAPP_LOCAL_URL } from './TestDApp';
 import {
   BrowserViewSelectorsIDs,
   BrowserViewSelectorsText,
@@ -137,16 +137,33 @@ class Browser {
   }
 
   async tapOpenAllTabsButton() {
-    await Gestures.waitAndTap(this.tabsButton);
+    await Gestures.waitAndTap(this.tabsButton, { delayBeforeTap: 4000 });
   }
 
   async tapSecondTabButton() {
-    const secondTab = Matchers.getElementByText('localhost', 1);
+    // the interger value is the tabID.
+    // This value comes from the `browser` object in fixture builder
+
+    const secondTab = Matchers.getElementByID('browser-tab-1749234797566');
+    await Gestures.waitAndTap(secondTab);
+  }
+
+  async tapFirstTabButton() {
+    // the interger value is the tabID.
+    // This value comes from the `browser` object in fixture builder
+    const secondTab = Matchers.getElementByID('browser-tab-1692550481062');
     await Gestures.waitAndTap(secondTab);
   }
 
   async tapCloseTabsButton() {
     await Gestures.waitAndTap(this.closeAllTabsButton);
+  }
+
+  async tapCloseSecondTabButton() {
+    // the interger value is the tabID.
+    // This value comes from the `browser` object in fixture builder
+    const secondTab = Matchers.getElementByID('tab-close-button-1749234797566');
+    await Gestures.waitAndTap(secondTab);
   }
 
   async tapOpenNewTabButton() {

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../helpers';
-import { TEST_DAPP_LOCAL_URL } from './TestDApp';
+import { TEST_DAPP_LOCAL_URL,SECOND_TEST_DAPP_LOCAL_URL } from './TestDApp';
 import {
   BrowserViewSelectorsIDs,
   BrowserViewSelectorsText,
@@ -201,6 +201,11 @@ class Browser {
   async navigateToTestDApp() {
     await this.tapUrlInputBox();
     await this.navigateToURL(TEST_DAPP_LOCAL_URL);
+    await waitForTestDappToLoad();
+  }
+  async navigateToSecondTestDApp() {
+    await this.tapUrlInputBox();
+    await this.navigateToURL(SECOND_TEST_DAPP_LOCAL_URL);
     await waitForTestDappToLoad();
   }
 

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -1,5 +1,4 @@
 import TestHelpers from '../../helpers';
-import { TEST_DAPP_LOCAL_URL, SECOND_TEST_DAPP_LOCAL_URL } from './TestDApp';
 import {
   BrowserViewSelectorsIDs,
   BrowserViewSelectorsText,
@@ -11,6 +10,7 @@ import { AddBookmarkViewSelectorsIDs } from '../../selectors/Browser/AddBookmark
 import Gestures from '../../utils/Gestures';
 import Matchers from '../../utils/Matchers';
 import { waitForTestDappToLoad } from '../../viewHelper';
+import { TEST_DAPP_LOCAL_URL,getSecondTestDappLocalUrl } from '../../fixtures/utils';
 
 class Browser {
   get searchButton() {
@@ -222,7 +222,7 @@ class Browser {
   }
   async navigateToSecondTestDApp() {
     await this.tapUrlInputBox();
-    await this.navigateToURL(SECOND_TEST_DAPP_LOCAL_URL);
+    await this.navigateToURL(getSecondTestDappLocalUrl());
     await waitForTestDappToLoad();
   }
 

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -140,6 +140,11 @@ class Browser {
     await Gestures.waitAndTap(this.tabsButton);
   }
 
+  async tapSecondTabButton() {
+    const secondTab = Matchers.getElementByText('localhost', 1);
+    await Gestures.waitAndTap(secondTab);
+  }
+
   async tapCloseTabsButton() {
     await Gestures.waitAndTap(this.closeAllTabsButton);
   }
@@ -190,7 +195,7 @@ class Browser {
   }
 
   async waitForBrowserPageToLoad() {
-    await TestHelpers.delay(5000);
+    await TestHelpers.delay(20000);
   }
 
   async navigateToTestDApp() {

--- a/e2e/pages/Browser/BrowserView.js
+++ b/e2e/pages/Browser/BrowserView.js
@@ -195,7 +195,7 @@ class Browser {
   }
 
   async waitForBrowserPageToLoad() {
-    await TestHelpers.delay(20000);
+    await TestHelpers.delay(5000);
   }
 
   async navigateToTestDApp() {

--- a/e2e/pages/Browser/ConnectedAccountsModal.js
+++ b/e2e/pages/Browser/ConnectedAccountsModal.js
@@ -166,6 +166,12 @@ class ConnectedAccountsModal {
   async tapConnectMoreAccountsButton() {
     await Gestures.waitAndTap(this.connectAccountsButton);
   }
+  async getNetworkName() {
+
+    const networkNameElement  = this.navigateToEditNetworksPermissionsButton
+    const attributes = await networkNameElement.label;
+    return attributes;
+  }
 }
 
 export default new ConnectedAccountsModal();

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -1,8 +1,6 @@
-import { device } from 'detox';
 import TestHelpers from '../../helpers';
 import {
-  getLocalTestDappPort,
-  getSecondTestDappPort,
+  TEST_DAPP_LOCAL_URL,
 } from '../../fixtures/utils';
 
 import { BrowserViewSelectorsIDs } from '../../selectors/Browser/BrowserView.selectors';
@@ -13,13 +11,9 @@ import enContent from '../../../locales/languages/en.json';
 import Browser from '../Browser/BrowserView';
 import Gestures from '../../utils/Gestures';
 import Matchers from '../../utils/Matchers';
-
-export const TEST_DAPP_LOCAL_URL = `http://localhost:${getLocalTestDappPort()}`;
-export const SECOND_TEST_DAPP_LOCAL_URL = `http://${
-  device.getPlatform() === 'android' ? '10.0.2.2' : '127.0.0.1'
-}:${getSecondTestDappPort()}`;
 const CONFIRM_BUTTON_TEXT = enContent.confirmation_modal.confirm_cta;
 const APPROVE_BUTTON_TEXT = enContent.transactions.tx_review_approve;
+
 
 class TestDApp {
   get confirmButtonText() {

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -1,5 +1,5 @@
 import TestHelpers from '../../helpers';
-import { getLocalTestDappPort } from '../../fixtures/utils';
+import { getLocalTestDappPort,getSecondTestDappPort } from '../../fixtures/utils';
 
 import { BrowserViewSelectorsIDs } from '../../selectors/Browser/BrowserView.selectors';
 import { TestDappSelectorsWebIDs } from '../../selectors/Browser/TestDapp.selectors';
@@ -11,6 +11,7 @@ import Gestures from '../../utils/Gestures';
 import Matchers from '../../utils/Matchers';
 
 export const TEST_DAPP_LOCAL_URL = `http://localhost:${getLocalTestDappPort()}`;
+export const SECOND_TEST_DAPP_LOCAL_URL = `http://localhost:${getSecondTestDappPort()}`;
 const CONFIRM_BUTTON_TEXT = enContent.confirmation_modal.confirm_cta;
 const APPROVE_BUTTON_TEXT = enContent.transactions.tx_review_approve;
 

--- a/e2e/pages/Browser/TestDApp.js
+++ b/e2e/pages/Browser/TestDApp.js
@@ -1,5 +1,9 @@
+import { device } from 'detox';
 import TestHelpers from '../../helpers';
-import { getLocalTestDappPort,getSecondTestDappPort } from '../../fixtures/utils';
+import {
+  getLocalTestDappPort,
+  getSecondTestDappPort,
+} from '../../fixtures/utils';
 
 import { BrowserViewSelectorsIDs } from '../../selectors/Browser/BrowserView.selectors';
 import { TestDappSelectorsWebIDs } from '../../selectors/Browser/TestDapp.selectors';
@@ -11,7 +15,9 @@ import Gestures from '../../utils/Gestures';
 import Matchers from '../../utils/Matchers';
 
 export const TEST_DAPP_LOCAL_URL = `http://localhost:${getLocalTestDappPort()}`;
-export const SECOND_TEST_DAPP_LOCAL_URL = `http://localhost:${getSecondTestDappPort()}`;
+export const SECOND_TEST_DAPP_LOCAL_URL = `http://${
+  device.getPlatform() === 'android' ? '10.0.2.2' : '127.0.0.1'
+}:${getSecondTestDappPort()}`;
 const CONFIRM_BUTTON_TEXT = enContent.confirmation_modal.confirm_cta;
 const APPROVE_BUTTON_TEXT = enContent.transactions.tx_review_approve;
 

--- a/e2e/pages/wallet/WalletView.js
+++ b/e2e/pages/wallet/WalletView.js
@@ -138,6 +138,11 @@ class WalletView {
       WalletViewSelectorsIDs.CAROUSEL_PROGRESS_DOTS,
     );
   }
+  get testCollectible() {
+    return device.getPlatform() === 'android'
+      ? Matchers.getElementByID(WalletViewSelectorsIDs.COLLECTIBLE_FALLBACK, 1)
+      : Matchers.getElementByID(WalletViewSelectorsIDs.TEST_COLLECTIBLE, 1);
+  }
 
   getCarouselSlide(id) {
     return Matchers.getElementByID(WalletViewSelectorsIDs.CAROUSEL_SLIDE(id));
@@ -187,18 +192,17 @@ class WalletView {
     await Gestures.swipe(this.nftTabContainer, 'up', 'slow', 0.6);
   }
 
+  async scrollDownOnTokensTab(tokenName) {
+    const tokenElement = await this.tokenInWallet(tokenName)
+    await Gestures.swipe(tokenElement, 'up', 'slow', 0.2);
+  }
+
   async scrollUpOnNFTsTab() {
     await Gestures.swipe(this.nftTabContainer, 'down', 'slow', 0.6);
   }
 
   async tapImportNFTButton() {
     await Gestures.waitAndTap(this.importNFTButton);
-  }
-
-  get testCollectible() {
-    return device.getPlatform() === 'android'
-      ? Matchers.getElementByID(WalletViewSelectorsIDs.COLLECTIBLE_FALLBACK, 1)
-      : Matchers.getElementByID(WalletViewSelectorsIDs.TEST_COLLECTIBLE, 1);
   }
 
   async tapOnNftName() {

--- a/e2e/specs/assets/multichain/asset-list.spec.js
+++ b/e2e/specs/assets/multichain/asset-list.spec.js
@@ -89,6 +89,8 @@ describe(SmokeNetworkAbstractions('Import Tokens'), () => {
     const BNB_NAME = 'BNB Smart Chain';
     await WalletView.tapTokenNetworkFilter();
     await WalletView.tapTokenNetworkFilterAll();
+    await TestHelpers.delay(5000);
+    await WalletView.scrollDownOnTokensTab('AVAX');
     const bnb = WalletView.tokenInWallet('BNB');
     await Assertions.checkIfVisible(bnb);
     await WalletView.tapOnToken('BNB');

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
@@ -39,10 +39,26 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await TabBarComponent.tapBrowser();
         await Assertions.checkIfVisible(Browser.browserScreenID);
 
-        // Step 2: Navigate to test dApp and open network settings
+        // Step 2: Navigate to 1st test dApp to load page this should be connected to global network selector: Eth mainnet
         await Browser.navigateToTestDApp();
 
         await Browser.waitForBrowserPageToLoad();
+
+        // Navigate to 2nd test dapp to load page. This is a verification check. It should  be connected to global network selector: Eth mainnet
+        await Browser.tapOpenAllTabsButton();
+        await Browser.tapSecondTabButton();
+        await Browser.waitForBrowserPageToLoad();
+
+        // This is here to debug whether or not the second test dapp loads and connected to chain
+        // await TestHelpers.delay(10000)
+
+        // Closing tabs because there is a webview challenging while selecting elements with more than 1 webview (tabs) are opened
+        await Browser.tapOpenAllTabsButton();
+        await Browser.tapCloseSecondTabButton();
+
+        // Back to First Dapp
+        await Browser.tapFirstTabButton();
+
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
         await device.enableSynchronization();
         // Navigate to chain permissions
@@ -51,7 +67,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
 
-        // Update network to Linea Sepolia
+        // In 1st Dapp, Update networks: grant Linea Sepolia permissions and remove permissions from mainnet
         await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
         await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
         await NetworkConnectMultiSelector.tapUpdateButton();
@@ -65,20 +81,29 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await PermissionSummaryBottomSheet.tapBackButton();
         await ConnectedAccountsModal.scrollToBottomOfModal();
 
-                await TestHelpers.delay(2000);
+        // Closing tabs because there is a webview challenging while selecting elements with more than 1 webview (tabs) are opened
         await Browser.tapOpenAllTabsButton();
         await Browser.tapCloseTabsButton();
         await Browser.tapOpenNewTabButton();
+
+        // In 2nd Dapp, Should verify that we are connected to Eth mainnet
 
         await Browser.navigateToSecondTestDApp();
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
         await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
+
+        /* ** A POTENTIAL BUG: On second Dapp Eth Mainnet should be selected by default. 
+          The test is tapping to select ETH mainnet because it is deselected. 
+          Also LineaSepolia is selected by default which says that the network selector from Dapp 1 carries over to Dapp 2 
+          Feel free to remove lines 102 - 104 if/when this bug is fixed.
+        */
         await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
         await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
         await NetworkConnectMultiSelector.tapUpdateButton();
 
+        await device.enableSynchronization(); // re-enabling synchronization
         await Assertions.checkIfElementHasLabel(
           ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
           'Use your enabled networks Ethereum Main Network',
@@ -86,7 +111,8 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         await PermissionSummaryBottomSheet.tapBackButton();
         await ConnectedAccountsModal.scrollToBottomOfModal();
-        // Update in Wallet
+
+        // Update in Global selector in Wallet
         await TabBarComponent.tapWallet();
         await WalletView.tapNetworksButtonOnNavBar();
         await NetworkListModal.changeNetworkTo('Linea Main Network');
@@ -97,7 +123,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await TabBarComponent.tapBrowser();
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
 
-        // Navigate to chain permissions
+        // Navigate back to second Dapp and verify chain permissions
         await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
 
@@ -127,7 +153,6 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
           ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
           'Use your enabled networks Linea Sepolia',
         );
-
       },
     );
   });

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import { device } from 'detox';
 import TestHelpers from '../../../../helpers';
 import { SmokeNetworkExpansion } from '../../../../tags';
 import Browser from '../../../../pages/Browser/BrowserView';
@@ -16,6 +17,17 @@ import NetworkEducationModal from '../../../../pages/Network/NetworkEducationMod
 
 import PermissionSummaryBottomSheet from '../../../../pages/Browser/PermissionSummaryBottomSheet';
 
+/*
+Test Steps:
+1. Opening wallet on ETH Mainnet
+2. Open Dapp 1 and Open Dapp 2
+3. Dapp 1: ETH => Linea Sepolia
+4. Close Dapp 1
+5. Dapp 2: ETH => Sepolia
+6. Wallet to Linea mainnet
+7. Check Dapp 1 is still on Linea Sepolia
+8. Check Dapp 2 is still on ETH Mainnet
+*/
 describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
@@ -28,7 +40,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         dapp: true,
         dappOptions: { numberOfDapps: 2 },
         fixture: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
+          .withPermissionControllerConnectedToTestDapp({}, true)
           .withChainPermission()
           .build(),
         restartDevice: true,
@@ -41,7 +53,6 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         // Step 2: Navigate to 1st test dApp to load page this should be connected to global network selector: Eth mainnet
         await Browser.navigateToTestDApp();
-
         await Browser.waitForBrowserPageToLoad();
 
         // Navigate to 2nd test dapp to load page. This is a verification check. It should  be connected to global network selector: Eth mainnet
@@ -94,19 +105,14 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
 
-        /* ** A POTENTIAL BUG: On second Dapp Eth Mainnet should be selected by default. 
-          The test is tapping to select ETH mainnet because it is deselected. 
-          Also LineaSepolia is selected by default which says that the network selector from Dapp 1 carries over to Dapp 2 
-          Feel free to remove lines 102 - 104 if/when this bug is fixed.
-        */
         await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
-        await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
+        await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
         await NetworkConnectMultiSelector.tapUpdateButton();
 
         await device.enableSynchronization(); // re-enabling synchronization
         await Assertions.checkIfElementHasLabel(
           ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
-          'Use your enabled networks Ethereum Main Network',
+          'Use your enabled networks Sepolia',
         );
 
         await PermissionSummaryBottomSheet.tapBackButton();
@@ -129,7 +135,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         await Assertions.checkIfElementHasLabel(
           ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
-          'Use your enabled networks Ethereum Main Network',
+          'Use your enabled networks Sepolia',
         );
 
         // // checking that dapp doesn't show the global selected network which in this case is linea mainnet

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
@@ -30,7 +30,7 @@ Test Steps:
 */
 describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
   beforeAll(async () => {
-    jest.setTimeout(150000);
+    jest.setTimeout(300000);
     await TestHelpers.reverseServerPort();
   });
 

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
@@ -1,0 +1,87 @@
+'use strict';
+import TestHelpers from '../../../../helpers';
+import { SmokeNetworkExpansion } from '../../../../tags';
+import Browser from '../../../../pages/Browser/BrowserView';
+import TabBarComponent from '../../../../pages/wallet/TabBarComponent';
+import NetworkListModal from '../../../../pages/Network/NetworkListModal';
+import ConnectedAccountsModal from '../../../../pages/Browser/ConnectedAccountsModal';
+import FixtureBuilder from '../../../../fixtures/fixture-builder';
+import { withFixtures } from '../../../../fixtures/fixture-helper';
+import { loginToApp } from '../../../../viewHelper';
+import Assertions from '../../../../utils/Assertions';
+import WalletView from '../../../../pages/wallet/WalletView';
+import NetworkNonPemittedBottomSheet from '../../../../pages/Network/NetworkNonPemittedBottomSheet';
+import { LINEA_MAINNET } from '../../../../../app/constants/network';
+
+describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+    await TestHelpers.reverseServerPort();
+  });
+
+  it('handles two dapps concurrently', async () => {
+    await withFixtures(
+      {
+        dapp: true,
+        dappOptions: { numberOfDapps: 2 },
+        fixture: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withChainPermission()
+          .build(),
+        restartDevice: true,
+      },
+      async () => {
+        // Step 1: Navigate to browser view
+        await loginToApp();
+        await TabBarComponent.tapBrowser();
+        await Assertions.checkIfVisible(Browser.browserScreenID);
+
+        // Step 2: Navigate to test dApp and open network settings
+        await Browser.navigateToTestDApp();
+        await Browser.tapOpenAllTabsButton();
+        await Browser.tapSecondTabButton();
+
+        await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
+
+        // Navigate to chain permissions
+        await ConnectedAccountsModal.tapManagePermissionsButton();
+        await ConnectedAccountsModal.tapPermissionsSummaryTab();
+        await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
+
+        // Uncheck Sepolia and check Linea Sepolia
+        await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
+        await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
+        await NetworkConnectMultiSelector.tapUpdateButton();
+
+        // Update in Wallet
+        await TabBarComponent.tapWallet();
+        await WalletView.tapNetworksButtonOnNavBar();
+        await NetworkListModal.scrollToBottomOfNetworkList();
+        await NetworkListModal.changeNetworkTo('Linea Mainnet');
+        await device.disableSynchronization();
+        await NetworkEducationModal.tapGotItButton();
+        await device.enableSynchronization();
+
+        await TabBarComponent.tapBrowser();
+        await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
+
+        // Navigate to chain permissions
+        await ConnectedAccountsModal.tapManagePermissionsButton();
+        await ConnectedAccountsModal.tapPermissionsSummaryTab();
+        // checking that dapp doesn't show the global selected network which in this case is linea mainnet
+        await Assertions.checkIfTextIsDisplayed('Linea Sepolia');
+
+        await Browser.navigateToTestDApp();
+        await Browser.tapOpenAllTabsButton();
+        await Browser.tapSecondTabButton();
+        await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
+
+        // Navigate to chain permissions
+        await ConnectedAccountsModal.tapManagePermissionsButton();
+        await ConnectedAccountsModal.tapPermissionsSummaryTab();
+        // checking that dapp doesn't show the global selected network which in this case is linea mainnet
+        await Assertions.checkIfTextIsDisplayed('Ethereum');
+      },
+    );
+  });
+});

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.js
@@ -11,7 +11,10 @@ import { loginToApp } from '../../../../viewHelper';
 import Assertions from '../../../../utils/Assertions';
 import WalletView from '../../../../pages/wallet/WalletView';
 import NetworkNonPemittedBottomSheet from '../../../../pages/Network/NetworkNonPemittedBottomSheet';
-import { LINEA_MAINNET } from '../../../../../app/constants/network';
+import NetworkConnectMultiSelector from '../../../../pages/Browser/NetworkConnectMultiSelector';
+import NetworkEducationModal from '../../../../pages/Network/NetworkEducationModal';
+
+import PermissionSummaryBottomSheet from '../../../../pages/Browser/PermissionSummaryBottomSheet';
 
 describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
   beforeAll(async () => {
@@ -38,26 +41,55 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         // Step 2: Navigate to test dApp and open network settings
         await Browser.navigateToTestDApp();
-        await Browser.tapOpenAllTabsButton();
-        await Browser.tapSecondTabButton();
 
+        await Browser.waitForBrowserPageToLoad();
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
-
+        await device.enableSynchronization();
         // Navigate to chain permissions
         await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
+
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
 
-        // Uncheck Sepolia and check Linea Sepolia
-        await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
+        // Update network to Linea Sepolia
+        await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
         await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
         await NetworkConnectMultiSelector.tapUpdateButton();
 
+        await Assertions.checkIfElementHasLabel(
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          'Use your enabled networks Linea Sepolia',
+        );
+
+        // await TestHelpers.delay(2000);
+        await PermissionSummaryBottomSheet.tapBackButton();
+        await ConnectedAccountsModal.scrollToBottomOfModal();
+
+                await TestHelpers.delay(2000);
+        await Browser.tapOpenAllTabsButton();
+        await Browser.tapCloseTabsButton();
+        await Browser.tapOpenNewTabButton();
+
+        await Browser.navigateToSecondTestDApp();
+        await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
+        await ConnectedAccountsModal.tapManagePermissionsButton();
+        await ConnectedAccountsModal.tapPermissionsSummaryTab();
+        await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
+        await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
+        await NetworkNonPemittedBottomSheet.tapLineaSepoliaNetworkName();
+        await NetworkConnectMultiSelector.tapUpdateButton();
+
+        await Assertions.checkIfElementHasLabel(
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          'Use your enabled networks Ethereum Main Network',
+        );
+
+        await PermissionSummaryBottomSheet.tapBackButton();
+        await ConnectedAccountsModal.scrollToBottomOfModal();
         // Update in Wallet
         await TabBarComponent.tapWallet();
         await WalletView.tapNetworksButtonOnNavBar();
-        await NetworkListModal.scrollToBottomOfNetworkList();
-        await NetworkListModal.changeNetworkTo('Linea Mainnet');
+        await NetworkListModal.changeNetworkTo('Linea Main Network');
         await device.disableSynchronization();
         await NetworkEducationModal.tapGotItButton();
         await device.enableSynchronization();
@@ -68,19 +100,34 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         // Navigate to chain permissions
         await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
-        // checking that dapp doesn't show the global selected network which in this case is linea mainnet
-        await Assertions.checkIfTextIsDisplayed('Linea Sepolia');
 
-        await Browser.navigateToTestDApp();
+        await Assertions.checkIfElementHasLabel(
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          'Use your enabled networks Ethereum Main Network',
+        );
+
+        // // checking that dapp doesn't show the global selected network which in this case is linea mainnet
+        await PermissionSummaryBottomSheet.tapBackButton();
+        await ConnectedAccountsModal.scrollToBottomOfModal();
+
+        // // Going back to test dapp 1 to verify that the network is still  linea sepolia
+        await TestHelpers.delay(2000);
         await Browser.tapOpenAllTabsButton();
-        await Browser.tapSecondTabButton();
+        await Browser.tapCloseTabsButton();
+        await Browser.tapOpenNewTabButton();
+        await Browser.navigateToTestDApp();
+
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
 
         // Navigate to chain permissions
         await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
-        // checking that dapp doesn't show the global selected network which in this case is linea mainnet
-        await Assertions.checkIfTextIsDisplayed('Ethereum');
+
+        await Assertions.checkIfElementHasLabel(
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          'Use your enabled networks Linea Sepolia',
+        );
+
       },
     );
   });

--- a/e2e/utils/Matchers.js
+++ b/e2e/utils/Matchers.js
@@ -87,9 +87,12 @@ class Matchers {
    * @returns {Detox.WebViewElement} WebView element
    */
   static getWebViewByID(elementId) {
-    return device.getPlatform() === 'ios'
-      ? web(by.id(elementId))
-      : web(by.type('android.webkit.WebView').withAncestor(by.id(elementId)));
+    if (process.env.CI) {
+      return device.getPlatform() === 'ios'
+        ? web(by.id(elementId))
+        : web(by.type('android.webkit.WebView').withAncestor(by.id(elementId)));
+    }
+    return web(by.id(elementId));
   }
 
   /**


### PR DESCRIPTION
This PR is to add e2e for per dapp flow:
1. when more than one dapp is connected and autoswitching should work

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
