### PR TITLE
test: Add Ethereum provider Snap test

### DIFF
--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -84,6 +84,30 @@ export const mockEvents = {
       responseCode: 200,
     },
 
+    remoteFeatureFlagsRedesignedConfirmationsFlask: {
+      urlEndpoint:
+        'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=flask&environment=dev',
+      response: [
+        {
+          mobileMinimumVersions: {
+            appMinimumBuild: 1243,
+            appleMinimumOS: 6,
+            androidMinimumAPIVersion: 21,
+          },
+        },
+        {
+          confirmation_redesign: {
+            signatures: true,
+            staking_confirmations: true,
+            contract_deployment: true,
+            contract_interaction: true,
+            transfer: true,
+          },
+        },
+      ],
+      responseCode: 200,
+    },
+
     // TODO: Remove when this feature is no longer behind a feature flag
     remoteFeatureFlagsDefiPositionsEnabled: {
       urlEndpoint:

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -94,16 +94,16 @@ class TestSnaps {
     );
   }
 
-  async selectEntropySource(
+  async selectInDropdown(
     selector: keyof typeof EntropyDropDownSelectorWebIDS,
-    entropySource: string,
+    text: string,
   ) {
     const webElement = (await Matchers.getElementByWebID(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
       EntropyDropDownSelectorWebIDS[selector],
     )) as IndexableWebElement;
 
-    const source = await this.getOptionValueByText(webElement, entropySource);
+    const source = await this.getOptionValueByText(webElement, text);
 
     await webElement.runScript(
       (el, value) => {

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -17,6 +17,7 @@ import TestHelpers from '../../helpers';
 import Assertions from '../../utils/Assertions';
 import { IndexableWebElement } from 'detox/detox';
 import Utilities from '../../utils/Utilities';
+import { ConfirmationFooterSelectorIDs } from '../../selectors/Confirmation/ConfirmationView.selectors';
 
 export const TEST_SNAPS_URL =
   'https://metamask.github.io/snaps/test-snaps/2.25.0/';
@@ -38,6 +39,10 @@ class TestSnaps {
     return Matchers.getElementByID(
       TestSnapBottomSheetSelectorWebIDS.BOTTOMSHEET_FOOTER_BUTTON_ID,
     );
+  }
+
+  get confirmSignatureButton() {
+    return Matchers.getElementByID(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON);
   }
 
   async checkResultSpan(
@@ -69,6 +74,7 @@ class TestSnaps {
   }
 
   async navigateToTestSnap() {
+    await Browser.tapUrlInputBox();
     await Browser.navigateToURL(TEST_SNAPS_URL);
   }
 
@@ -137,6 +143,10 @@ class TestSnaps {
 
   async approveSignRequest() {
     await Gestures.waitAndTap(this.getApproveSignRequestButton);
+  }
+
+  async approveNativeConfirmation() {
+    await Gestures.waitAndTap(this.confirmSignatureButton);
   }
 
   async waitForWebSocketUpdate(state: {

--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -3,6 +3,7 @@ export const TestSnapViewSelectorWebIDS = {
   connectBip32Button: 'connectbip32',
   connectBip44Button: 'connectbip44',
   connectNetworkAccessButton: 'connectnetwork-access',
+  connectEthereumProviderButton: 'connectethereum-provider',
   getPublicKeyBip44Button: 'sendBip44Test',
   signMessageBip44Button: 'signBip44Message',
   getPublicKeyBip32Button: 'bip32GetPublic',
@@ -14,6 +15,10 @@ export const TestSnapViewSelectorWebIDS = {
   startWebSocket: 'startWebSocket',
   stopWebSocket: 'stopWebSocket',
   getWebSocketState: 'getWebSocketState',
+  getChainIdButton: 'sendEthprovider',
+  getAccountsButton: 'sendEthproviderAccounts',
+  personalSignButton: 'signPersonalSignMessage',
+  signTypedDataButton: 'signTypedDataButton',
 };
 
 export const TestSnapInputSelectorWebIDS = {
@@ -22,11 +27,14 @@ export const TestSnapInputSelectorWebIDS = {
   messageEd25519Input: 'bip32Message-ed25519',
   messageSecp256k1Input: 'bip32Message-secp256k1',
   webSocketUrlInput: 'webSocketUrl',
+  personalSignMessageInput: 'personalSignMessage',
+  signTypedDataMessageInput: 'signTypedData',
 };
 
 export const EntropyDropDownSelectorWebIDS = {
   bip32EntropyDropDown: 'bip32-entropy-selector',
   bip44EntropyDropDown: 'bip44-entropy-selector',
+  networkDropDown: 'select-chain',
 };
 
 export const TestSnapResultSelectorWebIDS = {
@@ -34,9 +42,12 @@ export const TestSnapResultSelectorWebIDS = {
   bip44SignResultSpan: 'bip44SignResult',
   bip32MessageResultEd25519Span: 'bip32MessageResult-ed25519',
   bip32MessageResultSecp256k1Span: 'bip32MessageResult-secp256k1',
-  bip32MessageResultEd25519Bip32Span: '#bip32MessageResult-ed25519Bip32',
+  bip32MessageResultEd25519Bip32Span: 'bip32MessageResult-ed25519Bip32',
   bip32PublicKeyResultSpan: 'bip32PublicKeyResult',
   networkAccessResultSpan: 'networkAccessResult',
+  ethereumProviderResultSpan: 'ethproviderResult',
+  personalSignResultSpan: 'personalSignResult',
+  signTypedDataResultSpan: 'signTypedDataResult',
 };
 
 export const TestSnapBottomSheetSelectorWebIDS = {

--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -91,7 +91,7 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 1', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'SRP 1');
+    await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'SRP 1');
     await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
@@ -103,7 +103,7 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
   });
 
   it('can sign BIP-32 message using secp256k1 and SRP 2', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'SRP 2');
+    await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'SRP 2');
     await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');
@@ -115,7 +115,7 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
   });
 
   it('fails when choosing the invalid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid');
+    await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');
     await Assertions.checkIfTextIsDisplayed(

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -68,7 +68,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
   });
 
   it('can sign with entropy from SRP 1', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'SRP 1');
+    await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'SRP 1');
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
@@ -79,7 +79,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
   });
 
   it('can sign with entropy from SRP 2', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'SRP 2');
+    await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'SRP 2');
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await TestSnaps.approveSignRequest();
@@ -90,7 +90,7 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
   });
 
   it('fails when choosing the invalid entropy source', async () => {
-    await TestSnaps.selectEntropySource('bip44EntropyDropDown', 'Invalid');
+    await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');
     await Assertions.checkIfTextIsDisplayed(

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -47,6 +47,9 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         );
 
         await TestSnaps.tapButton('getAccountsButton');
+        await Assertions.checkIfVisible(
+          ConnectBottomSheet.connectButton,
+        );
         await ConnectBottomSheet.tapConnectButton();
         await TestHelpers.delay(500);
         await TestSnaps.checkResultSpanIncludes(

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -36,8 +36,10 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestHelpers.delay(3500); // Wait for page to load
         await Assertions.checkIfVisible(BrowserView.browserScreenID);
 
+        console.log("Installing Snap");
         await TestSnaps.installSnap('connectEthereumProviderButton');
 
+        console.log("Getting chain ID");
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
         await TestSnaps.checkResultSpan(
@@ -45,6 +47,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x1"',
         );
 
+        console.log("Getting accounts");
         await TestSnaps.tapButton('getAccountsButton');
         await ConnectBottomSheet.tapConnectButton();
         await TestHelpers.delay(500);
@@ -53,6 +56,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3"',
         );
 
+        console.log("personal_sign");
         // Test `personal_sign`.
         await TestSnaps.fillMessage('personalSignMessageInput', 'foo');
         await TestSnaps.tapButton('personalSignButton');
@@ -62,6 +66,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0xc87c81cc8592936ec9dedfb6040080a0ac100c713231fd3b2ee93942a175efb639ccda7918bd14cbe8ef2f5ec917bba1a35744c06d2d4ff3a8a6b077c3e2a1381c"',
         );
 
+        console.log("signTypedData");
         // Test `eth_signTypedData_v4`.
         await TestSnaps.fillMessage('signTypedDataMessageInput', 'bar');
         await TestSnaps.tapButton('signTypedDataButton');
@@ -71,6 +76,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x85094c93975d31ceddddf2894fc7bb96ce6cfdac2559a72417bc214e6e9f24195fa708010da7a52b5df6c75595d0e03f90749b2b5bfbd5605ca799ceb91a36681b"',
         );
 
