### PR TITLE
fix: show snap accounts in account count in AddNewAccount cp-7.47.0

### DIFF
--- a/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
@@ -445,7 +445,7 @@ describe('AddNewAccount', () => {
                   [mockAccount2.id]: mockAccount2,
                   [solanaAccount.id]: solanaAccount,
                 },
-                selectedAccount: mockAccount2.id,
+                selectedAccount: mockAccount1.id,
               },
             },
             KeyringController: {

--- a/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.test.tsx
@@ -5,6 +5,7 @@ import { strings } from '../../../../locales/i18n';
 import AddNewAccount from './AddNewAccount';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import {
+  createMockSnapInternalAccount,
   internalAccount1,
   internalAccount2,
 } from '../../../util/test/accountsControllerTestUtils';
@@ -18,6 +19,7 @@ import { RootState } from '../../../reducers';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { AddNewAccountIds } from '../../../../e2e/selectors/MultiSRP/AddHdAccount.selectors';
 import Logger from '../../../util/Logger';
+import { SolAccountType } from '@metamask/keyring-api';
 
 const mockAddNewHdAccount = jest.fn().mockResolvedValue(null);
 const mockNavigate = jest.fn();
@@ -420,5 +422,42 @@ describe('AddNewAccount', () => {
         ).toBeDefined();
       },
     );
+
+    it('shows the correct number of accounts in srp item', () => {
+      const solanaAccount = createMockSnapInternalAccount(
+        '0x1234567890123456789012345678901234567890',
+        'Solana Account 1',
+        SolAccountType.DataAccount,
+        mockKeyring1.metadata.id,
+      );
+      const snapKeyring = {
+        accounts: [solanaAccount.address],
+        type: KeyringTypes.snap,
+      };
+      const stateWithSnapAccount = {
+        engine: {
+          backgroundState: {
+            ...backgroundState,
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccount1.id]: mockAccount1,
+                  [mockAccount2.id]: mockAccount2,
+                  [solanaAccount.id]: solanaAccount,
+                },
+                selectedAccount: mockAccount2.id,
+              },
+            },
+            KeyringController: {
+              keyrings: [mockKeyring1, mockKeyring2, snapKeyring],
+            },
+          },
+        },
+      } as unknown as RootState;
+      const { getByText } = render(stateWithSnapAccount, {});
+
+      // 2 accounts are associated with the primary srp. 1 hd and 1 solana
+      expect(getByText('Show 2 accounts')).toBeDefined();
+    });
   });
 });

--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -45,6 +45,7 @@ import { getMultichainAccountName } from '../../../core/SnapKeyring/utils/getMul
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { MetaMetricsEvents } from '../../../core/Analytics/MetaMetrics.events';
 import useMetrics from '../../hooks/useMetrics/useMetrics';
+import { useHdKeyringsWithSnapAccounts } from '../../hooks/useHdKeyringsWithSnapAccounts';
 
 const AddNewAccount = ({
   scope,
@@ -59,8 +60,8 @@ const AddNewAccount = ({
   const [accountName, setAccountName] = useState<string | undefined>(undefined);
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const internalAccounts = useSelector(selectInternalAccounts);
-  const hdKeyrings = useSelector(selectHDKeyrings);
-  const [primaryKeyringId] = hdKeyrings;
+  const hdKeyringsWithSnapAccounts = useHdKeyringsWithSnapAccounts();
+  const [primaryKeyringId] = hdKeyringsWithSnapAccounts;
   const initialKeyringIdToUse = useMemo(
     () =>
       // For HD accounts (since v29.0.1), use the entropySource if available.
@@ -71,19 +72,20 @@ const AddNewAccount = ({
     [selectedInternalAccount, primaryKeyringId],
   );
   const [keyringId, setKeyringId] = useState<string>(initialKeyringIdToUse);
-  const hasMultipleSRPs = hdKeyrings.length > 1;
+  const hasMultipleSRPs = hdKeyringsWithSnapAccounts.length > 1;
   const [showSRPList, setShowSRPList] = useState(false);
   const [error, setError] = useState<string>('');
   const { trackEvent, createEventBuilder } = useMetrics();
 
   const { keyringToDisplay, keyringIndex } = useMemo(() => {
     const keyring =
-      hdKeyrings.find((kr) => kr.metadata.id === keyringId) ?? hdKeyrings[0];
+      hdKeyringsWithSnapAccounts.find((kr) => kr.metadata.id === keyringId) ??
+      hdKeyringsWithSnapAccounts[0];
     return {
       keyringToDisplay: keyring,
-      keyringIndex: hdKeyrings.indexOf(keyring) + 1,
+      keyringIndex: hdKeyringsWithSnapAccounts.indexOf(keyring) + 1,
     };
-  }, [hdKeyrings, keyringId]);
+  }, [hdKeyringsWithSnapAccounts, keyringId]);
 
   const handleOnBack = () => {
     if (showSRPList) {

--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -24,7 +24,6 @@ import Input from '../../../component-library/components/Form/TextField/foundati
 import { useStyles } from '../../hooks/useStyles';
 import styleSheet from './AddNewAccount.styles';
 import { useSelector } from 'react-redux';
-import { selectHDKeyrings } from '../../../selectors/keyringController';
 import Button, {
   ButtonVariants,
 } from '../../../component-library/components/Buttons/Button';

--- a/app/components/hooks/useHdKeyringsWithSnapAccounts.ts
+++ b/app/components/hooks/useHdKeyringsWithSnapAccounts.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { KeyringMetadata, KeyringObject } from '@metamask/keyring-controller';
+import {
+  KeyringMetadata,
+  KeyringObject,
+  KeyringTypes,
+} from '@metamask/keyring-controller';
 import { selectHDKeyrings } from '../../selectors/keyringController';
 import { selectInternalAccounts } from '../../selectors/accountsController';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -22,7 +26,10 @@ export const useHdKeyringsWithSnapAccounts = () => {
       const entropySource = account.options?.entropySource as
         | string
         | undefined;
-      if (entropySource) {
+      if (
+        entropySource &&
+        account.metadata.keyring.type === KeyringTypes.snap
+      ) {
         if (!accountsByEntropySource.has(entropySource)) {
           accountsByEntropySource.set(entropySource, []);
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the issue where the incorrect number of accounts are shown in `AddNewAccounts` and in `SRPList`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15828

## **Manual testing steps**

1. Start with a new wallt
2. Add another srp
3. Go to add new account
4. See that there are 2 accounts for the primary srp and also two accounts in the srp list. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/bedcb0b6-63ef-4951-b560-9c8008ce8da2



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
