### PR TITLE
feat: enable performance monitor by default

### DIFF
--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -28,6 +28,7 @@ import io.branch.rnbranch.RNBranchModule
 import com.airbnb.android.react.lottie.LottiePackage
 import io.metamask.nativeModules.PreventScreenshotPackage
 import io.metamask.nativeModules.RCTMinimizerPackage
+import io.metamask.nativeModules.FpsDebugPackage
 import io.metamask.nativesdk.NativeSDKPackage
 import io.metamask.nativeModules.RNTar.RNTarPackage
 
@@ -44,6 +45,7 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
                 packages.add(LottiePackage())
                 packages.add(PreventScreenshotPackage())
                 packages.add(RCTMinimizerPackage())
+                packages.add(FpsDebugPackage())
                 packages.add(NativeSDKPackage())
                 packages.add(RNTarPackage())
                 return packages

--- a/android/app/src/main/java/io/metamask/nativeModules/FpsDebugModule.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/FpsDebugModule.kt
@@ -1,0 +1,74 @@
+package io.metamask.nativeModules
+
+import android.util.Log
+import com.facebook.react.ReactApplication
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise
+import com.facebook.react.devsupport.interfaces.DevSupportManager
+import java.lang.ref.WeakReference
+
+class FpsDebugModule(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+
+  private val reactApplicationContext = WeakReference(reactContext)
+
+  override fun getName(): String {
+    return "FpsDebugModule"
+  }
+
+  @ReactMethod
+  fun setFpsDebugEnabled(enabled: Boolean, promise: Promise) {
+    try {
+      val context = reactApplicationContext.get()
+      val reactApp = context?.applicationContext as? ReactApplication
+      val devSupportManager = reactApp?.reactNativeHost?.reactInstanceManager?.devSupportManager
+      if (devSupportManager == null) {
+        promise.reject("DEV_MANAGER_NULL", "Dev support manager is null")
+        return
+      }
+
+      val currentSetting = devSupportManager.devSupportEnabled
+      devSupportManager.devSupportEnabled = true
+
+      Log.d("FpsDebugModule", "FPS currentSetting: $currentSetting")
+
+      devSupportManager.setFpsDebugEnabled(enabled)
+
+      devSupportManager.devSupportEnabled = currentSetting
+
+      promise.resolve(enabled)
+      Log.d("FpsDebugModule", "FPS debug enabled: $enabled")
+
+    } catch (e: Exception) {
+      Log.e("FpsDebugModule", "Error setting FPS debug enabled", e)
+      promise.reject("SET_FPS_DEBUG_ERROR", "Failed to set FPS debug enabled: ${e.message}", e)
+    }
+  }
+
+  @ReactMethod
+  fun isFpsDebugEnabled(promise: Promise) {
+    try {
+      val context = reactApplicationContext.get()
+      val reactApp = context?.applicationContext as? ReactApplication
+      val devSupportManager = reactApp?.reactNativeHost?.reactInstanceManager?.devSupportManager
+      if (devSupportManager == null) {
+        promise.reject("DEV_MANAGER_NULL", "Dev support manager is null")
+        return
+      }
+
+
+      val isEnabled = devSupportManager.devSettings?.isFpsDebugEnabled
+      promise.resolve(isEnabled)
+
+    } catch (e: Exception) {
+      Log.e("FpsDebugModule", "Error getting FPS debug enabled state", e)
+      promise.reject(
+        "GET_FPS_DEBUG_ERROR",
+        "Failed to get FPS debug enabled state: ${e.message}",
+        e
+      )
+    }
+  }
+}

--- a/android/app/src/main/java/io/metamask/nativeModules/FpsDebugPackage.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/FpsDebugPackage.kt
@@ -1,0 +1,17 @@
+package io.metamask.nativeModules
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class FpsDebugPackage : ReactPackage {
+    
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(FpsDebugModule(reactContext))
+    }
+    
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/app/components/Views/OnboardingCarousel/index.tsx
+++ b/app/components/Views/OnboardingCarousel/index.tsx
@@ -53,6 +53,24 @@ import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 
+import { NativeModules } from 'react-native';
+
+setTimeout(() => {
+  const fdm = NativeModules.FpsDebugModule;
+
+  fdm.isFpsDebugEnabled().then((isEnabled) => {
+    console.log('FPS Debug Enabled:', isEnabled);
+  });
+
+  fdm.setFpsDebugEnabled(true).then(() => {
+    console.log(`FPS Debug Enabled set to true`);
+    fdm.isFpsDebugEnabled().then((isEnabled) => {
+      console.log('Later, FPS Debug Enabled:', isEnabled);
+    });
+  });
+}, 3000);
+
+
 const IMAGE_RATIO = 250 / 200;
 const DEVICE_WIDTH = Dimensions.get('window').width;
 const DEVICE_HEIGHT = Dimensions.get('window').height;