+        console.log("Ethereum");
         // Check other networks.
         await TestSnaps.selectInDropdown('networkDropDown', 'Ethereum');
         await TestSnaps.tapButton('getChainIdButton');
@@ -80,6 +86,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x1"',
         );
 
+        console.log("Linea");
         await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
@@ -88,6 +95,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0xe708"',
         );
 
+        console.log("Sepolia");
         await TestSnaps.selectInDropdown('networkDropDown', 'Sepolia');
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -9,8 +9,7 @@ import BrowserView from '../../pages/Browser/BrowserView';
 import TestSnaps from '../../pages/Browser/TestSnaps';
 import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
 import { mockEvents } from '../../api-mocking/mock-config/mock-events';
-import FooterActions from '../../pages/Browser/Confirmations/FooterActions';
-import ConfirmationUITypes from '../../pages/Browser/Confirmations/ConfirmationUITypes';
+import RequestTypes from '../../pages/Browser/Confirmations/RequestTypes';
 
 describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
   beforeAll(async () => {
@@ -61,9 +60,9 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestSnaps.fillMessage('personalSignMessageInput', 'foo');
         await TestSnaps.tapButton('personalSignButton');
         await Assertions.checkIfVisible(
-          ConfirmationUITypes.ModalConfirmationContainer,
+          RequestTypes.PersonalSignRequest,
         );
-        await FooterActions.tapConfirmButton();
+        await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'personalSignResultSpan',
           '"0xc87c81cc8592936ec9dedfb6040080a0ac100c713231fd3b2ee93942a175efb639ccda7918bd14cbe8ef2f5ec917bba1a35744c06d2d4ff3a8a6b077c3e2a1381c"',
@@ -73,9 +72,9 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestSnaps.fillMessage('signTypedDataMessageInput', 'bar');
         await TestSnaps.tapButton('signTypedDataButton');
         await Assertions.checkIfVisible(
-          ConfirmationUITypes.ModalConfirmationContainer,
+          RequestTypes.TypedSignRequest,
         );
-        await FooterActions.tapConfirmButton();
+        await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'signTypedDataResultSpan',
           '"0x85094c93975d31ceddddf2894fc7bb96ce6cfdac2559a72417bc214e6e9f24195fa708010da7a52b5df6c75595d0e03f90749b2b5bfbd5605ca799ceb91a36681b"',

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -1,0 +1,101 @@
+import TestHelpers from '../../helpers';
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import { withFixtures } from '../../fixtures/fixture-helper';
+import Assertions from '../../utils/Assertions';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import BrowserView from '../../pages/Browser/BrowserView';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
+import { mockEvents } from '../../api-mocking/mock-config/mock-events';
+import FooterActions from '../../pages/Browser/Confirmations/FooterActions';
+
+describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
+  beforeAll(async () => {
+    await TestHelpers.reverseServerPort();
+  });
+
+  beforeEach(() => {
+    jest.setTimeout(150000);
+  });
+
+  it('can use the Ethereum provider', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock: { GET: [mockEvents.GET.remoteFeatureFlagsRedesignedConfirmationsFlask] },
+      },
+      async () => {
+        await loginToApp();
+
+        // Navigate to test snaps URL once for all tests
+        await TabBarComponent.tapBrowser();
+        await TestSnaps.navigateToTestSnap();
+        await TestHelpers.delay(3500); // Wait for page to load
+        await Assertions.checkIfVisible(BrowserView.browserScreenID);
+
+        await TestSnaps.installSnap('connectEthereumProviderButton');
+
+        await TestSnaps.tapButton('getChainIdButton');
+        await TestHelpers.delay(500);
+        await TestSnaps.checkResultSpan(
+          'ethereumProviderResultSpan',
+          '"0x1"',
+        );
+
+        await TestSnaps.tapButton('getAccountsButton');
+        await ConnectBottomSheet.tapConnectButton();
+        await TestHelpers.delay(500);
+        await TestSnaps.checkResultSpanIncludes(
+          'ethereumProviderResultSpan',
+          '"0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3"',
+        );
+
+        // Test `personal_sign`.
+        await TestSnaps.fillMessage('personalSignMessageInput', 'foo');
+        await TestSnaps.tapButton('personalSignButton');
+        await FooterActions.tapConfirmButton();
+        await TestSnaps.checkResultSpan(
+          'personalSignResultSpan',
+          '"0xc87c81cc8592936ec9dedfb6040080a0ac100c713231fd3b2ee93942a175efb639ccda7918bd14cbe8ef2f5ec917bba1a35744c06d2d4ff3a8a6b077c3e2a1381c"',
+        );
+
+        // Test `eth_signTypedData_v4`.
+        await TestSnaps.fillMessage('signTypedDataMessageInput', 'bar');
+        await TestSnaps.tapButton('signTypedDataButton');
+        await FooterActions.tapConfirmButton();
+        await TestSnaps.checkResultSpan(
+          'signTypedDataResultSpan',
+          '"0x85094c93975d31ceddddf2894fc7bb96ce6cfdac2559a72417bc214e6e9f24195fa708010da7a52b5df6c75595d0e03f90749b2b5bfbd5605ca799ceb91a36681b"',
+        );
+
+        // Check other networks.
+        await TestSnaps.selectInDropdown('networkDropDown', 'Ethereum');
+        await TestSnaps.tapButton('getChainIdButton');
+        await TestHelpers.delay(500);
+        await TestSnaps.checkResultSpan(
+          'ethereumProviderResultSpan',
+          '"0x1"',
+        );
+
+        await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
+        await TestSnaps.tapButton('getChainIdButton');
+        await TestHelpers.delay(500);
+        await TestSnaps.checkResultSpan(
+          'ethereumProviderResultSpan',
+          '"0xe708"',
+        );
+
+        await TestSnaps.selectInDropdown('networkDropDown', 'Sepolia');
+        await TestSnaps.tapButton('getChainIdButton');
+        await TestHelpers.delay(500);
+        await TestSnaps.checkResultSpan(
+          'ethereumProviderResultSpan',
+          '"0xaa36a7"',
+        );
+      },
+    );
+  });
+});

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -10,6 +10,7 @@ import TestSnaps from '../../pages/Browser/TestSnaps';
 import ConnectBottomSheet from '../../pages/Browser/ConnectBottomSheet';
 import { mockEvents } from '../../api-mocking/mock-config/mock-events';
 import FooterActions from '../../pages/Browser/Confirmations/FooterActions';
