### PR TITLE
chore(dev): Use fewer CPU cores to bundle on lesser machines 

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -48,7 +48,7 @@ module.exports = function (baseConfig) {
   // if you have 10 cores but only 16GB, only 3 workers would get used.
   const maxWorkers = Math.ceil(
     os.availableParallelism() *
-      Math.max(1, os.totalmem() / (64 * 1024 * 1024 * 1024)),
+      Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024)),
   );
 
   return wrapWithReanimatedMetroConfig(

--- a/metro.config.js
+++ b/metro.config.js
@@ -12,6 +12,8 @@ const { lockdownSerializer } = require('@lavamoat/react-native-lockdown');
 
 // eslint-disable-next-line import/no-nodejs-modules
 const { parseArgs } = require('node:util');
+// eslint-disable-next-line import/no-nodejs-modules
+const os = require('node:os');
 
 const parsedArgs = parseArgs({
   options: {
@@ -41,6 +43,13 @@ module.exports = function (baseConfig) {
   const {
     resolver: { assetExts, sourceExts },
   } = defaultConfig;
+
+  // For less powerful machines, leave room to do other tasks. For instance,
+  // if you have 10 cores but only 16GB, only 3 workers would get used.
+  const maxWorkers = Math.ceil(
+    os.availableParallelism() *
+      Math.max(1, os.totalmem() / (64 * 1024 * 1024 * 1024)),
+  );
 
   return wrapWithReanimatedMetroConfig(
     mergeConfig(defaultConfig, {
@@ -99,6 +108,7 @@ module.exports = function (baseConfig) {
         },
       ),
       resetCache: true,
+      maxWorkers,
     }),
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After running `yarn setup` or `yarn setup:expo`, running `yarn watch:clean`, bundling the app on less powerful machines (e.g. with only 16GB of RAM) can end hogging resources, making it very difficult to do anything else. This happens because by default Metro will use as many workers as the number of available CPU cores.

To fix this, this commit adjusts the number of workers to match the amount of RAM available, making sure not to cripple performance on more powerful computers. For instance, if there are 10 CPU cores available, only 3 workers will be used with 16GB of RAM, but all cores will be used with 64GB of RAM or more.

## **Related issues**

(N/A)

## **Manual testing steps**

1. Run `yarn setup:expo`.
2. Run `yarn watch:clean`.
3. Load the app in an emulator.
4. Start the bundling process.
5. Try to do anything else: switch back to the browser and review some PRs, watch a video, play some music, anything. Your computer shouldn't slow to a crawl.

## **Screenshots/Recordings**

(N/A)

### **Before**

https://github.com/user-attachments/assets/f5db0352-433e-4cbd-9657-c5ebf46de2e2

### **After**

https://github.com/user-attachments/assets/3e7c186c-0012-4b4d-8a0b-6cc74d40224a

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
