### PR TITLE
fix: display amount for nested transaction in advance view

### DIFF
--- a/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/currency-display.test.tsx
+++ b/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/currency-display.test.tsx
@@ -1,0 +1,71 @@
+import BigNumber from 'bignumber.js';
+import React from 'react';
+
+import { MOCK_NETWORK_CONTROLLER_STATE } from '../../../../../../../../util/test/confirm-data-helpers';
+import { RootState } from '../../../../../../../../reducers';
+import renderWithProvider from '../../../../../../../../util/test/renderWithProvider';
+import CurrencyDisplay from './currency-display';
+
+const mockState = {
+  engine: {
+    backgroundState: {
+      NetworkController: MOCK_NETWORK_CONTROLLER_STATE,
+    },
+  },
+} as unknown as RootState;
+
+describe('TokenValue', () => {
+  it('should render value correctly', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay value={1000000000000000000} chainId="0xaa36a7" />,
+      { state: mockState },
+    );
+    expect(getByText('1 SepoliaETH')).toBeDefined();
+  });
+
+  it('should render BigNumber value correctly', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay
+        value={new BigNumber('1000000000000000000')}
+        chainId="0xaa36a7"
+      />,
+      { state: mockState },
+    );
+    expect(getByText('1 SepoliaETH')).toBeDefined();
+  });
+
+  it('should handle small decimal values', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay value="1000" chainId="0xaa36a7" />,
+      { state: mockState },
+    );
+    expect(getByText('< 0.000001 SepoliaETH')).toBeDefined();
+  });
+
+  it('should handle large numbers', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay
+        value="123456789000000000000000000"
+        chainId="0xaa36a7"
+      />,
+      { state: mockState },
+    );
+    expect(getByText('123,456,789 SepoliaETH')).toBeDefined();
+  });
+
+  it('should handle zero value', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay value="0" chainId="0xaa36a7" />,
+      { state: mockState },
+    );
+    expect(getByText('0 SepoliaETH')).toBeDefined();
+  });
+
+  it('should handle very small numbers', () => {
+    const { getByText } = renderWithProvider(
+      <CurrencyDisplay value="100" chainId="0xaa36a7" />,
+      { state: mockState },
+    );
+    expect(getByText('< 0.000001 SepoliaETH')).toBeDefined();
+  });
+});

--- a/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/currency-display.tsx
+++ b/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/currency-display.tsx
@@ -1,0 +1,49 @@
+import BigNumber from 'bignumber.js';
+import React from 'react';
+import { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
+
+import { strings } from '../../../../../../../../../locales/i18n';
+import { RootState } from '../../../../../../../../reducers';
+import { calcTokenAmount } from '../../../../../../../../util/transactions';
+import { shortenString } from '../../../../../../../../util/notifications';
+import { selectNativeCurrencyByChainId } from '../../../../../../../../selectors/networkController';
+import {
+  formatAmount,
+  formatAmountMaxPrecision,
+} from '../../../../../../../UI/SimulationDetails/formatAmount';
+import TextWithTooltip from '../../../text-with-tooltip';
+
+const EVM_NATIVE_TOKEN_DECIMALS = 18;
+
+interface CurrencyDisplayProps {
+  chainId?: Hex;
+  value: number | string | BigNumber;
+}
+
+// Current implementation of the component support only native currenct for chainId provided
+// but this can be extended to support non-native currencies also.
+
+const CurrencyDisplay = ({ chainId, value }: CurrencyDisplayProps) => {
+  const nativeCurrency = useSelector((state: RootState) =>
+    selectNativeCurrencyByChainId(state, chainId),
+  );
+  const tokenValue = calcTokenAmount(value, EVM_NATIVE_TOKEN_DECIMALS);
+  const tokenText = formatAmount('en-US', tokenValue);
+  const tokenTextMaxPrecision = formatAmountMaxPrecision('en-US', tokenValue);
+
+  return (
+    <TextWithTooltip
+      label={strings('confirm.label.value')}
+      text={`${shortenString(tokenText, {
+        truncatedCharLimit: 15,
+        truncatedStartChars: 15,
+        truncatedEndChars: 0,
+        skipCharacterInEnd: true,
+      })} ${nativeCurrency}`}
+      tooltip={tokenTextMaxPrecision}
+    />
+  );
+};
+
+export default CurrencyDisplay;

--- a/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/index.ts
+++ b/app/components/Views/confirmations/components/UI/info-row/info-value/currency-display/index.ts
@@ -1,0 +1,1 @@
+export { default } from './currency-display';

--- a/app/components/Views/confirmations/components/nested-transaction-data/nested-transaction-data.test.tsx
+++ b/app/components/Views/confirmations/components/nested-transaction-data/nested-transaction-data.test.tsx
@@ -35,6 +35,7 @@ describe('NestedTransactionData', () => {
     );
     fireEvent.press(getByText('Transaction 1'));
     expect(getByText('Interacting with')).toBeTruthy();
+    expect(getByText('< 0.000001 SepoliaETH')).toBeTruthy();
     expect(getByText('Data')).toBeTruthy();
     expect(
       getByText(upgradeAccountConfirmation.nestedTransactions?.[0]?.data ?? ''),

--- a/app/components/Views/confirmations/components/nested-transaction-data/nested-transaction-data.tsx
+++ b/app/components/Views/confirmations/components/nested-transaction-data/nested-transaction-data.tsx
@@ -8,8 +8,9 @@ import { TextVariant } from '../../../../../component-library/components/Texts/T
 import Name from '../../../../UI/Name';
 import { NameType } from '../../../../UI/Name/Name.types';
 import InfoSectionAccordion from '../../components/UI/info-section-accordion';
-import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
+import CurrencyDisplay from '../UI/info-row/info-value/currency-display';
 import InfoRow from '../UI/info-row';
+import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 
 const TransactionInfo = ({
   chainId,
@@ -20,7 +21,7 @@ const TransactionInfo = ({
   index: number;
   transaction: NestedTransactionMetadata;
 }) => {
-  const { to, data } = transaction;
+  const { to, data, value } = transaction;
   return (
     <InfoSectionAccordion
       header={strings('confirm.nested_transaction_heading', {
@@ -34,6 +35,11 @@ const TransactionInfo = ({
           variation={chainId ?? ''}
         />
       </InfoRow>
+      {value && (
+        <InfoRow label={strings('confirm.label.amount')}>
+          <CurrencyDisplay chainId={chainId} value={value} />
+        </InfoRow>
+      )}
       <InfoRow label={strings('confirm.data')} copyText={data} valueOnNewLine>
         <Text variant={TextVariant.BodyMD}>{data}</Text>
       </InfoRow>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4143,6 +4143,8 @@
       "part3": "."
     },
     "label": {
+      "amount": "Amount",
+      "value": "Value",
       "account": "Account",
       "balance": "Balance",
       "interacting_with": "Interacting with",


### PR DESCRIPTION
## **Description**

Display amount for nested transaction in advance view

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5236

## **Manual testing steps**

1. Go to test dapp
2. Submit send call
3. Check nested transaction in advance view, ensure amount is displayed

## **Screenshots/Recordings**
<img width="399" alt="Screenshot 2025-06-25 at 7 10 51 PM" src="https://github.com/user-attachments/assets/5f05c57d-1d44-4fff-a3d5-ac3e4d996077" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