+import ConfirmationUITypes from '../../pages/Browser/Confirmations/ConfirmationUITypes';
 
 describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
   beforeAll(async () => {
@@ -36,10 +37,8 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestHelpers.delay(3500); // Wait for page to load
         await Assertions.checkIfVisible(BrowserView.browserScreenID);
 
-        console.log("Installing Snap");
         await TestSnaps.installSnap('connectEthereumProviderButton');
 
-        console.log("Getting chain ID");
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
         await TestSnaps.checkResultSpan(
@@ -47,7 +46,6 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x1"',
         );
 
-        console.log("Getting accounts");
         await TestSnaps.tapButton('getAccountsButton');
         await ConnectBottomSheet.tapConnectButton();
         await TestHelpers.delay(500);
@@ -56,27 +54,30 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3"',
         );
 
-        console.log("personal_sign");
         // Test `personal_sign`.
         await TestSnaps.fillMessage('personalSignMessageInput', 'foo');
         await TestSnaps.tapButton('personalSignButton');
+        await Assertions.checkIfVisible(
+          ConfirmationUITypes.ModalConfirmationContainer,
+        );
         await FooterActions.tapConfirmButton();
         await TestSnaps.checkResultSpan(
           'personalSignResultSpan',
           '"0xc87c81cc8592936ec9dedfb6040080a0ac100c713231fd3b2ee93942a175efb639ccda7918bd14cbe8ef2f5ec917bba1a35744c06d2d4ff3a8a6b077c3e2a1381c"',
         );
 
-        console.log("signTypedData");
         // Test `eth_signTypedData_v4`.
         await TestSnaps.fillMessage('signTypedDataMessageInput', 'bar');
         await TestSnaps.tapButton('signTypedDataButton');
+        await Assertions.checkIfVisible(
+          ConfirmationUITypes.ModalConfirmationContainer,
+        );
         await FooterActions.tapConfirmButton();
         await TestSnaps.checkResultSpan(
           'signTypedDataResultSpan',
           '"0x85094c93975d31ceddddf2894fc7bb96ce6cfdac2559a72417bc214e6e9f24195fa708010da7a52b5df6c75595d0e03f90749b2b5bfbd5605ca799ceb91a36681b"',
         );
 
-        console.log("Ethereum");
         // Check other networks.
         await TestSnaps.selectInDropdown('networkDropDown', 'Ethereum');
         await TestSnaps.tapButton('getChainIdButton');
@@ -86,7 +87,6 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0x1"',
         );
 
