### PR TITLE
fix: SRP paste with space

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -130,7 +130,6 @@ const ImportFromSecretRecoveryPhrase = ({
   const [biometryChoice, setBiometryChoice] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [spellCheckError, setSpellCheckError] = useState('');
   const [hideSeedPhraseInput, setHideSeedPhraseInput] = useState(true);
   const [seedPhrase, setSeedPhrase] = useState([]);
   const [seedPhraseInputFocusedIndex, setSeedPhraseInputFocusedIndex] =
@@ -171,13 +170,27 @@ const ImportFromSecretRecoveryPhrase = ({
     setErrorWordIndexes({});
     setShowAllSeedPhrase(false);
     setError('');
-    setSpellCheckError('');
   }, []);
 
   const handleSeedPhraseChange = useCallback(
-    async (seedPhraseText, index) => {
+    (seedPhraseText) => {
+      setError('');
+      const text = formatSeedPhraseToSingleLine(seedPhraseText);
+      const trimmedText = text.trim();
+      const updatedTrimmedText = trimmedText.split(' ');
+
+      if (SRP_LENGTHS.includes(updatedTrimmedText.length)) {
+        setSeedPhrase(updatedTrimmedText);
+      } else {
+        setSeedPhrase(text.split(' '));
+      }
+    },
+    [setSeedPhrase],
+  );
+
+  const handleSeedPhraseChangeAtIndex = useCallback(
+    (seedPhraseText, index) => {
       try {
-        setSpellCheckError('');
         setError('');
         const text = formatSeedPhraseToSingleLine(seedPhraseText);
 
@@ -228,7 +241,7 @@ const ImportFromSecretRecoveryPhrase = ({
       onScanSuccess: ({ seed = undefined }) => {
         if (seed) {
           handleClear();
-          handleSeedPhraseChange(seed, 0);
+          handleSeedPhraseChangeAtIndex(seed, 0);
         } else {
           Alert.alert(
             strings('import_from_seed.invalid_qr_code_title'),
@@ -241,7 +254,12 @@ const ImportFromSecretRecoveryPhrase = ({
         setHideSeedPhraseInput(shouldHideSRP);
       },
     });
-  }, [hideSeedPhraseInput, navigation, handleClear, handleSeedPhraseChange]);
+  }, [
+    hideSeedPhraseInput,
+    navigation,
+    handleClear,
+    handleSeedPhraseChangeAtIndex,
+  ]);
 
   const onBackPress = () => {
     if (currentStep === 0) {
@@ -407,15 +425,12 @@ const ImportFromSecretRecoveryPhrase = ({
     }
   };
 
-  const handlePaste = useCallback(
-    async (focusedIndex) => {
-      const text = await Clipboard.getString(); // Get copied text
-      if (text.trim() !== '') {
-        handleSeedPhraseChange(text, focusedIndex);
-      }
-    },
-    [handleSeedPhraseChange],
-  );
+  const handlePaste = useCallback(async () => {
+    const text = await Clipboard.getString(); // Get copied text
+    if (text.trim() !== '') {
+      handleSeedPhraseChange(text);
+    }
+  }, [handleSeedPhraseChange]);
 
   const toggleShowAllSeedPhrase = () => {
     setShowAllSeedPhrase((prev) => !prev);
@@ -441,7 +456,7 @@ const ImportFromSecretRecoveryPhrase = ({
     }
 
     if (hasSeedPhraseErrors(seedPhrase)) {
-      setSpellCheckError(strings('import_from_seed.spellcheck_error'));
+      setError(strings('import_from_seed.spellcheck_error'));
       return false;
     }
 
@@ -686,9 +701,7 @@ const ImportFromSecretRecoveryPhrase = ({
                             'import_from_seed.srp_placeholder',
                           )}
                           value={seedPhrase?.[0] || ''}
-                          onChangeText={(text) =>
-                            handleSeedPhraseChange(text, 0)
-                          }
+                          onChangeText={(text) => handleSeedPhraseChange(text)}
                           style={styles.seedPhraseDefaultInput}
                           placeholderTextColor={colors.text.alternative}
                           placeholderStyle={
@@ -743,8 +756,7 @@ const ImportFromSecretRecoveryPhrase = ({
                                   value={item}
                                   secureTextEntry={
                                     !(
-                                      Boolean(spellCheckError) &&
-                                      errorWordIndexes[index]
+                                      Boolean(error) && errorWordIndexes[index]
                                     ) && !canShowSeedPhraseWord(index)
                                   }
                                   onFocus={(e) => {
@@ -762,7 +774,7 @@ const ImportFromSecretRecoveryPhrase = ({
                                     handleOnFocus(index);
                                   }}
                                   onChangeText={(text) =>
-                                    handleSeedPhraseChange(text, index)
+                                    handleSeedPhraseChangeAtIndex(text, index)
                                   }
                                   placeholderTextColor={colors.text.muted}
                                   onSubmitEditing={(e) => {
@@ -775,8 +787,7 @@ const ImportFromSecretRecoveryPhrase = ({
                                   textAlignVertical="center"
                                   showSoftInputOnFocus
                                   isError={
-                                    Boolean(spellCheckError) &&
-                                    errorWordIndexes[index]
+                                    Boolean(error) && errorWordIndexes[index]
                                   }
                                   autoCapitalize="none"
                                   numberOfLines={1}
@@ -817,19 +828,19 @@ const ImportFromSecretRecoveryPhrase = ({
                           if (seedPhrase.length > 1) {
                             handleClear();
                           } else {
-                            handlePaste(seedPhraseInputFocusedIndex);
+                            handlePaste();
                           }
                         }}
                         width={ButtonWidthTypes.Full}
                       />
                     </View>
                   </View>
-                  {(Boolean(spellCheckError) || Boolean(error)) && (
+                  {Boolean(error) && (
                     <Text
                       variant={TextVariant.BodySMMedium}
                       color={TextColor.Error}
                     >
-                      {spellCheckError || error}
+                      {error}
                     </Text>
                   )}
                 </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Because of the autocomplete, it created the 13th input text field when we paste the srp.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to `let's get started` page
2. Click `I have an existing wallet`
3. Paste 12 word seed phrase with extra space at the end should create 12 input only

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **Before**

<!-- [screenshots/recordings] -->

![image](https://github.com/user-attachments/assets/e543578c-fee0-43bd-853c-2c00ec93a98a)


### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/d68d5d49-e448-4cae-b6f5-c688abc97a73



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