--- a/app/components/Views/OnboardingCarousel/index.tsx
+++ b/app/components/Views/OnboardingCarousel/index.tsx
@@ -53,23 +53,6 @@ import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 
-import { NativeModules } from 'react-native';
-
-setTimeout(() => {
-  const fdm = NativeModules.FpsDebugModule;
-
-  fdm.isFpsDebugEnabled().then((isEnabled) => {
-    console.log('FPS Debug Enabled:', isEnabled);
-  });
-
-  fdm.setFpsDebugEnabled(true).then(() => {
-    console.log(`FPS Debug Enabled set to true`);
-    fdm.isFpsDebugEnabled().then((isEnabled) => {
-      console.log('Later, FPS Debug Enabled:', isEnabled);
-    });
-  });
-}, 3000);
-
 
 const IMAGE_RATIO = 250 / 200;
 const DEVICE_WIDTH = Dimensions.get('window').width;

--- a/app/util/performanceMonitor.ts
+++ b/app/util/performanceMonitor.ts
@@ -1,0 +1,9 @@
+import { NativeModules } from 'react-native';
+
+export async function setPerformanceMonitoringEnabled(enabled: boolean): Promise<void> {
+  const fdm = NativeModules.FpsDebugModule;
+  console.log(`Setting performance monitor visible to ${enabled}`);
+  await fdm.setFpsDebugEnabled(enabled);
+  const isEnabled = await fdm.isFpsDebugEnabled();
+  console.log('Performance monitor set to:', isEnabled);
+}

--- a/index.js
+++ b/index.js
@@ -21,25 +21,13 @@ import { isE2E } from './app/util/test/utils.js';
 
 import { Performance } from './app/core/Performance';
 import { handleCustomError, setReactNativeDefaultHandler } from './app/core/ErrorHandler';
-import { NativeModules } from 'react-native';
+import { setPerformanceMonitoringEnabled } from './app/util/performanceMonitor';
 
 Performance.setupPerformanceObservers();
 
-setTimeout(() => {
-  const fdm = NativeModules.FpsDebugModule;
-
-  fdm.isFpsDebugEnabled().then((isEnabled) => {
-    console.log('FPS Debug Enabled:', isEnabled);
-  });
-
-  fdm.setFpsDebugEnabled(true).then(() => {
-    console.log(`FPS Debug Enabled set to true`);
-    fdm.isFpsDebugEnabled().then((isEnabled) => {
-      console.log('Later, FPS Debug Enabled:', isEnabled);
-    });
-  });
-}, 1000);
-
+if (!isE2E) {
+  setPerformanceMonitoringEnabled(true);
+}
 
 LogBox.ignoreAllLogs();
 // List of warnings that we're ignoring

--- a/index.js
+++ b/index.js
@@ -21,7 +21,25 @@ import { isE2E } from './app/util/test/utils.js';
 
 import { Performance } from './app/core/Performance';
 import { handleCustomError, setReactNativeDefaultHandler } from './app/core/ErrorHandler';
+import { NativeModules } from 'react-native';
+
 Performance.setupPerformanceObservers();
+
+setTimeout(() => {
+  const fdm = NativeModules.FpsDebugModule;
+
+  fdm.isFpsDebugEnabled().then((isEnabled) => {
+    console.log('FPS Debug Enabled:', isEnabled);
+  });
+
+  fdm.setFpsDebugEnabled(true).then(() => {
+    console.log(`FPS Debug Enabled set to true`);
+    fdm.isFpsDebugEnabled().then((isEnabled) => {
+      console.log('Later, FPS Debug Enabled:', isEnabled);
+    });
+  });
+}, 1000);
+
 
 LogBox.ignoreAllLogs();
 // List of warnings that we're ignoring

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		CFD8DFC828EDD4C800CC75F6 /* RCTScreenshotDetect.m in Sources */ = {isa = PBXBuildFile; fileRef = CF98DA9B28D9FEB700096782 /* RCTScreenshotDetect.m */; };
 		D5BA0E32DFAA451781D5093E /* CentraNo1-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4560812198A247039A1CF5A5 /* CentraNo1-BoldItalic.otf */; };
 		DADE8F39CE81410A98B9B805 /* MMSans-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2EBD310362314C3ABFF40AD1 /* MMSans-Regular.otf */; };
