### PR TITLE
fix: cp-7.49.0 Fix `useConfirmationRedesignEnabled` hook

### DIFF
--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
@@ -50,6 +50,13 @@ describe('useConfirmationRedesignEnabled', () => {
   const confirmationRedesignFlagsMock = jest.mocked(
     selectConfirmationRedesignFlags,
   );
+  const isHardwareAccountMock = jest.mocked(isHardwareAccount);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isHardwareAccountMock.mockReturnValue(false);
+    confirmationRedesignFlagsMock.mockReturnValue(disabledFeatureFlags);
+  });
 
   describe('signature confirmations', () => {
     it('returns true for personal sign request', async () => {
@@ -69,8 +76,6 @@ describe('useConfirmationRedesignEnabled', () => {
     });
 
     it('returns false when remote flag is disabled', async () => {
-      confirmationRedesignFlagsMock.mockReturnValue(disabledFeatureFlags);
-
       const { result } = renderHookWithProvider(
         useConfirmationRedesignEnabled,
         {
@@ -85,11 +90,6 @@ describe('useConfirmationRedesignEnabled', () => {
   describe('transaction redesigned confirmations', () => {
     describe('staking confirmations', () => {
       describe('staking deposit', () => {
-        beforeEach(() => {
-          jest.clearAllMocks();
-          (isHardwareAccount as jest.Mock).mockReturnValue(false);
-        });
-
         it('returns true when enabled', async () => {
           confirmationRedesignFlagsMock.mockReturnValue({
             ...disabledFeatureFlags,
@@ -187,7 +187,7 @@ describe('useConfirmationRedesignEnabled', () => {
             staking_confirmations: true,
           });
 
-          (isHardwareAccount as jest.Mock).mockReturnValue(true);
+          isHardwareAccountMock.mockReturnValue(true);
           const { result } = renderHookWithProvider(
             useConfirmationRedesignEnabled,
             {
@@ -277,5 +277,26 @@ describe('useConfirmationRedesignEnabled', () => {
         expect(result.current.isRedesignedEnabled).toBe(true);
       });
     });
+  });
+
+  it('checks hardware account if confirmation is a transaction, validates `txParams.from` is hardware account', () => {
+    isHardwareAccountMock.mockReturnValue(true);
+    confirmationRedesignFlagsMock.mockReturnValue({
+      ...disabledFeatureFlags,
+      transfer: true,
+    });
+
+    const { result } = renderHookWithProvider(useConfirmationRedesignEnabled, {
+      state: transferConfirmationState,
+    });
+
+    const expectedFromAddress =
+      transferConfirmationState.engine.backgroundState.TransactionController
+        .transactions[0].txParams.from;
+
+    expect(isHardwareAccountMock).toHaveBeenCalledTimes(1);
+    expect(isHardwareAccountMock).toHaveBeenCalledWith(expectedFromAddress);
+
+    expect(result.current.isRedesignedEnabled).toBe(false);
   });
 });

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.test.ts
@@ -279,7 +279,7 @@ describe('useConfirmationRedesignEnabled', () => {
     });
   });
 
-  it('checks hardware account if confirmation is a transaction, validates `txParams.from` is hardware account', () => {
+  it('if confirmation is a transaction, validates `txParams.from` is hardware account', () => {
     isHardwareAccountMock.mockReturnValue(true);
     confirmationRedesignFlagsMock.mockReturnValue({
       ...disabledFeatureFlags,

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -86,11 +86,12 @@ function isRedesignedTransaction({
 
 export const useConfirmationRedesignEnabled = () => {
   const { approvalRequest } = useApprovalRequest();
-  const fromAddress = approvalRequest?.requestData?.from;
   const transactionMetadata = useTransactionMetadataRequest();
   const confirmationRedesignFlags = useSelector(
     selectConfirmationRedesignFlags,
   );
+  const fromAddress =
+    approvalRequest?.requestData?.from || transactionMetadata?.txParams?.from;
 
   const approvalRequestType = approvalRequest?.type as ApprovalType;
 

--- a/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmationRedesignEnabled.ts
@@ -91,7 +91,7 @@ export const useConfirmationRedesignEnabled = () => {
     selectConfirmationRedesignFlags,
   );
   const fromAddress =
-    approvalRequest?.requestData?.from || transactionMetadata?.txParams?.from;
+    transactionMetadata?.txParams?.from ?? approvalRequest?.requestData?.from;
 
   const approvalRequestType = approvalRequest?.type as ApprovalType;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix removing unwanted redesigned confirmation appearance when using hardware wallet. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16189

## **Manual testing steps**

It is already manually tested by @Akaryatrh - no manual tests required anymore

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
