### PR TITLE
fix: correct switch / switch back labels in account modal to switch account type

### DIFF
--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
@@ -17,6 +17,9 @@ const styleSheet = () =>
       flexDirection: 'column',
       marginLeft: 16,
     },
+    network_name: {
+      width: 170,
+    },
     button_section: {
       flexDirection: 'row',
       justifyContent: 'flex-end',

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
@@ -8,6 +8,7 @@ const styleSheet = () =>
       justifyContent: 'space-between',
       paddingHorizontal: 32,
       paddingVertical: 4,
+      width: '100%',
     },
     left_section: {
       flexDirection: 'row',
@@ -18,8 +19,8 @@ const styleSheet = () =>
     },
     button_section: {
       flexDirection: 'row',
-      justifyContent: 'center',
-      width: 50,
+      justifyContent: 'flex-end',
+      width: 100,
     },
     multichain_accounts_row_wrapper: {
       width: '100%',

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-
-import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
-import { EIP7702NetworkConfiguration } from '../../../../hooks/7702/useEIP7702Networks';
-import AccountNetworkRow from './account-network-row';
 import { fireEvent, waitFor } from '@testing-library/react-native';
+
+import { SmartAccountIds } from '../../../../../../../../e2e/selectors/MultichainAccounts/SmartAccount.selectors';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
 import { RootState } from '../../../../../../../reducers';
 import { mockTransaction } from '../../../../../../../util/test/confirm-data-helpers';
-import { SmartAccountIds } from '../../../../../../../../e2e/selectors/MultichainAccounts/SmartAccount.selectors';
+import { EIP7702NetworkConfiguration } from '../../../../hooks/7702/useEIP7702Networks';
+import AccountNetworkRow from './account-network-row';
 
 const MOCK_NETWORK = {
   chainId: '0xaa36a7',
@@ -86,7 +86,7 @@ describe('Account Network Row', () => {
     );
 
     expect(getByText('Smart Account')).toBeTruthy();
-    expect(getByText('Switch')).toBeTruthy();
+    expect(getByText('Switch back')).toBeTruthy();
   });
 
   it('renders correctly for standard account', () => {
@@ -282,7 +282,7 @@ describe('Account Network Row', () => {
         { state: MOCK_STATE },
       );
 
-      fireEvent.press(getByText('Switch'));
+      fireEvent.press(getByText('Switch back'));
 
       expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
     });

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
@@ -140,7 +140,14 @@ const AccountNetworkRow = ({
           imageSource={networkImage}
         />
         <View style={styles.name_section}>
-          <Text variant={TextVariant.BodyMDBold}>{name}</Text>
+          <Text
+            variant={TextVariant.BodyMDBold}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={{ width: 170 }}
+          >
+            {name}
+          </Text>
           <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
             {addressSupportSmartAccount
               ? strings('confirm.7702_functionality.smartAccountLabel')
@@ -154,7 +161,11 @@ const AccountNetworkRow = ({
         ) : (
           <Button
             variant={ButtonVariants.Link}
-            label={strings('confirm.7702_functionality.switch')}
+            label={
+              addressSupportSmartAccount
+                ? strings('confirm.7702_functionality.switchBack')
+                : strings('confirm.7702_functionality.switch')
+            }
             onPress={onSwitch}
           />
         )}

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
@@ -144,7 +144,7 @@ const AccountNetworkRow = ({
             variant={TextVariant.BodyMDBold}
             numberOfLines={1}
             ellipsizeMode="tail"
-            style={{ width: 170 }}
+            style={styles.network_name}
           >
             {name}
           </Text>

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.test.tsx
@@ -80,7 +80,7 @@ describe('Switch Account Type Modal', () => {
     expect(getByText('Account 1')).toBeTruthy();
     expect(getByText('Sepolia')).toBeTruthy();
     expect(getByText('Smart Account')).toBeTruthy();
-    expect(getByText('Switch')).toBeTruthy();
+    expect(getByText('Switch back')).toBeTruthy();
   });
 
   it('displays spinner when network list is loading', () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4228,6 +4228,7 @@
       "smartAccountLabel": "Smart Account",
       "standardAccountLabel": "Standard Account",
       "switch": "Switch",
+      "switchBack": "Switch back",
       "splashpage": {
         "accept": "Yes",
         "betterTransaction": "Faster transactions, lower fees",


### PR DESCRIPTION
## **Description**

On account modal while switching account type, display `Switch back` label if account is already upgraded.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5253

## **Manual testing steps**

1. Open account modal to switch account type
2. Switch account type for an account
3. Check that `switch` button now changes to `switch back`, this can be used to switch back to standard account type.

## **Screenshots/Recordings**
<img width="390" alt="Screenshot 2025-06-25 at 8 27 42 PM" src="https://github.com/user-attachments/assets/f13021ae-e92b-4501-b763-0e1ffa094ed0" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
