### PR TITLE
fix: default to main code fence and opt-in for beta

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -54,7 +54,7 @@ const flaskFeatureSet = new Set([
  */
 function getBuildTypeFeatures() {
   const buildType = process.env.METAMASK_BUILD_TYPE ?? 'main';
-  const envType = process.env.METAMASK_ENVIRONMENT ?? 'prod';
+  const envType = process.env.METAMASK_ENVIRONMENT ?? 'production';
   switch (buildType) {
     case 'main':
       return envType === 'beta' ? betaFeatureSet : mainFeatureSet;

--- a/metro.transform.js
+++ b/metro.transform.js
@@ -57,7 +57,7 @@ function getBuildTypeFeatures() {
   const envType = process.env.METAMASK_ENVIRONMENT ?? 'prod';
   switch (buildType) {
     case 'main':
-      return envType === 'prod' ? mainFeatureSet : betaFeatureSet;
+      return envType === 'beta' ? betaFeatureSet : mainFeatureSet;
     case 'beta':
       return betaFeatureSet;
     case 'flask':


### PR DESCRIPTION

## **Description**

The current logic applies the `beta` code fence to beta and release candidates. This is not the behavior we want and it updates the code to only apply the beta code fence when beta is provided and defaults the code fence to `main`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run an RC build 
2. See that beta doesn't appear on the about section

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
