### PR TITLE
fix: cp-7.49.0 bump version of `@metamask/chain-agnostic-permission` with fix to helper function that was causing error thrown in certain cases when browser tabs were opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@metamask/bitcoin-wallet-snap": "^0.12.1",
     "@metamask/bridge-controller": "^32.1.1",
     "@metamask/bridge-status-controller": "^29.1.0",
-    "@metamask/chain-agnostic-permission": "^0.6.0",
+    "@metamask/chain-agnostic-permission": "^0.7.1",
     "@metamask/composable-controller": "^11.0.0",
     "@metamask/controller-utils": "^11.9.0",
     "@metamask/design-tokens": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,20 +4808,7 @@
     "@metamask/utils" "^11.2.0"
     lodash "^4.17.21"
 
-"@metamask/chain-agnostic-permission@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@metamask/chain-agnostic-permission/-/chain-agnostic-permission-0.7.0.tgz#6a34f213dee46234fab2d8dec760f63079243a1d"
-  integrity sha512-Encfd594BrKb4kk9nLczcz9zmFu3MXXgIOfwIPtguuttAUOrkoRIyVNPT4R9p67EAkwVvSy4+NZGv43f+iGH5Q==
-  dependencies:
-    "@metamask/api-specs" "^0.14.0"
-    "@metamask/controller-utils" "^11.9.0"
-    "@metamask/network-controller" "^23.5.0"
-    "@metamask/permission-controller" "^11.0.6"
-    "@metamask/rpc-errors" "^7.0.2"
-    "@metamask/utils" "^11.2.0"
-    lodash "^4.17.21"
-
-"@metamask/chain-agnostic-permission@^0.7.1":
+"@metamask/chain-agnostic-permission@^0.7.0", "@metamask/chain-agnostic-permission@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@metamask/chain-agnostic-permission/-/chain-agnostic-permission-0.7.1.tgz#9f2b45c21fe1447f33fd7c3007db91a860483c9e"
   integrity sha512-q2Hro95cgHkXPAsKMaWRaH8C6sGudsNLHqlG/ym62qbImx4Wjjh0abHMHjJN4TbIvDoyWqNZxYeCeUgKnfynIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,19 +4808,6 @@
     "@metamask/utils" "^11.2.0"
     lodash "^4.17.21"
 
-"@metamask/chain-agnostic-permission@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@metamask/chain-agnostic-permission/-/chain-agnostic-permission-0.6.0.tgz#3de97ffd5f60ae5e384e8f7663f53f38c819c855"
-  integrity sha512-2Nn/R2b4LiW+Nhq0Pxz7V1IGxcP5NxfVSvqOJNGH9r7qb9vPB+LM14XTQBnu4XJnVR9rc6mZPCLuJa7I0FhcCg==
-  dependencies:
-    "@metamask/api-specs" "^0.10.12"
-    "@metamask/controller-utils" "^11.7.0"
-    "@metamask/network-controller" "^23.3.0"
-    "@metamask/permission-controller" "^11.0.6"
-    "@metamask/rpc-errors" "^7.0.2"
-    "@metamask/utils" "^11.2.0"
-    lodash "^4.17.21"
-
 "@metamask/chain-agnostic-permission@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@metamask/chain-agnostic-permission/-/chain-agnostic-permission-0.7.0.tgz#6a34f213dee46234fab2d8dec760f63079243a1d"
@@ -4829,6 +4816,19 @@
     "@metamask/api-specs" "^0.14.0"
     "@metamask/controller-utils" "^11.9.0"
     "@metamask/network-controller" "^23.5.0"
+    "@metamask/permission-controller" "^11.0.6"
+    "@metamask/rpc-errors" "^7.0.2"
+    "@metamask/utils" "^11.2.0"
+    lodash "^4.17.21"
+
+"@metamask/chain-agnostic-permission@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@metamask/chain-agnostic-permission/-/chain-agnostic-permission-0.7.1.tgz#9f2b45c21fe1447f33fd7c3007db91a860483c9e"
+  integrity sha512-q2Hro95cgHkXPAsKMaWRaH8C6sGudsNLHqlG/ym62qbImx4Wjjh0abHMHjJN4TbIvDoyWqNZxYeCeUgKnfynIA==
+  dependencies:
+    "@metamask/api-specs" "^0.14.0"
+    "@metamask/controller-utils" "^11.10.0"
+    "@metamask/network-controller" "^23.6.0"
     "@metamask/permission-controller" "^11.0.6"
     "@metamask/rpc-errors" "^7.0.2"
     "@metamask/utils" "^11.2.0"
@@ -5368,7 +5368,7 @@
     uri-js "^4.4.1"
     uuid "^8.3.2"
 
-"@metamask/network-controller@^23.3.0", "@metamask/network-controller@^23.5.0", "@metamask/network-controller@^23.6.0":
+"@metamask/network-controller@^23.5.0", "@metamask/network-controller@^23.6.0":
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/@metamask/network-controller/-/network-controller-23.6.0.tgz#b07805c6f6cfb2d44c05f2a151dbff4dc9b2e0bc"
   integrity sha512-oAuqOn0+qd48qUSIQnPoRgfakW05oJDux+OmIXlJQao8iiWN2vQWrvt8xCbgg3l08Srhr2u3unrsKz6DcmJgbA==


### PR DESCRIPTION
[Core PR with fix to `isInternalAccountInPermittedAccountIds` & `isCaipAccountIdInPermittedAccountIds` ](https://github.com/MetaMask/core/pull/5980) which was causing this bug.

Bumps `@metamask/chain-agnostic-permission` to latest: `0.7.1`

## **Related issues**

[See slack thread where bug was initially reported](https://consensys.slack.com/archives/C08UFPWB3GB/p1749821334454809)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/921b48a5-87d0-4900-ac60-f69219881d15

### **After**

https://github.com/user-attachments/assets/b3f06069-66aa-485d-b90d-997ed4544466

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