-        console.log("Linea");
         await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
@@ -95,7 +95,6 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           '"0xe708"',
         );
 
-        console.log("Sepolia");
         await TestSnaps.selectInDropdown('networkDropDown', 'Sepolia');
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -25,7 +25,9 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
-        testSpecificMock: { GET: [mockEvents.GET.remoteFeatureFlagsRedesignedConfirmationsFlask] },
+        testSpecificMock: {
+          GET: [mockEvents.GET.remoteFeatureFlagsRedesignedConfirmationsFlask],
+        },
       },
       async () => {
         await loginToApp();
@@ -40,15 +42,10 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
 
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
-        await TestSnaps.checkResultSpan(
-          'ethereumProviderResultSpan',
-          '"0x1"',
-        );
+        await TestSnaps.checkResultSpan('ethereumProviderResultSpan', '"0x1"');
 
         await TestSnaps.tapButton('getAccountsButton');
-        await Assertions.checkIfVisible(
-          ConnectBottomSheet.connectButton,
-        );
+        await Assertions.checkIfVisible(ConnectBottomSheet.connectButton);
         await ConnectBottomSheet.tapConnectButton();
         await TestHelpers.delay(500);
         await TestSnaps.checkResultSpanIncludes(
@@ -59,9 +56,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         // Test `personal_sign`.
         await TestSnaps.fillMessage('personalSignMessageInput', 'foo');
         await TestSnaps.tapButton('personalSignButton');
-        await Assertions.checkIfVisible(
-          RequestTypes.PersonalSignRequest,
-        );
+        await Assertions.checkIfVisible(RequestTypes.PersonalSignRequest);
         await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'personalSignResultSpan',
@@ -71,9 +66,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         // Test `eth_signTypedData_v4`.
         await TestSnaps.fillMessage('signTypedDataMessageInput', 'bar');
         await TestSnaps.tapButton('signTypedDataButton');
-        await Assertions.checkIfVisible(
-          RequestTypes.TypedSignRequest,
-        );
+        await Assertions.checkIfVisible(RequestTypes.TypedSignRequest);
         await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'signTypedDataResultSpan',
@@ -84,10 +77,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestSnaps.selectInDropdown('networkDropDown', 'Ethereum');
         await TestSnaps.tapButton('getChainIdButton');
         await TestHelpers.delay(500);
-        await TestSnaps.checkResultSpan(
-          'ethereumProviderResultSpan',
-          '"0x1"',
-        );
+        await TestSnaps.checkResultSpan('ethereumProviderResultSpan', '"0x1"');
 
         await TestSnaps.selectInDropdown('networkDropDown', 'Linea');
         await TestSnaps.tapButton('getChainIdButton');

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -23,7 +23,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
   it('can use the Ethereum provider', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().build(),
+        fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         testSpecificMock: {
           GET: [mockEvents.GET.remoteFeatureFlagsRedesignedConfirmationsFlask],
@@ -50,7 +50,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestHelpers.delay(500);
         await TestSnaps.checkResultSpanIncludes(
           'ethereumProviderResultSpan',
-          '"0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3"',
+          '"0x5cfe73b6021e818b776b421b1c4db2474086a7e1"',
         );
 
         // Test `personal_sign`.
@@ -60,7 +60,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'personalSignResultSpan',
-          '"0xc87c81cc8592936ec9dedfb6040080a0ac100c713231fd3b2ee93942a175efb639ccda7918bd14cbe8ef2f5ec917bba1a35744c06d2d4ff3a8a6b077c3e2a1381c"',
+          '"0xf63c587cd42e7775e2e815a579f9744ea62944f263b3e69fad48535ba98a5ea107bc878088a99942733a59a89ef1d590eafdb467d59cf76564158d7e78351b751b"',
         );
 
         // Test `eth_signTypedData_v4`.
@@ -70,7 +70,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
         await TestSnaps.approveNativeConfirmation();
         await TestSnaps.checkResultSpan(
           'signTypedDataResultSpan',
-          '"0x85094c93975d31ceddddf2894fc7bb96ce6cfdac2559a72417bc214e6e9f24195fa708010da7a52b5df6c75595d0e03f90749b2b5bfbd5605ca799ceb91a36681b"',
+          '"0x7024dc071a7370eee444b2a3edc08d404dd03393694403cdca864653a7e8dd7c583419293d53602666cbe77faa8819fba04f8c57e95df2d4c0190968eece28021c"',
         );
 
         // Check other networks.

--- a/e2e/specs/snaps/test-snap-network-access.spec.ts
+++ b/e2e/specs/snaps/test-snap-network-access.spec.ts
@@ -47,7 +47,7 @@ describe(FlaskBuildTests('Network Access Snap Tests'), () => {
 
         // Use WebSockets
         const webSocketUrl = `ws://localhost:${AnvilPort()}`;
-        await TestSnaps.fillMessage('webSocketUrlInput', webSocketUrl)
+        await TestSnaps.fillMessage('webSocketUrlInput', webSocketUrl);
         await TestSnaps.tapButton('startWebSocket');
 
         await TestSnaps.waitForWebSocketUpdate({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds an E2E test that verifies the Ethereum provider functionality using an example Snap.

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3482
