### PR TITLE
fix: cp-7.50.0 align sdk connection with permission system

### DIFF
--- a/app/actions/sdk/state.ts
+++ b/app/actions/sdk/state.ts
@@ -4,6 +4,7 @@ export interface WC2Metadata {
   url: string;
   name: string;
   icon: string;
+  lastVerifiedUrl?: string;
 }
 export interface SDKState {
   connections: SDKSessions;

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -122,7 +122,13 @@ const PermissionsSummary = ({
   const [bottomSheetHeight, setBottomSheetHeight] = useState(0);
 
   const hostname = useMemo(
-    () => new URL(currentPageInformation.url).hostname,
+    () => {
+      try {
+        return new URL(currentPageInformation.url).hostname
+      } catch {
+        return currentPageInformation.url;
+      }
+    },
     [currentPageInformation.url],
   );
   const { networkName, networkImageSource } = useNetworkInfo(hostname);

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -334,66 +334,6 @@ describe('AccountConnect', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  describe('Renders different screens based on SDK URL status', () => {
-    it('should render SingleConnect screen when isSdkUrlUnknown is true', () => {
-      const mockPropsForUnknownUrl = {
-        route: {
-          params: {
-            hostInfo: {
-              metadata: {
-                id: 'mockId',
-                // Using an invalid/unknown format for origin
-                origin: '',
-              },
-              permissions: createMockCaip25Permission({
-                'wallet:eip155': {
-                  accounts: [],
-                },
-              }),
-            },
-            permissionRequestId: 'test',
-          },
-        },
-      };
-
-      const { getByTestId } = renderWithProvider(
-        <AccountConnect {...mockPropsForUnknownUrl} />,
-        { state: mockInitialState },
-      );
-
-      expect(getByTestId('connect-account-modal')).toBeDefined();
-    });
-
-    it('should render PermissionsSummary screen when isSdkUrlUnknown is false', () => {
-      const mockPropsForKnownUrl = {
-        route: {
-          params: {
-            hostInfo: {
-              metadata: {
-                id: 'mockId',
-                // Using a valid URL format
-                origin: 'https://example.com',
-              },
-              permissions: createMockCaip25Permission({
-                'wallet:eip155': {
-                  accounts: [],
-                },
-              }),
-            },
-            permissionRequestId: 'test',
-          },
-        },
-      };
-
-      const { getByTestId } = renderWithProvider(
-        <AccountConnect {...mockPropsForKnownUrl} />,
-        { state: mockInitialState },
-      );
-
-      expect(getByTestId('permission-summary-container')).toBeDefined();
-    });
-  });
-
   describe('AccountConnectMultiSelector handlers', () => {
     it('invokes onSubmit property and renders permissions summary', async () => {
       // Render the container component with necessary props

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -496,13 +496,11 @@ describe('AccountConnect', () => {
     const mockAcceptPermissionsRequest = jest.fn().mockResolvedValue(undefined);
     const mockUpdateCaveat = jest.fn();
     const mockGrantPermissionsIncremental = jest.fn();
-    const mockHasCaveat = jest.fn().mockReturnValue(false);
 
     // Override the Engine mock for this test
     Engine.context.PermissionController.acceptPermissionsRequest = mockAcceptPermissionsRequest;
     Engine.context.PermissionController.updateCaveat = mockUpdateCaveat;
     Engine.context.PermissionController.grantPermissionsIncremental = mockGrantPermissionsIncremental;
-    Engine.context.PermissionController.hasCaveat = mockHasCaveat;
 
     const { getByTestId } = renderWithProvider(
         <AccountConnect
@@ -547,17 +545,6 @@ describe('AccountConnect', () => {
         }),
       );
     });
-
-    // Verify network permissions were handled
-    expect(mockHasCaveat).toHaveBeenCalled();
-    expect(mockGrantPermissionsIncremental).toHaveBeenCalledWith(
-      expect.objectContaining({
-        subject: expect.objectContaining({
-          origin: 'https://example.com',
-        }),
-        approvedPermissions: expect.any(Object),
-      }),
-    );
   });
 
   it('AccountConnect should not change origin if browser URL changes', () => {

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -279,14 +279,6 @@ jest.mock('../../../core/SnapKeyring/MultichainWalletSnapClient', () => ({
 mockGetConnection.mockReturnValue(undefined);
 mockIsUUID.mockReturnValue(false);
 
-// Mock Toast context
-const mockToastRef = {
-  current: {
-    showToast: jest.fn(),
-    closeToast: jest.fn(),
-  },
-};
-
 describe('AccountConnect', () => {
   it('renders correctly with base request', () => {
     const { toJSON } = renderWithProvider(
@@ -370,7 +362,7 @@ describe('AccountConnect', () => {
   describe('AccountConnectMultiSelector handlers', () => {
     it('invokes onEditNetworks and renders multiconnect network selector', async () => {
             // Render the container component with necessary props
-            const { getByTestId, UNSAFE_getByType, findByTestId } =
+            const { getByTestId, findByTestId } =
             renderWithProvider(
               <AccountConnect
                 route={{

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -314,7 +314,7 @@ const AccountConnect = (props: AccountConnectProps) => {
         channelIdOrHostname.split(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN)[1],
       ).origin;
     } else if (isOriginWalletConnect) {
-      title = channelIdOrHostname;
+      title = wc2Metadata.lastVerifiedUrl ?? wc2Metadata.url;
       dappHostname = title;
     } else if (!isChannelId && (dappUrl || channelIdOrHostname)) {
       title = prefixUrlWithProtocol(dappUrl || channelIdOrHostname);

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -302,8 +302,6 @@ const AccountConnect = (props: AccountConnectProps) => {
     | undefined
   >(undefined);
 
-  const [isSdkUrlUnknown, setIsSdkUrlUnknown] = useState(false);
-
   const { domainTitle, hostname } = useMemo(() => {
     let title = '';
     let dappHostname = dappUrl || channelIdOrHostname;
@@ -323,7 +321,6 @@ const AccountConnect = (props: AccountConnectProps) => {
       dappHostname = channelIdOrHostname;
     } else {
       title = strings('sdk.unknown');
-      setIsSdkUrlUnknown(true);
     }
 
     return { domainTitle: title, hostname: dappHostname };
@@ -977,8 +974,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     renderSingleConnectSelectorScreen,
     renderMultiConnectSelectorScreen,
     renderMultiConnectNetworkSelectorScreen,
-    renderAddNewAccount,
-    isSdkUrlUnknown
+    renderAddNewAccount
   ]);
 
   return (

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -686,25 +686,22 @@ const AccountConnect = (props: AccountConnectProps) => {
     [sheetRef],
   );
 
-  const handleUpdateNetworkPermissions = useCallback(async () => {
-    let hasPermittedChains = false;
-    let chainsToPermit = selectedChainIds.length > 0 ? selectedChainIds : [];
-    if (chainId && chainsToPermit.length === 0) {
-      //This chainId is in format 0x1 but now we have caip25 format, eip155:1
-      chainsToPermit = [
-        formatChainIdToCaip(chainId)
-      ];
-    }
-
+  const hasPermittedChains = useMemo(() => {
     try {
-      hasPermittedChains = Engine.context.PermissionController.hasCaveat(
+      return Engine.context.PermissionController.hasCaveat(
         channelIdOrHostname,
         PermissionKeys.permittedChains,
         CaveatTypes.restrictNetworkSwitching,
       );
     } catch {
-      // noop
+      return false;
     }
+  }, [channelIdOrHostname]);
+
+  const handleUpdateNetworkPermissions = useCallback(async () => {
+    const chainsToPermit = selectedChainIds.length > 0 ?
+      selectedChainIds :
+      [formatChainIdToCaip(chainId)];
 
     if (hasPermittedChains) {
       Engine.context.PermissionController.updateCaveat(
@@ -730,7 +727,7 @@ const AccountConnect = (props: AccountConnectProps) => {
         },
       });
     }
-  }, [selectedChainIds, chainId, hostname]);
+  }, [selectedChainIds, chainId, hostname, hasPermittedChains]);
 
   const handleConfirm = useCallback(async () => {
     hideSheet();

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -702,9 +702,10 @@ const AccountConnect = (props: AccountConnectProps) => {
   }, [channelIdOrHostname, selectedChainIds, chainId, hasPermittedChains]);
 
   const handleConfirm = useCallback(async () => {
+    hideSheet();
     await handleConnect();
     await handleUpdateNetworkPermissions();
-    hideSheet();
+
   }, [handleUpdateNetworkPermissions, hideSheet, handleConnect]);
 
   /**
@@ -960,9 +961,7 @@ const AccountConnect = (props: AccountConnectProps) => {
   const renderConnectScreens = useCallback(() => {
     switch (screen) {
       case AccountConnectScreens.SingleConnect:
-        return isSdkUrlUnknown
-          ? renderPermissionsSummaryScreen()
-          : renderPermissionsSummaryScreen();
+        return renderPermissionsSummaryScreen();
       case AccountConnectScreens.SingleConnectSelector:
         return renderSingleConnectSelectorScreen();
       case AccountConnectScreens.MultiConnectSelector:

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -303,15 +303,14 @@ const AccountConnect = (props: AccountConnectProps) => {
   >(undefined);
 
   const { domainTitle, hostname } = useMemo(() => {
-    let title = '';
+    let title = strings('sdk.unknown');
     let dappHostname = dappUrl || channelIdOrHostname;
-
     if (
       isOriginMMSDKRemoteConn &&
       channelIdOrHostname.startsWith(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN)
     ) {
       title = getUrlObj(
-        channelIdOrHostname.split(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN)[1],
+        channelIdOrHostname.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, ''),
       ).origin;
     } else if (isOriginWalletConnect) {
       title = wc2Metadata?.lastVerifiedUrl ?? wc2Metadata?.url ?? channelIdOrHostname;
@@ -319,10 +318,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     } else if (!isChannelId && (dappUrl || channelIdOrHostname)) {
       title = prefixUrlWithProtocol(dappUrl || channelIdOrHostname);
       dappHostname = channelIdOrHostname;
-    } else {
-      title = strings('sdk.unknown');
     }
-
     return { domainTitle: title, hostname: dappHostname };
   }, [
     isOriginWalletConnect,
@@ -641,7 +637,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     ],
   );
 
-  const {chainId} = useNetworkInfo(hostname);
+  const {chainId} = useNetworkInfo(channelIdOrHostname);
 
   const handleNetworksSelected = useCallback(
     (newSelectedChainIds: CaipChainId[]) => {

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -17,14 +17,13 @@ import { strings } from '../../../../locales/i18n';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import { IconName } from '../../../component-library/components/Icons/Icon';
 import {
   ToastContext,
   ToastVariants,
 } from '../../../component-library/components/Toast';
 import { ToastOptions } from '../../../component-library/components/Toast/Toast.types';
 import { USER_INTENT } from '../../../constants/permissions';
-import { MetaMetricsEvents, store } from '../../../core/Analytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import Engine from '../../../core/Engine';
 import { selectAccountsLength } from '../../../selectors/accountTrackerController';
 import {
@@ -45,7 +44,6 @@ import { useAccounts } from '../../hooks/useAccounts';
 
 // Internal dependencies.
 import { PermissionsRequest } from '@metamask/permission-controller';
-import { ImageURISource } from 'react-native';
 import PhishingModal from '../../../components/UI/PhishingModal';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import Routes from '../../../constants/navigation/Routes';
@@ -75,7 +73,7 @@ import {
   AvatarSize,
   AvatarVariant,
 } from '../../../component-library/components/Avatars/Avatar';
-import { selectEvmNetworkConfigurationsByChainId, selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
+import { selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
 import { isUUID } from '../../../core/SDKConnect/utils/isUUID';
 import useOriginSource from '../../hooks/useOriginSource';
 import {
@@ -293,7 +291,6 @@ const AccountConnect = (props: AccountConnectProps) => {
     ],
   );
 
-  const dappIconUrl = sdkConnection?.originatorInfo?.icon;
   const dappUrl = sdkConnection?.originatorInfo?.url ?? '';
 
   // If it is undefined, it will enter the regular eth account creation flow.
@@ -343,7 +340,7 @@ const AccountConnect = (props: AccountConnectProps) => {
       ? prefixUrlWithProtocol(getHost(hostname))
       : domainTitle;
 
-  const { hostname: hostnameFromUrlObj, protocol: protocolFromUrlObj } =
+  const { hostname: hostnameFromUrlObj } =
     getUrlObj(urlWithProtocol);
 
   useEffect(() => {
@@ -367,31 +364,6 @@ const AccountConnect = (props: AccountConnectProps) => {
 
   const faviconSource = useFavicon(
     channelIdOrHostname || (!isChannelId ? channelIdOrHostname : ''),
-  );
-
-  const actualIcon = useMemo(() => {
-    // Priority to dappIconUrl
-    if (dappIconUrl) {
-      return { uri: dappIconUrl };
-    }
-
-    if (isOriginWalletConnect) {
-      // fetch icon from store
-      return { uri: wc2Metadata?.icon ?? '' };
-    }
-
-    const favicon = faviconSource as ImageURISource;
-    if ('uri' in favicon) {
-      return faviconSource;
-    }
-
-    return { uri: '' };
-  }, [dappIconUrl, wc2Metadata, faviconSource, isOriginWalletConnect]);
-
-  const secureIcon = useMemo(
-    () =>
-      protocolFromUrlObj === 'https:' ? IconName.Lock : IconName.LockSlash,
-    [protocolFromUrlObj],
   );
 
   const eventSource = useOriginSource({ origin: channelIdOrHostname });
@@ -795,7 +767,8 @@ const AccountConnect = (props: AccountConnectProps) => {
     cancelPermissionRequest,
     permissionRequestId,
     handleCreateAccount,
-    handleConnect,
+    handleConfirm,
+    hideSheet,
     trackEvent,
     createEventBuilder,
   ]);
@@ -1007,6 +980,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     renderMultiConnectSelectorScreen,
     renderMultiConnectNetworkSelectorScreen,
     renderAddNewAccount,
+    isSdkUrlUnknown
   ]);
 
   return (

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -94,8 +94,6 @@ import {
   toCaipAccountId,
 } from '@metamask/utils';
 import {
-  Caip25CaveatType,
-  Caip25CaveatValue,
   Caip25EndowmentPermissionName,
   getAllNamespacesFromCaip25CaveatValue,
   getAllScopesFromCaip25CaveatValue,
@@ -110,7 +108,6 @@ import { WalletClientType } from '../../../core/SnapKeyring/MultichainWalletSnap
 import AddNewAccount from '../AddNewAccount';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getApiAnalyticsProperties } from '../../../util/metrics/MultichainAPI/getApiAnalyticsProperties';
-import { useNetworkInfo } from '../../../selectors/selectedNetworkController';
 
 const AccountConnect = (props: AccountConnectProps) => {
   const { colors } = useTheme();

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -727,12 +727,12 @@ const AccountConnect = (props: AccountConnectProps) => {
         },
       });
     }
-  }, [selectedChainIds, chainId, hostname, hasPermittedChains]);
+  }, [channelIdOrHostname, selectedChainIds, chainId, hasPermittedChains]);
 
   const handleConfirm = useCallback(async () => {
-    hideSheet();
-    await handleUpdateNetworkPermissions();
     await handleConnect();
+    await handleUpdateNetworkPermissions();
+    hideSheet();
   }, [handleUpdateNetworkPermissions, hideSheet, handleConnect]);
 
   /**

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -974,7 +974,6 @@ const AccountConnect = (props: AccountConnectProps) => {
   }, [
     screen,
     renderPermissionsSummaryScreen,
-    renderPermissionsSummaryScreen,
     renderSingleConnectSelectorScreen,
     renderMultiConnectSelectorScreen,
     renderMultiConnectNetworkSelectorScreen,

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -636,8 +636,6 @@ const AccountConnect = (props: AccountConnectProps) => {
     ],
   );
 
-  const {chainId} = useNetworkInfo(channelIdOrHostname);
-
   const handleNetworksSelected = useCallback(
     (newSelectedChainIds: CaipChainId[]) => {
       setSelectedChainIds(newSelectedChainIds);
@@ -651,25 +649,6 @@ const AccountConnect = (props: AccountConnectProps) => {
       sheetRef?.current?.onCloseBottomSheet?.(callback),
     [sheetRef],
   );
-
-  const hasPermittedChains = useMemo(() => {
-    try {
-      const caveat = Engine.context.PermissionController.getCaveat(
-        channelIdOrHostname,
-        Caip25EndowmentPermissionName,
-        Caip25CaveatType,
-      );
-      if (caveat?.value) {
-        const scopes = getCaipAccountIdsFromCaip25CaveatValue(
-          caveat.value as Caip25CaveatValue,
-        );
-        return scopes.length > 0
-      }
-      return false;
-    } catch (err) {
-      return false;
-    }
-  }, [channelIdOrHostname]);
 
   const handleConfirm = useCallback(async () => {
     hideSheet();

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -314,7 +314,7 @@ const AccountConnect = (props: AccountConnectProps) => {
         channelIdOrHostname.split(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN)[1],
       ).origin;
     } else if (isOriginWalletConnect) {
-      title = wc2Metadata.lastVerifiedUrl ?? wc2Metadata.url;
+      title = wc2Metadata?.lastVerifiedUrl ?? wc2Metadata?.url ?? channelIdOrHostname;
       dappHostname = title;
     } else if (!isChannelId && (dappUrl || channelIdOrHostname)) {
       title = prefixUrlWithProtocol(dappUrl || channelIdOrHostname);
@@ -330,6 +330,8 @@ const AccountConnect = (props: AccountConnectProps) => {
     isChannelId,
     dappUrl,
     channelIdOrHostname,
+    wc2Metadata?.lastVerifiedUrl,
+    wc2Metadata?.url,
   ]);
 
   const urlWithProtocol =

--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -251,7 +251,7 @@ export class BackgroundBridge extends EventEmitter {
   }
 
   get origin() {
-    return this.isMMSDK ? this.channelId : this.hostname;
+    return this.isWalletConnect || this.isMMSDK ? this.channelId : this.hostname;
   }
 
   onUnlock() {
@@ -355,11 +355,8 @@ export class BackgroundBridge extends EventEmitter {
       DevLogger.log(
         `notifySelectedAddressChanged: ${selectedAddress} channelId=${this.channelId} wc=${this.isWalletConnect} url=${this.url}`,
       );
-      if (this.isWalletConnect) {
-        approvedAccounts = getPermittedAccounts(this.url);
-      } else {
-        approvedAccounts = getPermittedAccounts(this.channelId);
-      }
+      approvedAccounts = getPermittedAccounts(this.origin);
+
       // Check if selectedAddress is approved
       const found = approvedAccounts.some((addr) =>
         areAddressesEqual(addr, selectedAddress),

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -134,6 +134,8 @@ export const checkActiveAccountAndChainId = async ({
   isWalletConnect: boolean;
 }) => {
   let isInvalidAccount = false;
+  const origin = channelId ?? hostname;
+
   if (address) {
     const formattedAddress = safeToChecksumAddress(address);
     DevLogger.log('checkActiveAccountAndChainId', {
@@ -156,7 +158,6 @@ export const checkActiveAccountAndChainId = async ({
       permissionsController.state,
     );
 
-    const origin = channelId ?? hostname;
     const accounts = getPermittedAccounts(origin);
     const normalizedAccounts = accounts.map(safeToChecksumAddress);
 
@@ -190,13 +191,14 @@ export const checkActiveAccountAndChainId = async ({
       networkType && getAllNetworks().includes(networkType);
     let activeChainId;
 
-    if (hostname && isPerDappSelectedNetworkEnabled()) {
+    if (origin && isPerDappSelectedNetworkEnabled()) {
       const perOriginChainId = selectPerOriginChainId(
         store.getState(),
-        hostname,
+        origin,
       );
 
       activeChainId = perOriginChainId;
+
     } else if (isInitialNetwork) {
       activeChainId = ChainId[networkType as keyof typeof ChainId];
     } else if (networkType === RPC) {

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -191,11 +191,6 @@ export const checkActiveAccountAndChainId = async ({
       networkType && getAllNetworks().includes(networkType);
     let activeChainId;
 
-    /* eslint-disable no-debugger */
-    debugger;
-    /* eslint-enable no-debugger */
-
-
     if (origin && isPerDappSelectedNetworkEnabled()) {
       const perOriginChainId = selectPerOriginChainId(
         store.getState(),

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -191,6 +191,11 @@ export const checkActiveAccountAndChainId = async ({
       networkType && getAllNetworks().includes(networkType);
     let activeChainId;
 
+    /* eslint-disable no-debugger */
+    debugger;
+    /* eslint-enable no-debugger */
+
+
     if (origin && isPerDappSelectedNetworkEnabled()) {
       const perOriginChainId = selectPerOriginChainId(
         store.getState(),

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -156,9 +156,8 @@ export const checkActiveAccountAndChainId = async ({
       permissionsController.state,
     );
 
-    const origin = isWalletConnect ? hostname : channelId ?? hostname;
+    const origin = channelId ?? hostname;
     const accounts = getPermittedAccounts(origin);
-
     const normalizedAccounts = accounts.map(safeToChecksumAddress);
 
     if (!normalizedAccounts.includes(formattedAddress)) {

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -401,7 +401,7 @@ export const getRpcMethodMiddleware = ({
 }: RPCMethodsMiddleParameters) => {
   // Make sure to always have the correct origin
   hostname = hostname.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, '');
-  const origin = isWalletConnect ? hostname : channelId ?? hostname;
+  const origin = channelId ?? hostname;
   const hooks = getRpcMethodMiddlewareHooks(origin);
 
   DevLogger.log(

--- a/app/core/RPCMethods/lib/ethereum-chain-utils.js
+++ b/app/core/RPCMethods/lib/ethereum-chain-utils.js
@@ -223,6 +223,7 @@ export async function switchToNetwork({
   origin,
   autoApprove = false,
   hooks,
+  dappUrl = origin,
 }) {
   const {
     getCaveat,
@@ -277,7 +278,7 @@ export async function switchToNetwork({
     ticker: networkConfiguration.ticker || 'ETH',
     chainColor: networkConfiguration.color,
     pageMeta: {
-      url: origin,
+      url: dappUrl ?? origin,
     },
   };
 

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -416,7 +416,7 @@ describe('WalletConnect2Session', () => {
           eip155: {
             chains: ['eip155:1'],
             methods: ['eth_sendTransaction'],
-            events: ['chainChanges', 'accountsChanged'],
+            events: ['chainChanged', 'accountsChanged'],
             accounts: ['eip155:1:0x1234567890abcdef1234567890abcdef12345678'],
           },
         },
@@ -1065,7 +1065,7 @@ describe('WalletConnect2Session', () => {
       await buildCase(request, testChainId, testChainCaip);
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
-      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanged', parseInt(testChainId, 16));
 
 
     });
@@ -1109,7 +1109,7 @@ describe('WalletConnect2Session', () => {
 
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
-      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanged', parseInt(testChainId, 16));
     });
 
     it('handles eth_sendTransaction correctly with valid chainId that it has permissions for isPerDappSelectedNetworkEnabled() = false', async () => {
@@ -1151,7 +1151,7 @@ describe('WalletConnect2Session', () => {
 
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
-      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanged', parseInt(testChainId, 16));
     });
 
     it('handles eth_signTypedData_v3 correctly with valid chainId that it has permissions for', async () => {
@@ -1216,7 +1216,7 @@ describe('WalletConnect2Session', () => {
 
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
-      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanged', parseInt(testChainId, 16));
     });
 
   })

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -11,6 +11,8 @@ import Device from '../../util/device';
 import { Minimizer } from '../NativeModules';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 import { getGlobalNetworkClientId } from '../../util/networks/global-network';
+import { Hex, CaipChainId } from '@metamask/utils';
+
 
 jest.mock('../AppConstants', () => ({
   WALLET_CONNECT: {
@@ -103,19 +105,22 @@ jest.mock('../Permissions', () => ({
   getPermittedAccounts: jest
     .fn()
     .mockResolvedValue(['0x1234567890abcdef1234567890abcdef12345678']),
-  getPermittedChains: jest.fn().mockResolvedValue(['eip155:1']),
+  getPermittedChains: jest.fn().mockResolvedValue(['eip155:1', 'eip155:137']),
 }));
 jest.mock('../../store', () => ({
   store: {
     getState: jest.fn(),
     subscribe: jest.fn(),
+    dispatch: jest.fn(),
   },
 }));
 jest.mock('../RPCMethods/RPCMethodMiddleware', () => ({
   __esModule: true,
   default: () => () => ({ acknowledged: () => Promise.resolve() }),
+  getRpcMethodMiddlewareHooks: jest.fn().mockReturnValue({}),
 }));
 jest.mock('./wc-utils', () => ({
+  ...jest.requireActual('./wc-utils'),
   hideWCLoadingState: jest.fn(),
   showWCLoadingState: jest.fn(),
   checkWCPermissions: jest.fn().mockResolvedValue(true),
@@ -134,6 +139,7 @@ jest.mock('../../selectors/networkController', () => ({
   selectEvmChainId: jest.fn(),
   selectEvmNetworkConfigurationsByChainId: jest.fn().mockReturnValue({}),
   selectNetworkConfigurationsByCaipChainId: jest.fn().mockReturnValue({}),
+  selectNetworkConfigurations: jest.fn().mockReturnValue({}),
   selectIsAllNetworks: jest.fn().mockReturnValue(false),
   selectIsPopularNetwork: jest.fn().mockReturnValue(false),
 }));
@@ -188,11 +194,53 @@ jest.mock('../../util/networks/global-network', () => ({
   getGlobalNetworkClientId: jest.fn().mockReturnValue('1'),
 }));
 
+jest.mock('../../actions/sdk', () => ({
+  updateWC2Metadata: jest.fn().mockReturnValue({ type: 'UPDATE_WC2_METADATA' }),
+}));
+
+jest.mock('../RPCMethods/lib/ethereum-chain-utils', () => ({
+  findExistingNetwork: jest.fn().mockImplementation((chainId) => ({
+    chainId,
+    type: 'custom',
+    nickname: 'Test Network',
+    rpcUrl: 'https://test.com',
+  })),
+  switchToNetwork: jest.fn().mockResolvedValue(undefined),
+}));
+
+
+
+
 describe('WalletConnect2Session', () => {
   let session: WalletConnect2Session;
   let mockClient: IWalletKit;
   let mockSession: SessionTypes.Struct;
   let mockNavigation: NavigationContainerRef;
+
+  const testChainId = '0x89';
+  const testNetworkClientId = `test-network-${parseInt(testChainId, 16)}`;
+  const testChainCaip = `eip155:${parseInt(testChainId, 16)}` as CaipChainId;
+
+  const networkControllerMock = {
+    networkConfigurationsByCaipChainId: {
+      'eip155:1': {
+        chainId: '0x1',
+        rpcEndpoints: [{ networkClientId: 'mainnet' }]
+      },
+      [testChainCaip]: {
+        chainId: testChainId,
+        rpcEndpoints: [{ networkClientId: testNetworkClientId }]
+      }
+    },
+    networkConfigurationsByChainId: {
+      '0x1': {
+        rpcEndpoints: [{ networkClientId: 'mainnet' }]
+      },
+     [testChainId]: {
+        rpcEndpoints: [{ networkClientId: testNetworkClientId}]
+      }
+    }
+  };
 
   beforeEach(() => {
     mockClient = new (jest.requireMock('@reown/walletkit').Client)();
@@ -211,28 +259,18 @@ describe('WalletConnect2Session', () => {
       inpageProvider: {
         networkId: '1',
       },
+      sdk: {
+        wc2Metadata: {
+          id: 'test-channel',
+          url: 'https://example.com',
+          name: 'Test App',
+          icon: 'https://example.com/icon.png',
+          lastVerifiedUrl: 'https://example.com',
+        }
+      },
       engine: {
         backgroundState: {
-          NetworkController: {
-            networkConfigurationsByCaipChainId: {
-              'eip155:1': {
-                chainId: '0x1',
-                rpcEndpoints: [{ networkClientId: 'mainnet' }]
-              },
-              'eip155:137': {
-                chainId: '0x89',
-                rpcEndpoints: [{ networkClientId: 'polygon' }]
-              }
-            },
-            networkConfigurationsByChainId: {
-              '0x1': {
-                rpcEndpoints: [{ networkClientId: 'mainnet' }]
-              },
-              '0x89': {
-                rpcEndpoints: [{ networkClientId: 'polygon' }]
-              }
-            }
-          }
+          NetworkController: networkControllerMock
         }
       }
     });
@@ -241,11 +279,13 @@ describe('WalletConnect2Session', () => {
     const { selectNetworkConfigurationsByCaipChainId, selectEvmNetworkConfigurationsByChainId } = jest.requireMock('../../selectors/networkController');
     selectNetworkConfigurationsByCaipChainId.mockReturnValue({
       'eip155:1': { chainId: '0x1' },
-      'eip155:137': { chainId: '0x89' },
+      'eip155:2': { chainId: '0x2' },
+      [testChainCaip]: { chainId: testChainId },
     });
     selectEvmNetworkConfigurationsByChainId.mockReturnValue({
       '0x1': { rpcEndpoints: [{ networkClientId: 'mainnet' }] },
-      '0x89': { rpcEndpoints: [{ networkClientId: 'polygon' }] }
+      '0x2': { rpcEndpoints: [{ networkClientId: 'optimism' }] },
+      [testChainId]: { rpcEndpoints: [{ networkClientId: testNetworkClientId }] }
     });
 
     session = new WalletConnect2Session({
@@ -376,7 +416,7 @@ describe('WalletConnect2Session', () => {
           eip155: {
             chains: ['eip155:1'],
             methods: ['eth_sendTransaction'],
-            events: ['chainChanged', 'accountsChanged'],
+            events: ['chainChanges', 'accountsChanged'],
             accounts: ['eip155:1:0x1234567890abcdef1234567890abcdef12345678'],
           },
         },
@@ -759,60 +799,55 @@ describe('WalletConnect2Session', () => {
     });
   });
 
-  describe('handles wallet_switchEthereumChain correctly', () => {
+  describe('handles wc grpc operations correctly', () => {
     const { isPerDappSelectedNetworkEnabled: isPerDappSelectedNetworkEnabledMock } = jest.requireMock('../../util/networks');
     const mockedEngine = jest.requireMock('../Engine/Engine');
-    const testNetworkClientId = 'test-network-client-id';
-    const testChainId = '0x89'
 
     async function buildCase(
-      isPerDappSelectedNetworkEnabled: boolean,
-      chainId: string
+      request: WalletKitTypes.SessionRequest,
+      switchIntoChainId: Hex,
+      switchIntoCaip2ChainId: CaipChainId
     ) {
-      (store.getState as jest.Mock).mockReturnValue({
-        inpageProvider: {
-          networkId: '1',
-        },
-        engine: {
-          backgroundState: {
-            NetworkController: {
-              networkConfigurationsByChainId: {
-                '0x1': {
-                  rpcEndpoints: [{ networkClientId: 'mainnet' }]
-                },
-                '0x89': {
-                  rpcEndpoints: [{ networkClientId: testNetworkClientId }]
-                }
-              }
-            }
-          }
-        }
-      });
-
-      // Update the mock selectors for this specific test
-      const { selectNetworkConfigurationsByCaipChainId, selectEvmNetworkConfigurationsByChainId } = jest.requireMock('../../selectors/networkController');
+      session.setDeeplink(false);
+      jest.useRealTimers();
+      const networkClientId = `test-network-${parseInt(switchIntoChainId, 16)}`;
+      const {
+        selectNetworkConfigurationsByCaipChainId,
+        selectEvmNetworkConfigurationsByChainId,
+         selectNetworkConfigurations
+      } = jest.requireMock('../../selectors/networkController');
       selectNetworkConfigurationsByCaipChainId.mockReturnValue({
         'eip155:1': { chainId: '0x1' },
-        'eip155:137': { chainId: '0x89' }
+        [switchIntoCaip2ChainId]: { chainId: switchIntoChainId }
       });
       selectEvmNetworkConfigurationsByChainId.mockReturnValue({
         '0x1': { rpcEndpoints: [{ networkClientId: 'mainnet' }] },
-        '0x89': { rpcEndpoints: [{ networkClientId: testNetworkClientId }] }
+       [switchIntoChainId]: { rpcEndpoints: [{ networkClientId }] }
+      });
+      selectNetworkConfigurations.mockReturnValue({
+        'mainnet': { chainId: '0x1' },
+        [networkClientId]: { chainId: switchIntoChainId }
       });
       (selectEvmChainId as unknown as jest.Mock).mockReturnValue('0x1');
       // Reset mock function before test
       mockedEngine.context.MultichainNetworkController.setActiveNetwork.mockClear();
+      // Mock getGlobalNetworkClientId to return networkClientId
+      (getGlobalNetworkClientId as jest.Mock).mockReturnValue(networkClientId);
+      (session as any).topicByRequestId[request.id] = request.topic;
+      await session.handleRequest(request);
+    }
 
-      // Mock getGlobalNetworkClientId to return testNetworkClientId
-      (getGlobalNetworkClientId as jest.Mock).mockReturnValue(testNetworkClientId);
+    it('handles wallet_switchEthereumChain correctly with isPerDappSelectedNetworkEnabled()', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
 
+      const requestId = Math.floor(Math.random() * 1000000);
       const request: WalletKitTypes.SessionRequest = {
-        id: 42,
+        id: requestId,
         topic: mockSession.topic,
         params: {
           request: {
             method: 'wallet_switchEthereumChain',
-            params: [{ chainId }],
+            params: [{ chainId:testChainId }],
           },
           chainId: 'eip155:1', // Current chain before switch
         },
@@ -824,47 +859,366 @@ describe('WalletConnect2Session', () => {
           },
         },
       };
-
-      (session as any).topicByRequestId[request.id] = request.topic;
-      isPerDappSelectedNetworkEnabledMock.mockReturnValue(isPerDappSelectedNetworkEnabled);
-
       const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
       const approveRequestSpy = jest.spyOn(session, 'approveRequest');
+      handleChainChangeSpy.mockResolvedValue(undefined);
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(true);
 
-      await session.handleRequest(request);
-
-      expect(handleChainChangeSpy).toHaveBeenCalledWith(parseInt(chainId, 16));
-      expect(isPerDappSelectedNetworkEnabledMock).toHaveReturnedWith(isPerDappSelectedNetworkEnabled);
+      await buildCase(request, testChainId, testChainCaip);
+      expect(handleChainChangeSpy).toHaveBeenCalledWith(parseInt(testChainId, 16));
+      expect(isPerDappSelectedNetworkEnabledMock).toHaveReturnedWith(true);
       expect(approveRequestSpy).toHaveBeenCalledWith({
         id: request.id + '',
         result: true,
       });
-    }
-
-    it('handles wallet_switchEthereumChain correctly with isPerDappSelectedNetworkEnabled()', async () => {
-      // Directly spy on the getNetworkClientIdForChainId method
-      const getNetworkClientIdSpy = jest.spyOn(session as any, 'getNetworkClientIdForCaipChainId');
-
-      await buildCase(true, testChainId);
-
-      expect(getNetworkClientIdSpy).toHaveBeenCalled();
-      expect(mockedEngine.context.SelectedNetworkController.setNetworkClientIdForDomain).toHaveBeenCalledWith(
-        'example.com',
-        testNetworkClientId
-      );
-      // Restore the original method
-      getNetworkClientIdSpy.mockRestore();
     });
 
     it('handles wallet_switchEthereumChain correctly with isPerDappSelectedNetworkEnabled() = false', async () => {
-      // Directly spy on the getNetworkClientIdForChainId method
-      const getNetworkClientIdSpy = jest.spyOn(session as any, 'getNetworkClientIdForCaipChainId');
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
 
-      await buildCase(false, testChainId);
-      expect(getNetworkClientIdSpy).toHaveBeenCalledTimes(0);
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'wallet_switchEthereumChain',
+            params: [{ chainId:testChainId }],
+          },
+          chainId: 'eip155:1', // Current chain before switch
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const approveRequestSpy = jest.spyOn(session, 'approveRequest');
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
 
-      // Restore the original method
-      getNetworkClientIdSpy.mockRestore();
+      await buildCase(request, testChainId, testChainCaip);
+      expect(handleChainChangeSpy).toHaveBeenCalledWith(parseInt(testChainId, 16));
+      expect(isPerDappSelectedNetworkEnabledMock).toHaveReturnedWith(false);
+      expect(approveRequestSpy).toHaveBeenCalledWith({
+        id: request.id + '',
+        result: true,
+      });
     });
-  });
-});
+
+    it('handles wallet_switchEthereumChain correctly with invalid chainId', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'wallet_switchEthereumChain',
+            params: [{ chainId:testChainId }],
+          },
+          chainId: 'eip155:1', // Current chain before switch
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockRespondSessionRequest = jest.spyOn(mockClient, 'respondSessionRequest').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+
+      // Test with an invalid chainId that should cause handleSwitchToChain to throw
+      await buildCase(request, '0x2', 'eip155:1234567890abcdef1234567890abcdef12345678');
+
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).toHaveBeenCalled();
+
+      // Check if the spy threw an exception by examining its results
+      expect(mockRespondSessionRequest).toHaveBeenCalledWith({
+        topic: mockSession.topic,
+        response: {
+          id: request.id,
+          jsonrpc: '2.0',
+          error: { code: 4902, message: 'Invalid chainId' },
+        },
+      });
+    });
+
+    it('handles personal_sign correctly with invalid chainId network config', async () => {
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: [{ chainId: 'eip155:2', message: 'test' }],
+          },
+          chainId: 'eip155:2', // Current chain before switch
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+      jest.spyOn(jest.requireMock('./wc-utils') as any, 'getChainIdForCaipChainId').mockReturnValue('eip155:2');
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+
+      // Test with an invalid chainId that should cause handleSwitchToChain to throw
+      await expect(buildCase(request, '0x2', 'eip155:1234567890abcdef1234567890abcdef12345678'))
+      .rejects.toThrow('Invalid parameters: active chainId is different than the one provided.');
+    });
+
+
+    it('handles personal_sign correctly with invalid chainId', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: [{ message: 'test' }],
+          },
+          chainId: 'eip155:2', // Current chain before switch
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockRespondSessionRequest = jest.spyOn(mockClient, 'respondSessionRequest').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+
+      // Test with an invalid chainId that should cause handleSwitchToChain to throw
+      await buildCase(request, '0x2', 'eip155:1234567890abcdef1234567890abcdef12345678');
+
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).not.toHaveBeenCalled();
+
+      // Check if the spy threw an exception by examining its results
+      expect(mockRespondSessionRequest).toHaveBeenCalledWith({
+        topic: mockSession.topic,
+        response: {
+          id: request.id,
+          jsonrpc: '2.0',
+          error: { code: 4902, message: 'Invalid chainId' },
+        },
+      });
+    });
+
+    it('handles personal_sign correctly with valid chainId that it has permissions for', async () => {
+
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: [{ message: 'test' }],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+
+
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockChainChangedEvent = jest.spyOn(session, 'emitEvent').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+      await buildCase(request, testChainId, testChainCaip);
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).toHaveBeenCalled();
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+
+
+    });
+
+    it('handles eth_sendTransaction correctly with valid chainId that it has permissions for', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [{
+              from: '0x1234567890abcdef1234567890abcdef12345678',
+              to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+              value: '0x16345785d8a0000', // 0.1 ETH in wei
+              gas: '0x5208', // 21000
+              gasPrice: '0x4a817c800', // 20 Gwei
+              data: '0x'
+            }],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockChainChangedEvent = jest.spyOn(session, 'emitEvent').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+      await buildCase(request, testChainId, testChainCaip);
+
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).toHaveBeenCalled();
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+    });
+
+    it('handles eth_sendTransaction correctly with valid chainId that it has permissions for isPerDappSelectedNetworkEnabled() = false', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [{
+              from: '0x1234567890abcdef1234567890abcdef12345678',
+              to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+              value: '0x16345785d8a0000', // 0.1 ETH in wei
+              gas: '0x5208', // 21000
+              gasPrice: '0x4a817c800', // 20 Gwei
+              data: '0x'
+            }],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockChainChangedEvent = jest.spyOn(session, 'emitEvent').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(true);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+      await buildCase(request, testChainId, testChainCaip);
+
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).toHaveBeenCalled();
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+    });
+
+    it('handles eth_signTypedData_v3 correctly with valid chainId that it has permissions for', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+      const requestId = Math.floor(Math.random() * 1000000);
+      const typedData = {
+        domain: {
+          name: 'Test DApp',
+          version: '1',
+          chainId: parseInt(testChainId, 16),
+          verifyingContract: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef'
+        },
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ],
+          Transfer: [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'amount', type: 'uint256' }
+          ]
+        },
+        message: {
+          from: '0x1234567890abcdef1234567890abcdef12345678',
+          to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+          amount: '1000000000000000000' // 1 ETH
+        }
+      };
+
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_signTypedData_v3',
+            params: [
+              '0x1234567890abcdef1234567890abcdef12345678',
+              JSON.stringify(typedData)
+            ],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: ''
+          },
+        },
+      };
+
+      const handleChainChangeSpy = jest.spyOn(session as any, 'handleChainChange');
+      const handleSwitchToChainSpy = jest.spyOn(session,'switchToChain');
+      const mockChainChangedEvent = jest.spyOn(session, 'emitEvent').mockResolvedValue(undefined);
+
+      isPerDappSelectedNetworkEnabledMock.mockReturnValue(false);
+      handleChainChangeSpy.mockResolvedValue(undefined);
+      await buildCase(request, testChainId, testChainCaip);
+
+      // Verify that handleSwitchToChain was called
+      expect(handleSwitchToChainSpy).toHaveBeenCalled();
+      expect(mockChainChangedEvent).toHaveBeenCalledWith('chainChanges', parseInt(testChainId, 16));
+    });
+
+  })
+
+})

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -37,6 +37,7 @@ import { isPerDappSelectedNetworkEnabled } from '../../util/networks';
 import { selectPerOriginChainId } from '../../selectors/selectedNetworkController';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { switchToNetwork } from '../RPCMethods/lib/ethereum-chain-utils';
+import { updateWC2Metadata } from '../../actions/sdk';
 
 const ERROR_CODES = {
   USER_REJECT_CODE: 5000,
@@ -554,6 +555,17 @@ class WalletConnect2Session {
     const caip2ChainId = `eip155:${parseInt(hexChainId, 16)}`as CaipChainId;
     const methodParams = requestEvent.params.request.params;
 
+    const currentMetadata = store.getState().sdk.wc2Metadata ?? {
+      id: this.channelId,
+      url: origin,
+      name: this.session.peer.metadata.name,
+      icon: this.session.peer.metadata.icons?.[0] as string,
+    };
+    
+    store.dispatch(updateWC2Metadata({
+      ...currentMetadata,
+      lastVerifiedUrl: origin,
+    }))
     DevLogger.log(
       `WalletConnect2Session::handleRequest caip2ChainId=${caip2ChainId} method=${method} origin=${origin}`,
     );

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -180,7 +180,7 @@ class WalletConnect2Session {
     }
   }
 
-  private getCurrentChainId() {
+  public getCurrentChainId() {
     const providerConfigChainId = selectEvmChainId(store.getState());
     if (isPerDappSelectedNetworkEnabled()) {
       const perOriginChainId = selectPerOriginChainId(
@@ -273,6 +273,10 @@ class WalletConnect2Session {
       chainId: `eip155:${data}`,
     });
   };
+
+  public get getAllowedChainIds(): CaipChainId[] {
+    return this.session.namespaces.eip155?.chains?.map((chain) => chain as CaipChainId) || [];
+  }
 
   /** Handle chain change by updating session namespaces and emitting event */
   private async handleChainChange(chainIdDecimal: number) {
@@ -501,13 +505,7 @@ class WalletConnect2Session {
       });
     }
 
-    const providerConfig = selectProviderConfig(store.getState());
-    const activeChainIdHex = providerConfig.chainId;
-    const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
-      activeChainIdHex,
-      16,
-    )}`;
-
+    const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(this.getCurrentChainId(), 16)}`;
     if (caip2ChainId !== activeCaip2ChainId) {
       DevLogger.log(`WC::checkWCPermissions switching to network:`, existingNetwork);
       // Switching to the network is allowed so try switching into it

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -392,6 +392,7 @@ export class WC2Manager {
     //  Open session proposal modal for confirmation / rejection
     const { id, params } = proposal;
 
+    const channelId = `${id}`
     const pairingTopic = proposal.params.pairingTopic;
     DevLogger.log(
       `WC2::session_proposal id=${id} pairingTopic=${pairingTopic}`,
@@ -436,14 +437,15 @@ export class WC2Manager {
       const caveatValue = getDefaultCaip25CaveatValue();
 
       // Important: Use hostname as the origin for permission request to ensure consistency
-      DevLogger.log(`WC2::session_proposal requestPermissions for hostname`, {
+      DevLogger.log(`WC2::session_proposal requestPermissions for hostname and channelId`, {
         hostname,
         caveatValue,
+        channelId,
       });
 
       // Request permissions via the permissions controller
       await permissionsController.requestPermissions(
-        { origin: hostname },
+        { origin: channelId },
         {
           [Caip25EndowmentPermissionName]: {
             caveats: [
@@ -464,7 +466,7 @@ export class WC2Manager {
         const hexChainId = `0x${walletChainIdDecimal.toString(16)}` as `0x${string}`;
         DevLogger.log(`WC2::session_proposal ensuring chain ${hexChainId} is permitted for ${hostname}`);
 
-        updatePermittedChains(hostname, [`eip155:${walletChainIdDecimal}`]);
+        updatePermittedChains(channelId, [`eip155:${walletChainIdDecimal}`]);
         DevLogger.log(`WC2::session_proposal chain permission added successfully`);
       } catch (err) {
         DevLogger.log(`WC2::session_proposal error adding chain permission`, err);
@@ -482,7 +484,7 @@ export class WC2Manager {
 
     try {
       // Use the hostname for consistent permissions
-      const approvedAccounts = getPermittedAccounts(hostname);
+      const approvedAccounts = getPermittedAccounts(channelId);
 
       DevLogger.log(`WC2::session_proposal getScopedPermissions`, {
         hostname,
@@ -492,7 +494,7 @@ export class WC2Manager {
       });
 
       // Use getScopedPermissions to get properly formatted namespaces
-      const namespaces = await getScopedPermissions({ origin });
+      const namespaces = await getScopedPermissions({ channelId });
 
       DevLogger.log(`WC2::session_proposal namespaces`, namespaces);
 
@@ -504,7 +506,7 @@ export class WC2Manager {
       const deeplink = !!this.deeplinkSessions[activeSession.pairingTopic];
       const session = new WalletConnect2Session({
         session: activeSession,
-        channelId: `${proposal.id}`,
+        channelId,
         deeplink,
         web3Wallet: this.web3Wallet,
         navigation: this.navigation,

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -130,7 +130,7 @@ export class WC2Manager {
             JSON.stringify(permissionController.state, null, 2),
           );
           const accountPermission = permissionController.getPermission(
-            sessionKey,
+            pairingTopic,
             'eth_accounts',
           );
 
@@ -140,7 +140,7 @@ export class WC2Manager {
           );
 
           let approvedAccounts =
-            getPermittedAccounts(sessionKey) ?? [];
+            getPermittedAccounts(pairingTopic) ?? [];
 
           DevLogger.log(
             `WC2::init approvedAccounts id ${accountPermission?.id}`,
@@ -157,13 +157,13 @@ export class WC2Manager {
             DevLogger.log(`WC2::init approvedAccounts`, approvedAccounts);
           }
 
-          updatePermittedChains(sessionKey, wcSession.getAllowedChainIds, true);
+          updatePermittedChains(pairingTopic, wcSession.getAllowedChainIds, true);
 
           const chainId = wcSession.getCurrentChainId();
 
           const nChainId = parseInt(chainId, 16);
           DevLogger.log(
-            `WC2::init updateSession session=${sessionKey} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedInternalAccountChecksummedAddress}`,
+            `WC2::init updateSession session=${pairingTopic} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedInternalAccountChecksummedAddress}`,
             approvedAccounts,
           );
           await this.sessions[sessionKey].updateSession({

--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -14,12 +14,6 @@ import type { NavigationContainerRef } from '@react-navigation/native';
 import Routes from '../../../app/constants/navigation/Routes';
 // eslint-disable-next-line import/no-namespace
 import * as StoreModule from '../../../app/store';
-import { selectProviderConfig } from '../../selectors/networkController';
-import {
-  findExistingNetwork,
-  switchToNetwork,
-} from '../RPCMethods/lib/ethereum-chain-utils';
-
 import Engine from '../Engine';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 
@@ -316,8 +310,6 @@ describe('WalletConnect Utils', () => {
   describe('getHostname', () => {
     it('returns empty string for null or undefined URI', () => {
       expect(getHostname('')).toBe('');
-      expect(getHostname(undefined as unknown as string)).toBe('');
-      expect(getHostname(null as unknown as string)).toBe('');
     });
 
     it('returns protocol part for protocol-based URIs', () => {

--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -6,7 +6,6 @@ import {
   waitForNetworkModalOnboarding,
   getApprovedSessionMethods,
   getScopedPermissions,
-  checkWCPermissions,
   networkModalOnboardingConfig,
   onRequestUserApproval,
   getHostname,
@@ -229,7 +228,7 @@ describe('WalletConnect Utils', () => {
 
   describe('getApprovedSessionMethods', () => {
     it('returns all approved EIP-155 methods', () => {
-      const methods = getApprovedSessionMethods({ origin: 'test' });
+      const methods = getApprovedSessionMethods();
       expect(methods).toContain('eth_sendTransaction');
       expect(methods).toContain('wallet_switchEthereumChain');
     });
@@ -237,7 +236,7 @@ describe('WalletConnect Utils', () => {
 
   describe('getScopedPermissions', () => {
     it('returns correct scoped permissions', async () => {
-      const result = await getScopedPermissions({ origin: 'test' });
+      const result = await getScopedPermissions({ channelId: 'test' });
       expect(result).toEqual({
         eip155: {
           chains: ['eip155:1'],
@@ -246,78 +245,6 @@ describe('WalletConnect Utils', () => {
           accounts: ['eip155:1:0x123'],
         },
       });
-    });
-  });
-
-  describe('checkWCPermissions', () => {
-    beforeEach(() => {
-      (findExistingNetwork as jest.Mock).mockReturnValue({ chainId: '0x1' });
-    });
-
-    it('returns true for permitted chain', async () => {
-      const result = await checkWCPermissions({
-        origin: 'test',
-        caip2ChainId: 'eip155:1',
-      });
-      expect(result).toBe(true);
-    });
-
-    it('throws error for non-existent network', async () => {
-      (findExistingNetwork as jest.Mock).mockReturnValue(null);
-      await expect(
-        checkWCPermissions({
-          origin: 'test',
-          caip2ChainId: 'eip155:2',
-        }),
-      ).rejects.toThrow('Invalid parameters');
-    });
-
-    it('throws error for not allowed chain', async () => {
-      const mockPermittedChains =
-        jest.requireMock('../Permissions').getPermittedChains;
-      mockPermittedChains.mockResolvedValueOnce([]);
-      await expect(
-        checkWCPermissions({
-          origin: 'test',
-          caip2ChainId: 'eip155:2',
-        }),
-      ).rejects.toThrow('Invalid parameters');
-    });
-
-    it('switches network when chainIds differ', async () => {
-      (selectProviderConfig as unknown as jest.Mock).mockReturnValue({
-        chainId: '0x2',
-      });
-      await checkWCPermissions({
-        origin: 'test',
-        caip2ChainId: 'eip155:1',
-      });
-      expect(switchToNetwork).toHaveBeenCalled();
-    });
-
-    it('adds permitted chain when allowSwitchingToNewChain is true', async () => {
-      // Mock that the chain is not permitted
-      const mockPermittedChains =
-        jest.requireMock('../Permissions').getPermittedChains;
-      mockPermittedChains.mockResolvedValueOnce([]);
-
-      // Mock the updatePermittedChains function
-      const mockUpdatePermittedChain =
-        jest.requireMock('../Permissions').updatePermittedChains;
-
-      // Test with allowSwitchingToNewChain set to true
-      const result = await checkWCPermissions({
-        origin: 'test-dapp.com',
-        caip2ChainId: 'eip155:3',
-        allowSwitchingToNewChain: true,
-      });
-
-      // Verify addPermittedChain was called with the right parameters
-      expect(mockUpdatePermittedChain).toHaveBeenCalledWith('test-dapp.com', [
-        'eip155:3',
-      ]);
-      expect(switchToNetwork).toHaveBeenCalled();
-      expect(result).toBe(true);
     });
   });
 

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -1,6 +1,6 @@
 import { toHex } from '@metamask/controller-utils';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
-import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import { CaipChainId, Hex, KnownCaipNamespace } from '@metamask/utils';
 import { NavigationContainerRef } from '@react-navigation/native';
 import { RelayerTypes } from '@walletconnect/types';
 import { parseRelayParams } from '@walletconnect/utils';
@@ -8,18 +8,19 @@ import qs from 'qs';
 import Routes from '../../../app/constants/navigation/Routes';
 import { store } from '../../../app/store';
 import {
+  selectEvmNetworkConfigurationsByChainId,
   selectNetworkConfigurations,
+  selectNetworkConfigurationsByCaipChainId,
   selectProviderConfig,
 } from '../../selectors/networkController';
 import Engine from '../Engine';
 import { getPermittedAccounts, getPermittedChains, removePermittedChain, updatePermittedChains } from '../Permissions';
 import {
   findExistingNetwork,
-  switchToNetwork,
 } from '../RPCMethods/lib/ethereum-chain-utils';
-import { getRpcMethodMiddlewareHooks } from '../RPCMethods/RPCMethodMiddleware';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 import { wait } from '../SDKConnect/utils/wait.util';
+import { WalletKitTypes } from '@reown/walletkit';
 
 export interface WCMultiVersionParams {
   protocol: string;
@@ -160,7 +161,7 @@ export const waitForNetworkModalOnboarding = async ({
   }
 };
 
-export const getApprovedSessionMethods = (_: { origin: string }): string[] => {
+export const getApprovedSessionMethods = (): string[] => {
   const allEIP155Methods = [
     // Standard JSON-RPC methods
     'eth_sendTransaction',
@@ -199,18 +200,17 @@ export const getApprovedSessionMethods = (_: { origin: string }): string[] => {
   return allEIP155Methods;
 };
 
-export const getScopedPermissions = async ({ origin }: { origin: string }) => {
-  const hostname = getHostname(origin);
-  const approvedAccounts = getPermittedAccounts(hostname);
-  const chains = await getPermittedChains(hostname);
+export const getScopedPermissions = async ({ channelId }: { channelId: string }) => {
+  const approvedAccounts = getPermittedAccounts(channelId);
+  const chains = await getPermittedChains(channelId);
 
   DevLogger.log(
-    `WC::getScopedPermissions for ${origin}, found accounts:`,
+    `WC::getScopedPermissions for ${channelId}, found accounts:`,
     approvedAccounts,
   );
 
   DevLogger.log(
-    `WC::getScopedPermissions for ${origin}, found chains:`,
+    `WC::getScopedPermissions for ${channelId}, found chains:`,
     chains,
   );
 
@@ -223,7 +223,7 @@ export const getScopedPermissions = async ({ origin }: { origin: string }) => {
 
   const scopedPermissions = {
     chains,
-    methods: getApprovedSessionMethods({ origin }),
+    methods: getApprovedSessionMethods(),
     events: ['chainChanged', 'accountsChanged'],
     accounts: accountsPerChains,
   };
@@ -250,14 +250,36 @@ export const onRequestUserApproval = (origin: string) => async (args: any) => {
   return responseData;
 };
 
-export const checkWCPermissions = async ({
-  origin,
-  caip2ChainId,
-  allowSwitchingToNewChain = false,
-}: { origin: string; caip2ChainId: CaipChainId; allowSwitchingToNewChain?: boolean }) => {
+
+export const getRequestCaip2ChainId = (request: WalletKitTypes.SessionRequest) => {
+  const isSwitchingChain = isSwitchingChainRequest(request);
+  return (isSwitchingChain ? `eip155:${parseInt(request.params.request.params[0].chainId, 16)}` : request.params.chainId) as CaipChainId;
+}
+
+
+export const getChainIdForCaipChainId = (caipChainId: CaipChainId) => {
+    const caipNetworkConfiguration = selectNetworkConfigurationsByCaipChainId(store.getState());
+    const { chainId } = caipNetworkConfiguration[caipChainId];
+    return chainId as Hex;
+}
+
+
+export const getNetworkClientIdForCaipChainId = (caipChainId: CaipChainId) => {
+    const networkConfigurationsByChainId = selectEvmNetworkConfigurationsByChainId(store.getState());
+    const chainId = getChainIdForCaipChainId(caipChainId);
+    const { rpcEndpoints: [{ networkClientId }] } = networkConfigurationsByChainId[chainId as Hex];
+    return networkClientId;
+}
+
+export const hasPermissionsToSwitchChainRequest = async (
+  request: WalletKitTypes.SessionRequest,
+  origin: string,
+  channelId: string
+) => {
+  const allowSwitchingToNewChain = isSwitchingChainRequest(request);
+  const caip2ChainId = getRequestCaip2ChainId(request);
   const networkConfigurations = selectNetworkConfigurations(store.getState());
-  const decimalChainId = caip2ChainId.split(':')[1];
-  const hexChainIdString = toHex(`0x${parseInt(decimalChainId, 10).toString(16)}`);
+  const hexChainIdString = getChainIdForCaipChainId(caip2ChainId);
 
   const existingNetwork = findExistingNetwork(
     hexChainIdString,
@@ -271,14 +293,14 @@ export const checkWCPermissions = async ({
     });
   }
 
-  const hostname = getHostname(origin);
-  const permittedChains = await getPermittedChains(hostname);
+  const permittedChains = await getPermittedChains(channelId);
   const isAllowedChainId = permittedChains.includes(caip2ChainId);
 
   DevLogger.log(`WC::checkWCPermissions permittedChains: ${permittedChains}`);
 
   const providerConfig = selectProviderConfig(store.getState());
   const activeChainIdHex = providerConfig.chainId;
+  debugger;
   const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
     activeChainIdHex,
     16,
@@ -288,7 +310,6 @@ export const checkWCPermissions = async ({
     `WC::checkWCPermissions origin=${origin} caip2ChainId=${caip2ChainId} activeCaip2ChainId=${activeCaip2ChainId} permittedChains=${permittedChains} isAllowedChainId=${isAllowedChainId}`,
   );
 
-  // If the chainId is not permitted and we're not allowed to switch to a new chain, throw an error
   if (!isAllowedChainId && !allowSwitchingToNewChain) {
     DevLogger.log(`WC::checkWCPermissions chainId is not permitted`);
     throw rpcErrors.invalidParams({
@@ -301,39 +322,116 @@ export const checkWCPermissions = async ({
     existingNetwork,
   );
 
-  if (caip2ChainId !== activeCaip2ChainId) {
-    try {
-      if (!isAllowedChainId && allowSwitchingToNewChain) {
-        // Preemptively add the chain to the permitted chains
-        // This is to prevent a race condition where WalletConnect is told about the chain switch before permissions are updated
-        DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${hostname}:`, caip2ChainId);
-        updatePermittedChains(getHostname(origin), [caip2ChainId]);
-      }
-
-      await switchToNetwork({
-        network: existingNetwork,
-        chainId: hexChainIdString,
-        requestUserApproval: onRequestUserApproval(origin),
-        analytics: {},
-        origin,
-        hooks: getRpcMethodMiddlewareHooks(origin),
-      });
-    } catch (error) {
-      DevLogger.log(
-        `WC::checkWCPermissions error switching to network:`,
-        error,
-      );
-
-      if (!isAllowedChainId && allowSwitchingToNewChain) {
-        // If we failed to switch to the network, remove the chain from the permitted chains
-        // This is so we don't leave any dangling permissions if the user rejects the switch
-        DevLogger.log(`WC::checkWCPermissions removing permitted chain for ${hostname}:`, caip2ChainId);
-        removePermittedChain(getHostname(origin), caip2ChainId);
-      }
-
-      return false;
-    }
+  return {
+    allowed: isAllowedChainId,
+    existingNetwork,
+    hexChainIdString,
   }
+}
 
-  return true;
-};
+
+export const isSwitchingChainRequest = (request: WalletKitTypes.SessionRequest) => {
+  const {params: {request: {method}}} = request;
+  return method === 'wallet_switchEthereumChain';
+}
+
+export const getRequestOrigin = (
+  request: WalletKitTypes.SessionRequest,
+  defaultOrigin: string
+) => {
+  const {verifyContext: {verified: {origin}}} = request;
+  return origin || defaultOrigin;
+}
+
+
+// /**
+//  * @deprecated
+//  */
+// export const checkWCPermissions = async ({
+//   origin,
+//   caip2ChainId,
+//   allowSwitchingToNewChain = false,
+// }: { origin: string; caip2ChainId: CaipChainId; allowSwitchingToNewChain?: boolean }) => {
+//   const networkConfigurations = selectNetworkConfigurations(store.getState());
+//   const decimalChainId = caip2ChainId.split(':')[1];
+//   const hexChainIdString = toHex(`0x${parseInt(decimalChainId, 10).toString(16)}`);
+
+//   const existingNetwork = findExistingNetwork(
+//     hexChainIdString,
+//     networkConfigurations,
+//   );
+
+//   if (!existingNetwork) {
+//     DevLogger.log(`WC::checkWCPermissions no existing network found`);
+//     throw rpcErrors.invalidParams({
+//       message: `Invalid parameters: active chainId is different than the one provided.`,
+//     });
+//   }
+
+//   const hostname = getHostname(origin);
+//   const permittedChains = await getPermittedChains(hostname);
+//   const isAllowedChainId = permittedChains.includes(caip2ChainId);
+
+//   DevLogger.log(`WC::checkWCPermissions permittedChains: ${permittedChains}`);
+
+//   const providerConfig = selectProviderConfig(store.getState());
+//   const activeChainIdHex = providerConfig.chainId;
+//   const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
+//     activeChainIdHex,
+//     16,
+//   )}`;
+
+//   DevLogger.log(
+//     `WC::checkWCPermissions origin=${origin} caip2ChainId=${caip2ChainId} activeCaip2ChainId=${activeCaip2ChainId} permittedChains=${permittedChains} isAllowedChainId=${isAllowedChainId}`,
+//   );
+
+//   // If the chainId is not permitted and we're not allowed to switch to a new chain, throw an error
+//   if (!isAllowedChainId && !allowSwitchingToNewChain) {
+//     DevLogger.log(`WC::checkWCPermissions chainId is not permitted`);
+//     throw rpcErrors.invalidParams({
+//       message: `Invalid parameters: active chainId is different than the one provided.`,
+//     });
+//   }
+
+//   DevLogger.log(
+//     `WC::checkWCPermissions switching to network:`,
+//     existingNetwork,
+//   );
+
+
+//   if (caip2ChainId !== activeCaip2ChainId) {
+//     try {
+//       if (!isAllowedChainId && allowSwitchingToNewChain) {
+//         // Preemptively add the chain to the permitted chains
+//         // This is to prevent a race condition where WalletConnect is told about the chain switch before permissions are updated
+//         DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${hostname}:`, caip2ChainId);
+//         updatePermittedChains(getHostname(origin), [caip2ChainId]);
+//       }
+
+//       await switchToNetwork({
+//         network: existingNetwork,
+//         chainId: hexChainIdString,
+//         requestUserApproval: onRequestUserApproval(origin),
+//         analytics: {},
+//         origin,
+//         hooks: getRpcMethodMiddlewareHooks(origin),
+//       });
+//     } catch (error) {
+//       DevLogger.log(
+//         `WC::checkWCPermissions error switching to network:`,
+//         error,
+//       );
+
+//       if (!isAllowedChainId && allowSwitchingToNewChain) {
+//         // If we failed to switch to the network, remove the chain from the permitted chains
+//         // This is so we don't leave any dangling permissions if the user rejects the switch
+//         DevLogger.log(`WC::checkWCPermissions removing permitted chain for ${hostname}:`, caip2ChainId);
+//         removePermittedChain(getHostname(origin), caip2ChainId);
+//       }
+
+//       return false;
+//     }
+//   }
+
+//   return true;
+// };

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -335,12 +335,5 @@ export const getRequestOrigin = (
   request: WalletKitTypes.SessionRequest,
   defaultOrigin: string
 ) => {
-  const {verifyContext} = request;
-  if (verifyContext) {
-    const {verified} = verifyContext;
-    if (verified) {
-      return verified.origin;
-    }
-  }
-  return defaultOrigin;
+  return request.verifyContext?.verified?.origin ?? defaultOrigin
 }

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -272,12 +272,9 @@ export const getNetworkClientIdForCaipChainId = (caipChainId: CaipChainId) => {
 }
 
 export const hasPermissionsToSwitchChainRequest = async (
-  request: WalletKitTypes.SessionRequest,
-  origin: string,
+  caip2ChainId: CaipChainId,
   channelId: string
 ) => {
-  const allowSwitchingToNewChain = isSwitchingChainRequest(request);
-  const caip2ChainId = getRequestCaip2ChainId(request);
   const networkConfigurations = selectNetworkConfigurations(store.getState());
   const hexChainIdString = getChainIdForCaipChainId(caip2ChainId);
 
@@ -300,22 +297,10 @@ export const hasPermissionsToSwitchChainRequest = async (
 
   const providerConfig = selectProviderConfig(store.getState());
   const activeChainIdHex = providerConfig.chainId;
-  debugger;
   const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
     activeChainIdHex,
     16,
   )}`;
-
-  DevLogger.log(
-    `WC::checkWCPermissions origin=${origin} caip2ChainId=${caip2ChainId} activeCaip2ChainId=${activeCaip2ChainId} permittedChains=${permittedChains} isAllowedChainId=${isAllowedChainId}`,
-  );
-
-  if (!isAllowedChainId && !allowSwitchingToNewChain) {
-    DevLogger.log(`WC::checkWCPermissions chainId is not permitted`);
-    throw rpcErrors.invalidParams({
-      message: `Invalid parameters: active chainId is different than the one provided.`,
-    });
-  }
 
   DevLogger.log(
     `WC::checkWCPermissions switching to network:`,

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -292,20 +292,7 @@ export const hasPermissionsToSwitchChainRequest = async (
 
   const permittedChains = await getPermittedChains(channelId);
   const isAllowedChainId = permittedChains.includes(caip2ChainId);
-
   DevLogger.log(`WC::checkWCPermissions permittedChains: ${permittedChains}`);
-
-  const providerConfig = selectProviderConfig(store.getState());
-  const activeChainIdHex = providerConfig.chainId;
-  const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
-    activeChainIdHex,
-    16,
-  )}`;
-
-  DevLogger.log(
-    `WC::checkWCPermissions switching to network:`,
-    existingNetwork,
-  );
 
   return {
     allowed: isAllowedChainId,

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -334,6 +334,4 @@ export const hasPermissionsToSwitchChainRequest = async (
 export const getRequestOrigin = (
   request: WalletKitTypes.SessionRequest,
   defaultOrigin: string
-) => {
-  return request.verifyContext?.verified?.origin ?? defaultOrigin
-}
+) => request.verifyContext?.verified?.origin ?? defaultOrigin

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -14,7 +14,7 @@ import {
   selectProviderConfig,
 } from '../../selectors/networkController';
 import Engine from '../Engine';
-import { getPermittedAccounts, getPermittedChains, removePermittedChain, updatePermittedChains } from '../Permissions';
+import { getPermittedAccounts, getPermittedChains  } from '../Permissions';
 import {
   findExistingNetwork,
 } from '../RPCMethods/lib/ethereum-chain-utils';
@@ -327,96 +327,3 @@ export const getRequestOrigin = (
   const {verifyContext: {verified: {origin}}} = request;
   return origin || defaultOrigin;
 }
-
-
-// /**
-//  * @deprecated
-//  */
-// export const checkWCPermissions = async ({
-//   origin,
-//   caip2ChainId,
-//   allowSwitchingToNewChain = false,
-// }: { origin: string; caip2ChainId: CaipChainId; allowSwitchingToNewChain?: boolean }) => {
-//   const networkConfigurations = selectNetworkConfigurations(store.getState());
-//   const decimalChainId = caip2ChainId.split(':')[1];
-//   const hexChainIdString = toHex(`0x${parseInt(decimalChainId, 10).toString(16)}`);
-
-//   const existingNetwork = findExistingNetwork(
-//     hexChainIdString,
-//     networkConfigurations,
-//   );
-
-//   if (!existingNetwork) {
-//     DevLogger.log(`WC::checkWCPermissions no existing network found`);
-//     throw rpcErrors.invalidParams({
-//       message: `Invalid parameters: active chainId is different than the one provided.`,
-//     });
-//   }
-
-//   const hostname = getHostname(origin);
-//   const permittedChains = await getPermittedChains(hostname);
-//   const isAllowedChainId = permittedChains.includes(caip2ChainId);
-
-//   DevLogger.log(`WC::checkWCPermissions permittedChains: ${permittedChains}`);
-
-//   const providerConfig = selectProviderConfig(store.getState());
-//   const activeChainIdHex = providerConfig.chainId;
-//   const activeCaip2ChainId = `${KnownCaipNamespace.Eip155}:${parseInt(
-//     activeChainIdHex,
-//     16,
-//   )}`;
-
-//   DevLogger.log(
-//     `WC::checkWCPermissions origin=${origin} caip2ChainId=${caip2ChainId} activeCaip2ChainId=${activeCaip2ChainId} permittedChains=${permittedChains} isAllowedChainId=${isAllowedChainId}`,
-//   );
-
-//   // If the chainId is not permitted and we're not allowed to switch to a new chain, throw an error
-//   if (!isAllowedChainId && !allowSwitchingToNewChain) {
-//     DevLogger.log(`WC::checkWCPermissions chainId is not permitted`);
-//     throw rpcErrors.invalidParams({
-//       message: `Invalid parameters: active chainId is different than the one provided.`,
-//     });
-//   }
-
-//   DevLogger.log(
-//     `WC::checkWCPermissions switching to network:`,
-//     existingNetwork,
-//   );
-
-
-//   if (caip2ChainId !== activeCaip2ChainId) {
-//     try {
-//       if (!isAllowedChainId && allowSwitchingToNewChain) {
-//         // Preemptively add the chain to the permitted chains
-//         // This is to prevent a race condition where WalletConnect is told about the chain switch before permissions are updated
-//         DevLogger.log(`WC::checkWCPermissions adding permitted chain for ${hostname}:`, caip2ChainId);
-//         updatePermittedChains(getHostname(origin), [caip2ChainId]);
-//       }
-
-//       await switchToNetwork({
-//         network: existingNetwork,
-//         chainId: hexChainIdString,
-//         requestUserApproval: onRequestUserApproval(origin),
-//         analytics: {},
-//         origin,
-//         hooks: getRpcMethodMiddlewareHooks(origin),
-//       });
-//     } catch (error) {
-//       DevLogger.log(
-//         `WC::checkWCPermissions error switching to network:`,
-//         error,
-//       );
-
-//       if (!isAllowedChainId && allowSwitchingToNewChain) {
-//         // If we failed to switch to the network, remove the chain from the permitted chains
-//         // This is so we don't leave any dangling permissions if the user rejects the switch
-//         DevLogger.log(`WC::checkWCPermissions removing permitted chain for ${hostname}:`, caip2ChainId);
-//         removePermittedChain(getHostname(origin), caip2ChainId);
-//       }
-
-//       return false;
-//     }
-//   }
-
-//   return true;
-// };

--- a/app/util/url/url.test.ts
+++ b/app/util/url/url.test.ts
@@ -3,7 +3,6 @@ import {
   isBridgeUrl,
   isValidASCIIURL,
   toPunycodeURL,
-  getHostname,
 } from './index';
 import AppConstants from '../../core/AppConstants';
 
@@ -122,71 +121,6 @@ describe('URL Check Functions', () => {
       expect(
         toPunycodeURL('https://opensea.io/language=français'),
       ).toStrictEqual('https://opensea.io/language=fran%C3%A7ais');
-    });
-  });
-
-  describe('getHostname', () => {
-    it('returns hostname for standard HTTPS URLs', () => {
-      const url = 'https://www.google.com';
-      const result = getHostname(url);
-      expect(result).toBe('www.google.com');
-    });
-
-    it('returns hostname for HTTP URLs', () => {
-      const url = 'http://example.com';
-      expect(getHostname(url)).toBe('example.com');
-    });
-
-    it('returns hostname for URLs with port numbers', () => {
-      const url = 'https://example.com:8080';
-      expect(getHostname(url)).toBe('example.com');
-    });
-
-    it('returns hostname for URLs with subdomains', () => {
-      const url = 'https://api.subdomain.example.com/path';
-      expect(getHostname(url)).toBe('api.subdomain.example.com');
-    });
-
-    it('returns hostname for URLs with paths and query parameters', () => {
-      const url = 'https://example.com/path/to/resource?param=value';
-      expect(getHostname(url)).toBe('example.com');
-    });
-
-    it('returns protocol for protocol-based URIs', () => {
-      const wcUri = 'wc:some-session-data';
-      expect(getHostname(wcUri)).toBe('wc');
-    });
-
-    it('returns empty string for empty input', () => {
-      const emptyString = '';
-      const result = getHostname(emptyString);
-      expect(result).toBe('');
-    });
-
-    it('returns original string for URIs without protocol separator', () => {
-      const plainString = 'example.com';
-      expect(getHostname(plainString)).toBe('example.com');
-    });
-
-    it('handles malformed URLs gracefully', () => {
-      const malformedUrl = 'https://';
-      const result = getHostname(malformedUrl);
-      expect(result).toBe('https');
-    });
-
-    it('handles URLs with special characters in hostname', () => {
-      const url = 'https://test-site.example.com';
-      expect(getHostname(url)).toBe('test-site.example.com');
-    });
-
-    it('handles localhost URLs', () => {
-      const url = 'http://localhost:3000';
-      expect(getHostname(url)).toBe('localhost');
-    });
-
-    it('handles IP address URLs', () => {
-      const url = 'https://192.168.1.1:8080';
-      expect(getHostname(url)).toBe('192.168.1.1');
     });
   });
 });

--- a/app/util/url/url.test.ts
+++ b/app/util/url/url.test.ts
@@ -3,6 +3,7 @@ import {
   isBridgeUrl,
   isValidASCIIURL,
   toPunycodeURL,
+  getHostname,
 } from './index';
 import AppConstants from '../../core/AppConstants';
 
@@ -121,6 +122,81 @@ describe('URL Check Functions', () => {
       expect(
         toPunycodeURL('https://opensea.io/language=français'),
       ).toStrictEqual('https://opensea.io/language=fran%C3%A7ais');
+    });
+  });
+
+  describe('getHostname', () => {
+    it('returns hostname for standard HTTPS URLs', () => {
+      // Arrange
+      const url = 'https://www.google.com';
+
+      // Act
+      const result = getHostname(url);
+
+      // Assert
+      expect(result).toBe('www.google.com');
+    });
+
+    it('returns hostname for HTTP URLs', () => {
+      const url = 'http://example.com';
+      expect(getHostname(url)).toBe('example.com');
+    });
+
+    it('returns hostname for URLs with port numbers', () => {
+      const url = 'https://example.com:8080';
+      expect(getHostname(url)).toBe('example.com');
+    });
+
+    it('returns hostname for URLs with subdomains', () => {
+      const url = 'https://api.subdomain.example.com/path';
+      expect(getHostname(url)).toBe('api.subdomain.example.com');
+    });
+
+    it('returns hostname for URLs with paths and query parameters', () => {
+      const url = 'https://example.com/path/to/resource?param=value';
+      expect(getHostname(url)).toBe('example.com');
+    });
+
+    it('returns protocol for protocol-based URIs', () => {
+      const wcUri = 'wc:some-session-data';
+      expect(getHostname(wcUri)).toBe('wc');
+    });
+
+    it('returns empty string for empty input', () => {
+      // Arrange
+      const emptyString = '';
+
+      // Act
+      const result = getHostname(emptyString);
+
+      // Assert
+      expect(result).toBe('');
+    });
+
+    it('returns original string for URIs without protocol separator', () => {
+      const plainString = 'example.com';
+      expect(getHostname(plainString)).toBe('example.com');
+    });
+
+    it('handles malformed URLs gracefully', () => {
+      const malformedUrl = 'https://';
+      const result = getHostname(malformedUrl);
+      expect(result).toBe('https');
+    });
+
+    it('handles URLs with special characters in hostname', () => {
+      const url = 'https://test-site.example.com';
+      expect(getHostname(url)).toBe('test-site.example.com');
+    });
+
+    it('handles localhost URLs', () => {
+      const url = 'http://localhost:3000';
+      expect(getHostname(url)).toBe('localhost');
+    });
+
+    it('handles IP address URLs', () => {
+      const url = 'https://192.168.1.1:8080';
+      expect(getHostname(url)).toBe('192.168.1.1');
     });
   });
 });

--- a/app/util/url/url.test.ts
+++ b/app/util/url/url.test.ts
@@ -127,13 +127,8 @@ describe('URL Check Functions', () => {
 
   describe('getHostname', () => {
     it('returns hostname for standard HTTPS URLs', () => {
-      // Arrange
       const url = 'https://www.google.com';
-
-      // Act
       const result = getHostname(url);
-
-      // Assert
       expect(result).toBe('www.google.com');
     });
 
@@ -163,13 +158,8 @@ describe('URL Check Functions', () => {
     });
 
     it('returns empty string for empty input', () => {
-      // Arrange
       const emptyString = '';
-
-      // Act
       const result = getHostname(emptyString);
-
-      // Assert
       expect(result).toBe('');
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the SDK connection flow to consistently use the latest permissions system UI, removing legacy components and streamlining the connection experience.

- Removed the legacy `AccountConnectSingle` component in favor of using the newer `PermissionsSummary` component consistently
- Eliminated the conditional rendering between old and new UI based on `isSdkUrlUnknown`
- Simplified icon handling and URL state management
- Improved callback handling with proper memoization using `useCallback`
- Consolidated connection confirmation logic into a single `handleConfirm` function
- Use channelIdOrHostname to fetch and store permissions instead of just hostname
- Fixed lots of Wallet Connect issues as part of this PR those addresses in the videos mainly, apart from the minor UI change

## **Related issues**

- Depends on #14602 

## **Manual testing steps**

- SDK connection requests from dapps
- WalletConnect connection flows
- Permission granting for both known and unknown origins
- Network switching during connection
- Multiple account selection flows



## **Screenshots/Recordings**
We first want to alignt eh AccountConnect.tsx component to the latest permission UI.

| Before       | After      |  
|--------------|--------------|
|  ![image](https://github.com/user-attachments/assets/2ed702ff-6ec9-4bd5-94b3-57ef92485d70) | ![image](https://github.com/user-attachments/assets/93c1f8a3-9af4-40bf-97fe-1970770fe030) | 

## Additional recordings
Switching networks with pre-approved networks (addEthereumNetwork + SwitchEthereumNetwork) VS only SwitchEthereumNetwork
| Without pre-approved networks  | with pre-approved networks     |  
|--------------|--------------|
|  <video src="https://github.com/user-attachments/assets/0e0eb6ec-7a89-441c-83be-fc634bb0e89a" /> | <video src="https://github.com/user-attachments/assets/1f6943ee-13f5-4f4c-b902-0594c278c1de" /> | 

| WC Session restore on cold start |  
|--------------|
|  <video src="https://github.com/user-attachments/assets/8e8967cb-1241-4040-9c53-de259076ff0b" /> |










<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
