### PR TITLE
test: remove uncessary non-permitted flow test now that per-dapp-selected-network is enabled these tests are not needed #16150

### DIFF
--- a/e2e/specs/multichain/permissions/chains/permission-system-add-non-permitted.spec.js
+++ b/e2e/specs/multichain/permissions/chains/permission-system-add-non-permitted.spec.js
@@ -18,7 +18,7 @@ import NetworkConnectMultiSelector from '../../../../pages/Browser/NetworkConnec
 
 const SEPOLIA = CustomNetworks.Sepolia.providerConfig.nickname;
 
-describe(
+xdescribe(
   SmokeNetworkExpansion('Chain Permission System, non-permitted chain, '),
   () => {
     beforeAll(async () => {


### PR DESCRIPTION
## **Description**

Cherry pick of commit to disable network e2e test cases which are no longer needed and currently failing in CI.

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
