### PR TITLE
fix: contact-sync tests naming conventions

### DIFF
--- a/app/util/identity/hooks/useContactSyncing/useContactSyncing.test.tsx
+++ b/app/util/identity/hooks/useContactSyncing/useContactSyncing.test.tsx
@@ -80,7 +80,7 @@ describe('useShouldDispatchContactSyncing()', () => {
     return { successTestCase, failureStateCases };
   })();
 
-  it('should return true if all conditions are met', () => {
+  it('returns true if all conditions are met', () => {
     const { state } = arrangeMockState(testCases.successTestCase.state);
     const hook = renderHookWithProvider(
       () => useShouldDispatchContactSyncing(),
@@ -89,14 +89,10 @@ describe('useShouldDispatchContactSyncing()', () => {
     expect(hook.result.current).toBe(true);
   });
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   it.each(testCases.failureStateCases)(
-    'should return false if not all conditions are met [%s = false]',
-    ({
-      state: failureState,
-    }: (typeof testCases)['failureStateCases'][number]) => {
-      const { state } = arrangeMockState(failureState);
+    'returns false if not all conditions are met [%s = false]',
+    (testCase: { state: ArrangeMocksMetamaskStateOverrides; failingField: string }) => {
+      const { state } = arrangeMockState(testCase.state);
       const hook = renderHookWithProvider(
         () => useShouldDispatchContactSyncing(),
         { state },
@@ -132,7 +128,7 @@ describe('useContactSyncing', () => {
     return { mocks, dispatchContactSyncing, shouldDispatchContactSyncing };
   };
 
-  it('should dispatch if conditions are met', async () => {
+  it('dispatches if conditions are met', async () => {
     const { mocks, dispatchContactSyncing, shouldDispatchContactSyncing } =
       arrangeAndAct({
         completedOnboarding: true,

--- a/e2e/specs/identity/contact-syncing/backup-and-sync-settings.spec.ts
+++ b/e2e/specs/identity/contact-syncing/backup-and-sync-settings.spec.ts
@@ -60,7 +60,7 @@ describe(
       }
     });
 
-    it('should not sync new contacts when contacts sync toggle is off', async () => {
+    it('does not sync new contacts when contacts sync toggle is off', async () => {
       await importWalletWithRecoveryPhrase({
         seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
         password: IDENTITY_TEAM_PASSWORD,


### PR DESCRIPTION
## **Description**

Updates test descriptions to follow MetaMask's naming conventions and removes unnecessary `eslint` ignore directive.

## **Related issues**

Follow-up of: https://github.com/MetaMask/metamask-mobile/pull/15784#pullrequestreview-2941003921

## **Manual testing steps**

N/A 

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
