### PR TITLE
fix: android login page status-bar

### DIFF
--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Login renders matching snapshot 1`] = `
     {
       "backgroundColor": "#ffffff",
       "flex": 1,
+      "paddingTop": 0,
     }
   }
 >
@@ -375,6 +376,7 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
     {
       "backgroundColor": "#ffffff",
       "flex": 1,
+      "paddingTop": 0,
     }
   }
 >

--- a/app/components/Views/Login/styles.ts
+++ b/app/components/Views/Login/styles.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@metamask/design-tokens';
-import { StyleSheet } from 'react-native';
+import { Platform, StatusBar, StyleSheet } from 'react-native';
 import Device from '../../../util/device';
 import { fontStyles } from '../../../styles/common';
 const deviceHeight = Device.getDeviceHeight();
@@ -12,6 +12,10 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     mainWrapper: {
+      paddingTop: Platform.select({
+        android: StatusBar.currentHeight ?? 0,
+        default: 0,
+      }),
       backgroundColor: colors.background.default,
       flex: 1,
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Login Screen Header is overlapping with the Status bar for android.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:
Add paddingTop with Statusbar current Height for android platform only

 
## **Manual testing steps**

```gherkin
Fix: Login Screen Overlap with Status Bar in Android
  Scenario: Go to Login Screen (Lock App or open existing App)
```
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
![Screenshot 2025-06-16 at 11 28 44 AM](https://github.com/user-attachments/assets/86c61444-28f3-499b-85f6-8cec3aaebf23)

### **After**

<!-- [screenshots/recordings] -->
![Screenshot 2025-06-16 at 11 56 16 AM](https://github.com/user-attachments/assets/c601cdb9-0a72-4640-a4ad-119e5bfc3eb6)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
