### PR TITLE
fix: cp-7.50.0 use actual origin for `MultichainRouter:handleRequest` call in Multichain API

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -244,7 +244,7 @@ export class BackgroundBridge extends EventEmitter {
     // so that messages sent before BackgroundBridge's EIP-1193 JSON-RPC pipeline was
     // fully initialized can be retried
     if (!this.isRemoteConn && !this.isWalletConnect) {
-      this.notifyChainChanged()
+      this.notifyChainChanged();
     }
 
     if (this.isRemoteConn) {
@@ -762,7 +762,8 @@ export class BackgroundBridge extends EventEmitter {
         handleNonEvmRequestForOrigin: (params) =>
           Engine.controllerMessenger.call('MultichainRouter:handleRequest', {
             ...params,
-            origin,
+            // The MultichainRouter expects a proper origin value.
+            origin: new URL(this.url).origin,
           }),
         getNonEvmAccountAddresses: Engine.controllerMessenger.call.bind(
           Engine.controllerMessenger,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Resolves the issue where hostname is being used as the origin value used to call `MultichainRouter:handleRequest` from the `wallet_invokeMethod` handler. This PR changes it so that the correct value is used for origin.

Note that this does not work for channel IDs which is okay right now as the Multichain API is only exposed over the in app injected wallet standard provider.

## **Related issues**

Fixed: https://github.com/MetaMask/metamask-mobile/issues/16552
Fixes: https://consensys.slack.com/archives/C08UFPWB3GB/p1750263145265409?thread_ts=1749812521.452409&cid=C08UFPWB3GB

## **Manual testing steps**

1. From the in app browser, visit https://metamask.github.io/test-dapp-solana/latest/
2. Try signMessage and signTransaction
3. Both should work as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/3a8e3f44-da00-4c9c-8553-4b85682e43ad


### **After**

https://github.com/user-attachments/assets/b01b386e-3b81-4dd8-863d-448a7877086c


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
