### PR TITLE
feat: Add support for gas fees component for batch transactions

### DIFF
--- a/app/components/Views/confirmations/components/info/transaction-batch/transaction-batch.tsx
+++ b/app/components/Views/confirmations/components/info/transaction-batch/transaction-batch.tsx
@@ -8,6 +8,7 @@ import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmat
 import useNavbar from '../../../hooks/ui/useNavbar';
 import AccountNetworkInfo from '../../rows/account-network-info-row';
 import OriginRow from '../../rows/origin-row';
+import GasFeesDetailsRow from '../../rows/transactions/gas-fee-details-row';
 
 const TransactionBatch = () => {
   useNavbar(strings('confirm.transaction'), true);
@@ -24,6 +25,7 @@ const TransactionBatch = () => {
     <View>
       <AccountNetworkInfo />
       {!isWalletInitiated && <OriginRow isSignatureRequest={false} />}
+      <GasFeesDetailsRow disableUpdate />
     </View>
   );
 };

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import { TransactionMeta } from '@metamask/transaction-controller';
-
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import Icon, {
   IconSize,
@@ -21,6 +19,8 @@ import AlertRow from '../../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import { GasSpeed } from '../../../gas/gas-speed';
 import styleSheet from './gas-fee-details-row.styles';
+import { useTransactionBatchesMetadata } from '../../../../hooks/transactions/useTransactionBatchesMetadata';
+import { useFeeCalculationsTransactionBatch } from '../../../../hooks/gas/useFeeCalculationsTransactionBatch';
 
 
 const EstimationInfo = ({
@@ -74,9 +74,15 @@ const ClickableEstimationInfo = ({
 const GasFeesDetailsRow = ({ disableUpdate = false }) => {
   const [gasModalVisible, setGasModalVisible] = useState(false);
   const { styles } = useStyles(styleSheet, {});
+
   const transactionMetadata = useTransactionMetadataRequest();
+  const transactionBatchesMetadata = useTransactionBatchesMetadata();
+
   const feeCalculations = useFeeCalculations(
-    transactionMetadata as TransactionMeta,
+    transactionMetadata,
+  );
+  const feeCalculationsTransactionBatch = useFeeCalculationsTransactionBatch(
+    transactionBatchesMetadata,
   );
   const hideFiatForTestnet = useHideFiatForTestnet(
     transactionMetadata?.chainId,
@@ -104,13 +110,13 @@ const GasFeesDetailsRow = ({ disableUpdate = false }) => {
             {disableUpdate ? (
               <EstimationInfo
                 hideFiatForTestnet={hideFiatForTestnet}
-                feeCalculations={feeCalculations}
+                feeCalculations={transactionBatchesMetadata ? feeCalculationsTransactionBatch : feeCalculations}
               />
             ) : (
               <ClickableEstimationInfo
                 onPress={() => setGasModalVisible(true)}
                 hideFiatForTestnet={hideFiatForTestnet}
-                feeCalculations={feeCalculations}
+                feeCalculations={transactionBatchesMetadata ? feeCalculationsTransactionBatch : feeCalculations}
               />
             )}
           </View>

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -1,27 +1,27 @@
+import { TransactionBatchMeta, TransactionMeta } from '@metamask/transaction-controller';
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
-import Icon, {
-  IconSize,
-  IconName,
-} from '../../../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../../../locales/i18n';
-import { TOOLTIP_TYPES } from '../../../../../../../core/Analytics/events/confirmations';
-import { useStyles } from '../../../../../../../component-library/hooks';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../../../component-library/components/Icons/Icon';
 import Text from '../../../../../../../component-library/components/Texts/Text/Text';
+import { useStyles } from '../../../../../../../component-library/hooks';
+import { TOOLTIP_TYPES } from '../../../../../../../core/Analytics/events/confirmations';
 import useHideFiatForTestnet from '../../../../../../hooks/useHideFiatForTestnet';
 import { useFeeCalculations } from '../../../../hooks/gas/useFeeCalculations';
-import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
+import { useFeeCalculationsTransactionBatch } from '../../../../hooks/gas/useFeeCalculationsTransactionBatch';
 import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfirmationMetricEvents';
+import { useTransactionBatchesMetadata } from '../../../../hooks/transactions/useTransactionBatchesMetadata';
+import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
+import { GasSpeed } from '../../../gas/gas-speed';
 import { GasFeeModal } from '../../../modals/gas-fee-modal';
-import InfoSection from '../../../UI/info-row/info-section';
 import AlertRow from '../../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
-import { GasSpeed } from '../../../gas/gas-speed';
+import InfoSection from '../../../UI/info-row/info-section';
 import styleSheet from './gas-fee-details-row.styles';
-import { useTransactionBatchesMetadata } from '../../../../hooks/transactions/useTransactionBatchesMetadata';
-import { useFeeCalculationsTransactionBatch } from '../../../../hooks/gas/useFeeCalculationsTransactionBatch';
-
 
 const EstimationInfo = ({
   hideFiatForTestnet,
@@ -45,16 +45,44 @@ const EstimationInfo = ({
   );
 };
 
+const SingleEstimateInfo = ({ hideFiatForTestnet }: { hideFiatForTestnet: boolean }) => {
+  const transactionMetadata = useTransactionMetadataRequest();
+  const feeCalculations = useFeeCalculations(transactionMetadata as TransactionMeta);
+
+  return (
+    <EstimationInfo
+      hideFiatForTestnet={hideFiatForTestnet}
+      feeCalculations={feeCalculations}
+    />
+  );
+};
+
+const BatchEstimateInfo = ({ hideFiatForTestnet }: { hideFiatForTestnet: boolean }) => {
+  const transactionBatchesMetadata = useTransactionBatchesMetadata();
+  const feeCalculations = useFeeCalculationsTransactionBatch(transactionBatchesMetadata as TransactionBatchMeta);
+
+  return (
+    <EstimationInfo
+      hideFiatForTestnet={hideFiatForTestnet}
+      feeCalculations={feeCalculations}
+    />
+  );
+};
+
 const ClickableEstimationInfo = ({
   hideFiatForTestnet,
-  feeCalculations,
   onPress,
 }: {
   hideFiatForTestnet: boolean;
-  feeCalculations: ReturnType<typeof useFeeCalculations>;
   onPress: () => void;
 }) => {
   const { styles, theme } = useStyles(styleSheet, {});
+
+  const transactionMetadata = useTransactionMetadataRequest();
+  const feeCalculations = useFeeCalculations(
+    transactionMetadata as TransactionMeta,
+  );
+
   return (
     <TouchableOpacity onPress={onPress} style={styles.editButton}>
       <Icon
@@ -71,6 +99,19 @@ const ClickableEstimationInfo = ({
   );
 };
 
+const RenderEstimationInfo = ({
+  transactionBatchesMetadata,
+  hideFiatForTestnet,
+}: {
+  transactionBatchesMetadata: TransactionBatchMeta | undefined;
+  hideFiatForTestnet: boolean;
+}) => {
+  if (transactionBatchesMetadata) {
+    return <BatchEstimateInfo hideFiatForTestnet={hideFiatForTestnet} />;
+  }
+  return <SingleEstimateInfo hideFiatForTestnet={hideFiatForTestnet} />;
+};
+
 const GasFeesDetailsRow = ({ disableUpdate = false }) => {
   const [gasModalVisible, setGasModalVisible] = useState(false);
   const { styles } = useStyles(styleSheet, {});
@@ -78,12 +119,6 @@ const GasFeesDetailsRow = ({ disableUpdate = false }) => {
   const transactionMetadata = useTransactionMetadataRequest();
   const transactionBatchesMetadata = useTransactionBatchesMetadata();
 
-  const feeCalculations = useFeeCalculations(
-    transactionMetadata,
-  );
-  const feeCalculationsTransactionBatch = useFeeCalculationsTransactionBatch(
-    transactionBatchesMetadata,
-  );
   const hideFiatForTestnet = useHideFiatForTestnet(
     transactionMetadata?.chainId,
   );
@@ -108,15 +143,14 @@ const GasFeesDetailsRow = ({ disableUpdate = false }) => {
         >
           <View style={styles.valueContainer}>
             {disableUpdate ? (
-              <EstimationInfo
+              <RenderEstimationInfo
+                transactionBatchesMetadata={transactionBatchesMetadata}
                 hideFiatForTestnet={hideFiatForTestnet}
-                feeCalculations={transactionBatchesMetadata ? feeCalculationsTransactionBatch : feeCalculations}
               />
             ) : (
               <ClickableEstimationInfo
                 onPress={() => setGasModalVisible(true)}
                 hideFiatForTestnet={hideFiatForTestnet}
-                feeCalculations={transactionBatchesMetadata ? feeCalculationsTransactionBatch : feeCalculations}
               />
             )}
           </View>

--- a/app/components/Views/confirmations/hooks/gas/feeCalculationsShared.ts
+++ b/app/components/Views/confirmations/hooks/gas/feeCalculationsShared.ts
@@ -1,0 +1,174 @@
+import { hexToBN } from '@metamask/controller-utils';
+import { Hex, add0x } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+import I18n from '../../../../../../locales/i18n';
+import { formatAmount } from '../../../../../components/UI/SimulationDetails/formatAmount';
+import {
+  addHexes,
+  decGWEIToHexWEI,
+  decimalToHex,
+  getValueFromWeiHex,
+  multiplyHexes,
+} from '../../../../../util/conversions';
+
+const HEX_ZERO = '0x0';
+
+export function getFeesFromHex({
+  hexFee,
+  nativeConversionRate,
+  nativeCurrency,
+  fiatFormatter,
+  shouldHideFiat,
+}: {
+  hexFee: string;
+  nativeConversionRate: number | null | undefined;
+  nativeCurrency: string | undefined;
+  fiatFormatter: (amount: BigNumber) => string;
+  shouldHideFiat: boolean;
+}) {
+  if (
+    nativeConversionRate === undefined ||
+    nativeConversionRate === null ||
+    !nativeCurrency
+  ) {
+    return {
+      currentCurrencyFee: null,
+      nativeCurrencyFee: null,
+      preciseNativeCurrencyFee: null,
+      preciseNativeFeeInHex: null,
+    };
+  }
+
+  const nativeConversionRateInBN = new BigNumber(
+    nativeConversionRate as number,
+  );
+  const locale = I18n.locale;
+  const nativeCurrencyFee = `${formatAmount(
+    locale,
+    new BigNumber(
+      getValueFromWeiHex({
+        value: hexFee,
+        fromCurrency: 'WEI',
+        toCurrency: 'ETH',
+        numberOfDecimals: 4,
+        conversionRate: 1,
+        toDenomination: 'ETH',
+      }) || 0,
+    ),
+  )} ${nativeCurrency}`;
+
+  const preciseNativeCurrencyFee = `${formatAmount(
+    locale,
+    new BigNumber(
+      getValueFromWeiHex({
+        value: hexFee,
+        fromCurrency: 'WEI',
+        toCurrency: 'ETH',
+        numberOfDecimals: 18,
+        conversionRate: 1,
+        toDenomination: 'ETH',
+      }) || 0,
+    ),
+  )} ${nativeCurrency}`;
+
+  const decimalCurrentCurrencyFee = Number(
+    getValueFromWeiHex({
+      value: hexFee,
+      conversionRate: nativeConversionRateInBN,
+      fromCurrency: 'GWEI',
+      toCurrency: 'ETH',
+      numberOfDecimals: 2,
+      toDenomination: 'ETH',
+    }),
+  );
+
+  // This is used to check if the fee is less than $0.01 - more precise than decimalCurrentCurrencyFee
+  // Because decimalCurrentCurrencyFee is rounded to 2 decimal places
+  const preciseCurrentCurrencyFee = Number(
+    getValueFromWeiHex({
+      value: hexFee,
+      conversionRate: nativeConversionRateInBN,
+      fromCurrency: 'GWEI',
+      toCurrency: 'ETH',
+      numberOfDecimals: 3,
+      toDenomination: 'ETH',
+    }),
+  );
+
+  let currentCurrencyFee;
+  if (preciseCurrentCurrencyFee < 0.01) {
+    currentCurrencyFee = `< ${fiatFormatter(new BigNumber(0.01))}`;
+  } else {
+    currentCurrencyFee = fiatFormatter(
+      new BigNumber(decimalCurrentCurrencyFee),
+    );
+  }
+
+  if (shouldHideFiat) {
+    currentCurrencyFee = null;
+  }
+
+  return {
+    currentCurrencyFee,
+    nativeCurrencyFee,
+    preciseNativeCurrencyFee,
+    preciseNativeFeeInHex: add0x(hexFee),
+  };
+}
+
+export function calculateGasEstimate({
+  feePerGas,
+  gasPrice,
+  gas,
+  shouldUseEIP1559FeeLogic,
+  priorityFeePerGas,
+  estimatedBaseFee,
+  layer1GasFee,
+  getFeesFromHexFn,
+}: {
+  feePerGas: string;
+  priorityFeePerGas: string;
+  gasPrice: string;
+  gas: string;
+  shouldUseEIP1559FeeLogic: boolean;
+  estimatedBaseFee: string | undefined;
+  layer1GasFee?: string;
+  getFeesFromHexFn: (hexFee: string) => {
+    currentCurrencyFee: string | null;
+    nativeCurrencyFee: string | null;
+    preciseNativeCurrencyFee: string | null;
+    preciseNativeFeeInHex: string | null;
+  };
+}) {
+  let minimumFeePerGas = addHexes(
+    decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
+    decimalToHex(priorityFeePerGas),
+  );
+
+  const minimumFeePerGasBN = hexToBN(minimumFeePerGas as Hex);
+
+  // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
+  if (minimumFeePerGasBN.gt(hexToBN(feePerGas as Hex))) {
+    minimumFeePerGas = feePerGas;
+  }
+
+  const estimation = multiplyHexes(
+    shouldUseEIP1559FeeLogic
+      ? (minimumFeePerGas as Hex)
+      : (gasPrice as Hex),
+    gas as Hex,
+  );
+
+  const hasLayer1GasFee = Boolean(layer1GasFee);
+
+  if (hasLayer1GasFee && layer1GasFee) {
+    const estimatedTotalFeesForL2 = addHexes(
+      estimation,
+      layer1GasFee,
+    ) as Hex;
+
+    return getFeesFromHexFn(estimatedTotalFeesForL2);
+  }
+
+  return getFeesFromHexFn(estimation);
+}

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -1,28 +1,18 @@
-import { hexToBN } from '@metamask/controller-utils';
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { type TransactionMeta } from '@metamask/transaction-controller';
-import { Hex, add0x } from '@metamask/utils';
-import { BigNumber } from 'bignumber.js';
+import { Hex } from '@metamask/utils';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import I18n from '../../../../../../locales/i18n';
-import { formatAmount } from '../../../../../components/UI/SimulationDetails/formatAmount';
 import { RootState } from '../../../../../reducers';
 import { selectConversionRateByChainId } from '../../../../../selectors/currencyRateController';
 import { selectNetworkConfigurationByChainId } from '../../../../../selectors/networkController';
-import {
-  addHexes,
-  decGWEIToHexWEI,
-  decimalToHex,
-  getValueFromWeiHex,
-  multiplyHexes,
-} from '../../../../../util/conversions';
 import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
-import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { isTestNet } from '../../../../../util/networks';
+import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { useEIP1559TxFees } from './useEIP1559TxFees';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 import { useSupportsEIP1559 } from '../transactions/useSupportsEIP1559';
+import { getFeesFromHex, calculateGasEstimate } from './feeCalculationsShared';
 
 const HEX_ZERO = '0x0';
 
@@ -66,100 +56,19 @@ export const useFeeCalculations = (transactionMeta?: TransactionMeta) => {
     ?.estimatedBaseFee;
   const txParamsGasPrice = safeTransactionMeta.txParams?.gasPrice || HEX_ZERO;
 
-  const getFeesFromHex = useCallback(
-    (hexFee: string) => {
-      if (
-        nativeConversionRate === undefined ||
-        nativeConversionRate === null ||
-        !nativeCurrency
-      ) {
-        return {
-          currentCurrencyFee: null,
-          nativeCurrencyFee: null,
-          preciseNativeFeeInHex: null,
-        };
-      }
-
-      const nativeConversionRateInBN = new BigNumber(
-        nativeConversionRate as number,
-      );
-      const locale = I18n.locale;
-      const nativeCurrencyFee = `${formatAmount(
-        locale,
-        new BigNumber(
-          getValueFromWeiHex({
-            value: hexFee,
-            fromCurrency: 'WEI',
-            toCurrency: 'ETH',
-            numberOfDecimals: 4,
-            conversionRate: 1,
-            toDenomination: 'ETH',
-          }) || 0,
-        ),
-      )} ${nativeCurrency}`;
-
-      const preciseNativeCurrencyFee = `${formatAmount(
-        locale,
-        new BigNumber(
-          getValueFromWeiHex({
-            value: hexFee,
-            fromCurrency: 'WEI',
-            toCurrency: 'ETH',
-            numberOfDecimals: 18,
-            conversionRate: 1,
-            toDenomination: 'ETH',
-          }) || 0,
-        ),
-      )} ${nativeCurrency}`;
-
-      const decimalCurrentCurrencyFee = Number(
-        getValueFromWeiHex({
-          value: hexFee,
-          conversionRate: nativeConversionRateInBN,
-          fromCurrency: 'GWEI',
-          toCurrency: 'ETH',
-          numberOfDecimals: 2,
-          toDenomination: 'ETH',
-        }),
-      );
-
-      // This is used to check if the fee is less than $0.01 - more precise than decimalCurrentCurrencyFee
-      // Because decimalCurrentCurrencyFee is rounded to 2 decimal places
-      const preciseCurrentCurrencyFee = Number(
-        getValueFromWeiHex({
-          value: hexFee,
-          conversionRate: nativeConversionRateInBN,
-          fromCurrency: 'GWEI',
-          toCurrency: 'ETH',
-          numberOfDecimals: 3,
-          toDenomination: 'ETH',
-        }),
-      );
-
-      let currentCurrencyFee;
-      if (preciseCurrentCurrencyFee < 0.01) {
-        currentCurrencyFee = `< ${fiatFormatter(new BigNumber(0.01))}`;
-      } else {
-        currentCurrencyFee = fiatFormatter(
-          new BigNumber(decimalCurrentCurrencyFee),
-        );
-      }
-
-      if(shouldHideFiat) {
-        currentCurrencyFee = null;
-      }
-
-      return {
-        currentCurrencyFee,
-        nativeCurrencyFee,
-        preciseNativeCurrencyFee,
-        preciseNativeFeeInHex: add0x(hexFee),
-      };
-    },
+  const getFeesFromHexCallback = useCallback(
+    (hexFee: string) =>
+      getFeesFromHex({
+        hexFee,
+        nativeConversionRate,
+        nativeCurrency,
+        fiatFormatter,
+        shouldHideFiat,
+      }),
     [fiatFormatter, nativeConversionRate, nativeCurrency, shouldHideFiat],
   );
 
-  const calculateGasEstimate = useCallback(
+  const calculateGasEstimateCallback = useCallback(
     ({
       feePerGas,
       gasPrice,
@@ -172,46 +81,24 @@ export const useFeeCalculations = (transactionMeta?: TransactionMeta) => {
       gasPrice: string;
       gas: string;
       shouldUseEIP1559FeeLogic: boolean;
-    }) => {
-      let minimumFeePerGas = addHexes(
-        decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
-        decimalToHex(priorityFeePerGas),
-      );
-
-      const minimumFeePerGasBN = hexToBN(minimumFeePerGas as Hex);
-
-      // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
-      if (minimumFeePerGasBN.gt(hexToBN(feePerGas as Hex))) {
-        minimumFeePerGas = feePerGas;
-      }
-
-      const estimation = multiplyHexes(
-        shouldUseEIP1559FeeLogic
-          ? (minimumFeePerGas as Hex)
-          : (gasPrice as Hex),
-        gas as Hex,
-      );
-
-      const hasLayer1GasFee = Boolean(layer1GasFee);
-
-      if (hasLayer1GasFee) {
-        const estimatedTotalFeesForL2 = addHexes(
-          estimation,
-          layer1GasFee,
-        ) as Hex;
-
-        return getFeesFromHex(estimatedTotalFeesForL2);
-      }
-
-      return getFeesFromHex(estimation);
-    },
-    [estimatedBaseFee, layer1GasFee, getFeesFromHex],
+    }) =>
+      calculateGasEstimate({
+        feePerGas,
+        priorityFeePerGas,
+        gasPrice,
+        gas,
+        shouldUseEIP1559FeeLogic,
+        estimatedBaseFee,
+        layer1GasFee,
+        getFeesFromHexFn: getFeesFromHexCallback,
+      }),
+    [estimatedBaseFee, layer1GasFee, getFeesFromHexCallback],
   );
 
   // Estimated fee
   const estimatedFees = useMemo(
     () =>
-      calculateGasEstimate({
+      calculateGasEstimateCallback({
         feePerGas: maxFeePerGas,
         priorityFeePerGas: maxPriorityFeePerGas,
         gas: gasLimitNoBuffer || HEX_ZERO,
@@ -223,7 +110,7 @@ export const useFeeCalculations = (transactionMeta?: TransactionMeta) => {
       maxFeePerGas,
       maxPriorityFeePerGas,
       supportsEIP1559,
-      calculateGasEstimate,
+      calculateGasEstimateCallback,
       gasLimitNoBuffer,
     ],
   );
@@ -232,6 +119,6 @@ export const useFeeCalculations = (transactionMeta?: TransactionMeta) => {
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,
     estimatedFeeNative: estimatedFees.nativeCurrencyFee,
     preciseNativeFeeInHex: estimatedFees.preciseNativeFeeInHex,
-    calculateGasEstimate,
+    calculateGasEstimate: calculateGasEstimateCallback,
   };
 };

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculationsTransactionBatch.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculationsTransactionBatch.test.ts
@@ -1,0 +1,232 @@
+import { GasFeeEstimateLevel, GasFeeEstimateType, type TransactionBatchMeta, TransactionStatus } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { toHex } from 'viem';
+import { stakingDepositConfirmationState } from '../../../../../util/test/confirm-data-helpers';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useFeeCalculationsTransactionBatch } from './useFeeCalculationsTransactionBatch';
+
+const GWEI_IN_WEI = 10 ** 9;
+
+jest.mock('../../../../../util/networks', () => ({
+  isTestNet: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    GasFeeController: {
+      startPolling: jest.fn(),
+      stopPollingByPollingToken: jest.fn(),
+    },
+    NetworkController: {
+      getNetworkConfigurationByNetworkClientId: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../utils/token', () => ({
+  ...jest.requireActual('../../../../utils/token'),
+  fetchErc20Decimals: jest.fn().mockResolvedValue(18),
+}));
+
+describe('useFeeCalculationsTransactionBatch', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // Create mock transaction batch meta
+  const mockTransactionBatchMeta: TransactionBatchMeta = {
+    id: 'test-batch-1',
+    from: '0x1234567890123456789012345678901234567890' as Hex,
+    status: TransactionStatus.unapproved,
+    chainId: toHex(1),
+    gas: toHex(21000),
+    networkClientId: 'mainnet',
+    gasFeeEstimates: {
+      type: GasFeeEstimateType.FeeMarket,
+      [GasFeeEstimateLevel.Low]: {
+        maxFeePerGas: toHex(1 * GWEI_IN_WEI),
+        maxPriorityFeePerGas: toHex(1 * GWEI_IN_WEI),
+      },
+      [GasFeeEstimateLevel.Medium]: {
+        maxFeePerGas: toHex(2 * GWEI_IN_WEI),
+        maxPriorityFeePerGas: toHex(2 * GWEI_IN_WEI),
+      },
+      [GasFeeEstimateLevel.High]: {
+        maxFeePerGas: toHex(3 * GWEI_IN_WEI),
+        maxPriorityFeePerGas: toHex(3 * GWEI_IN_WEI),
+      },
+    },
+    transactions: [],
+  };
+
+  const mockTransactionBatchMetaGasPrice: TransactionBatchMeta = {
+    ...mockTransactionBatchMeta,
+    gasFeeEstimates: {
+      type: GasFeeEstimateType.GasPrice,
+      gasPrice: toHex(2 * GWEI_IN_WEI),
+    },
+  };
+
+  const mockTransactionBatchMetaLegacy: TransactionBatchMeta = {
+    ...mockTransactionBatchMeta,
+    gasFeeEstimates: {
+      type: GasFeeEstimateType.Legacy,
+      [GasFeeEstimateLevel.Low]: toHex(1 * GWEI_IN_WEI),
+      [GasFeeEstimateLevel.Medium]: toHex(2 * GWEI_IN_WEI),
+      [GasFeeEstimateLevel.High]: toHex(3 * GWEI_IN_WEI),
+    },
+  };
+
+  it('returns fee calculations for FeeMarket type', () => {
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMeta),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('$0.15');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x2632e314a000');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns fee calculations for GasPrice type', () => {
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMetaGasPrice),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('$0.15');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x2632e314a000');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns fee calculations for Legacy type', () => {
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMetaLegacy),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('$0.15');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x2632e314a000');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns fee calculations less than $0.01', () => {
+    const clonedStakingDepositConfirmationState = cloneDeep(
+      stakingDepositConfirmationState,
+    );
+    clonedStakingDepositConfirmationState.engine.backgroundState.CurrencyRateController.currencyRates.ETH =
+      {
+        conversionDate: 1732887955.694,
+        conversionRate: 80,
+        usdConversionRate: 80,
+      };
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMeta),
+      {
+        state: clonedStakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x2632e314a000');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns null as estimatedFeeFiat if conversion rate is not available', () => {
+    const clonedStakingDepositConfirmationState = cloneDeep(
+      stakingDepositConfirmationState,
+    );
+
+    // No type is exported for CurrencyRate, so we need to cast it to the correct type
+    clonedStakingDepositConfirmationState.engine.backgroundState.CurrencyRateController.currencyRates.ETH =
+      null as unknown as {
+        conversionDate: number;
+        conversionRate: number;
+        usdConversionRate: number;
+      };
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMeta),
+      {
+        state: clonedStakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe(null);
+    expect(result.current.estimatedFeeNative).toBe(null);
+    expect(result.current.preciseNativeFeeInHex).toBe(null);
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('handles batch meta with no gas limit', () => {
+    const batchMetaWithoutGas = {
+      ...mockTransactionBatchMeta,
+      gas: undefined as unknown as string,
+    };
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(batchMetaWithoutGas),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x0');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('handles batch meta with no gasFeeEstimates', () => {
+    const batchMetaWithoutEstimates = {
+      ...mockTransactionBatchMeta,
+      gasFeeEstimates: undefined,
+    };
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(batchMetaWithoutEstimates),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
+    expect(result.current.estimatedFeeNative).toBe('0 ETH');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x0');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('uses calculateGasEstimate callback correctly', () => {
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculationsTransactionBatch(mockTransactionBatchMeta),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    const gasEstimate = result.current.calculateGasEstimate({
+      feePerGas: '0x5572e9c22d00',
+      priorityFeePerGas: toHex(2 * GWEI_IN_WEI),
+      gas: '0x5208',
+      shouldUseEIP1559FeeLogic: true,
+      gasPrice: '0x5572e9c22d00',
+    });
+
+    expect(gasEstimate).toBeDefined();
+    expect(gasEstimate.nativeCurrencyFee).toBeDefined();
+    expect(gasEstimate.currentCurrencyFee).toBeDefined();
+    expect(gasEstimate.preciseNativeFeeInHex).toBeDefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/transactions/useSupportsEIP1559.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useSupportsEIP1559.ts
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 import {
-  TransactionBatchMeta,
   TransactionEnvelopeType,
   TransactionMeta,
 } from '@metamask/transaction-controller';
@@ -8,7 +7,7 @@ import {
 import { checkNetworkAndAccountSupports1559 } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
 
-export function useSupportsEIP1559(transactionMeta: TransactionMeta | TransactionBatchMeta) {
+export function useSupportsEIP1559(transactionMeta: TransactionMeta) {
   const { networkClientId } = transactionMeta;
   const isLegacyTxn = (transactionMeta as TransactionMeta)?.txParams?.type === TransactionEnvelopeType.legacy;
   const networkSupportsEIP1559 = useSelector((state: RootState) =>

--- a/app/components/Views/confirmations/hooks/transactions/useSupportsEIP1559.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useSupportsEIP1559.ts
@@ -9,7 +9,7 @@ import { RootState } from '../../../../../reducers';
 
 export function useSupportsEIP1559(transactionMeta: TransactionMeta) {
   const { networkClientId } = transactionMeta;
-  const isLegacyTxn = (transactionMeta as TransactionMeta)?.txParams?.type === TransactionEnvelopeType.legacy;
+  const isLegacyTxn = transactionMeta?.txParams?.type === TransactionEnvelopeType.legacy;
   const networkSupportsEIP1559 = useSelector((state: RootState) =>
     checkNetworkAndAccountSupports1559(state, networkClientId),
   );

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionBatchSupportsEIP1559.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionBatchSupportsEIP1559.ts
@@ -1,0 +1,20 @@
+import {
+  GasFeeEstimateType,
+  TransactionBatchMeta
+} from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../../reducers';
+import { checkNetworkAndAccountSupports1559 } from '../../../../../selectors/networkController';
+
+export function useTransactionBatchSupportsEIP1559(transactionBatchMeta: TransactionBatchMeta) {
+  const { networkClientId } = transactionBatchMeta;
+  const isLegacyTxn = transactionBatchMeta.gasFeeEstimates?.type === GasFeeEstimateType.Legacy ||
+    transactionBatchMeta.gasFeeEstimates?.type === GasFeeEstimateType.GasPrice;
+  const networkSupportsEIP1559 = useSelector((state: RootState) =>
+    checkNetworkAndAccountSupports1559(state, networkClientId),
+  );
+
+  const supportsEIP1559 = networkSupportsEIP1559 && !isLegacyTxn;
+
+  return { supportsEIP1559 };
+}

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -1,15 +1,15 @@
 import { hexToBN } from '@metamask/controller-utils';
 import { Hex, add0x } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
-import I18n from '../../../../../../locales/i18n';
-import { formatAmount } from '../../../../../components/UI/SimulationDetails/formatAmount';
+import I18n from '../../../../../locales/i18n';
+import { formatAmount } from '../../../../components/UI/SimulationDetails/formatAmount';
 import {
   addHexes,
   decGWEIToHexWEI,
   decimalToHex,
   getValueFromWeiHex,
   multiplyHexes,
-} from '../../../../../util/conversions';
+} from '../../../../util/conversions';
 
 const HEX_ZERO = '0x0';
 
@@ -40,7 +40,7 @@ export function getFeesFromHex({
   }
 
   const nativeConversionRateInBN = new BigNumber(
-    nativeConversionRate as number,
+    nativeConversionRate,
   );
   const locale = I18n.locale;
   const nativeCurrencyFee = `${formatAmount(
@@ -53,7 +53,7 @@ export function getFeesFromHex({
         numberOfDecimals: 4,
         conversionRate: 1,
         toDenomination: 'ETH',
-      }) || 0,
+      }) ?? 0,
     ),
   )} ${nativeCurrency}`;
 
@@ -67,7 +67,7 @@ export function getFeesFromHex({
         numberOfDecimals: 18,
         conversionRate: 1,
         toDenomination: 'ETH',
-      }) || 0,
+      }) ?? 0,
     ),
   )} ${nativeCurrency}`;
 
@@ -141,7 +141,7 @@ export function calculateGasEstimate({
   };
 }) {
   let minimumFeePerGas = addHexes(
-    decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
+    decGWEIToHexWEI(estimatedBaseFee) ?? HEX_ZERO,
     decimalToHex(priorityFeePerGas),
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5165

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="487" alt="Screenshot 2025-06-13 at 13 44 01" src="https://github.com/user-attachments/assets/8368a31c-b852-4af9-a5d5-fc19d71cc1ca" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
