### PR TITLE
fix: cp-7.49.0 Integrate ErrorReportingService to fix NetworkController init

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -225,6 +225,8 @@ import {
   MultichainRouterGetSupportedAccountsEvent,
   MultichainRouterIsSupportedScopeEvent,
 } from './controllers/multichain-router/constants';
+import { ErrorReportingService } from '@metamask/error-reporting-service';
+import { captureException } from '@sentry/react-native';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -327,10 +329,24 @@ export class Engine {
       },
     });
 
+    const errorReportingServiceMessenger =
+      this.controllerMessenger.getRestricted({
+        name: 'ErrorReportingService',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+    // We only use the ErrorReportingService through the
+    // messenger. But we need to assign a variable to make Sonar happy.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const errorReportingService = new ErrorReportingService({
+      messenger: errorReportingServiceMessenger,
+      captureException: (error) => captureException(error as Error),
+    });
+
     const networkControllerMessenger = this.controllerMessenger.getRestricted({
       name: 'NetworkController',
       allowedEvents: [],
-      allowedActions: [],
+      allowedActions: ['ErrorReportingService:captureException'],
     });
 
     const additionalDefaultNetworks = [

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -270,6 +270,7 @@ import {
   AppMetadataControllerEvents,
   AppMetadataControllerState,
 } from '@metamask/app-metadata-controller';
+import type { ErrorReportingServiceActions } from '@metamask/error-reporting-service';
 
 /**
  * Controllers that area always instantiated
@@ -355,7 +356,8 @@ type GlobalActions =
   | EarnControllerActions
   | AppMetadataControllerActions
   | MultichainRouterActions
-  | DeFiPositionsControllerActions;
+  | DeFiPositionsControllerActions
+  | ErrorReportingServiceActions;
 
 type GlobalEvents =
   | ComposableControllerEvents<EngineState>

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "@metamask/design-tokens": "^7.0.0",
     "@metamask/earn-controller": "^0.13.0",
     "@metamask/eip1193-permission-middleware": "^0.1.0",
+    "@metamask/error-reporting-service": "^1.0.0",
     "@metamask/eth-hd-keyring": "^12.1.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^17.0.1",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The changelog for `@metamask/network-controller` 23.5.1 was missing some key instructions. To properly upgrade to this version, it's necessary to initialize an ErrorReportingService so that NetworkController can call it via the messenger. Without this change, if the selected network client ID is invalid, the wallet will still crash, as it is not able to report an error to Sentry.

This commit fixes the problem by adding `@metamask/error-reporting-service` as a dependency and then initializing it prior to NetworkController.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

N/A

## **Manual testing steps**

1. Open `Engine.ts`, find where `networkControllerOptions` is assigned, and change:
    ```
    state: initialNetworkControllerState,
    ```
    to:
    ```
    state: {
      ...initialNetworkControllerState,
      selectedNetworkClientId: 'aslksjasdflk',
    },
    ``` 
3. Start the app. It should not crash.

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
