### PR TITLE
fix: Fix/bottom sheet notch padding

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
@@ -11,7 +11,6 @@ import React, {
 } from 'react';
 import {
   LayoutChangeEvent,
-  useWindowDimensions,
   View,
   Platform,
   KeyboardAvoidingView,
@@ -66,14 +65,9 @@ const BottomSheetDialog = forwardRef<
   ) => {
     const { top: screenTopPadding, bottom: screenBottomPadding } =
       useSafeAreaInsets();
-    const { y: frameY } = useSafeAreaFrame();
-    const { height: screenHeight } = useWindowDimensions();
-    // on Android, the status bar height is already included in screenHeight so we don't need to subtract it
-    const statusBarHeight = Platform.select({
-      ios: screenTopPadding,
-      android: 0,
-    }) || 0;
-    const maxSheetHeight = screenHeight - statusBarHeight;
+    const { y: frameY, height: screenHeight } = useSafeAreaFrame();
+
+    const maxSheetHeight = screenHeight - screenTopPadding;
     const { styles } = useStyles(styleSheet, {
       maxSheetHeight,
       screenBottomPadding,

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/__snapshots__/BottomSheetDialog.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/__snapshots__/BottomSheetDialog.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`BottomSheetDialog should render correctly 1`] = `
           "borderTopLeftRadius": 8,
           "borderTopRightRadius": 8,
           "borderWidth": 1,
-          "maxHeight": 1333,
+          "maxHeight": 5,
           "overflow": "hidden",
           "paddingBottom": 3,
           "shadowColor": "#0000001a",
@@ -47,7 +47,7 @@ exports[`BottomSheetDialog should render correctly 1`] = `
         {
           "transform": [
             {
-              "translateY": 1334,
+              "translateY": 6,
             },
           ],
         },

--- a/app/components/UI/BasicFunctionality/BasicFunctionalityModal/__snapshots__/BasicFunctionalityModal.test.js.snap
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityModal/__snapshots__/BasicFunctionalityModal.test.js.snap
@@ -77,7 +77,7 @@ exports[`BasicFunctionalityModal should render correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`BasicFunctionalityModal should render correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`QuoteInfoModal renders correctly 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`QuoteInfoModal renders correctly 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`EarnTokenList render matches snapshot 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`EarnTokenList render matches snapshot 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/__snapshots__/ConfirmTurnOnBackupAndSyncModal.test.tsx.snap
+++ b/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/__snapshots__/ConfirmTurnOnBackupAndSyncModal.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ConfirmTurnOnBackupAndSyncModal renders correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`ConfirmTurnOnBackupAndSyncModal renders correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/UI/Notification/ResetNotificationsModal/__snapshots__/ResetNotificationsModal.test.tsx.snap
+++ b/app/components/UI/Notification/ResetNotificationsModal/__snapshots__/ResetNotificationsModal.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ResetNotificationsModal should render correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`ResetNotificationsModal should render correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`GasImpactModal render matches snapshot 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`GasImpactModal render matches snapshot 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
               "borderTopLeftRadius": 8,
               "borderTopRightRadius": 8,
               "borderWidth": 1,
-              "maxHeight": 1334,
+              "maxHeight": 640,
               "overflow": "hidden",
               "paddingBottom": 0,
               "shadowColor": "#0000001a",
@@ -102,7 +102,7 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
             {
               "transform": [
                 {
-                  "translateY": 1334,
+                  "translateY": 640,
                 },
               ],
             },

--- a/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
+++ b/app/components/Views/AccountConnect/__snapshots__/AccountConnect.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`AccountConnect renders correctly with base request 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`AccountConnect renders correctly with base request 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },
@@ -1399,7 +1399,7 @@ exports[`AccountConnect renders correctly with request including chains and acco
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -1413,7 +1413,7 @@ exports[`AccountConnect renders correctly with request including chains and acco
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },
@@ -2721,7 +2721,7 @@ exports[`AccountConnect renders correctly with request including only chains 1`]
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -2735,7 +2735,7 @@ exports[`AccountConnect renders correctly with request including only chains 1`]
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`AccountPermissions renders correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`AccountPermissions renders correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/Views/AddAsset/components/__snapshots__/NetworkFilterBottomSheet.test.tsx.snap
+++ b/app/components/Views/AddAsset/components/__snapshots__/NetworkFilterBottomSheet.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`NetworkFilterBottomSheet should render correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 844,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -92,7 +92,7 @@ exports[`NetworkFilterBottomSheet should render correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 844,
               },
             ],
           },

