### PR TITLE
fix: Remove delay for dispatch of INIT_BG_STATE_KEY

### DIFF
--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -110,6 +110,8 @@ export class EngineService {
           Logger.log('keyringController vault missing for INIT_BG_STATE_KEY');
         }
         this.updateBatcher.add(INIT_BG_STATE_KEY);
+        // immediately flush the redux action
+        // so that the initial state is available to the redux store
         this.updateBatcher.flush();
         this.engineInitialized = true;
       },

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -110,6 +110,7 @@ export class EngineService {
           Logger.log('keyringController vault missing for INIT_BG_STATE_KEY');
         }
         this.updateBatcher.add(INIT_BG_STATE_KEY);
+        this.updateBatcher.flush();
         this.engineInitialized = true;
       },
       () => !this.engineInitialized,


### PR DESCRIPTION
## **Description**

The purpose of this task is to fix the `keyringsController.length` issue, which seems to be caused by a batcher delay for the `INIT_BG_STATE` Redux action

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2214

## **Manual testing steps**

1. Go to settings and start the password reset process
2. After entering the EXISTING password, shut the app down
3. When you log back in, it should enter the home screen just fine without crashing

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/959c22e4-220c-49f7-ab22-bf97cd260bc7

### **After**

https://github.com/user-attachments/assets/af57ac68-b3a4-476e-b62c-47423fd939d1

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
