### PR TITLE
fix: cp-7.49.0 Make `confirmation_redesign` feature flags work as true kill-switch

### DIFF
--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -19,7 +19,7 @@ export type ConfirmationRedesignRemoteFlags = {
  * is set, the remote flag value takes precedence. If a remote flag is explicitly
  * set to `false`, it can disable the feature remotely.
  *
- * ## Adding New Confirmation Types
+ * ## Adding New Confirmation Flag
  *
  * **During Development:**
  * Use a local environment variable with a default fallback:

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -30,7 +30,7 @@ export type ConfirmationRedesignRemoteFlags = {
  * );
  * ```
  *
- * **After Development (Release):**
+ * **After Development (On Release):**
  * Replace the fallback with the remote kill switch:
  * ```
  * const isNewConfirmationTypeEnabled = getFeatureFlagValue(

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -23,7 +23,6 @@ export type ConfirmationRedesignRemoteFlags = {
  *
  * **During Development:**
  * Use a local environment variable with a default fallback:
- *
  * ```
  * const isNewConfirmationTypeEnabled = getFeatureFlagValue(
  *   process.env.FEATURE_FLAG_REDESIGNED_NEW_CONFIRMATION_TYPE,
@@ -33,12 +32,17 @@ export type ConfirmationRedesignRemoteFlags = {
  *
  * **After Development (Release):**
  * Replace the fallback with the remote kill switch:
- *
  * ```
  * const isNewConfirmationTypeEnabled = getFeatureFlagValue(
  *   process.env.FEATURE_FLAG_REDESIGNED_NEW_CONFIRMATION_TYPE,
  *   remoteValues?.new_confirmation_type !== false,
  * );
+ * ```
+ * 
+ * **After Validation In Production For Certain Time(When old code is decided to be removed):**
+ * Remove the both local environment variable and remote flag as kill switch is non-functional.
+ * ```
+ * const isNewConfirmationTypeEnabled = true;
  * ```
  *
  * @param remoteFeatureFlags - The remote feature flags object containing confirmation_redesign settings

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -1,4 +1,3 @@
-import { Json, hasProperty, isObject } from '@metamask/utils';
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import { getFeatureFlagValue } from '../env';
@@ -12,52 +11,63 @@ export type ConfirmationRedesignRemoteFlags = {
   transfer: boolean;
 };
 
-const isRemoteFeatureFlagValuesValid = (
-  obj: Json,
-): obj is ConfirmationRedesignRemoteFlags =>
-  isObject(obj) &&
-  hasProperty(obj, 'signatures') &&
-  hasProperty(obj, 'staking_confirmations') &&
-  hasProperty(obj, 'contract_interaction') &&
-  hasProperty(obj, 'transfer');
-
-const confirmationRedesignFlagsDefaultValues: ConfirmationRedesignRemoteFlags =
-  {
-    signatures: true,
-    staking_confirmations: false,
-    contract_interaction: false,
-    transfer: false,
-  };
-
+/**
+ * Determines the enabled state of confirmation redesign features by combining
+ * local environment variables with remote feature flags.
+ *
+ * Remote feature flags act as a "kill switch" - when no local environment variable
+ * is set, the remote flag value takes precedence. If a remote flag is explicitly
+ * set to `false`, it can disable the feature remotely.
+ *
+ * ## Adding New Confirmation Types
+ *
+ * **During Development:**
+ * Use a local environment variable with a default fallback:
+ *
+ * ```
+ * const isNewConfirmationTypeEnabled = getFeatureFlagValue(
+ *   process.env.FEATURE_FLAG_REDESIGNED_NEW_CONFIRMATION_TYPE,
+ *   false,
+ * );
+ * ```
+ *
+ * **After Development (Release):**
+ * Replace the fallback with the remote kill switch:
+ *
+ * ```
+ * const isNewConfirmationTypeEnabled = getFeatureFlagValue(
+ *   process.env.FEATURE_FLAG_REDESIGNED_NEW_CONFIRMATION_TYPE,
+ *   remoteValues?.new_confirmation_type !== false,
+ * );
+ * ```
+ *
+ * @param remoteFeatureFlags - The remote feature flags object containing confirmation_redesign settings
+ * @returns An object with boolean flags for each confirmation redesign feature
+ */
 export const selectConfirmationRedesignFlagsFromRemoteFeatureFlags = (
   remoteFeatureFlags: ReturnType<typeof selectRemoteFeatureFlags>,
-) => {
-  const remoteValues = remoteFeatureFlags.confirmation_redesign;
-
-    const confirmationRedesignFlags = isRemoteFeatureFlagValuesValid(
-      remoteValues,
-    )
-      ? remoteValues
-      : confirmationRedesignFlagsDefaultValues;
+): ConfirmationRedesignRemoteFlags => {
+  const remoteValues =
+    remoteFeatureFlags.confirmation_redesign as ConfirmationRedesignRemoteFlags;
 
   const isSignaturesEnabled = getFeatureFlagValue(
     process.env.FEATURE_FLAG_REDESIGNED_SIGNATURES,
-    confirmationRedesignFlags.signatures,
+    remoteValues?.signatures !== false,
   );
 
   const isStakingConfirmationsEnabled = getFeatureFlagValue(
     process.env.FEATURE_FLAG_REDESIGNED_STAKING_TRANSACTIONS,
-    confirmationRedesignFlags.staking_confirmations,
+    remoteValues?.staking_confirmations !== false,
   );
 
   const isContractInteractionEnabled = getFeatureFlagValue(
     process.env.FEATURE_FLAG_REDESIGNED_CONTRACT_INTERACTION,
-    confirmationRedesignFlags.contract_interaction,
+    remoteValues?.contract_interaction !== false,
   );
 
   const isTransferEnabled = getFeatureFlagValue(
     process.env.FEATURE_FLAG_REDESIGNED_TRANSFER,
-    confirmationRedesignFlags.transfer,
+    remoteValues?.transfer !== false,
   );
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Refactored the confirmation redesign feature flag selector to use a simpler "kill switch" approach instead of validation-based fallbacks.

### **Simplified feature flag logic:**

- Replaced validation and default fallback pattern with direct `remoteValues?.property !== false` checks
- Remote flags now act purely as "kill switches" - they can disable features when explicitly set to `false`

The logic now defaults to `true` for features when remote flags are not explicitly set to `false`, rather than falling back to predefined default values. This maintains the same kill switch functionality while simplifying the implementation.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5110

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