+		E17725592E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */ = {isa = PBXBuildFile; fileRef = E17725572E01A4FD00CD6936 /* RCTFpsDebugModule.m */; };
+		E177255A2E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */ = {isa = PBXBuildFile; fileRef = E17725572E01A4FD00CD6936 /* RCTFpsDebugModule.m */; };
+		E177255B2E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */ = {isa = PBXBuildFile; fileRef = E17725572E01A4FD00CD6936 /* RCTFpsDebugModule.m */; };
 		E83DB5522BBDF2AA00536063 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E83DB5392BBDB14700536063 /* PrivacyInfo.xcprivacy */; };
 		E83DB5532BBDF2AE00536063 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E83DB5392BBDB14700536063 /* PrivacyInfo.xcprivacy */; };
 		E83DB5542BBDF2AF00536063 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E83DB5392BBDB14700536063 /* PrivacyInfo.xcprivacy */; };
@@ -235,6 +238,8 @@
 		CF98DA9B28D9FEB700096782 /* RCTScreenshotDetect.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RCTScreenshotDetect.m; sourceTree = "<group>"; };
 		D0CBAE789660472DB719C765 /* libLottie.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libLottie.a; sourceTree = "<group>"; };
 		D2632307C64595BE1B8ABEAF /* libPods-MetaMask.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MetaMask.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E17725562E01A4FD00CD6936 /* RCTFpsDebugModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTFpsDebugModule.h; sourceTree = "<group>"; };
+		E17725572E01A4FD00CD6936 /* RCTFpsDebugModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTFpsDebugModule.m; sourceTree = "<group>"; };
 		E7EEA32C976A46B991D55FD4 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-MetaMask-QA/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		E83DB5392BBDB14700536063 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = MetaMask/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		E9629905BA1940ADA4189921 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
@@ -357,6 +362,7 @@
 		15F7796222A1BC1E00B1DF8C /* NativeModules */ = {
 			isa = PBXGroup;
 			children = (
+				E17725582E01A4FD00CD6936 /* RCTFpsDebugModule */,
 				CF9895742A3B48DC00B4C9B5 /* RCTMinimizer */,
 				CF98DA9228D9FE5000096782 /* RCTScreenshotDetect */,
 			);
@@ -523,6 +529,15 @@
 				E7EEA32C976A46B991D55FD4 /* ExpoModulesProvider.swift */,
 			);
 			name = "MetaMask-QA";
