### PR TITLE
fix: Switch to smart account action should not be available for hardware wallet accounts

### DIFF
--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -23,6 +23,8 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import { strings } from '../../../../locales/i18n';
 // eslint-disable-next-line import/no-namespace
 import * as Networks7702 from '../confirmations/hooks/7702/useEIP7702Networks';
+// eslint-disable-next-line import/no-namespace
+import * as AddressUtils from '../../../util/address';
 import { act } from '@testing-library/react-hooks';
 import { RPC } from '../../../constants/network';
 
@@ -677,6 +679,16 @@ describe('AccountActions', () => {
         network7702List: [],
         networkSupporting7702Present: false,
       });
+
+      const { queryByText } = renderWithProvider(<AccountActions />, {
+        state: initialState,
+      });
+
+      expect(queryByText('Switch to Smart account')).toBeNull();
+    });
+
+    it('option should not be displayed for hardware wallet accounts', () => {
+      jest.spyOn(AddressUtils, 'isHardwareAccount').mockReturnValue(true);
 
       const { queryByText } = renderWithProvider(<AccountActions />, {
         state: initialState,

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -407,7 +407,7 @@ const AccountActions = () => {
             }
           />
         )}
-        {selectedAddress && !isHardwareAccount(selectedAddress) && (
+        {selectedAddress && isHardwareAccount(selectedAddress) && (
           <AccountAction
             actionTitle={strings('accounts.remove_hardware_account')}
             iconName={IconName.Close}

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -429,8 +429,8 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {networkSupporting7702Present &&
-          !isHardwareAccount(selectedAddress) && (
+        {(networkSupporting7702Present &&
+          !isHardwareAccount(selectedAddress)) && (
             <AccountAction
               actionTitle={strings('account_actions.switch_to_smart_account')}
               iconName={IconName.SwapHorizontal}

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -407,7 +407,7 @@ const AccountActions = () => {
             }
           />
         )}
-        {selectedAddress && isHardwareAccount(selectedAddress) && (
+        {selectedAddress && !isHardwareAccount(selectedAddress) && (
           <AccountAction
             actionTitle={strings('accounts.remove_hardware_account')}
             iconName={IconName.Close}
@@ -429,13 +429,14 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {networkSupporting7702Present && (
-          <AccountAction
-            actionTitle={strings('account_actions.switch_to_smart_account')}
-            iconName={IconName.SwapHorizontal}
-            onPress={goToSwitchAccountType}
-          />
-        )}
+        {networkSupporting7702Present &&
+          !isHardwareAccount(selectedAddress) && (
+            <AccountAction
+              actionTitle={strings('account_actions.switch_to_smart_account')}
+              iconName={IconName.SwapHorizontal}
+              onPress={goToSwitchAccountType}
+            />
+          )}
       </View>
       <BlockingActionModal
         modalVisible={blockingModalVisible}

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -43,10 +43,7 @@ import type {
   NetworkClientId,
   NetworkState,
 } from '@metamask/network-controller';
-import {
-  KeyringObject,
-  KeyringTypes,
-} from '@metamask/keyring-controller';
+import { KeyringObject, KeyringTypes } from '@metamask/keyring-controller';
 import { type Hex, isHexString } from '@metamask/utils';
 import PREINSTALLED_SNAPS from '../../lib/snaps/preinstalled-snaps';
 


### PR DESCRIPTION
## **Description**

Switch to smart account action should not be available for hardware wallet accounts

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5258

## **Manual testing steps**

1. Open account action modal for hardware wallet account
2. Check that switch account action is not available

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
