### PR TITLE
fix: hide solana accounts in EVM send flow

### DIFF
--- a/app/components/UI/AccountFromToInfoCard/AddressFrom.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AddressFrom.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../util/address';
 import useAddressBalance from '../../hooks/useAddressBalance/useAddressBalance';
 import stylesheet from './AddressFrom.styles';
-import { selectInternalAccounts } from '../../../selectors/accountsController';
+import { selectInternalEvmAccounts } from '../../../selectors/accountsController';
 import { useNetworkInfo } from '../../../selectors/selectedNetworkController';
 import { isPerDappSelectedNetworkEnabled } from '../../../util/networks';
 
@@ -61,7 +61,7 @@ const AddressFrom = ({
 
   const accountsByChainId = useSelector(selectAccountsByChainId);
 
-  const internalAccounts = useSelector(selectInternalAccounts);
+  const internalAccounts = useSelector(selectInternalEvmAccounts);
   const activeAddress = toChecksumAddress(from);
 
   const networkName = useSelector(selectEvmNetworkName);

--- a/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
@@ -52,6 +52,7 @@ const AccountSelector = () => {
       navigation.navigate(
         ...createAccountSelectorNavDetails({
           disablePrivacyMode: true,
+          isEvmOnly: true,
         }),
       ),
     [navigation],

--- a/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
@@ -52,7 +52,6 @@ const AccountSelector = () => {
       navigation.navigate(
         ...createAccountSelectorNavDetails({
           disablePrivacyMode: true,
-          isEvmOnly: true,
         }),
       ),
     [navigation],

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -51,6 +51,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     checkBalanceError,
     disablePrivacyMode,
     navigateToAddAccountActions,
+    isEvmOnly,
   } = routeParams || {};
 
   const reloadAccounts = useSelector(
@@ -67,7 +68,15 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     }),
     [checkBalanceError, reloadAccounts],
   );
-  const { accounts, ensByAccountAddress } = useAccounts(accountsParams);
+
+  const {
+    accounts: allAccounts,
+    ensByAccountAddress,
+    evmAccounts,
+  } = useAccounts(accountsParams);
+
+  const accounts = isEvmOnly ? evmAccounts : allAccounts;
+
   const [screen, setScreen] = useState<AccountSelectorScreens>(
     () => navigateToAddAccountActions ?? AccountSelectorScreens.AccountSelector,
   );

--- a/app/components/Views/AccountSelector/AccountSelector.types.ts
+++ b/app/components/Views/AccountSelector/AccountSelector.types.ts
@@ -43,6 +43,10 @@ export interface AccountSelectorParams {
    * Optional navigation screen to indicate if should navigate to add account actions sheet.
    */
   navigateToAddAccountActions?: AccountSelectorScreens.AddAccountActions;
+  /**
+   * Only show EVM accounts.
+   */
+  isEvmOnly?: boolean;
 }
 
 /**

--- a/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
@@ -468,6 +468,20 @@ exports[`AccountSelector should render correctly 1`] = `
                           </View>
                           <RCTScrollView
                             collapsable={false}
+                            data={
+                              [
+                                {
+                                  "address": "0xc4966c0d659d99699bfd7eb54d8fafee40e4a756",
+                                  "balance": "0x0",
+                                  "name": "EVM Account 1",
+                                },
+                                {
+                                  "address": "0x2B5634C42055806a59e9107ED44D43c426E58258",
+                                  "balance": "0x0",
+                                  "name": "EVM Account 2",
+                                },
+                              ]
+                            }
                             getItem={[Function]}
                             getItemCount={[Function]}
                             initialNumToRender={999}
@@ -489,7 +503,654 @@ exports[`AccountSelector should render correctly 1`] = `
                             testID="account-list"
                             viewabilityConfigCallbackPairs={[]}
                           >
-                            <View />
+                            <View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={null}
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "flex": 1,
+                                        "opacity": 1,
+                                        "padding": 16,
+                                        "position": "relative",
+                                        "zIndex": 1,
+                                      }
+                                    }
+                                    testID="select-with-menu"
+                                  >
+                                    <View
+                                      accessibilityRole="none"
+                                      accessible={true}
+                                      style={
+                                        {
+                                          "alignItems": "flex-start",
+                                          "flexDirection": "column",
+                                          "padding": 16,
+                                          "paddingBottom": 0,
+                                          "paddingLeft": 0,
+                                          "paddingRight": 0,
+                                          "paddingTop": 0,
+                                          "zIndex": 2,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "flexDirection": "row",
+                                              "opacity": 1,
+                                            }
+                                          }
+                                        >
+                                          <View
+                                            style={
+                                              {
+                                                "backgroundColor": "#ffffff",
+                                                "borderRadius": 16,
+                                                "height": 32,
+                                                "marginRight": 16,
+                                                "overflow": "hidden",
+                                                "width": 32,
+                                              }
+                                            }
+                                            testID="cellbase-avatar"
+                                          >
+                                            <View
+                                              style={
+                                                [
+                                                  {
+                                                    "overflow": "hidden",
+                                                  },
+                                                  {
+                                                    "backgroundColor": "#FC4800",
+                                                    "borderRadius": 16,
+                                                    "height": 32,
+                                                    "width": 32,
+                                                  },
+                                                  undefined,
+                                                ]
+                                              }
+                                            >
+                                              <RNSVGSvgView
+                                                bbHeight={32}
+                                                bbWidth={32}
+                                                focusable={false}
+                                                height={32}
+                                                style={
+                                                  [
+                                                    {
+                                                      "backgroundColor": "transparent",
+                                                      "borderWidth": 0,
+                                                    },
+                                                    {
+                                                      "flex": 0,
+                                                      "height": 32,
+                                                      "width": 32,
+                                                    },
+                                                  ]
+                                                }
+                                                width={32}
+                                              >
+                                                <RNSVGGroup
+                                                  fill={
+                                                    {
+                                                      "payload": 4278190080,
+                                                      "type": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4278291575,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        -0.41310442982454204,
+                                                        -0.910683660806177,
+                                                        0.910683660806177,
+                                                        -0.41310442982454204,
+                                                        8.80960563430791,
+                                                        40.3361680482215,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4278410587,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        0.903335292863301,
+                                                        -0.42893513340314526,
+                                                        0.42893513340314526,
+                                                        0.903335292863301,
+                                                        -18.594021578605165,
+                                                        6.725269324133852,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4294382337,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        -0.6921431738704069,
+                                                        -0.7217602280983622,
+                                                        0.7217602280983622,
+                                                        -0.6921431738704069,
+                                                        -12.339279260280694,
+                                                        30.41598471866334,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                </RNSVGGroup>
+                                              </RNSVGSvgView>
+                                            </View>
+                                          </View>
+                                          <View
+                                            style={
+                                              {
+                                                "alignItems": "flex-start",
+                                                "flex": 1,
+                                              }
+                                            }
+                                          >
+                                            <Text
+                                              accessibilityRole="text"
+                                              numberOfLines={1}
+                                              style={
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "CentraNo1-Medium",
+                                                  "fontSize": 16,
+                                                  "fontWeight": "500",
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="cellbase-avatar-title"
+                                            >
+                                              EVM Account 1
+                                            </Text>
+                                            <TouchableOpacity
+                                              accessibilityState={
+                                                {
+                                                  "busy": undefined,
+                                                  "checked": undefined,
+                                                  "disabled": undefined,
+                                                  "expanded": undefined,
+                                                  "selected": undefined,
+                                                }
+                                              }
+                                              accessible={true}
+                                              focusable={false}
+                                              onClick={[Function]}
+                                              onResponderGrant={[Function]}
+                                              onResponderMove={[Function]}
+                                              onResponderRelease={[Function]}
+                                              onResponderTerminate={[Function]}
+                                              onResponderTerminationRequest={[Function]}
+                                              onStartShouldSetResponder={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "flex-start",
+                                                  "flexDirection": "row",
+                                                  "marginBottom": 0,
+                                                  "zIndex": 1,
+                                                }
+                                              }
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                numberOfLines={1}
+                                                style={
+                                                  {
+                                                    "color": "#686e7d",
+                                                    "fontFamily": "CentraNo1-Book",
+                                                    "fontSize": 16,
+                                                    "fontWeight": "400",
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                0xC4966...4a756
+                                              </Text>
+                                            </TouchableOpacity>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </TouchableOpacity>
+                                  <View
+                                    style={
+                                      {
+                                        "paddingRight": 20,
+                                      }
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      activeOpacity={1}
+                                      disabled={false}
+                                      onPress={[Function]}
+                                      onPressIn={[Function]}
+                                      onPressOut={[Function]}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 8,
+                                          "height": 24,
+                                          "justifyContent": "center",
+                                          "opacity": 1,
+                                          "width": 24,
+                                        }
+                                      }
+                                      testID="main-wallet-account-actions-0"
+                                    >
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={16}
+                                        name="MoreVertical"
+                                        style={
+                                          {
+                                            "height": 16,
+                                            "width": 16,
+                                          }
+                                        }
+                                        width={16}
+                                      />
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={null}
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#ffffff",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "flex": 1,
+                                        "opacity": 1,
+                                        "padding": 16,
+                                        "position": "relative",
+                                        "zIndex": 1,
+                                      }
+                                    }
+                                    testID="select-with-menu"
+                                  >
+                                    <View
+                                      accessibilityRole="none"
+                                      accessible={true}
+                                      style={
+                                        {
+                                          "alignItems": "flex-start",
+                                          "flexDirection": "column",
+                                          "padding": 16,
+                                          "paddingBottom": 0,
+                                          "paddingLeft": 0,
+                                          "paddingRight": 0,
+                                          "paddingTop": 0,
+                                          "zIndex": 2,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "flexDirection": "row",
+                                              "opacity": 1,
+                                            }
+                                          }
+                                        >
+                                          <View
+                                            style={
+                                              {
+                                                "backgroundColor": "#ffffff",
+                                                "borderRadius": 16,
+                                                "height": 32,
+                                                "marginRight": 16,
+                                                "overflow": "hidden",
+                                                "width": 32,
+                                              }
+                                            }
+                                            testID="cellbase-avatar"
+                                          >
+                                            <View
+                                              style={
+                                                [
+                                                  {
+                                                    "overflow": "hidden",
+                                                  },
+                                                  {
+                                                    "backgroundColor": "#034D5D",
+                                                    "borderRadius": 16,
+                                                    "height": 32,
+                                                    "width": 32,
+                                                  },
+                                                  undefined,
+                                                ]
+                                              }
+                                            >
+                                              <RNSVGSvgView
+                                                bbHeight={32}
+                                                bbWidth={32}
+                                                focusable={false}
+                                                height={32}
+                                                style={
+                                                  [
+                                                    {
+                                                      "backgroundColor": "transparent",
+                                                      "borderWidth": 0,
+                                                    },
+                                                    {
+                                                      "flex": 0,
+                                                      "height": 32,
+                                                      "width": 32,
+                                                    },
+                                                  ]
+                                                }
+                                                width={32}
+                                              >
+                                                <RNSVGGroup
+                                                  fill={
+                                                    {
+                                                      "payload": 4278190080,
+                                                      "type": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4279604210,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        -0.34202014332566855,
+                                                        -0.9396926207859084,
+                                                        0.9396926207859084,
+                                                        -0.34202014332566855,
+                                                        6.786476184084575,
+                                                        40.75416276870581,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4294736384,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        0.33873792024529187,
+                                                        -0.9408807689542253,
+                                                        0.9408807689542253,
+                                                        0.33873792024529187,
+                                                        -23.280918942626094,
+                                                        24.013190640384032,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                  <RNSVGRect
+                                                    fill={
+                                                      {
+                                                        "payload": 4280574433,
+                                                        "type": 0,
+                                                      }
+                                                    }
+                                                    height={32}
+                                                    matrix={
+                                                      [
+                                                        -0.632029302664851,
+                                                        -0.7749444887041794,
+                                                        0.7749444887041794,
+                                                        -0.632029302664851,
+                                                        -13.309800792272908,
+                                                        27.878374550266756,
+                                                      ]
+                                                    }
+                                                    propList={
+                                                      [
+                                                        "fill",
+                                                      ]
+                                                    }
+                                                    width={32}
+                                                    x={0}
+                                                    y={0}
+                                                  />
+                                                </RNSVGGroup>
+                                              </RNSVGSvgView>
+                                            </View>
+                                          </View>
+                                          <View
+                                            style={
+                                              {
+                                                "alignItems": "flex-start",
+                                                "flex": 1,
+                                              }
+                                            }
+                                          >
+                                            <Text
+                                              accessibilityRole="text"
+                                              numberOfLines={1}
+                                              style={
+                                                {
+                                                  "color": "#121314",
+                                                  "fontFamily": "CentraNo1-Medium",
+                                                  "fontSize": 16,
+                                                  "fontWeight": "500",
+                                                  "letterSpacing": 0,
+                                                  "lineHeight": 24,
+                                                }
+                                              }
+                                              testID="cellbase-avatar-title"
+                                            >
+                                              EVM Account 2
+                                            </Text>
+                                            <TouchableOpacity
+                                              accessibilityState={
+                                                {
+                                                  "busy": undefined,
+                                                  "checked": undefined,
+                                                  "disabled": undefined,
+                                                  "expanded": undefined,
+                                                  "selected": undefined,
+                                                }
+                                              }
+                                              accessible={true}
+                                              focusable={false}
+                                              onClick={[Function]}
+                                              onResponderGrant={[Function]}
+                                              onResponderMove={[Function]}
+                                              onResponderRelease={[Function]}
+                                              onResponderTerminate={[Function]}
+                                              onResponderTerminationRequest={[Function]}
+                                              onStartShouldSetResponder={[Function]}
+                                              style={
+                                                {
+                                                  "alignItems": "flex-start",
+                                                  "flexDirection": "row",
+                                                  "marginBottom": 0,
+                                                  "zIndex": 1,
+                                                }
+                                              }
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                numberOfLines={1}
+                                                style={
+                                                  {
+                                                    "color": "#686e7d",
+                                                    "fontFamily": "CentraNo1-Book",
+                                                    "fontSize": 16,
+                                                    "fontWeight": "400",
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                0x2B563...58258
+                                              </Text>
+                                            </TouchableOpacity>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </TouchableOpacity>
+                                  <View
+                                    style={
+                                      {
+                                        "paddingRight": 20,
+                                      }
+                                    }
+                                  >
+                                    <TouchableOpacity
+                                      accessibilityRole="button"
+                                      accessible={true}
+                                      activeOpacity={1}
+                                      disabled={false}
+                                      onPress={[Function]}
+                                      onPressIn={[Function]}
+                                      onPressOut={[Function]}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 8,
+                                          "height": 24,
+                                          "justifyContent": "center",
+                                          "opacity": 1,
+                                          "width": 24,
+                                        }
+                                      }
+                                      testID="main-wallet-account-actions-1"
+                                    >
+                                      <SvgMock
+                                        color="#121314"
+                                        fill="currentColor"
+                                        height={16}
+                                        name="MoreVertical"
+                                        style={
+                                          {
+                                            "height": 16,
+                                            "width": 16,
+                                          }
+                                        }
+                                        width={16}
+                                      />
+                                    </TouchableOpacity>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </RCTScrollView>
                           <View
                             style={

--- a/app/components/Views/confirmations/legacy/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/confirmations/legacy/SendFlow/AddressFrom/AddressFrom.tsx
@@ -131,6 +131,7 @@ const SendFlowAddressFrom = ({
         isSelectOnly: true,
         onSelectAccount,
         disablePrivacyMode: true,
+        isEvmOnly: true,
       },
     });
   };

--- a/app/components/Views/confirmations/legacy/SendFlow/AddressList/AddressList.jsx
+++ b/app/components/Views/confirmations/legacy/SendFlow/AddressList/AddressList.jsx
@@ -12,7 +12,7 @@ import Text from '../../../../../../component-library/components/Texts/Text/Text
 import { TextVariant } from '../../../../../../component-library/components/Texts/Text';
 import { regex } from '../../../../../../util/regex';
 import { SendViewSelectorsIDs } from '../../../../../../../e2e/selectors/SendFlow/SendView.selectors';
-import { selectInternalAccounts } from '../../../../../../selectors/accountsController';
+import { selectInternalEvmAccounts } from '../../../../../../selectors/accountsController';
 import styleSheet from './AddressList.styles';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { selectAddressBook } from '../../../../../../selectors/addressBookController';
@@ -38,7 +38,7 @@ const AddressList = ({
   const styles = styleSheet(colors);
   const [contactElements, setContactElements] = useState([]);
   const [fuse, setFuse] = useState(undefined);
-  const internalAccounts = useSelector(selectInternalAccounts);
+  const internalAccounts = useSelector(selectInternalEvmAccounts);
   const addressBook = useSelector(selectAddressBook);
   const ambiguousAddressEntries = useSelector(
     (state) => state.user.ambiguousAddressEntries,

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -1157,6 +1157,7 @@ class Confirm extends PureComponent {
         isSelectOnly: true,
         onSelectAccount: this.onSelectAccount,
         checkBalanceError: this.getBalanceError,
+        isEvmOnly: true,
       },
     });
   };

--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -23,6 +23,7 @@ import {
   selectSolanaAccount,
   selectPreviouslySelectedEvmAccount,
   selectSelectedInternalAccountId,
+  selectInternalEvmAccounts,
 } from './accountsController';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -771,5 +772,32 @@ describe('selectSelectedInternalAccountId', () => {
     const result2 = selectSelectedInternalAccountId(state);
     expect(result1).toBe(result2);
     expect(selectSelectedInternalAccountId.recomputations()).toBe(1);
+  });
+});
+
+describe('selectInternalEvmAccounts', () => {
+  it(`returns internal accounts with evm account type`, () => {
+    const mockAccountsControllerReversed =
+      MOCK_GENERATED_ACCOUNTS_CONTROLLER_REVERSED();
+
+    const stateAccountsList = Object.values(
+      mockAccountsControllerReversed.internalAccounts.accounts,
+    );
+
+    expect(stateAccountsList).toHaveLength(6);
+
+    stateAccountsList[0].type = 'solana:data-account';
+    stateAccountsList[1].type = 'bip122:p2pkh';
+
+    const result = selectInternalEvmAccounts({
+      engine: {
+        backgroundState: {
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+          AccountsController: mockAccountsControllerReversed,
+        },
+      },
+    } as RootState);
+
+    expect(result).toHaveLength(4);
   });
 });

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -60,6 +60,11 @@ export const selectInternalAccounts = createDeepEqualSelector(
   },
 );
 
+export const selectInternalEvmAccounts = createSelector(
+  selectInternalAccounts,
+  (accounts) => accounts.filter((account) => isEvmAccountType(account.type)),
+);
+
 /**
  * A memoized selector that returns internal accounts from the AccountsController,
  * sorted by the order of KeyringController's keyring accounts,


### PR DESCRIPTION
## **Description**

Hide Solana accounts in EVM send flow.

Including:

- Add `selectInternalEvmAccounts` selector.
- Add `isEvmOnly` route param to `AccountSelector` page.

## **Related issues**

Fixes: #16188 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/9e26f7dd-a595-4e2b-ac64-5e0ce6e3e464

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
