### PR TITLE
fix: cp-7.50.0 TAT-927: USDT allowance increase on deposit confirmation screen hangs

### DIFF
--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -66,7 +66,7 @@ import {
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getIsRedesignedStablecoinLendingScreenEnabled } from './utils';
 import { useEarnAnalyticsEventLogging } from '../../hooks/useEarnEventAnalyticsLogging';
-import { tokenRequiresAllowanceReset } from '../../utils';
+import { doesTokenRequireAllowanceReset } from '../../utils';
 
 const EarnInputView = () => {
   // navigation hooks
@@ -280,22 +280,13 @@ const EarnInputView = () => {
       ? allowanceMinimalTokenUnitBN.toString()
       : '0';
 
-    // const needsAllowanceIncrease = new BigNumber(
-    //   allowanceMinimalTokenUnit ?? '',
-    // ).isLessThan(amountTokenMinimalUnitString);
-
     const needsAllowanceIncrease = (() => {
-      const isEdgeCaseToken = tokenRequiresAllowanceReset(
-        earnToken.chainId,
-        earnToken.symbol,
-      );
-
       const isExistingAllowanceLowerThanNeeded = new BigNumber(
         allowanceMinimalTokenUnit ?? '',
       ).isLessThan(amountTokenMinimalUnitString);
 
       if (
-        isEdgeCaseToken &&
+        doesTokenRequireAllowanceReset(earnToken.chainId, earnToken.symbol) &&
         isExistingAllowanceLowerThanNeeded &&
         allowanceMinimalTokenUnit !== '0'
       )

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -66,6 +66,7 @@ import {
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getIsRedesignedStablecoinLendingScreenEnabled } from './utils';
 import { useEarnAnalyticsEventLogging } from '../../hooks/useEarnEventAnalyticsLogging';
+import { tokenRequiresAllowanceReset } from '../../utils';
 
 const EarnInputView = () => {
   // navigation hooks
@@ -279,9 +280,29 @@ const EarnInputView = () => {
       ? allowanceMinimalTokenUnitBN.toString()
       : '0';
 
-    const needsAllowanceIncrease = new BigNumber(
-      allowanceMinimalTokenUnit ?? '',
-    ).isLessThan(amountTokenMinimalUnitString);
+    // const needsAllowanceIncrease = new BigNumber(
+    //   allowanceMinimalTokenUnit ?? '',
+    // ).isLessThan(amountTokenMinimalUnitString);
+
+    const needsAllowanceIncrease = (() => {
+      const isEdgeCaseToken = tokenRequiresAllowanceReset(
+        earnToken.chainId,
+        earnToken.symbol,
+      );
+
+      const isExistingAllowanceLowerThanNeeded = new BigNumber(
+        allowanceMinimalTokenUnit ?? '',
+      ).isLessThan(amountTokenMinimalUnitString);
+
+      if (
+        isEdgeCaseToken &&
+        isExistingAllowanceLowerThanNeeded &&
+        allowanceMinimalTokenUnit !== '0'
+      )
+        return true;
+
+      return isExistingAllowanceLowerThanNeeded;
+    })();
 
     const lendingPoolContractAddress =
       CHAIN_ID_TO_AAVE_POOL_CONTRACT[getDecimalChainId(earnToken.chainId)] ??
@@ -362,8 +383,6 @@ const EarnInputView = () => {
           token,
           amountTokenMinimalUnit: amountTokenMinimalUnit.toString(),
           amountFiat: amountFiatNumber,
-          // TODO: These values are inaccurate since useEarnInputHandlers doesn't support stablecoin lending yet.
-          // Make sure these values are accurate after updating useEarnInputHandlers to support stablecoin lending.
           annualRewardsToken,
           annualRewardsFiat,
           annualRewardRate,
@@ -372,6 +391,7 @@ const EarnInputView = () => {
           action: needsAllowanceIncrease
             ? EARN_LENDING_ACTIONS.ALLOWANCE_INCREASE
             : EARN_LENDING_ACTIONS.DEPOSIT,
+          allowanceMinimalTokenUnit,
         },
       });
     };

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
@@ -373,9 +373,7 @@ describe('EarnLendingDepositConfirmationView', () => {
         Engine.context.EarnController.executeLendingTokenApprove,
       ).toHaveBeenCalledWith({
         amount: '0',
-        gasOptions: {
-          gasLimit: 60000,
-        },
+        gasOptions: {},
         protocol: 'AAVE v3',
         txOptions: {
           deviceConfirmedOn: 'metamask_mobile',
@@ -829,9 +827,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       amount: '5000000',
       protocol: 'AAVE v3',
       underlyingTokenAddress: MOCK_USDC_MAINNET_ASSET.address,
-      gasOptions: {
-        gasLimit: 78000,
-      },
+      gasOptions: {},
       txOptions: {
         deviceConfirmedOn: 'metamask_mobile',
         networkClientId: 'mainnet',
@@ -920,9 +916,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       amount: '5000000',
       protocol: 'AAVE v3',
       underlyingTokenAddress: MOCK_USDC_MAINNET_ASSET.address,
-      gasOptions: {
-        gasLimit: 78000,
-      },
+      gasOptions: {},
       txOptions: {
         deviceConfirmedOn: 'metamask_mobile',
         networkClientId: 'mainnet',

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
@@ -1295,10 +1295,25 @@ exports[`EarnLendingDepositConfirmationView matches snapshot 1`] = `
                   "fontWeight": "400",
                   "letterSpacing": 0,
                   "lineHeight": 22,
+                  "textAlign": "center",
                 }
               }
             >
-              Approve
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "CentraNo1-Book",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Approve
+              </Text>
             </Text>
           </View>
           <View
@@ -1351,10 +1366,25 @@ exports[`EarnLendingDepositConfirmationView matches snapshot 1`] = `
                   "fontWeight": "400",
                   "letterSpacing": 0,
                   "lineHeight": 22,
+                  "textAlign": "center",
                 }
               }
             >
-              Deposit
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "CentraNo1-Book",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                Deposit
+              </Text>
             </Text>
           </View>
         </View>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/__snapshots__/ConfirmationFooter.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/__snapshots__/ConfirmationFooter.test.tsx.snap
@@ -151,10 +151,25 @@ exports[`ConfirmationFooter renders correctly 1`] = `
                 "fontWeight": "400",
                 "letterSpacing": 0,
                 "lineHeight": 22,
+                "textAlign": "center",
               }
             }
           >
-            Approve
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#4459ff",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              Approve
+            </Text>
           </Text>
         </View>
         <View
@@ -207,10 +222,25 @@ exports[`ConfirmationFooter renders correctly 1`] = `
                 "fontWeight": "400",
                 "letterSpacing": 0,
                 "lineHeight": 22,
+                "textAlign": "center",
               }
             }
           >
-            Deposit
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#4459ff",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              Deposit
+            </Text>
           </Text>
         </View>
       </View>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/ProgressStepper.styles.ts
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/ProgressStepper.styles.ts
@@ -25,8 +25,6 @@ const styleSheet = (params: { theme: Theme }) => {
       bottom: 17,
     },
     stepLabelContainer: {
-      // flexWrap: 'wrap',
-      // maxWidth: 100,
       textAlign: 'center',
     },
   });

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/ProgressStepper.styles.ts
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/ProgressStepper.styles.ts
@@ -24,6 +24,11 @@ const styleSheet = (params: { theme: Theme }) => {
       position: 'relative',
       bottom: 17,
     },
+    stepLabelContainer: {
+      // flexWrap: 'wrap',
+      // maxWidth: 100,
+      textAlign: 'center',
+    },
   });
 };
 

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/__snapshots__/ProgressStepper.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/__snapshots__/ProgressStepper.test.tsx.snap
@@ -141,10 +141,25 @@ exports[`ProgressStepper renders correctly 1`] = `
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Approve
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Approve
+        </Text>
       </Text>
     </View>
     <View
@@ -197,10 +212,25 @@ exports[`ProgressStepper renders correctly 1`] = `
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Deposit
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Deposit
+        </Text>
       </Text>
     </View>
   </View>
@@ -346,10 +376,25 @@ exports[`ProgressStepper renders first and second step complete state when activ
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Approve
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Approve
+        </Text>
       </Text>
     </View>
     <View
@@ -400,10 +445,25 @@ exports[`ProgressStepper renders first and second step complete state when activ
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Deposit
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Deposit
+        </Text>
       </Text>
     </View>
   </View>
@@ -549,10 +609,25 @@ exports[`ProgressStepper renders first step complete and second step pending sta
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Approve
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Approve
+        </Text>
       </Text>
     </View>
     <View
@@ -605,10 +680,25 @@ exports[`ProgressStepper renders first step complete and second step pending sta
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Deposit
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Deposit
+        </Text>
       </Text>
     </View>
   </View>
@@ -762,10 +852,25 @@ exports[`ProgressStepper renders first step loading when isLoading prop set to t
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Approve
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Approve
+        </Text>
       </Text>
     </View>
     <View
@@ -818,10 +923,25 @@ exports[`ProgressStepper renders first step loading when isLoading prop set to t
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Deposit
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Deposit
+        </Text>
       </Text>
     </View>
   </View>
@@ -969,10 +1089,25 @@ exports[`ProgressStepper renders first step pending state when active step is 0 
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Approve
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Approve
+        </Text>
       </Text>
     </View>
     <View
@@ -1025,10 +1160,25 @@ exports[`ProgressStepper renders first step pending state when active step is 0 
             "fontWeight": "400",
             "letterSpacing": 0,
             "lineHeight": 22,
+            "textAlign": "center",
           }
         }
       >
-        Deposit
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#4459ff",
+              "fontFamily": "CentraNo1-Book",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          Deposit
+        </Text>
       </Text>
     </View>
   </View>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/index.tsx
@@ -161,8 +161,25 @@ const ProgressStepper = ({
             testID={`${PROGRESS_STEPPER_TEST_IDS.STEP}-${index}`}
           >
             {getStepIcon(index, isLoading)}
-            <Text variant={TextVariant.BodySM} color={TextColor.Primary}>
-              {label}
+            <Text
+              style={styles.stepLabelContainer}
+              variant={TextVariant.BodySM}
+              color={TextColor.Primary}
+            >
+              {label.split(' ').map((word, wordIndex) => (
+                <>
+                  <Text
+                    key={`${word}-${wordIndex}`}
+                    variant={TextVariant.BodySM}
+                    color={TextColor.Primary}
+                  >
+                    {word}
+                  </Text>
+                  {wordIndex !== label.split(' ').length - 1 && (
+                    <Text>{'\n'}</Text>
+                  )}
+                </>
+              ))}
             </Text>
           </View>
         ))}

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -549,7 +549,6 @@ const EarnLendingDepositConfirmationView = () => {
     navigation.goBack();
   };
 
-  // TODO: Add tests
   // Sets the allowance to zero for a given token.
   const resetTokenAllowance = async (networkClientId: string) => {
     try {
@@ -569,10 +568,7 @@ const EarnLendingDepositConfirmationView = () => {
           amount: '0',
           underlyingTokenAddress:
             earnToken?.experience?.market?.underlying?.address,
-          gasOptions: {
-            // 50,000 + 20% buffer
-            gasLimit: 60000,
-          },
+          gasOptions: {},
           txOptions: {
             deviceConfirmedOn: WalletDevice.MM_MOBILE,
             networkClientId,
@@ -605,9 +601,7 @@ const EarnLendingDepositConfirmationView = () => {
         amount: amountTokenMinimalUnit,
         underlyingTokenAddress:
           earnToken?.experience?.market?.underlying?.address,
-        gasOptions: {
-          gasLimit: 78000,
-        },
+        gasOptions: {},
         txOptions: {
           deviceConfirmedOn: WalletDevice.MM_MOBILE,
           networkClientId,
@@ -703,7 +697,7 @@ const EarnLendingDepositConfirmationView = () => {
         case Steps.ALLOWANCE_RESET:
           txResult = await resetTokenAllowance(networkClientId);
           break;
-        // Increase token allowance
+        // Increase token allowance before depositing
         case Steps.ALLOWANCE_INCREASE:
           txResult = await increaseTokenAllowance(networkClientId);
           break;
@@ -721,7 +715,6 @@ const EarnLendingDepositConfirmationView = () => {
         return;
       }
 
-      // 3. Setup Transaction Event Listeners
       createTransactionEventListeners(transactionId, txType);
     } catch (error) {
       // allow user to try again

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -26,7 +26,7 @@ import { TokenI } from '../../../Tokens/types';
 import useEarnToken from '../../hooks/useEarnToken';
 import { selectStablecoinLendingEnabledFlag } from '../../selectors/featureFlags';
 import { EARN_LENDING_ACTIONS } from '../../types/lending.types';
-import { parseFloatSafe, tokenRequiresAllowanceReset } from '../../utils';
+import { parseFloatSafe, doesTokenRequireAllowanceReset } from '../../utils';
 import ConfirmationFooter from './components/ConfirmationFooter';
 import DepositInfoSection from './components/DepositInfoSection';
 import DepositReceiveSection from './components/DepositReceiveSection';
@@ -106,7 +106,7 @@ const EarnLendingDepositConfirmationView = () => {
     if (!earnToken?.chainId || !earnToken?.symbol) return false;
     return (
       // Is one of the edge case tokens that requires setting allowance to zero before it can be increased.
-      tokenRequiresAllowanceReset(earnToken.chainId, earnToken.symbol) &&
+      doesTokenRequireAllowanceReset(earnToken.chainId, earnToken.symbol) &&
       // If allowance is zero we don't need a reset
       allowanceMinimalTokenUnit !== '0' &&
       // No need to reset if user has available allowance
@@ -600,7 +600,7 @@ const EarnLendingDepositConfirmationView = () => {
 
     setIsApprovalLoading(true);
 
-    const amount = tokenRequiresAllowanceReset(
+    const amount = doesTokenRequireAllowanceReset(
       earnToken?.chainId,
       earnToken.symbol,
     )

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -229,68 +229,58 @@ const EarnLendingDepositConfirmationView = () => {
   };
 
   const createResetTokenAllowanceTxEventListeners = useCallback(
-    (transactionId: string): Promise<boolean> => {
+    (transactionId: string) => {
       const emitAllowanceTxMetaMetric = emitTxMetaMetric(
         TransactionType.tokenMethodIncreaseAllowance,
       )(transactionId);
 
-      return new Promise((resolve, reject) => {
-        Engine.controllerMessenger.subscribeOnceIf(
-          'TransactionController:transactionSubmitted',
-          () => {
-            emitAllowanceTxMetaMetric(
-              MetaMetricsEvents.EARN_TRANSACTION_SUBMITTED,
-            );
-          },
-          ({ transactionMeta }) => transactionMeta.id === transactionId,
-        );
-        Engine.controllerMessenger.subscribeOnceIf(
-          'TransactionController:transactionDropped',
-          () => {
-            emitAllowanceTxMetaMetric(
-              MetaMetricsEvents.EARN_TRANSACTION_DROPPED,
-            );
-            unsetAllowanceResetLoadingState();
-            reject(new Error('Allowance reset transaction dropped'));
-          },
-          ({ transactionMeta }) => transactionMeta.id === transactionId,
-        );
-        Engine.controllerMessenger.subscribeOnceIf(
-          'TransactionController:transactionFailed',
-          () => {
-            emitAllowanceTxMetaMetric(
-              MetaMetricsEvents.EARN_TRANSACTION_FAILED,
-            );
-            unsetAllowanceResetLoadingState();
-            reject(new Error('Allowance reset transaction failed'));
-          },
-          ({ transactionMeta }) => transactionMeta.id === transactionId,
-        );
-        Engine.controllerMessenger.subscribeOnceIf(
-          'TransactionController:transactionRejected',
-          () => {
-            emitAllowanceTxMetaMetric(
-              MetaMetricsEvents.EARN_TRANSACTION_REJECTED,
-            );
-            unsetAllowanceResetLoadingState();
-            reject(new Error('Allowance reset transaction rejected'));
-          },
-          ({ transactionMeta }) => transactionMeta.id === transactionId,
-        );
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionSubmitted',
+        () => {
+          emitAllowanceTxMetaMetric(
+            MetaMetricsEvents.EARN_TRANSACTION_SUBMITTED,
+          );
+        },
+        ({ transactionMeta }) => transactionMeta.id === transactionId,
+      );
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionDropped',
+        () => {
+          emitAllowanceTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_DROPPED);
+          unsetAllowanceResetLoadingState();
+        },
+        ({ transactionMeta }) => transactionMeta.id === transactionId,
+      );
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionFailed',
+        () => {
+          emitAllowanceTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_FAILED);
+          unsetAllowanceResetLoadingState();
+        },
+        ({ transactionMeta }) => transactionMeta.id === transactionId,
+      );
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionRejected',
+        () => {
+          emitAllowanceTxMetaMetric(
+            MetaMetricsEvents.EARN_TRANSACTION_REJECTED,
+          );
+          unsetAllowanceResetLoadingState();
+        },
+        ({ transactionMeta }) => transactionMeta.id === transactionId,
+      );
 
-        Engine.controllerMessenger.subscribeOnceIf(
-          'TransactionController:transactionConfirmed',
-          () => {
-            emitAllowanceTxMetaMetric(
-              MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED,
-            );
-            setActiveStep(Steps.ALLOWANCE_INCREASE);
-            unsetAllowanceResetLoadingState();
-            resolve(true);
-          },
-          (transactionMeta) => transactionMeta.id === transactionId,
-        );
-      });
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionConfirmed',
+        () => {
+          emitAllowanceTxMetaMetric(
+            MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED,
+          );
+          setActiveStep(Steps.ALLOWANCE_INCREASE);
+          unsetAllowanceResetLoadingState();
+        },
+        (transactionMeta) => transactionMeta.id === transactionId,
+      );
     },
     [emitTxMetaMetric],
   );
@@ -398,22 +388,7 @@ const EarnLendingDepositConfirmationView = () => {
         'TransactionController:transactionConfirmed',
         () => {
           emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED);
-        },
-        (transactionMeta) => transactionMeta.id === transactionId,
-      );
 
-      Engine.controllerMessenger.subscribeOnceIf(
-        'TransactionController:transactionFailed',
-        () => {
-          unsetDepositLoadingState();
-          emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_FAILED);
-        },
-        ({ transactionMeta }) => transactionMeta.id === transactionId,
-      );
-
-      Engine.controllerMessenger.subscribeOnceIf(
-        'TransactionController:transactionConfirmed',
-        () => {
           if (!outputToken) {
             const networkClientId =
               Engine.context.NetworkController.findNetworkClientIdByChainId(
@@ -434,6 +409,15 @@ const EarnLendingDepositConfirmationView = () => {
           }
         },
         (transactionMeta) => transactionMeta.id === transactionId,
+      );
+
+      Engine.controllerMessenger.subscribeOnceIf(
+        'TransactionController:transactionFailed',
+        () => {
+          unsetDepositLoadingState();
+          emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_FAILED);
+        },
+        ({ transactionMeta }) => transactionMeta.id === transactionId,
       );
     },
     [emitTxMetaMetric, navigation, outputToken, tokenSnapshot],

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -38,7 +38,6 @@ import { selectNetworkConfigurationByChainId } from '../../../../../selectors/ne
 import { IMetaMetricsEvent } from '../../../../../core/Analytics';
 import { EVENT_LOCATIONS, EVENT_PROVIDERS } from '../../constants/events';
 import { ProgressStep } from './components/ProgressStepper';
-import { UINT256_BN_MAX_VALUE } from '../../../../../constants/transaction';
 import BN from 'bnjs4';
 
 export interface LendingDepositViewRouteParams {
@@ -600,17 +599,10 @@ const EarnLendingDepositConfirmationView = () => {
 
     setIsApprovalLoading(true);
 
-    const amount = doesTokenRequireAllowanceReset(
-      earnToken?.chainId,
-      earnToken.symbol,
-    )
-      ? UINT256_BN_MAX_VALUE.toString()
-      : amountTokenMinimalUnit;
-
     const allowanceIncreaseTransaction =
       await Engine.context.EarnController.executeLendingTokenApprove({
         protocol: earnToken?.experience?.market?.protocol,
-        amount,
+        amount: amountTokenMinimalUnit,
         underlyingTokenAddress:
           earnToken?.experience?.market?.underlying?.address,
         gasOptions: {

--- a/app/components/UI/Earn/constants/token.ts
+++ b/app/components/UI/Earn/constants/token.ts
@@ -1,0 +1,4 @@
+// Additional tokens requiring manual token reset can be added here.
+export const TOKENS_REQUIRING_ALLOWANCE_RESET: Record<string, string[]> = {
+  '0x1': ['USDT'],
+};

--- a/app/components/UI/Earn/types/lending.types.ts
+++ b/app/components/UI/Earn/types/lending.types.ts
@@ -6,6 +6,7 @@ import { TokenI } from '../../Tokens/types';
 export enum EARN_LENDING_ACTIONS {
   DEPOSIT = 'DEPOSIT',
   ALLOWANCE_INCREASE = 'ALLOWANCE_INCREASE',
+  ALLOWANCE_RESET = 'ALLOWANCE_RESET',
 }
 
 export type EarnTokenDetails = TokenI & {

--- a/app/components/UI/Earn/utils/token/index.ts
+++ b/app/components/UI/Earn/utils/token/index.ts
@@ -4,6 +4,7 @@ import {
   renderFromTokenMinimalUnit,
 } from '../../../../../util/number';
 import { EarnTokenDetails } from '../../types/lending.types';
+import { TOKENS_REQUIRING_ALLOWANCE_RESET } from '../../constants/token';
 
 export const getEstimatedAnnualRewards = (
   apr: string,
@@ -74,3 +75,12 @@ export const sortByHighestApr = (tokensToSort: EarnTokenDetails[]) =>
   [...tokensToSort].sort(
     (a, b) => parseFloat(b.experience.apr) - parseFloat(a.experience.apr),
   );
+
+// TODO: Add tests
+export const tokenRequiresAllowanceReset = (
+  chainId: string,
+  symbol: string,
+) => {
+  if (!chainId || !symbol) return false;
+  return TOKENS_REQUIRING_ALLOWANCE_RESET[chainId].includes(symbol);
+};

--- a/app/components/UI/Earn/utils/token/index.ts
+++ b/app/components/UI/Earn/utils/token/index.ts
@@ -76,7 +76,6 @@ export const sortByHighestApr = (tokensToSort: EarnTokenDetails[]) =>
     (a, b) => parseFloat(b.experience.apr) - parseFloat(a.experience.apr),
   );
 
-// TODO: Add tests
 export const tokenRequiresAllowanceReset = (
   chainId: string,
   symbol: string,

--- a/app/components/UI/Earn/utils/token/index.ts
+++ b/app/components/UI/Earn/utils/token/index.ts
@@ -76,7 +76,7 @@ export const sortByHighestApr = (tokensToSort: EarnTokenDetails[]) =>
     (a, b) => parseFloat(b.experience.apr) - parseFloat(a.experience.apr),
   );
 
-export const tokenRequiresAllowanceReset = (
+export const doesTokenRequireAllowanceReset = (
   chainId: string,
   symbol: string,
 ) => {

--- a/app/components/UI/Earn/utils/token/index.ts
+++ b/app/components/UI/Earn/utils/token/index.ts
@@ -82,5 +82,5 @@ export const tokenRequiresAllowanceReset = (
   symbol: string,
 ) => {
   if (!chainId || !symbol) return false;
-  return TOKENS_REQUIRING_ALLOWANCE_RESET[chainId].includes(symbol);
+  return Boolean(TOKENS_REQUIRING_ALLOWANCE_RESET[chainId]?.includes(symbol));
 };

--- a/app/components/UI/Earn/utils/token/token.test.ts
+++ b/app/components/UI/Earn/utils/token/token.test.ts
@@ -3,6 +3,7 @@ import {
   getEstimatedAnnualRewards,
   sortByHighestRewards,
   sortByHighestApr,
+  tokenRequiresAllowanceReset,
 } from '.';
 import {
   createMockEarnToken,
@@ -10,6 +11,11 @@ import {
 } from '../../../Stake/testUtils';
 import { TOKENS_WITH_DEFAULT_OPTIONS } from '../../../Stake/testUtils/testUtils.types';
 import { EarnTokenDetails } from '../../types/lending.types';
+import {
+  MOCK_USDC_MAINNET_ASSET,
+  MOCK_USDT_BASE_MAINNET_ASSET,
+  MOCK_USDT_MAINNET_ASSET,
+} from '../../../Stake/__mocks__/stakeMockData';
 
 describe('tokenUtils', () => {
   describe('getEstimatedAnnualRewards', () => {
@@ -197,6 +203,72 @@ describe('tokenUtils', () => {
 
     it('returns empty array if input is empty', () => {
       expect(sortByHighestApr([])).toEqual([]);
+    });
+  });
+
+  describe('tokenRequiresAllowanceReset', () => {
+    describe('Ethereum mainnet', () => {
+      it('returns true when token requires allowance reset', () => {
+        const { chainId, symbol } = MOCK_USDT_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(chainId, symbol);
+
+        expect(result).toBe(true);
+      });
+
+      it("returns false when token doesn't require allowance reset", () => {
+        const { chainId, symbol } = MOCK_USDC_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(chainId, symbol);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when chainId is undefined', () => {
+        const { symbol } = MOCK_USDC_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(
+          undefined as unknown as string,
+          symbol,
+        );
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when symbol is undefined', () => {
+        const { chainId } = MOCK_USDC_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(
+          chainId,
+          undefined as unknown as string,
+        );
+
+        expect(result).toBe(false);
+      });
+    });
+    describe('Non-Mainnet Networks (Base)', () => {
+      it("returns false when token doesn't require allowance reset", () => {
+        const { chainId, symbol } = MOCK_USDT_BASE_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(chainId, symbol);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when chainId is undefined', () => {
+        const { symbol } = MOCK_USDT_BASE_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(
+          undefined as unknown as string,
+          symbol,
+        );
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when symbol is undefined', () => {
+        const { chainId } = MOCK_USDT_BASE_MAINNET_ASSET;
+        const result = tokenRequiresAllowanceReset(
+          chainId,
+          undefined as unknown as string,
+        );
+
+        expect(result).toBe(false);
+      });
     });
   });
 });

--- a/app/components/UI/Earn/utils/token/token.test.ts
+++ b/app/components/UI/Earn/utils/token/token.test.ts
@@ -3,7 +3,7 @@ import {
   getEstimatedAnnualRewards,
   sortByHighestRewards,
   sortByHighestApr,
-  tokenRequiresAllowanceReset,
+  doesTokenRequireAllowanceReset,
 } from '.';
 import {
   createMockEarnToken,
@@ -206,25 +206,25 @@ describe('tokenUtils', () => {
     });
   });
 
-  describe('tokenRequiresAllowanceReset', () => {
+  describe('doesTokenRequireAllowanceReset', () => {
     describe('Ethereum mainnet', () => {
       it('returns true when token requires allowance reset', () => {
         const { chainId, symbol } = MOCK_USDT_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(chainId, symbol);
+        const result = doesTokenRequireAllowanceReset(chainId, symbol);
 
         expect(result).toBe(true);
       });
 
       it("returns false when token doesn't require allowance reset", () => {
         const { chainId, symbol } = MOCK_USDC_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(chainId, symbol);
+        const result = doesTokenRequireAllowanceReset(chainId, symbol);
 
         expect(result).toBe(false);
       });
 
       it('returns false when chainId is undefined', () => {
         const { symbol } = MOCK_USDC_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(
+        const result = doesTokenRequireAllowanceReset(
           undefined as unknown as string,
           symbol,
         );
@@ -234,7 +234,7 @@ describe('tokenUtils', () => {
 
       it('returns false when symbol is undefined', () => {
         const { chainId } = MOCK_USDC_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(
+        const result = doesTokenRequireAllowanceReset(
           chainId,
           undefined as unknown as string,
         );
@@ -245,14 +245,14 @@ describe('tokenUtils', () => {
     describe('Non-Mainnet Networks (Base)', () => {
       it("returns false when token doesn't require allowance reset", () => {
         const { chainId, symbol } = MOCK_USDT_BASE_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(chainId, symbol);
+        const result = doesTokenRequireAllowanceReset(chainId, symbol);
 
         expect(result).toBe(false);
       });
 
       it('returns false when chainId is undefined', () => {
         const { symbol } = MOCK_USDT_BASE_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(
+        const result = doesTokenRequireAllowanceReset(
           undefined as unknown as string,
           symbol,
         );
@@ -262,7 +262,7 @@ describe('tokenUtils', () => {
 
       it('returns false when symbol is undefined', () => {
         const { chainId } = MOCK_USDT_BASE_MAINNET_ASSET;
-        const result = tokenRequiresAllowanceReset(
+        const result = doesTokenRequireAllowanceReset(
           chainId,
           undefined as unknown as string,
         );

--- a/app/components/UI/Stake/__mocks__/stakeMockData.ts
+++ b/app/components/UI/Stake/__mocks__/stakeMockData.ts
@@ -134,6 +134,10 @@ export const MOCK_USDT_MAINNET_ASSET = createMockToken(
   ),
 );
 
+export const MOCK_USDT_BASE_MAINNET_ASSET = createMockToken(
+  getCreateMockTokenOptions(CHAIN_IDS.BASE, TOKENS_WITH_DEFAULT_OPTIONS.USDT),
+);
+
 export const MOCK_AUSDT_MAINNET_ASSET = createMockToken({
   chainId: '0x1',
   symbol: 'AUSDT',

--- a/app/components/UI/Stake/__mocks__/stakeMockData.ts
+++ b/app/components/UI/Stake/__mocks__/stakeMockData.ts
@@ -142,6 +142,7 @@ export const MOCK_AUSDT_MAINNET_ASSET = createMockToken({
   chainId: '0x1',
   symbol: 'AUSDT',
   name: 'Aave v3 USDT',
+  address: '0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a',
 });
 
 export const MOCK_DAI_MAINNET_ASSET = createMockToken(

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
@@ -71,17 +71,6 @@ export const Confirm = ({ route }: ConfirmProps) => {
 
   const { styles } = useStyles(styleSheet, {});
 
-  // Wrapping navigation.setOptions in useEffect solve the
-  // Cannot update a component (StackNavigator) while rendering a different component error
-  useEffect(() => {
-    if (isFullScreenConfirmation) {
-      // Keep this navigation option to prevent Android navigation flickering
-      navigation.setOptions({
-        headerShown: true,
-      });
-    }
-  }, [isFullScreenConfirmation, navigation]);
-
   if (!isRedesignedEnabled) {
     navigation.setOptions({
       headerShown: false,
@@ -90,6 +79,10 @@ export const Confirm = ({ route }: ConfirmProps) => {
   }
 
   if (isFullScreenConfirmation) {
+    // Keep this navigation option to prevent Android navigation flickering
+    navigation.setOptions({
+      headerShown: true,
+    });
     return (
       <View style={styles.flatContainer} testID={ConfirmationUIType.FLAT}>
         <ConfirmWrapped styles={styles} route={route} />

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
@@ -71,6 +71,17 @@ export const Confirm = ({ route }: ConfirmProps) => {
 
   const { styles } = useStyles(styleSheet, {});
 
+  // Wrapping navigation.setOptions in useEffect solve the
+  // Cannot update a component (StackNavigator) while rendering a different component error
+  useEffect(() => {
+    if (isFullScreenConfirmation) {
+      // Keep this navigation option to prevent Android navigation flickering
+      navigation.setOptions({
+        headerShown: true,
+      });
+    }
+  }, [isFullScreenConfirmation, navigation]);
+
   if (!isRedesignedEnabled) {
     navigation.setOptions({
       headerShown: false,
@@ -79,10 +90,6 @@ export const Confirm = ({ route }: ConfirmProps) => {
   }
 
   if (isFullScreenConfirmation) {
-    // Keep this navigation option to prevent Android navigation flickering
-    navigation.setOptions({
-      headerShown: true,
-    });
     return (
       <View style={styles.flatContainer} testID={ConfirmationUIType.FLAT}>
         <ConfirmWrapped styles={styles} route={route} />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3941,7 +3941,8 @@
     "earnings_history_list_title": {
       "lending": "Position history",
       "staking": "Payout history"
-    }
+    },
+    "allowance_reset": "Allowance Reset"
   },
   "stake": {
     "stake": "Stake",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes broken lending deposits for Ethereum mainnet USDT. The USDT contract on mainnet doesn't support updating the token allowance directly via the `approve` method. Instead, we must manually call `approve` with a zero amount then we can increase it.

Mainnet USDT Approve Method from [Etherscan](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#code)
```solidity
    /**
    * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */
    function approve(address _spender, uint _value) public onlyPayloadSize(2 * 32) {

        // To change the approve amount you first have to reduce the addresses`
        //  allowance to zero by calling `approve(_spender, 0)` if it is not
        //  already 0 to mitigate the race condition described here:
        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
        require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));

        allowed[msg.sender][_spender] = _value;
        Approval(msg.sender, _spender, _value);
    }
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16763
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-927

## **Manual testing steps**
prerequisites:
- You must have a non-zero mainnet USDT balance in order to deposit.
- You must not have a max allowance set for mainnet USDT

1. Click mainnet USDT "Earn" CTA in token list (home screen).
2. On the deposit screen, enter an amount that is less than your max amount (e.g. 1 USDT)
3. Click "Review" to navigate to the confirmation screen.
4. Ensure that you have not yet completed the "Approve" step.
5. Click "Approve" and accept the allowance increase confirmation.
6. Wait for Transaction to confirm.
7. On confirm, go back and enter a larger value than the previous (e.g. 2 USDT)
8. Click "Review" to navigate to the confirmation screen once again.
9. Assert that you see the additional "Reset Allowance" step. This step is very similar to the Approve except we reset your USDT allowance to zero.
10. Once this completes you should be able to proceed with the regular lending deposit 2-step flow.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **After**

<!-- [screenshots/recordings] -->
![image](https://github.com/user-attachments/assets/75c7847d-32bd-4200-9eeb-59fd418b2b93)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
