### PR TITLE
fix: Exclude smart transaction approval requests from rate limiting

### DIFF
--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
@@ -6,6 +6,7 @@ import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import type { ApprovalControllerMessenger } from '../../messengers/approval-controller-messenger';
 import { ControllerInitRequest } from '../../types';
 import { ApprovalControllerInit } from './approval-controller-init';
+import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
 
 jest.mock('@metamask/approval-controller');
 
@@ -59,6 +60,7 @@ describe('ApprovalController Init', () => {
       expect(constructorOptions.typesExcludedFromRateLimiting).toEqual([
         ApprovalType.Transaction,
         ApprovalType.WatchAsset,
+        ApprovalTypes.SMART_TRANSACTION_STATUS,
       ]);
     });
 

--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
@@ -2,8 +2,9 @@ import { ApprovalController } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 
 import Logger from '../../../../util/Logger';
-import type { ControllerInitFunction } from '../../types';
+import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
 import { type ApprovalControllerMessenger } from '../../messengers/approval-controller-messenger';
+import type { ControllerInitFunction } from '../../types';
 
 export const ApprovalControllerInit: ControllerInitFunction<
   ApprovalController,
@@ -18,6 +19,7 @@ export const ApprovalControllerInit: ControllerInitFunction<
       typesExcludedFromRateLimiting: [
         ApprovalType.Transaction,
         ApprovalType.WatchAsset,
+        ApprovalTypes.SMART_TRANSACTION_STATUS,
       ],
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The approval controller has a mechanism to throttle multiple requests by the same origin. We are adding smart transaction approvals to the allowlist.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13719

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
