### PR TITLE
test: Add BIP-32 example Snap test

### DIFF
--- a/e2e/fixtures/fixture-builder.js
+++ b/e2e/fixtures/fixture-builder.js
@@ -1150,6 +1150,15 @@ class FixtureBuilder {
     return this;
   }
 
+  // Mirrors the vault contents from the extension fixture.
+  withMultiSRPKeyringController() {
+    merge(this.fixture.state.engine.backgroundState.KeyringController, {
+      vault: '{"keyMetadata":{"algorithm":"PBKDF2","params":{"iterations":5000}},"lib":"original","cipher":"LOubqgWR4O7Hv/RcdHPZ0Xi0GmCPD6whWLbO/jtnv44cAbBDumnAKX1NK1vgDNORSPVlUTkjyZwaHaStzuTIoJDurCBJN4TtsNUe5qIoJgttZ4Yv4hHxlg04V4nq/DXqAQaXedILMXnhbqZ+DP+tMc7JBXcVi12GIOiqV+ycLj8xFcasS/cdxtU6Os3pItdEZS89Rp7U58YOJBRQ2dlhBg0tCo2JnCrRhQmPGcTBuQVpn7SdkDx5PPC2slz3TRCjaHXWGCMPmx6jCDqI2sJL9ljpFB0/Jvlp18/9PE/cZ53GxybdtQiJ9andNHlfPf5WK+qI+QgySR8CMSRDWaP3hfEGHF1H0oqO7y/v6/pkShitdx7i5bC8Wt++heUOT8qpHTo1gDgUmNuZJsF4sG0Y18Hw8vLu+LfkoZgundb+cFjPFD1teTEnl2mmkpBvQCciynsCHPnHgnhKNHj6KMLhlSXWEItuYL/FY7dRpttfXzWfVQt56dQLLEYEYmO/f7C1uzAv6jbHBHqg16QtX3hCEnX0qzi1h3DQ8J5v44ckkQ/UGVvy6bOUC83b8DMLNPiSoMJDSsMaDzMmQ4J4xHzoHdD7/wBcXcbtUwccMGRHXv3jFLtHjuV+HQo0//I9xnjjAxfxX9SgyBQE8WCvUOxgCdwF8W7aBKcFEsoksLAWIQFxerWc3OxdvKSzvinI/j/MvyFMvVP5pm/BLWNj639GpFmIJVMprxkDL4H45CsgUcMe1Kiim/PFvo0D449vO1XL31ZIl9TxRVLaIr2cE3a95MFbzru9stqNkXz0EHrhSltFyoANMCim1HFxK/1yRl5Tt4u9Vjjyvj6a4Wtzy7SyLHhx0PfrlARq2euwGQal46cZYYKuMsnwvQf3ba/uJF3hF3FyAl9fn28HKRurImsiKNDvT+kaoUMFYoX6i+qR0LHoA7OfeqXpsKYyMx8LnUq7zKP4ZVc8sysI95YYYwdzhq2xzHDQfOplYRFkQllxqtkoTxMPHz/J1W1kjBTpCI7M8n8qLv53ryNq4y+hQx0RQNtvGPE9OcQTDUpkCM5dv7p8Ja8uLTDehKeKzs315IRBVJN8mdGy18EK5sjDoileDQ==","iv":"e88d2415e223bb8cc67c74ce47de1a6b","salt":"BX+ED3hq9K3tDBdnobBphA=="}'
+    })
+
+    return this
+  }
+
   withTokens(tokens) {
     merge(this.fixture.state.engine.backgroundState.TokensController, {
       allTokens: {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -10,18 +10,15 @@ import {
   EntropyDropDownSelectorWebIDS,
 } from '../../selectors/Browser/TestSnaps.selectors';
 import Gestures from '../../utils/Gestures';
-import {
-  SNAP_INSTALL_CONNECT,
-} from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants';
-import {
-  SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE,
-} from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants';
+import { SNAP_INSTALL_CONNECT } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants';
+import { SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants';
 import { SNAP_INSTALL_OK } from '../../../app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants';
 import TestHelpers from '../../helpers';
 import Assertions from '../../utils/Assertions';
 import { IndexableWebElement } from 'detox/detox';
 
-export const TEST_SNAPS_URL = 'https://metamask.github.io/snaps/test-snaps/2.23.1/';
+export const TEST_SNAPS_URL =
+  'https://metamask.github.io/snaps/test-snaps/2.23.1/';
 
 class TestSnaps {
   get container() {
@@ -46,11 +43,14 @@ class TestSnaps {
     );
   }
 
-  async checkResultSpan(selector: keyof typeof TestSnapResultSelectorWebIDS, expectedMessage: string) {
-    const webElement = await Matchers.getElementByWebID(
+  async checkResultSpan(
+    selector: keyof typeof TestSnapResultSelectorWebIDS,
+    expectedMessage: string,
+  ) {
+    const webElement = (await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapResultSelectorWebIDS[selector],
-    ) as IndexableWebElement;
+    )) as IndexableWebElement;
 
     const actualText = await webElement.getText();
     await Assertions.checkIfTextMatches(actualText, expectedMessage);
@@ -71,18 +71,26 @@ class TestSnaps {
   }
 
   async getOptionValueByText(webElement: IndexableWebElement, text: string) {
-    return await webElement.runScript((el, searchText) => {
-      if (!el?.options) return null;
-      const option = Array.from(el.options).find((opt: any) => opt.text.includes(searchText));
-      return option ? (option as any).value : null;
-    }, [text]);
+    return await webElement.runScript(
+      (el, searchText) => {
+        if (!el?.options) return null;
+        const option = Array.from(el.options).find((opt: any) =>
+          opt.text.includes(searchText),
+        );
+        return option ? (option as any).value : null;
+      },
+      [text],
+    );
   }
 
-  async selectEntropySource(selector: keyof typeof EntropyDropDownSelectorWebIDS, entropySource: string) {
-    const webElement = await Matchers.getElementByWebID(
+  async selectEntropySource(
+    selector: keyof typeof EntropyDropDownSelectorWebIDS,
+    entropySource: string,
+  ) {
+    const webElement = (await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       EntropyDropDownSelectorWebIDS[selector],
-    ) as IndexableWebElement;
+    )) as IndexableWebElement;
 
     const source = await this.getOptionValueByText(webElement, entropySource);
 
@@ -91,7 +99,7 @@ class TestSnaps {
         el.value = value;
         el.dispatchEvent(new Event('change', { bubbles: true }));
       },
-      [source]
+      [source],
     );
   }
 
@@ -105,7 +113,10 @@ class TestSnaps {
     await Gestures.waitAndTap(this.getConnectSnapInstallOkButton);
   }
 
-  async fillMessage(locator: keyof typeof TestSnapInputSelectorWebIDS, message: string) {
+  async fillMessage(
+    locator: keyof typeof TestSnapInputSelectorWebIDS,
+    message: string,
+  ) {
     const webElement = Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapInputSelectorWebIDS[locator],

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -21,10 +21,6 @@ export const TEST_SNAPS_URL =
   'https://metamask.github.io/snaps/test-snaps/2.23.1/';
 
 class TestSnaps {
-  get container() {
-    return Matchers.getElementByID(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID);
-  }
-
   get getConnectSnapButton() {
     return Matchers.getElementByID(SNAP_INSTALL_CONNECT);
   }
@@ -122,10 +118,6 @@ class TestSnaps {
       TestSnapInputSelectorWebIDS[locator],
     ) as Promise<IndexableWebElement>;
     await Gestures.typeInWebElement(webElement, message);
-  }
-
-  async swipeUpSmall() {
-    await Gestures.swipe(this.container as any, 'up', 'slow', 0.2);
   }
 
   async approveSignRequest() {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -14,7 +14,6 @@ import {
   SNAP_INSTALL_CONNECT,
 } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants';
 import {
-  SNAP_INSTALL_PERMISSIONS_REQUEST,
   SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE,
 } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants';
 import { SNAP_INSTALL_OK } from '../../../app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants';
@@ -31,10 +30,6 @@ class TestSnaps {
 
   get getConnectSnapButton() {
     return Matchers.getElementByID(SNAP_INSTALL_CONNECT);
-  }
-
-  get getConnectSnapPermissionsRequestButton() {
-    return Matchers.getElementByID(SNAP_INSTALL_PERMISSIONS_REQUEST);
   }
 
   get getApproveSnapPermissionsRequestButton() {
@@ -103,22 +98,11 @@ class TestSnaps {
   async installSnap(buttonLocator: keyof typeof TestSnapViewSelectorWebIDS) {
     await this.tapButton(buttonLocator);
 
-    await Gestures.waitAndTap(this.getConnectSnapButton, {
-      skipVisibilityCheck: true,
-      delayBeforeTap: 2500,
-    });
+    await Gestures.waitAndTap(this.getConnectSnapButton);
 
-    await Gestures.waitAndTap(this.getConnectSnapPermissionsRequestButton, {
-      delayBeforeTap: 2500,
-    });
+    await Gestures.waitAndTap(this.getApproveSnapPermissionsRequestButton);
 
-    await Gestures.waitAndTap(this.getApproveSnapPermissionsRequestButton, {
-      delayBeforeTap: 2500,
-    });
-
-    await Gestures.waitAndTap(this.getConnectSnapInstallOkButton, {
-      delayBeforeTap: 2500,
-    });
+    await Gestures.waitAndTap(this.getConnectSnapInstallOkButton);
   }
 
   async fillMessage(locator: keyof typeof TestSnapInputSelectorWebIDS, message: string) {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -19,55 +19,13 @@ import {
 } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants';
 import { SNAP_INSTALL_OK } from '../../../app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants';
 import TestHelpers from '../../helpers';
+import Assertions from '../../utils/Assertions';
 
 export const TEST_SNAPS_URL = 'https://metamask.github.io/snaps/test-snaps/2.23.1/';
 
 class TestSnaps {
   get container() {
     return Matchers.getElementByID(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID);
-  }
-
-  // Only the getters that are actually used
-  get getConnectBip44Button() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapViewSelectorWebIDS.BIP_44_BUTTON_ID,
-    );
-  }
-
-  get getPublicKeyBip44Button() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapViewSelectorWebIDS.PUBLIC_KEY_BIP44_BUTTON_ID,
-    );
-  }
-
-  get getSignBip44MessageButton() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapViewSelectorWebIDS.SIGN_BIP44_MESSAGE_BUTTON_ID,
-    );
-  }
-
-  get getMessageBip44Input() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapInputSelectorWebIDS.MESSAGE_BIP44_INPUT_ID,
-    );
-  }
-
-  get getEntropyDropDown() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      EntropyDropDownSelectorWebIDS.SNAP44_ENTROPY_DROP_DOWN,
-    );
-  }
-
-  get getBip44ResultSpan() {
-    return Matchers.getElementByWebID(
-      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapResultSelectorWebIDS.BIP44_RESULT_SPAN_ID,
-    );
   }
 
   get getConnectSnapButton() {
@@ -92,125 +50,90 @@ class TestSnaps {
     );
   }
 
-  get getSignBip44MessageResultSpan() {
-    return Matchers.getElementByWebID(
+  async checkResultSpan(selector: keyof typeof TestSnapResultSelectorWebIDS, expectedMessage: string) {
+    const element = await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-      TestSnapResultSelectorWebIDS.BIP44_SIGN_RESULT_SPAN_ID,
+      TestSnapResultSelectorWebIDS[selector],
     );
-  }
 
-  // Only the methods that are actually used
-  async getBip44ResultText() {
-    const webElement = await this.getBip44ResultSpan;
-    return await (webElement as any).getText();
-  }
-
-  async getSignBip44MessageResultText() {
-    const webElement = await this.getSignBip44MessageResultSpan;
-    return await (webElement as any).getText();
-  }
-
-  async typeSignMessage(message: any) {
-    await Gestures.typeInWebElement(this.getMessageBip44Input as any, message);
+    const actualText = await element.getText();
+    await Assertions.checkIfTextMatches(actualText, expectedMessage);
   }
 
   async navigateToTestSnap() {
     await Browser.navigateToURL(TEST_SNAPS_URL);
   }
 
-  async tapButton(elementId: any) {
-    await Gestures.scrollToWebViewPort(elementId);
+  async tapButton(buttonLocator: keyof typeof TestSnapViewSelectorWebIDS) {
+    const element = Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestSnapViewSelectorWebIDS[buttonLocator],
+    );
+    await Gestures.scrollToWebViewPort(element);
     await TestHelpers.delay(1000);
-    await Gestures.tapWebElement(elementId);
+    await Gestures.tapWebElement(element);
   }
 
-  async tapEntropyDropDown() {
-    await this.tapButton(this.getEntropyDropDown);
-  }
-
-  async tapInvalidEntropySource() {
-    await this.selectEntropySource('invalid', EntropyDropDownSelectorWebIDS.SNAP44_ENTROPY_DROP_DOWN as any);
-  }
-
-  async tapValidEntropySource() {
-    await this.selectEntropySource('01JYCMT5Q344VAE9XDVH98WH1W', EntropyDropDownSelectorWebIDS.SNAP44_ENTROPY_DROP_DOWN as any);
-  }
-
-  async getOptionValueByText(selectorID: any, text: string) {
-    const webview = Matchers.getWebViewByID(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID);
-    return await webview.element(by.web.id(selectorID)).runScript((el, searchText) => {
+  async getOptionValueByText(element: any, text: string) {
+    return await element.runScript((el, searchText) => {
       if (!el?.options) return null;
       const option = Array.from(el.options).find((opt: any) => opt.text.includes(searchText));
       return option ? (option as any).value : null;
     }, [text]);
   }
 
-  async selectPrimaryEntropySource() {
-    const primaryValue = await this.getOptionValueByText(
-      EntropyDropDownSelectorWebIDS.SNAP44_ENTROPY_DROP_DOWN,
-      '(primary)'
+  async selectEntropySource(selector: keyof typeof EntropyDropDownSelectorWebIDS, entropySource: string) {
+    const element = await Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      EntropyDropDownSelectorWebIDS[selector],
     );
-    if (primaryValue) {
-      await this.selectEntropySource(primaryValue, EntropyDropDownSelectorWebIDS.SNAP44_ENTROPY_DROP_DOWN);
-    } else {
-      throw new Error('Primary option not found in entropy dropdown');
-    }
-  }
 
-  async selectEntropySource(entropySource: string, selectorID: any) {
-    const webview = Matchers.getWebViewByID(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID);
-    await webview.element(by.web.id(selectorID)).runScript(
+    const source = await this.getOptionValueByText(element, entropySource);
+
+    await element.runScript(
       (el, value) => {
         el.value = value;
         el.dispatchEvent(new Event('change', { bubbles: true }));
       },
-      [entropySource]
+      [source]
     );
   }
 
-  async connectToSnap() {
+  async installSnap(buttonLocator: keyof typeof TestSnapViewSelectorWebIDS) {
+    await this.tapButton(buttonLocator);
+
     await Gestures.waitAndTap(this.getConnectSnapButton, {
       skipVisibilityCheck: true,
       delayBeforeTap: 2500,
     });
-  }
 
-  async connectToSnapPermissionsRequest() {
     await Gestures.waitAndTap(this.getConnectSnapPermissionsRequestButton, {
       delayBeforeTap: 2500,
     });
-  }
 
-  async approveSnapPermissionsRequest() {
     await Gestures.waitAndTap(this.getApproveSnapPermissionsRequestButton, {
       delayBeforeTap: 2500,
     });
-  }
 
-  async connectToSnapInstallOk() {
     await Gestures.waitAndTap(this.getConnectSnapInstallOkButton, {
       delayBeforeTap: 2500,
     });
+  }
+
+  async fillMessage(locator: keyof typeof TestSnapInputSelectorWebIDS, message: string) {
+    const element = Matchers.getElementByWebID(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      TestSnapInputSelectorWebIDS[locator],
+    );
+    await Gestures.typeInWebElement(element, message);
   }
 
   async swipeUpSmall() {
     await Gestures.swipe(this.container as any, 'up', 'slow', 0.2);
   }
 
-  async tapPublicKeyBip44Button() {
-    await this.tapButton(this.getPublicKeyBip44Button);
-  }
-
-  async tapSignBip44MessageButton() {
-    await this.tapButton(this.getSignBip44MessageButton);
-  }
-
   async approveSignRequest() {
     await Gestures.waitAndTap(this.getApproveSignRequestButton);
-  }
-
-  async connectToBip44Snap() {
-    await this.tapButton(this.getConnectBip44Button);
   }
 }
 

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -20,6 +20,7 @@ import {
 import { SNAP_INSTALL_OK } from '../../../app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants';
 import TestHelpers from '../../helpers';
 import Assertions from '../../utils/Assertions';
+import { IndexableWebElement } from 'detox/detox';
 
 export const TEST_SNAPS_URL = 'https://metamask.github.io/snaps/test-snaps/2.23.1/';
 
@@ -54,7 +55,7 @@ class TestSnaps {
     const element = await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapResultSelectorWebIDS[selector],
-    );
+    ) as IndexableWebElement;
 
     const actualText = await element.getText();
     await Assertions.checkIfTextMatches(actualText, expectedMessage);
@@ -68,13 +69,13 @@ class TestSnaps {
     const element = Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapViewSelectorWebIDS[buttonLocator],
-    );
+    ) as any;
     await Gestures.scrollToWebViewPort(element);
     await TestHelpers.delay(1000);
     await Gestures.tapWebElement(element);
   }
 
-  async getOptionValueByText(element: any, text: string) {
+  async getOptionValueByText(element: IndexableWebElement, text: string) {
     return await element.runScript((el, searchText) => {
       if (!el?.options) return null;
       const option = Array.from(el.options).find((opt: any) => opt.text.includes(searchText));
@@ -86,7 +87,7 @@ class TestSnaps {
     const element = await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       EntropyDropDownSelectorWebIDS[selector],
-    );
+    ) as IndexableWebElement;
 
     const source = await this.getOptionValueByText(element, entropySource);
 
@@ -124,7 +125,7 @@ class TestSnaps {
     const element = Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapInputSelectorWebIDS[locator],
-    );
+    ) as any;
     await Gestures.typeInWebElement(element, message);
   }
 

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -122,11 +122,11 @@ class TestSnaps {
   }
 
   async fillMessage(locator: keyof typeof TestSnapInputSelectorWebIDS, message: string) {
-    const element = Matchers.getElementByWebID(
+    const webElement = Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapInputSelectorWebIDS[locator],
-    ) as any;
-    await Gestures.typeInWebElement(element, message);
+    ) as Promise<IndexableWebElement>;
+    await Gestures.typeInWebElement(webElement, message);
   }
 
   async swipeUpSmall() {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -52,12 +52,12 @@ class TestSnaps {
   }
 
   async checkResultSpan(selector: keyof typeof TestSnapResultSelectorWebIDS, expectedMessage: string) {
-    const element = await Matchers.getElementByWebID(
+    const webElement = await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapResultSelectorWebIDS[selector],
     ) as IndexableWebElement;
 
-    const actualText = await element.getText();
+    const actualText = await webElement.getText();
     await Assertions.checkIfTextMatches(actualText, expectedMessage);
   }
 
@@ -66,17 +66,17 @@ class TestSnaps {
   }
 
   async tapButton(buttonLocator: keyof typeof TestSnapViewSelectorWebIDS) {
-    const element = Matchers.getElementByWebID(
+    const webElement = Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       TestSnapViewSelectorWebIDS[buttonLocator],
     ) as any;
-    await Gestures.scrollToWebViewPort(element);
+    await Gestures.scrollToWebViewPort(webElement);
     await TestHelpers.delay(1000);
-    await Gestures.tapWebElement(element);
+    await Gestures.tapWebElement(webElement);
   }
 
-  async getOptionValueByText(element: IndexableWebElement, text: string) {
-    return await element.runScript((el, searchText) => {
+  async getOptionValueByText(webElement: IndexableWebElement, text: string) {
+    return await webElement.runScript((el, searchText) => {
       if (!el?.options) return null;
       const option = Array.from(el.options).find((opt: any) => opt.text.includes(searchText));
       return option ? (option as any).value : null;
@@ -84,14 +84,14 @@ class TestSnaps {
   }
 
   async selectEntropySource(selector: keyof typeof EntropyDropDownSelectorWebIDS, entropySource: string) {
-    const element = await Matchers.getElementByWebID(
+    const webElement = await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       EntropyDropDownSelectorWebIDS[selector],
     ) as IndexableWebElement;
 
-    const source = await this.getOptionValueByText(element, entropySource);
+    const source = await this.getOptionValueByText(webElement, entropySource);
 
-    await element.runScript(
+    await webElement.runScript(
       (el, value) => {
         el.value = value;
         el.dispatchEvent(new Event('change', { bubbles: true }));

--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -1,21 +1,35 @@
 // Only keep selectors that are actually used in tests
 export const TestSnapViewSelectorWebIDS = {
-  BIP_44_BUTTON_ID: 'connectbip44',
-  PUBLIC_KEY_BIP44_BUTTON_ID: 'sendBip44Test',
-  SIGN_BIP44_MESSAGE_BUTTON_ID: 'signBip44Message',
+  connectBip32Button: 'connectbip32',
+  connectBip44Button: 'connectbip44',
+  getPublicKeyBip44Button: 'sendBip44Test',
+  signMessageBip44Button: 'signBip44Message',
+  getPublicKeyBip32Button: 'bip32GetPublic',
+  getCompressedPublicKeyBip32Button: 'bip32GetCompressedPublic',
+  signMessageBip32Secp256k1Button: 'sendBip32-secp256k1',
+  signMessageBip32ed25519Button: 'sendBip32-ed25519',
+  signMessageBip32ed25519Bip32Button: 'sendBip32-ed25519Bip32',
 };
 
 export const TestSnapInputSelectorWebIDS = {
-  MESSAGE_BIP44_INPUT_ID: 'bip44Message',
+  messageBip44Input: 'bip44Message',
+  messageEd25519Bip32Input: 'bip32Message-ed25519Bip32',
+  messageEd25519Input: 'bip32Message-ed25519',
+  messageSecp256k1Input: 'bip32Message-secp256k1',
 };
 
 export const EntropyDropDownSelectorWebIDS = {
-  SNAP44_ENTROPY_DROP_DOWN: 'bip44-entropy-selector',
+  bip32EntropyDropDown: 'bip32-entropy-selector',
+  bip44EntropyDropDown: 'bip44-entropy-selector',
 };
 
 export const TestSnapResultSelectorWebIDS = {
-  BIP44_RESULT_SPAN_ID: 'bip44Result',
-  BIP44_SIGN_RESULT_SPAN_ID: 'bip44SignResult',
+  bip44ResultSpan: 'bip44Result',
+  bip44SignResultSpan: 'bip44SignResult',
+  bip32MessageResultEd25519Span: 'bip32MessageResult-ed25519',
+  bip32MessageResultSecp256k1Span: 'bip32MessageResult-secp256k1',
+  bip32MessageResultEd25519Bip32Span: '#bip32MessageResult-ed25519Bip32',
+  bip32PublicKeyResultSpan: 'bip32PublicKeyResult',
 };
 
 export const TestSnapBottomSheetSelectorWebIDS = {

--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -1,0 +1,109 @@
+import TestHelpers from '../../helpers';
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  loadFixture,
+  startFixtureServer,
+  stopFixtureServer,
+} from '../../fixtures/fixture-helper';
+import { getFixturesServerPort } from '../../fixtures/utils';
+import FixtureServer from '../../fixtures/fixture-server';
+import Assertions from '../../utils/Assertions';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import BrowserView from '../../pages/Browser/BrowserView';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+
+const fixtureServer = new FixtureServer();
+
+describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
+
+  beforeAll(async () => {
+    await TestHelpers.reverseServerPort();
+    const fixture = new FixtureBuilder().withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController().build();
+    await startFixtureServer(fixtureServer);
+    await loadFixture(fixtureServer, { fixture });
+    await TestHelpers.launchApp({
+      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
+    });
+    await loginToApp();
+
+    // Navigate to test snaps URL once for all tests
+    await TabBarComponent.tapBrowser();
+    await TestSnaps.navigateToTestSnap();
+    await TestHelpers.delay(3500); // Wait for page to load
+    await Assertions.checkIfVisible(BrowserView.browserScreenID);
+  });
+
+  afterAll(async () => {
+    await stopFixtureServer(fixtureServer);
+  });
+
+  beforeEach(() => {
+    jest.setTimeout(150000);
+  });
+
+  it('can connect to BIP-32 snap', async ()=> {
+    await TestSnaps.installSnap('connectBip32Button');
+  });
+
+  it('can get BIP-32 public key', async () => {
+    await TestSnaps.tapButton('getPublicKeyBip32Button');
+    await TestHelpers.delay(3000);
+    await TestSnaps.checkResultSpan('bip32PublicKeyResultSpan', '"0x046d718eee8a4e85aac6b6a02c802a60e4d13981ab5cf7d620466c9d23fe24d9cfb2548ed7bdb658ef24d119b70cf49e05a111e8054e53a8d0548e10e684afc40b"');
+  });
+
+  it('can sign BIP-32 message using secp256k1', async () => {
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
+    await Assertions.checkIfTextIsDisplayed('Signature request');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.swipeUpSmall();
+    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"');
+  });
+
+  it('can sign BIP-32 message using ed25519', async () => {
+    await TestSnaps.fillMessage('messageEd25519Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32ed25519Button');
+    await Assertions.checkIfTextIsDisplayed('Signature request');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.swipeUpSmall();
+    await TestSnaps.checkResultSpan('bip32MessageResultEd25519Span', '"0x52b797a80452402e93d1a53a972a5d22ae77c88c0883233839849f142ab6cef69e91500c4109ff40216cc4327d1914ab05facce372817db532463a38f225e408"');
+  });
+
+  it.skip('can sign BIP-32 message using ed25519Bip32', async () => {
+    await TestSnaps.fillMessage('messageEd25519Bip32Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32ed25519Bip32Button');
+    await Assertions.checkIfTextIsDisplayed('Signature request');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.swipeUpSmall();
+    await TestSnaps.checkResultSpan('bip32MessageResultEd25519Bip32Span', '""');
+  });
+
+  it('can sign BIP-32 message using secp256k1 and SRP 1', async () => {
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', '01JX9NJ15HPNS6RRRYBCKDK33R')
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
+    await Assertions.checkIfTextIsDisplayed('Signature request');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.swipeUpSmall();
+    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"');
+  });
+
+  it('can sign BIP-32 message using secp256k1 and SRP 2', async () => {
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', '01JX9NZWRAVQKES02TWSN8GD91')
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
+    await Assertions.checkIfTextIsDisplayed('Signature request');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.swipeUpSmall();
+    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x30430220458e02536d6f84029ac13401ac59b9d241255d2e0f58f1c000da7e5d77a76e25021f1a14788d550e9d6b5265a70b17473d18a96aa5c3866efdac87c8bbc6f1db6f"');
+  });
+
+  it('fails when choosing the invalid entropy source', async () => {
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid')
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
+    await Assertions.checkIfTextIsDisplayed('Entropy source with ID "invalid" not found.');
+  });
+});

--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -62,7 +62,6 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
       '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
@@ -74,7 +73,6 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip32ed25519Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultEd25519Span',
       '"0x52b797a80452402e93d1a53a972a5d22ae77c88c0883233839849f142ab6cef69e91500c4109ff40216cc4327d1914ab05facce372817db532463a38f225e408"',
@@ -86,7 +84,6 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip32ed25519Bip32Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan('bip32MessageResultEd25519Bip32Span', '""');
   });
 
@@ -99,7 +96,6 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
       '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
@@ -115,7 +111,6 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
       '"0x30430220458e02536d6f84029ac13401ac59b9d241255d2e0f58f1c000da7e5d77a76e25021f1a14788d550e9d6b5265a70b17473d18a96aa5c3866efdac87c8bbc6f1db6f"',

--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -20,7 +20,7 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
     const fixture = new FixtureBuilder()
-      .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController()
+      .withMultiSRPKeyringController()
       .build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
@@ -53,73 +53,70 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await TestHelpers.delay(3000);
     await TestSnaps.checkResultSpan(
       'bip32PublicKeyResultSpan',
-      '"0x046d718eee8a4e85aac6b6a02c802a60e4d13981ab5cf7d620466c9d23fe24d9cfb2548ed7bdb658ef24d119b70cf49e05a111e8054e53a8d0548e10e684afc40b"',
+      '"0x043e98d696ae15caef75fa8dd204a7c5c08d1272b2218ba3c20feeb4c691eec366606ece56791c361a2320e7fad8bcbb130f66d51c591fc39767ab2856e93f8dfb"',
     );
   });
 
   it('can sign BIP-32 message using secp256k1', async () => {
-    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
-      '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
+      '"0x3045022100b3ade2992ea3e5eb58c7550e9bddad356e9554233c8b099ebc3cb418e9301ae2022064746e15ae024808f0ba5d860e44dc4c97e65c8cba6f5ef9ea2e8c819930d2dc"',
     );
   });
 
   it('can sign BIP-32 message using ed25519', async () => {
-    await TestSnaps.fillMessage('messageEd25519Input', 'foo');
+    await TestSnaps.fillMessage('messageEd25519Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip32ed25519Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultEd25519Span',
-      '"0x52b797a80452402e93d1a53a972a5d22ae77c88c0883233839849f142ab6cef69e91500c4109ff40216cc4327d1914ab05facce372817db532463a38f225e408"',
+      '"0xf3215b4d6c59aac7e01b4ceef530d1e2abf4857926b85a81aaae3894505699243768a887b7da4a8c2e0f25196196ba290b6531050db8dc15c252bdd508532a0a"',
     );
   });
 
   it.skip('can sign BIP-32 message using ed25519Bip32', async () => {
-    await TestSnaps.fillMessage('messageEd25519Bip32Input', 'foo');
+    await TestSnaps.fillMessage('messageEd25519Bip32Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip32ed25519Bip32Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.checkResultSpan('bip32MessageResultEd25519Bip32Span', '""');
+    await TestSnaps.checkResultSpan(
+      'bip32MessageResultEd25519Bip32Span',
+      '"0xc279ee3e49f7e392a4e511136c39791e076f9be01d8648f3f1586ecf0f41def1739fa2978f90cfb2da4cf53ccb99405558cffcc4d190199b6949b03b1b8dae05"',
+    );
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 1', async () => {
-    await TestSnaps.selectEntropySource(
-      'bip32EntropyDropDown',
-      '01JX9NJ15HPNS6RRRYBCKDK33R',
-    );
-    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'SRP 1');
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
-      '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
+      '"0x3045022100bd7301b5288fcc15e9c19bf548b666356230343a57f4ef0327a8e81f19ac562c022062698ed00a36e9ddd1563e1dc2e357d747bdfb233192ee1597cabb6c7210a6ba"',
     );
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 2', async () => {
-    await TestSnaps.selectEntropySource(
-      'bip32EntropyDropDown',
-      '01JX9NZWRAVQKES02TWSN8GD91',
-    );
-    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'SRP 2');
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip32MessageResultSecp256k1Span',
-      '"0x30430220458e02536d6f84029ac13401ac59b9d241255d2e0f58f1c000da7e5d77a76e25021f1a14788d550e9d6b5265a70b17473d18a96aa5c3866efdac87c8bbc6f1db6f"',
+      '"0x3045022100ad81b36b28f5f5dd47f45a46b2e7cf42e501d2e9b5768627b0702c100f80eb3c02200a481cbbe22b47b4ea6cd923a7da22952f5b21a0dc52e841dcd08f7af8c74e05"',
     );
   });
 
   it('fails when choosing the invalid entropy source', async () => {
     await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid');
-    await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
+    await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed(
       'Entropy source with ID "invalid" not found.',

--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -17,10 +17,11 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 const fixtureServer = new FixtureServer();
 
 describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
-
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
-    const fixture = new FixtureBuilder().withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController().build();
+    const fixture = new FixtureBuilder()
+      .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController()
+      .build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await TestHelpers.launchApp({
@@ -43,14 +44,17 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     jest.setTimeout(150000);
   });
 
-  it('can connect to BIP-32 snap', async ()=> {
+  it('can connect to BIP-32 snap', async () => {
     await TestSnaps.installSnap('connectBip32Button');
   });
 
   it('can get BIP-32 public key', async () => {
     await TestSnaps.tapButton('getPublicKeyBip32Button');
     await TestHelpers.delay(3000);
-    await TestSnaps.checkResultSpan('bip32PublicKeyResultSpan', '"0x046d718eee8a4e85aac6b6a02c802a60e4d13981ab5cf7d620466c9d23fe24d9cfb2548ed7bdb658ef24d119b70cf49e05a111e8054e53a8d0548e10e684afc40b"');
+    await TestSnaps.checkResultSpan(
+      'bip32PublicKeyResultSpan',
+      '"0x046d718eee8a4e85aac6b6a02c802a60e4d13981ab5cf7d620466c9d23fe24d9cfb2548ed7bdb658ef24d119b70cf49e05a111e8054e53a8d0548e10e684afc40b"',
+    );
   });
 
   it('can sign BIP-32 message using secp256k1', async () => {
@@ -59,7 +63,10 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"');
+    await TestSnaps.checkResultSpan(
+      'bip32MessageResultSecp256k1Span',
+      '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
+    );
   });
 
   it('can sign BIP-32 message using ed25519', async () => {
@@ -68,7 +75,10 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    await TestSnaps.checkResultSpan('bip32MessageResultEd25519Span', '"0x52b797a80452402e93d1a53a972a5d22ae77c88c0883233839849f142ab6cef69e91500c4109ff40216cc4327d1914ab05facce372817db532463a38f225e408"');
+    await TestSnaps.checkResultSpan(
+      'bip32MessageResultEd25519Span',
+      '"0x52b797a80452402e93d1a53a972a5d22ae77c88c0883233839849f142ab6cef69e91500c4109ff40216cc4327d1914ab05facce372817db532463a38f225e408"',
+    );
   });
 
   it.skip('can sign BIP-32 message using ed25519Bip32', async () => {
@@ -81,29 +91,43 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 1', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', '01JX9NJ15HPNS6RRRYBCKDK33R')
+    await TestSnaps.selectEntropySource(
+      'bip32EntropyDropDown',
+      '01JX9NJ15HPNS6RRRYBCKDK33R',
+    );
     await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"');
+    await TestSnaps.checkResultSpan(
+      'bip32MessageResultSecp256k1Span',
+      '"0x304402204b206e3fa1620727c9699ac30869b9c53b3084375531a20196328776b7a315ac02207320be06767c377a1a44ec3729e91455ec700c7c486697c010e7c672a4c3fc6e"',
+    );
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 2', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', '01JX9NZWRAVQKES02TWSN8GD91')
+    await TestSnaps.selectEntropySource(
+      'bip32EntropyDropDown',
+      '01JX9NZWRAVQKES02TWSN8GD91',
+    );
     await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    await TestSnaps.checkResultSpan('bip32MessageResultSecp256k1Span', '"0x30430220458e02536d6f84029ac13401ac59b9d241255d2e0f58f1c000da7e5d77a76e25021f1a14788d550e9d6b5265a70b17473d18a96aa5c3866efdac87c8bbc6f1db6f"');
+    await TestSnaps.checkResultSpan(
+      'bip32MessageResultSecp256k1Span',
+      '"0x30430220458e02536d6f84029ac13401ac59b9d241255d2e0f58f1c000da7e5d77a76e25021f1a14788d550e9d6b5265a70b17473d18a96aa5c3866efdac87c8bbc6f1db6f"',
+    );
   });
 
   it('fails when choosing the invalid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid')
+    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageSecp256k1Input', 'foo');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
-    await Assertions.checkIfTextIsDisplayed('Entropy source with ID "invalid" not found.');
+    await Assertions.checkIfTextIsDisplayed(
+      'Entropy source with ID "invalid" not found.',
+    );
   });
 });

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -66,7 +66,6 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
     await TestSnaps.fillMessage('messageBip44Input', customMessage);
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
     await TestSnaps.checkResultSpan(
       'bip44SignResultSpan',
       EXPECTED_CUSTOM_SIGNATURE,

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -88,7 +88,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
   });
 
   it('should select an invalid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'invalid');
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageBip44Input', customMessage);
     await TestSnaps.tapButton('signMessageBip44Button');
     await Assertions.checkIfTextIsDisplayed(

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -17,16 +17,19 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 const fixtureServer = new FixtureServer();
 
 describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
-
-  const EXPECTED_PUBLIC_KEY = '"0x90043dd7faa56b3ed9fe959d25ae17132dc7e0f604663e68a84cf21e0f64390fbdd4781e4baa99c236f3bbf95182bdee"';
-  const EXPECTED_CUSTOM_SIGNATURE = '"0xac396aaaf817d880ceab9b24995818436dee605524ae68061661fd69e340068fd55a24f579017c3591ed60d4738f25720ac3f23964c0209119e8afb2e20088a652b581a32b96002b7a282bf200ef1a463fb0ff56e2c3937f140a5300a5eacbc1"';
+  const EXPECTED_PUBLIC_KEY =
+    '"0x90043dd7faa56b3ed9fe959d25ae17132dc7e0f604663e68a84cf21e0f64390fbdd4781e4baa99c236f3bbf95182bdee"';
+  const EXPECTED_CUSTOM_SIGNATURE =
+    '"0xac396aaaf817d880ceab9b24995818436dee605524ae68061661fd69e340068fd55a24f579017c3591ed60d4738f25720ac3f23964c0209119e8afb2e20088a652b581a32b96002b7a282bf200ef1a463fb0ff56e2c3937f140a5300a5eacbc1"';
   const customMessage = 'This is a custom test message.';
-  const EXPECTED_FOO_BAR_SIGNATURE = '"0x988251404ed60124cc6a4c17bfda9659d59273b675d1cd942478960b0747f1c182076df7bc695ac1459416d0ab7e789f078a3c6f3e438d568f9c05260d95b716c7ba1942661f22f966f2691dc282b40523c073e88b6b43d9dd2983c85cbe6142"';
-
+  const EXPECTED_FOO_BAR_SIGNATURE =
+    '"0x988251404ed60124cc6a4c17bfda9659d59273b675d1cd942478960b0747f1c182076df7bc695ac1459416d0ab7e789f078a3c6f3e438d568f9c05260d95b716c7ba1942661f22f966f2691dc282b40523c073e88b6b43d9dd2983c85cbe6142"';
 
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
-    const fixture = new FixtureBuilder().withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController().build();
+    const fixture = new FixtureBuilder()
+      .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController()
+      .build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await TestHelpers.launchApp({
@@ -49,7 +52,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
     jest.setTimeout(150000);
   });
 
-  it('should connect to BIP-44 snap', async ()=> {
+  it('should connect to BIP-44 snap', async () => {
     await TestSnaps.installSnap('connectBip44Button');
   });
 
@@ -64,21 +67,32 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    await TestSnaps.checkResultSpan('bip44SignResultSpan', EXPECTED_CUSTOM_SIGNATURE);
+    await TestSnaps.checkResultSpan(
+      'bip44SignResultSpan',
+      EXPECTED_CUSTOM_SIGNATURE,
+    );
   });
 
   it('should select an valid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', '01JX9NJ15HPNS6RRRYBCKDK33R')
+    await TestSnaps.selectEntropySource(
+      'bip44EntropyDropDown',
+      '01JX9NJ15HPNS6RRRYBCKDK33R',
+    );
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.checkResultSpan('bip44SignResultSpan', EXPECTED_FOO_BAR_SIGNATURE);
+    await TestSnaps.checkResultSpan(
+      'bip44SignResultSpan',
+      EXPECTED_FOO_BAR_SIGNATURE,
+    );
   });
 
   it('should select an invalid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'invalid')
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'invalid');
     await TestSnaps.fillMessage('messageBip44Input', customMessage);
     await TestSnaps.tapButton('signMessageBip44Button');
-    await Assertions.checkIfTextIsDisplayed('Entropy source with ID "invalid" not found.');
+    await Assertions.checkIfTextIsDisplayed(
+      'Entropy source with ID "invalid" not found.',
+    );
   });
 });

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -18,9 +18,7 @@ const fixtureServer = new FixtureServer();
 
 describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
 
-  const BIP_44_SNAP_NAME = 'BIP-44 Example Snap';
   const EXPECTED_PUBLIC_KEY = '"0x90043dd7faa56b3ed9fe959d25ae17132dc7e0f604663e68a84cf21e0f64390fbdd4781e4baa99c236f3bbf95182bdee"';
-  const EXPECTED_SIGNATURE = '"0xa0cb4e931890059764c8ef1c4a7380c1d0bd11209eb899d49f5d2856224cb2a8a82f5136b7bc579c539332609336f3a6159fc1df6116acfe55dbbe5ccdffecc4984904c603dda0b3c91757dc6a590069a6c41837e1ab88e9dc21769d742f9a67"';
   const EXPECTED_CUSTOM_SIGNATURE = '"0xac396aaaf817d880ceab9b24995818436dee605524ae68061661fd69e340068fd55a24f579017c3591ed60d4738f25720ac3f23964c0209119e8afb2e20088a652b581a32b96002b7a282bf200ef1a463fb0ff56e2c3937f140a5300a5eacbc1"';
   const customMessage = 'This is a custom test message.';
   const EXPECTED_FOO_BAR_SIGNATURE = '"0x988251404ed60124cc6a4c17bfda9659d59273b675d1cd942478960b0747f1c182076df7bc695ac1459416d0ab7e789f078a3c6f3e438d568f9c05260d95b716c7ba1942661f22f966f2691dc282b40523c073e88b6b43d9dd2983c85cbe6142"';
@@ -28,7 +26,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
 
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
-    const fixture = new FixtureBuilder().build();
+    const fixture = new FixtureBuilder().withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController().build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
     await TestHelpers.launchApp({
@@ -52,57 +50,35 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
   });
 
   it('should connect to BIP-44 snap', async ()=> {
-    // Connect to BIP-44 snap
-    await TestSnaps.connectToBip44Snap();
-    await TestSnaps.connectToSnap();
-    await Assertions.checkIfTextIsDisplayed(BIP_44_SNAP_NAME);
-    await TestSnaps.connectToSnapPermissionsRequest();
-    await TestSnaps.approveSnapPermissionsRequest();
-    await TestSnaps.connectToSnapInstallOk();
+    await TestSnaps.installSnap('connectBip44Button');
   });
 
   it('should get BIP-44 public key', async () => {
-    // Get public key
-    await TestSnaps.tapPublicKeyBip44Button();
+    await TestSnaps.tapButton('getPublicKeyBip44Button');
     await TestHelpers.delay(3000);
-    const actualText = await TestSnaps.getBip44ResultText();
-    await Assertions.checkIfTextMatches(actualText, EXPECTED_PUBLIC_KEY);
+    await TestSnaps.checkResultSpan('bip44ResultSpan', EXPECTED_PUBLIC_KEY);
   });
 
-  it('should sign BIP-44 message', async () => {
-    // Click sign button
-    await TestSnaps.tapSignBip44MessageButton();
-    await Assertions.checkIfTextIsDisplayed('Signature request');
+  it('should sign a BIP-44 message', async () => {
+    await TestSnaps.fillMessage('messageBip44Input', customMessage);
+    await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
     await TestSnaps.swipeUpSmall();
-    const actualText = await TestSnaps.getSignBip44MessageResultText();
-    await Assertions.checkIfTextMatches(actualText, EXPECTED_SIGNATURE);
+    await TestSnaps.checkResultSpan('bip44SignResultSpan', EXPECTED_CUSTOM_SIGNATURE);
   });
 
-  it('should sign a custom message', async () => {
-    await TestSnaps.typeSignMessage(customMessage);
-    await TestSnaps.tapSignBip44MessageButton();
+  it('should select an valid entropy source', async () => {
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', '01JX9NJ15HPNS6RRRYBCKDK33R')
+    await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
+    await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
-    await TestSnaps.swipeUpSmall();
-    const actualText = await TestSnaps.getSignBip44MessageResultText();
-    await Assertions.checkIfTextMatches(actualText, EXPECTED_CUSTOM_SIGNATURE);
+    await TestSnaps.checkResultSpan('bip44SignResultSpan', EXPECTED_FOO_BAR_SIGNATURE);
   });
 
-  it('should select an valid entropy source ', async () => {
-    await TestSnaps.tapEntropyDropDown();
-    await TestSnaps.selectPrimaryEntropySource();
-    await TestSnaps.typeSignMessage('foo bar');
-    await TestSnaps.tapSignBip44MessageButton();
-    await TestSnaps.approveSignRequest();
-    const actualText = await TestSnaps.getSignBip44MessageResultText();
-    await Assertions.checkIfTextMatches(actualText, EXPECTED_FOO_BAR_SIGNATURE);
-  });
-
-  it('should select an invalid entropy source ', async () => {
-    await TestSnaps.tapEntropyDropDown();
-    await TestSnaps.tapInvalidEntropySource();
-    await TestSnaps.typeSignMessage(customMessage);
-    await TestSnaps.tapSignBip44MessageButton();
+  it('should select an invalid entropy source', async () => {
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'invalid')
+    await TestSnaps.fillMessage('messageBip44Input', customMessage);
+    await TestSnaps.tapButton('signMessageBip44Button');
     await Assertions.checkIfTextIsDisplayed('Entropy source with ID "invalid" not found.');
   });
 });

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -17,18 +17,10 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 const fixtureServer = new FixtureServer();
 
 describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
-  const EXPECTED_PUBLIC_KEY =
-    '"0x90043dd7faa56b3ed9fe959d25ae17132dc7e0f604663e68a84cf21e0f64390fbdd4781e4baa99c236f3bbf95182bdee"';
-  const EXPECTED_CUSTOM_SIGNATURE =
-    '"0xac396aaaf817d880ceab9b24995818436dee605524ae68061661fd69e340068fd55a24f579017c3591ed60d4738f25720ac3f23964c0209119e8afb2e20088a652b581a32b96002b7a282bf200ef1a463fb0ff56e2c3937f140a5300a5eacbc1"';
-  const customMessage = 'This is a custom test message.';
-  const EXPECTED_FOO_BAR_SIGNATURE =
-    '"0x988251404ed60124cc6a4c17bfda9659d59273b675d1cd942478960b0747f1c182076df7bc695ac1459416d0ab7e789f078a3c6f3e438d568f9c05260d95b716c7ba1942661f22f966f2691dc282b40523c073e88b6b43d9dd2983c85cbe6142"';
-
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
     const fixture = new FixtureBuilder()
-      .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountKeyringController()
+      .withMultiSRPKeyringController()
       .build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
@@ -52,43 +44,54 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
     jest.setTimeout(150000);
   });
 
-  it('should connect to BIP-44 snap', async () => {
+  it('can connect to BIP-44 snap', async () => {
     await TestSnaps.installSnap('connectBip44Button');
   });
 
-  it('should get BIP-44 public key', async () => {
+  it('can get BIP-44 public key', async () => {
     await TestSnaps.tapButton('getPublicKeyBip44Button');
     await TestHelpers.delay(3000);
-    await TestSnaps.checkResultSpan('bip44ResultSpan', EXPECTED_PUBLIC_KEY);
+    await TestSnaps.checkResultSpan(
+      'bip44ResultSpan',
+      '"0x86debb44fb3a984d93f326131d4c1db0bc39644f1a67b673b3ab45941a1cea6a385981755185ac4594b6521e4d1e08d1"',
+    );
   });
 
-  it('should sign a BIP-44 message', async () => {
-    await TestSnaps.fillMessage('messageBip44Input', customMessage);
+  it('can sign a BIP-44 message', async () => {
+    await TestSnaps.fillMessage('messageBip44Input', '1234');
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip44SignResultSpan',
-      EXPECTED_CUSTOM_SIGNATURE,
+      '"0xa41ab87ca50606eefd47525ad90294bbe44c883f6bc53655f1b8a55aa8e1e35df216f31be62e52c7a1faa519420e20810162e07dedb0fde2a4d997ff7180a78232ecd8ce2d6f4ba42ccacad33c5e9e54a8c4d41506bdffb2bb4c368581d8b086"',
     );
   });
 
-  it('should select an valid entropy source', async () => {
-    await TestSnaps.selectEntropySource(
-      'bip44EntropyDropDown',
-      '01JX9NJ15HPNS6RRRYBCKDK33R',
-    );
+  it('can sign with entropy from SRP 1', async () => {
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'SRP 1');
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
     await TestSnaps.checkResultSpan(
       'bip44SignResultSpan',
-      EXPECTED_FOO_BAR_SIGNATURE,
+      '"0x978f82799b8f48cb78ac56153a34d360873c976fd5ec84f7a5291382dde52d6cb478cadd94153970e58e5205c054cdda0071be0551b729d79bd417f7b0fc2b0c51071ca4771c9b2d8238d7d982bc5ec9256645287402348ca0f89202fb1e0773"',
     );
   });
 
-  it('should select an invalid entropy source', async () => {
+  it('can sign with entropy from SRP 2', async () => {
+    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'SRP 2');
+    await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
+    await TestSnaps.tapButton('signMessageBip44Button');
+    await TestSnaps.approveSignRequest();
+    await TestSnaps.checkResultSpan(
+      'bip44SignResultSpan',
+      '"0xa8fdc184ded6d9a1b16d2d4070470720e4a946c9899ceb5165c05f9a8c4b026e8f630d6bdb60151f9e84b3c415c4b46c11bc2571022c8391b07faedc0d8c258d532d34c33149c5fc29e17c310437dc47e8afb43b2c55bd47b1b09ea295f7dcb3"',
+    );
+  });
+
+  it('fails when choosing the invalid entropy source', async () => {
     await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'Invalid');
-    await TestSnaps.fillMessage('messageBip44Input', customMessage);
+    await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await Assertions.checkIfTextIsDisplayed(
       'Entropy source with ID "invalid" not found.',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR ports most of the BIP-32 example Snap E2E to mobile. It also adds and refactors some of the `TestSnaps` functionality to be more reusable across E2E tests.

To ensure that key derivation works as intended this PR adds a fixture containing SRPs from the extension client. The fixture was generated using the following code:

```js

const vault = [
    {
        "type": "HD Key Tree",
        "data": {
            "mnemonic": [
                115, 112, 114, 101, 97, 100, 32, 114, 97, 105, 115, 101, 32, 115, 104,
                111, 114, 116, 32, 99, 114, 97, 110, 101, 32, 111, 109, 105, 116, 32,
                116, 101, 110, 116, 32, 102, 114, 105, 110, 103, 101, 32, 109, 97, 110,
                100, 97, 116, 101, 32, 110, 101, 103, 108, 101, 99, 116, 32, 100, 101,
                116, 97, 105, 108, 32, 115, 117, 115, 112, 101, 99, 116, 32, 99, 114,
                97, 100, 108, 101
            ],
            "numberOfAccounts": 1,
            "hdPath": "m/44'/60'/0'/0"
        },
        "metadata": {
            "id": "01JNGTRZ3QCEEQ7GYYFXBSQSBK",
            "name": "SRP 1"
        }
    },
    {
        "type": "HD Key Tree",
        "data": {
            "mnemonic": [
                116, 101, 115, 116, 32, 116, 101, 115, 116, 32, 116, 101, 115, 116, 32,
                116, 101, 115, 116, 32, 116, 101, 115, 116, 32, 116, 101, 115, 116, 32,
                116, 101, 115, 116, 32, 116, 101, 115, 116, 32, 116, 101, 115, 116, 32,
                116, 101, 115, 116, 32, 116, 101, 115, 116, 32, 98, 97, 108, 108
            ],
            "numberOfAccounts": 1,
            "hdPath": "m/44'/60'/0'/0"
        },
        "metadata": {
            "id": "01JNGTTNRVYNQVN5FN8YTFAMJ4",
            "name": "SRP 2"
        }
    }
]

export function generateSalt(byteCount = 32) {
    const view = new Uint8Array(byteCount);
    globalThis.crypto.getRandomValues(view);

    return btoa(
        String.fromCharCode.apply(null, view),
    );
}

async function main() {
    const salt = generateSalt(16);
    // Hardcoded password in mobile E2E.
    const passBuffer = Buffer.from('123123123', 'utf-8');
    // Parse base 64 string as utf-8 because mobile encryptor is flawed.
    const saltBuffer = Buffer.from(salt, 'utf-8')
    const iv = crypto.getRandomValues(new Uint8Array(16))

    const baseKey = await crypto.subtle.importKey(
        'raw',
        passBuffer,
        { name: 'PBKDF2' },
        false,
        ['deriveBits', 'deriveKey'],
    );

    const derivedBits = await crypto.subtle.deriveBits(
        {
            name: 'PBKDF2',
            salt: saltBuffer,
            iterations: 5000,
            hash: 'SHA-512',
        },
        baseKey,
        256
    );

    const importedKey = await crypto.subtle.importKey(
        'raw',
        derivedBits,
        { name: 'AES-CBC', length: 256 },
        true,
        ['encrypt', 'decrypt'],
    );

    const json = JSON.stringify(vault);

    const buffer = Buffer.from(json, 'utf-8');

    const encrypted = await crypto.subtle.encrypt({ name: 'AES-CBC', iv }, importedKey, buffer);

    const result = {
        keyMetadata: { "algorithm": "PBKDF2", "params": { "iterations": 5000 } },
        lib: "original",
        cipher: Buffer.from(encrypted).toString('base64'), 
        iv: Buffer.from(iv).toString('hex'),
        salt,
    };

    console.log(JSON.stringify(result));
}


main().catch(console.error)

```

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3476