--- a/app/components/Views/Browser/__snapshots__/MaxBrowserTabsModal.test.tsx.snap
+++ b/app/components/Views/Browser/__snapshots__/MaxBrowserTabsModal.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`MaxBrowserTabsModal should render correctly 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": 0,
             "overflow": "hidden",
             "paddingBottom": 0,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`MaxBrowserTabsModal should render correctly 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 0,
               },
             ],
           },

--- a/app/components/Views/DataCollectionModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/DataCollectionModal/__snapshots__/index.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`DataCollectionModal should render expected snapshot 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1333,
+            "maxHeight": 5,
             "overflow": "hidden",
             "paddingBottom": 3,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`DataCollectionModal should render expected snapshot 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 6,
               },
             ],
           },

--- a/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1333,
+            "maxHeight": 5,
             "overflow": "hidden",
             "paddingBottom": 3,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": 6,
               },
             ],
           },

--- a/app/components/Views/Settings/AdvancedSettings/FiatOnTestnetsFriction/__snapshots__/FiatOnTestnetsFriction.test.tsx.snap
+++ b/app/components/Views/Settings/AdvancedSettings/FiatOnTestnetsFriction/__snapshots__/FiatOnTestnetsFriction.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`Show fiat on testnets friction bottom sheet should render 1`] = `
             "borderTopLeftRadius": 8,
             "borderTopRightRadius": 8,
             "borderWidth": 1,
-            "maxHeight": 1334,
+            "maxHeight": NaN,
             "overflow": "hidden",
             "paddingBottom": undefined,
             "shadowColor": "#0000001a",
@@ -91,7 +91,7 @@ exports[`Show fiat on testnets friction bottom sheet should render 1`] = `
           {
             "transform": [
               {
-                "translateY": 1334,
+                "translateY": undefined,
               },
             ],
           },


### PR DESCRIPTION
## **Description**
Ensure that bottom sheet dialog respects the top notch for all devices. Specifically lower Pixel devices like Pixel 3. The behaviour should remain the same for all other devices including iOS

## **Related issues**

https://github.com/MetaMask/metamask-mobile/issues/15491
https://github.com/MetaMask/MetaMask-planning/issues/5128
https://github.com/MetaMask/metamask-mobile/issues/16338


## **Manual testing steps**
We need to test a fullscreen bottom sheet. Here is one of the example from deeplink modal

1. In the file app/components/Nav/Main/Index.js. Import import handleDeepLinkModalDisplay from '../../../core/DeeplinkManager/Handlers/handleDeepLinkModalDisplay'; and add this line inside the useEffect in line 130
   handleDeepLinkModalDisplay({
    linkType: 'public',
    pageTitle: 'MetaMask',
    onContinueCallBack: () => alert('continue'),
  });
2. Private deep link modal should pop up when you start the app

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Pixel 3 
<img width="326" alt="Screenshot 2025-06-24 at 5 28 50 PM" src="https://github.com/user-attachments/assets/c7a654b7-96d8-4285-bce8-b1ff180fd003" />

### **After**
Pixel 3
<img width="340" alt="Screenshot 2025-06-24 at 5 01 28 PM" src="https://github.com/user-attachments/assets/b32212ac-bd49-4d95-80f2-29ab621f77b8" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
