### PR TITLE
fix: Pass proper arguments in `eth_requestAccounts` implementation

### DIFF
--- a/app/core/RPCMethods/eth-request-accounts.js
+++ b/app/core/RPCMethods/eth-request-accounts.js
@@ -3,6 +3,7 @@ import { MESSAGE_TYPE } from '../createTracingMiddleware';
 import {
   trackDappViewedEvent,
 } from '../../util/metrics';
+import { isSnapId } from '@metamask/snaps-utils';
 
 const requestEthereumAccounts = {
   methodNames: [MESSAGE_TYPE.ETH_REQUEST_ACCOUNTS],
@@ -87,7 +88,10 @@ async function requestEthereumAccountsHandler(
   // because the accounts will not be in order of lastSelected
   ethAccounts = getAccounts({ ignoreLock: true });
 
-  trackDappViewedEvent(origin, ethAccounts.length);
+  if (!isSnapId(origin)) {
+    // Origin is actually a hostname here, this should change in the future.
+    trackDappViewedEvent({ hostname: origin, numberOfConnectedAccounts: ethAccounts.length });
+  }
 
   res.result = ethAccounts;
   return end();

--- a/app/core/RPCMethods/eth-request-accounts.test.ts
+++ b/app/core/RPCMethods/eth-request-accounts.test.ts
@@ -195,8 +195,10 @@ describe('requestEthereumAccountsHandler', () => {
 
       await handler(baseRequest);
       expect(trackDappViewedEvent).toHaveBeenCalledWith(
-        'http://test.com',
-        mockAccounts.length,
+        {
+          hostname: 'http://test.com',
+          numberOfConnectedAccounts: mockAccounts.length,
+        }
       );
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `eth_requestAccounts` implementation was calling `trackDappViewedEvent` with invalid parameters causing an error to be returned each time.

## **Manual testing steps**

1. Go to the test-snaps page
2. Click get accounts in the transaction insights section
3. See that it doesn't error

## **Screenshots/Recordings**

### **Before**

<img src="https://github.com/user-attachments/assets/2d54d7da-2c1b-4e71-9f88-35225611357b" width="200" />