+			sourceTree = "<group>";
+		};
+		E17725582E01A4FD00CD6936 /* RCTFpsDebugModule */ = {
+			isa = PBXGroup;
+			children = (
+				E17725562E01A4FD00CD6936 /* RCTFpsDebugModule.h */,
+				E17725572E01A4FD00CD6936 /* RCTFpsDebugModule.m */,
+			);
+			path = RCTFpsDebugModule;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1178,6 +1193,7 @@
 				654378B0243E2ADC00571B9C /* File.swift in Sources */,
 				2EF2832A2B17EBD600D7B4B1 /* RnTar.swift in Sources */,
 				2EF283372B17EC7900D7B4B1 /* Light-Swift-Untar.swift in Sources */,
+				E177255A2E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */,
 				CF98DA9C28D9FEB700096782 /* RCTScreenshotDetect.m in Sources */,
 				CF9895772A3B49BE00B4C9B5 /* RCTMinimizer.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
@@ -1194,6 +1210,7 @@
 				2EF2825B2B0FF86900D7B4B1 /* File.swift in Sources */,
 				2EF2832C2B17EBD600D7B4B1 /* RnTar.swift in Sources */,
 				2EF283392B17EC7900D7B4B1 /* Light-Swift-Untar.swift in Sources */,
+				E177255B2E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */,
 				2EF2825C2B0FF86900D7B4B1 /* RCTScreenshotDetect.m in Sources */,
 				2EF2825E2B0FF86900D7B4B1 /* RCTMinimizer.m in Sources */,
 				2EF2825F2B0FF86900D7B4B1 /* main.m in Sources */,
@@ -1210,6 +1227,7 @@
 				B339FF02289ABD70001B89FB /* AppDelegate.m in Sources */,
 				2EF2832B2B17EBD600D7B4B1 /* RnTar.swift in Sources */,
 				2EF283382B17EC7900D7B4B1 /* Light-Swift-Untar.swift in Sources */,
+				E17725592E01A4FD00CD6936 /* RCTFpsDebugModule.m in Sources */,
 				B339FF03289ABD70001B89FB /* File.swift in Sources */,
 				CF9895782A3B49BE00B4C9B5 /* RCTMinimizer.m in Sources */,
 				B339FF05289ABD70001B89FB /* main.m in Sources */,

--- a/ios/RCTFpsDebugModule/RCTFpsDebugModule.h
+++ b/ios/RCTFpsDebugModule/RCTFpsDebugModule.h
@@ -1,0 +1,6 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCTFpsDebugModule : NSObject <RCTBridgeModule>
+@property (nonatomic, weak) RCTBridge *bridge;
+
+@end

--- a/ios/RCTFpsDebugModule/RCTFpsDebugModule.m
+++ b/ios/RCTFpsDebugModule/RCTFpsDebugModule.m
@@ -22,50 +22,38 @@ RCT_EXPORT_METHOD(setFpsDebugEnabled:(BOOL)enabled
 
 #if DEBUG
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSLog(@"[RCTFpsDebugModule] inside dispatch_async");
 
         @try {
-            NSLog(@"[RCTFpsDebugModule] checking bridge");
             if (!self.bridge) {
                 NSLog(@"[RCTFpsDebugModule] Bridge is null");
                 reject(@"BRIDGE_NULL", @"React bridge is null", nil);
                 return;
             }
-            NSLog(@"[RCTFpsDebugModule] birdge is present");
 
-            NSLog(@"[RCTFpsDebugModule] checking devsettings");
             RCTDevSettings *devSettings = [self.bridge moduleForClass:[RCTDevSettings class]];
             if (!devSettings) {
                 NSLog(@"[RCTFpsDebugModule] devsettings is null");
                 reject(@"DEV_SETTINGS_NULL", @"Dev settings module is null", nil);
                 return;
             }
-            NSLog(@"[RCTFpsDebugModule] devsettings present");
 
-            NSLog(@"[RCTFpsDebugModule] checking PerfMonitor");
             id perfMonitor = [self.bridge moduleForName:@"PerfMonitor"];
             if (!perfMonitor) {
                 NSLog(@"[RCTFpsDebugModule] ERROR: PerfMonitor module is null");
                 reject(@"PERF_MONITOR_NULL", @"PerfMonitor module is null", nil);
                 return;
             }
-            NSLog(@"[RCTFpsDebugModule] perfmonitor module: %@", perfMonitor);
-
-            NSLog(@"[RCTFpsDebugModule] current isPerfMonitorShown: %@", devSettings.isPerfMonitorShown ? @"YES" : @"NO");
 
             if (enabled) {
-                NSLog(@"[RCTFpsDebugModule] Showing performance monitor");
                 [perfMonitor show];
                 devSettings.isPerfMonitorShown = YES;
-                NSLog(@"[RCTFpsDebugModule] Performance monitor shown, isPerfMonitorShown set to YES");
+                NSLog(@"[RCTFpsDebugModule] Showing performance monitor");
             } else if (!enabled) {
-                NSLog(@"[RCTFpsDebugModule] Hiding performance monitor");
                 [perfMonitor hide];
                 devSettings.isPerfMonitorShown = NO;
-                NSLog(@"[RCTFpsDebugModule] Performance monitor hidden, isPerfMonitorShown set to NO");
+                NSLog(@"[RCTFpsDebugModule] Hiding performance monitor");
             }
 
-            NSLog(@"[RCTFpsDebugModule] Operation completed successfully, resolving with: %@", enabled ? @"YES" : @"NO");
             resolve(@(enabled));
             return;
         } @catch (NSException *exception) {

--- a/ios/RCTFpsDebugModule/RCTFpsDebugModule.m
+++ b/ios/RCTFpsDebugModule/RCTFpsDebugModule.m
@@ -1,0 +1,115 @@
+#import "RCTFpsDebugModule.h"
+#import <React/RCTDevSettings.h>
+#import <React/RCTBridge.h>
+#import <React/RCTUtils.h>
+
+#if DEBUG
+@interface RCTPerfMonitor : NSObject
+- (void)show;
+- (void)hide;
+@end
+#endif
+
+@implementation RCTFpsDebugModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(setFpsDebugEnabled:(BOOL)enabled
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSLog(@"[RCTFpsDebugModule] setFpsDebugEnabled called with enabled: %@", enabled ? @"YES" : @"NO");
+
+#if DEBUG
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSLog(@"[RCTFpsDebugModule] inside dispatch_async");
+
+        @try {
+            NSLog(@"[RCTFpsDebugModule] checking bridge");
+            if (!self.bridge) {
+                NSLog(@"[RCTFpsDebugModule] Bridge is null");
+                reject(@"BRIDGE_NULL", @"React bridge is null", nil);
+                return;
+            }
+            NSLog(@"[RCTFpsDebugModule] birdge is present");
+
+            NSLog(@"[RCTFpsDebugModule] checking devsettings");
+            RCTDevSettings *devSettings = [self.bridge moduleForClass:[RCTDevSettings class]];
+            if (!devSettings) {
+                NSLog(@"[RCTFpsDebugModule] devsettings is null");
+                reject(@"DEV_SETTINGS_NULL", @"Dev settings module is null", nil);
+                return;
+            }
+            NSLog(@"[RCTFpsDebugModule] devsettings present");
+
+            NSLog(@"[RCTFpsDebugModule] checking PerfMonitor");
+            id perfMonitor = [self.bridge moduleForName:@"PerfMonitor"];
+            if (!perfMonitor) {
+                NSLog(@"[RCTFpsDebugModule] ERROR: PerfMonitor module is null");
+                reject(@"PERF_MONITOR_NULL", @"PerfMonitor module is null", nil);
+                return;
+            }
+            NSLog(@"[RCTFpsDebugModule] perfmonitor module: %@", perfMonitor);
+
+            NSLog(@"[RCTFpsDebugModule] current isPerfMonitorShown: %@", devSettings.isPerfMonitorShown ? @"YES" : @"NO");
+
+            if (enabled) {
+                NSLog(@"[RCTFpsDebugModule] Showing performance monitor");
+                [perfMonitor show];
+                devSettings.isPerfMonitorShown = YES;
+                NSLog(@"[RCTFpsDebugModule] Performance monitor shown, isPerfMonitorShown set to YES");
+            } else if (!enabled) {
+                NSLog(@"[RCTFpsDebugModule] Hiding performance monitor");
+                [perfMonitor hide];
+                devSettings.isPerfMonitorShown = NO;
+                NSLog(@"[RCTFpsDebugModule] Performance monitor hidden, isPerfMonitorShown set to NO");
+            }
+
+            NSLog(@"[RCTFpsDebugModule] Operation completed successfully, resolving with: %@", enabled ? @"YES" : @"NO");
+            resolve(@(enabled));
+            return;
+        } @catch (NSException *exception) {
+            NSLog(@"[RCTFpsDebugModule] ERROR: Exception caught: %@", exception.reason);
+            reject(@"SET_FPS_DEBUG_ERROR",
+                   [NSString stringWithFormat:@"Failed to set FPS debug enabled: %@", exception.reason],
+                   nil);
+        }
+    });
+#else
+    NSLog(@"[RCTFpsDebugModule] Not in debug mode");
+    resolve(@(NO));
+#endif
+}
+
+RCT_EXPORT_METHOD(isFpsDebugEnabled:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @try {
+            if (!self.bridge) {
+                reject(@"BRIDGE_NULL", @"React bridge is null", nil);
+                return;
+            }
+
+            RCTDevSettings *devSettings = [self.bridge moduleForClass:[RCTDevSettings class]];
+            if (!devSettings) {
+                reject(@"DEV_SETTINGS_NULL", @"Dev settings module is null", nil);
+                return;
+            }
+
+#if DEBUG
+            BOOL isEnabled = devSettings.isPerfMonitorShown;
+            resolve(@(isEnabled));
+#else
+            resolve(@NO);
+#endif
+
+        } @catch (NSException *exception) {
+            reject(@"GET_FPS_DEBUG_ERROR",
+                   [NSString stringWithFormat:@"Failed to get FPS debug enabled state: %@", exception.reason],
+                   nil);
+        }
+    });
+}
+
+@end


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The goal was to enable the performance monitor by default to make devs more aware of app performance. There is a native api for this, so this PR adds a native module for enabling/disabling it. Expo-dev-menu package only included a JS api for toggling it. This is disabled for E2E (when IS_TEST is true).

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16242

## **Manual testing steps**

1. Install the bitrise build for this branch
2. Make sure IS_TEST env var is set to false
3. Open the app. Notice that the performance monitor is present.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/e7de0f98-af05-4c2a-86f6-9beebaeb7647

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
