### PR TITLE
fix: use disable sync before assertion

### DIFF
--- a/e2e/specs/multisrp/import-srp.spec.ts
+++ b/e2e/specs/multisrp/import-srp.spec.ts
@@ -47,23 +47,25 @@ describe(SmokeWalletPlatform('Import new srp to wallet'), () => {
     await goToImportSrp();
     await inputSrp(valid12WordMnemonic);
     await ImportSrpView.tapImportButton();
-
+    await device.disableSynchronization();
     await Assertions.checkIfVisible(WalletView.container);
     await Assertions.checkIfElementNotToHaveText(
       WalletView.accountName as Promise<Detox.IndexableNativeElement>,
       'Account 1',
     );
+    await device.enableSynchronization();
   });
 
   it('imports a new 24 word srp', async () => {
     await goToImportSrp();
     await inputSrp(valid24WordMnemonic);
     await ImportSrpView.tapImportButton();
-
+    await device.disableSynchronization();
     await Assertions.checkIfVisible(WalletView.container);
     await Assertions.checkIfElementNotToHaveText(
       WalletView.accountName as Promise<Detox.IndexableNativeElement>,
       'Account 1',
     );
+    await device.enableSynchronization();
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the multisrp import srp e2e tests. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: None

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
