### PR TITLE
test: fix flakey swaps e2e tests

### DIFF
--- a/e2e/specs/swaps/swap-action-smoke.spec.ts
+++ b/e2e/specs/swaps/swap-action-smoke.spec.ts
@@ -135,6 +135,11 @@ describe(SmokeTrade('Swap from Actions'), (): void => {
           'Max slippage 0%',
         );
       }
+
+      // The swap screen has many animations and transitions
+      // Disabling temporarily to speed up checks and taps on the swap confirm screen
+      await device.disableSynchronization();
+
       await QuoteView.tapOnGetQuotes();
       await Assertions.checkIfVisible(SwapView.quoteSummary);
       await Assertions.checkIfVisible(SwapView.gasFee);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This e2e test seemed to always be stuck waiting on the swap confirm screen for the Matchers and `.tap()`s.
I've added `disableSynchronization` during the swap confirmation page to prevent page transitions and animations from blocking the checks and taps.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: Flakey tests - E.g. https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/346edd60-187b-4d7b-a791-ebd7d80ef2d4

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
