### PR TITLE
fix: `number_of_hd_entropies` value when keyring is unlocked

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -121,6 +121,8 @@ import { prepareNftDetectionEvents } from '../../../util/assets';
 import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
 import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
 import { toFormattedAddress } from '../../../util/address';
+import { selectHDKeyrings } from '../../../selectors/keyringController';
+import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 
 const createStyles = ({ colors, typography }: Theme) =>
   StyleSheet.create({
@@ -260,7 +262,7 @@ const Wallet = ({
   const walletRef = useRef(null);
   const theme = useTheme();
   const { toastRef } = useContext(ToastContext);
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder, addTraitsToUser } = useMetrics();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { colors } = theme;
 
@@ -312,6 +314,8 @@ const Wallet = ({
 
   const currentToast = toastRef?.current;
 
+  const hdKeyrings = useSelector(selectHDKeyrings);
+
   const accountName = useAccountName();
   useAccountsWithNetworkActivitySync();
 
@@ -336,6 +340,12 @@ const Wallet = ({
     isParticipatingInMetaMetrics,
     navigate,
   ]);
+
+  useEffect(() => {
+    addTraitsToUser({
+      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: hdKeyrings.length,
+    });
+  }, [addTraitsToUser, hdKeyrings.length]);
 
   useEffect(() => {
     if (!shouldShowNewPrivacyToast) return;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -28,6 +28,6 @@ export interface UserProfileMetaData {
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
   [UserProfileProperty.HAS_MARKETING_CONSENT]: string;
-  [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: number;
+  [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]?: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];
 }

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -66,136 +66,6 @@ describe('generateUserProfileAnalyticsMetaData', () => {
     security: { dataCollectionForMarketing: true },
   };
 
-  describe('NUMBER_OF_HD_ENTROPIES', () => {
-    const testCases = [
-      {
-        name: 'with empty keyrings array',
-        state: {
-          engine: {
-            backgroundState: {
-              KeyringController: {
-                keyrings: [],
-              },
-            },
-          },
-        },
-        expected: 0,
-      },
-      {
-        name: 'with one HD keyring',
-        state: {
-          engine: {
-            backgroundState: {
-              KeyringController: {
-                keyrings: [
-                  {
-                    type: ExtendedKeyringTypes.hd,
-                    accounts: ['0x123'],
-                    metadata: {
-                      id: '01JPM7NFVHW8V9KKN34053JVFU',
-                      name: '',
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        },
-        expected: 1,
-      },
-      {
-        name: 'with two HD keyrings',
-        state: {
-          engine: {
-            backgroundState: {
-              KeyringController: {
-                keyrings: [
-                  {
-                    type: ExtendedKeyringTypes.hd,
-                    accounts: ['0x123'],
-                    metadata: {
-                      id: '01JPM7NFVHW8V9KKN34053JVFU',
-                      name: '',
-                    },
-                  },
-                  {
-                    type: ExtendedKeyringTypes.hd,
-                    accounts: ['0x456'],
-                    metadata: {
-                      id: '01JPM8NFVHW8V9KKN34055JVFV',
-                      name: '',
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        },
-        expected: 2,
-      },
-      {
-        name: 'with mixed keyring types',
-        state: {
-          engine: {
-            backgroundState: {
-              KeyringController: {
-                keyrings: [
-                  {
-                    type: ExtendedKeyringTypes.hd,
-                    accounts: ['0x123'],
-                    metadata: {
-                      id: '01JPM7NFVHW8V9KKN34053JVFU',
-                      name: '',
-                    },
-                  },
-                  {
-                    type: ExtendedKeyringTypes.simple,
-                    accounts: ['0x456'],
-                    metadata: {
-                      id: '01JPM8NFVHW8V9KKN34055JVFV',
-                      name: '',
-                    },
-                  },
-                  {
-                    type: ExtendedKeyringTypes.qr,
-                    accounts: ['0x789'],
-                    metadata: {
-                      id: '01JPM9NFVHW8V9KKN34056JVFW',
-                      name: '',
-                    },
-                  },
-                  {
-                    type: ExtendedKeyringTypes.hd,
-                    accounts: ['0xabc'],
-                    metadata: {
-                      id: '01JPM10NFVHW8V9KKN34057JVFX',
-                      name: '',
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        },
-        expected: 2,
-      },
-    ];
-
-    testCases.forEach(({ name, state, expected }) => {
-      it(name, () => {
-        mockGetState.mockReturnValue({
-          ...mockState,
-          ...state,
-        });
-
-        const metadata = generateUserProfileAnalyticsMetaData();
-        expect(metadata[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(
-          expected,
-        );
-      });
-    });
-  });
-
   it('returns metadata', () => {
     mockGetState.mockReturnValue(mockState);
     mockIsMetricsEnabled.mockReturnValue(true);
@@ -209,7 +79,6 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
       [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
       [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
-      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 1,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });
@@ -248,7 +117,6 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
       [UserProfileProperty.SECURITY_PROVIDERS]: '',
-      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -4,7 +4,6 @@ import {
   UserProfileMetaData,
   UserProfileProperty,
 } from './UserProfileAnalyticsMetaData.types';
-import { selectHDKeyrings } from '../../../selectors/keyringController';
 import { getConfiguredCaipChainIds } from '../MultichainAPI/networkMetricUtils';
 
 /**
@@ -21,8 +20,6 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
     appTheme === 'os' ? Appearance.getColorScheme() : appTheme;
   const isDataCollectionForMarketingEnabled =
     reduxState?.security?.dataCollectionForMarketing;
-
-  const hdKeyrings = selectHDKeyrings(reduxState);
 
   const chainIds = getConfiguredCaipChainIds();
 
@@ -50,7 +47,7 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
       isDataCollectionForMarketingEnabled
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
-    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: hdKeyrings.length,
+    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0, // Default value should be updated after login
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
 };

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -47,7 +47,6 @@ const generateUserProfileAnalyticsMetaData = (): UserProfileMetaData => {
       isDataCollectionForMarketingEnabled
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
-    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0, // Default value should be updated after login
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
 };


### PR DESCRIPTION
## **Description**
the number_of_hd_entropies user trait was added in [this PR](https://github.com/MetaMask/metamask-mobile/pull/15566).  The problem with my old implementation is that when `generateUserProfileAnalyticsMetaData` is called, the keyring is unlocked so the value was always 0. This was leading to incorrect data. 

My change moves this property outside of the `generateUserProfileAnalyticsMetaData` and moves it to a specific `addTraitsToUser` call on the wallet view where the keyring will be unlocked and thus give us the correct value. The additional value to having this on the wallet view is that when a user adds a new SRP, this trait will immediately get updated with the new value (since users land on the wallet view after SRP import). 

## **Related issues**

Fixes:

## **Manual testing steps**

1. set IS_TEST to false in your js.env
2. open the app on android using expo
3. shake the device and then click open react native menu, open dev tools
4. dev tools should open on your laptop
5. open the console for dev tools and look for the keyword `IDENTIFY event saved`
6. then create a wallet and watch the logs
7. once you complete the wallet creation, you should see an event logged with the following properties

```

IDENTIFY event saved {type: 'identify', userId: '5836187f-76af-4518-8958-a0fa10dd62a3', 
traits: {number_of_hd_entropies: 1}
type : "identify"
userId: "5836187f-76af-4518-8958-a0fa10dd62a3"
```

8. then, import a new SRP
9. verify that the IDENTIFY call is made with your new SRP count


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1196" alt="Screenshot 2025-06-10 at 8 58 02 PM" src="https://github.com/user-attachments/assets/597b75b5-6ec9-4444-b569-b4f61687d223" />

(event called with the same accounts as showed below. 3 srps)

### **After**

<image src="https://github.com/user-attachments/assets/0f8d4cdd-8d87-4348-ba28-9463918bce3b" width="200" height="450" />


<img width="1198" alt="Screenshot 2025-06-10 at 8 29 31 PM" src="https://github.com/user-attachments/assets/7bb0df9a-cb31-40b6-b35f-fdcc7d1c7073" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
