### PR TITLE
feat: add ConfirmationView class for end-to-end testing

### DIFF
--- a/e2e/pages/Confirmation/ConfirmationView.ts
+++ b/e2e/pages/Confirmation/ConfirmationView.ts
@@ -2,14 +2,13 @@ import { ConfirmationTopSheetSelectorsIDs } from '../../selectors/Confirmation/C
 import Matchers from '../../utils/Matchers';
 
 class ConfirmationView {
-  get securityAlertBanner() {
+  get securityAlertBanner(): Promise<Detox.IndexableNativeElement | Detox.NativeElement | Detox.IndexableSystemElement> {
     return Matchers.getElementByID(ConfirmationTopSheetSelectorsIDs.SECURITY_ALERT_BANNER);
   }
 
-  get securityAlertResponseFailedBanner() {
+  get securityAlertResponseFailedBanner(): Promise<Detox.IndexableNativeElement | Detox.NativeElement | Detox.IndexableSystemElement> {
     return Matchers.getElementByID(ConfirmationTopSheetSelectorsIDs.SECURITY_ALERT_RESPONSE_FAILED_BANNER);
   }
-
 }
 
-export default new ConfirmationView();
+export default new ConfirmationView(); 

--- a/e2e/pages/Confirmation/ConfirmationView.ts
+++ b/e2e/pages/Confirmation/ConfirmationView.ts
@@ -1,12 +1,14 @@
 import { ConfirmationTopSheetSelectorsIDs } from '../../selectors/Confirmation/ConfirmationView.selectors';
 import Matchers from '../../utils/Matchers';
 
+type DetoxElement = Promise<Detox.IndexableNativeElement | Detox.NativeElement | Detox.IndexableSystemElement>;
+
 class ConfirmationView {
-  get securityAlertBanner(): Promise<Detox.IndexableNativeElement | Detox.NativeElement | Detox.IndexableSystemElement> {
+  get securityAlertBanner(): DetoxElement {
     return Matchers.getElementByID(ConfirmationTopSheetSelectorsIDs.SECURITY_ALERT_BANNER);
   }
 
-  get securityAlertResponseFailedBanner(): Promise<Detox.IndexableNativeElement | Detox.NativeElement | Detox.IndexableSystemElement> {
+  get securityAlertResponseFailedBanner(): DetoxElement {
     return Matchers.getElementByID(ConfirmationTopSheetSelectorsIDs.SECURITY_ALERT_RESPONSE_FAILED_BANNER);
   }
 }

--- a/e2e/pages/Send/TransactionConfirmView.js
+++ b/e2e/pages/Send/TransactionConfirmView.js
@@ -8,7 +8,7 @@ import {
   TransactionConfirmViewSelectorsText,
   TransactionConfirmViewSelectorsIDs,
 } from '../../selectors/SendFlow/TransactionConfirmView.selectors.js';
-import { ConfirmationTopSheetSelectorsIDs } from '../../selectors/Confirmation/ConfirmationView.selectors.js';
+import { ConfirmationTopSheetSelectorsIDs } from '../../selectors/Confirmation/ConfirmationView.selectors';
 import TestHelpers from '../../helpers';
 
 class TransactionConfirmationView {

--- a/e2e/selectors/Confirmation/ConfirmationView.selectors.ts
+++ b/e2e/selectors/Confirmation/ConfirmationView.selectors.ts
@@ -6,25 +6,25 @@ export const ConfirmationTopSheetSelectorsIDs = {
   SECURITY_ALERT_RESPONSE_FAILED_BANNER:
     'security-alert-response-failed-banner',
   SECURITY_ALERT_BANNER_REDESIGNED: 'security-alert-banner-0',
-};
+} as const;
 
 export const ConfirmationTopSheetSelectorsText = {
   BANNER_FAILED_TITLE: enContent.blockaid_banner.failed_title,
   BANNER_FAILED_DESCRIPTION: enContent.blockaid_banner.failed_description,
   BANNER_MALICIOUS_TITLE: enContent.blockaid_banner.deceptive_request_title,
   BANNER_MALICIOUS_DESCRIPTION: enContent.blockaid_banner.malicious_domain_description,
-};
+} as const;
 
 export const ConfirmationRequestTypeIDs = {
   PERSONAL_SIGN_REQUEST: ApprovalType.PersonalSign,
   TYPED_SIGN_REQUEST: ApprovalType.EthSignTypedData,
   TRANSACTION_REQUEST: ApprovalType.Transaction,
-};
+} as const;
 
 export const ConfirmationUIType = {
   MODAL: 'modal-confirmation-container',
   FLAT: 'flat-confirmation-container',
-}
+} as const;
 
 export const ConfirmationRowComponentIDs = {
   ACCOUNT_NETWORK: 'account-network',
@@ -38,28 +38,28 @@ export const ConfirmationRowComponentIDs = {
   SIWE_SIGNING_ACCOUNT_INFO: 'siwe-signing-account-info',
   STAKING_DETAILS: 'staking-details',
   TOKEN_HERO: 'token-hero',
-}
+} as const;
 
 export const ConfirmationFooterSelectorIDs = {
   CANCEL_BUTTON: 'cancel-button',
   CONFIRM_BUTTON: 'confirm-button',
-};
+} as const;
 
 export const ConfirmAlertModalSelectorsIDs = {
   CONFIRM_ALERT_CHECKBOX: 'confirm-alert-checkbox',
   CONFIRM_ALERT_BUTTON: 'confirm-alert-confirm-button',
   CONFIRM_ALERT_MODAL: 'confirm-alert-modal',
-};
+} as const;
 
 export const AlertModalSelectorsIDs = {
   ALERT_MODAL_CHECKBOX: 'alert-modal-checkbox',
   ALERT_MODAL_GOT_IT_BUTTON: 'alert-modal-got-it-button',
-};
+} as const;
 
 export const AlertModalSelectorsText = {
   ALERT_ORIGIN_MISMATCH_TITLE: enContent.alert_system.domain_mismatch.title,
-};
+} as const;
 
 export const AlertTypeIDs = {
   INLINE_ALERT: 'inline-alert',
-}
+} as const; 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This commit introduces a new `ConfirmationView` class that encapsulates the selectors for the confirmation screen's security alert banners. This addition aims to enhance the end-to-end testing capabilities by providing a structured way to access these elements during tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-373

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
