### PR TITLE
fix: cp-7.50.0 Prevent cronjob state from getting out of sync

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1247,8 +1247,8 @@ export class Engine {
         DeFiPositionsController: defiPositionsControllerInit,
         ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
         ExecutionService: executionServiceInit,
-        SnapController: snapControllerInit,
         CronjobController: cronjobControllerInit,
+        SnapController: snapControllerInit,
         SnapInterfaceController: snapInterfaceControllerInit,
         SnapsRegistry: snapsRegistryInit,
         NotificationServicesController: notificationServicesControllerInit,
@@ -1337,6 +1337,7 @@ export class Engine {
 
     ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
     snapController.init();
+    cronjobController.init();
     // Notification Setup
     notificationServicesController.init();
     ///: END:ONLY_INCLUDE_IF

--- a/patches/@metamask+snaps-controllers+13.1.1.patch
+++ b/patches/@metamask+snaps-controllers+13.1.1.patch
@@ -21,6 +21,90 @@ index 0e8feeb..2bf546a 100644
          this.#start();
          this.#clear();
          this.#reschedule();
+diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts
+index 99f72dd..bac97d5 100644
+--- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts
++++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts
+@@ -5,6 +5,14 @@ import type { BackgroundEvent, SnapId } from "@metamask/snaps-sdk";
+ import type { HandleSnapRequest, SnapDisabled, SnapEnabled, SnapInstalled, SnapUninstalled, SnapUpdated } from "../index.cjs";
+ export type CronjobControllerGetStateAction = ControllerGetStateAction<typeof controllerName, CronjobControllerState>;
+ export type CronjobControllerStateChangeEvent = ControllerStateChangeEvent<typeof controllerName, CronjobControllerState>;
++/**
++ * Initialise the CronjobController. This should be called after all controllers
++ * are created.
++ */
++export type CronjobControllerInitAction = {
++    type: `${typeof controllerName}:init`;
++    handler: CronjobController['init'];
++};
+ export type Schedule = {
+     type: `${typeof controllerName}:schedule`;
+     handler: CronjobController['schedule'];
+@@ -17,7 +25,7 @@ export type Get = {
+     type: `${typeof controllerName}:get`;
+     handler: CronjobController['get'];
+ };
+-export type CronjobControllerActions = CronjobControllerGetStateAction | HandleSnapRequest | GetPermissions | Schedule | Cancel | Get;
++export type CronjobControllerActions = CronjobControllerGetStateAction | HandleSnapRequest | GetPermissions | Schedule | Cancel | Get | CronjobControllerInitAction;
+ export type CronjobControllerEvents = CronjobControllerStateChangeEvent | SnapInstalled | SnapUninstalled | SnapUpdated | SnapEnabled | SnapDisabled;
+ export type CronjobControllerMessenger = RestrictedMessenger<typeof controllerName, CronjobControllerActions, CronjobControllerEvents, CronjobControllerActions['type'], CronjobControllerEvents['type']>;
+ export declare const DAILY_TIMEOUT: number;
+@@ -71,6 +79,13 @@ declare const controllerName = "CronjobController";
+ export declare class CronjobController extends BaseController<typeof controllerName, CronjobControllerState, CronjobControllerMessenger> {
+     #private;
+     constructor({ messenger, state }: CronjobControllerArgs);
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init(): void;
+     /**
+      * Schedule a non-recurring background event.
+      *
+diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.mts b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.mts
+index 40ba2e1..ae0fb31 100644
+--- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.mts
++++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.mts
+@@ -5,6 +5,14 @@ import type { BackgroundEvent, SnapId } from "@metamask/snaps-sdk";
+ import type { HandleSnapRequest, SnapDisabled, SnapEnabled, SnapInstalled, SnapUninstalled, SnapUpdated } from "../index.mjs";
+ export type CronjobControllerGetStateAction = ControllerGetStateAction<typeof controllerName, CronjobControllerState>;
+ export type CronjobControllerStateChangeEvent = ControllerStateChangeEvent<typeof controllerName, CronjobControllerState>;
++/**
++ * Initialise the CronjobController. This should be called after all controllers
++ * are created.
++ */
++export type CronjobControllerInitAction = {
++    type: `${typeof controllerName}:init`;
++    handler: CronjobController['init'];
++};
+ export type Schedule = {
+     type: `${typeof controllerName}:schedule`;
+     handler: CronjobController['schedule'];
+@@ -17,7 +25,7 @@ export type Get = {
+     type: `${typeof controllerName}:get`;
+     handler: CronjobController['get'];
+ };
+-export type CronjobControllerActions = CronjobControllerGetStateAction | HandleSnapRequest | GetPermissions | Schedule | Cancel | Get;
++export type CronjobControllerActions = CronjobControllerGetStateAction | HandleSnapRequest | GetPermissions | Schedule | Cancel | Get | CronjobControllerInitAction;
+ export type CronjobControllerEvents = CronjobControllerStateChangeEvent | SnapInstalled | SnapUninstalled | SnapUpdated | SnapEnabled | SnapDisabled;
+ export type CronjobControllerMessenger = RestrictedMessenger<typeof controllerName, CronjobControllerActions, CronjobControllerEvents, CronjobControllerActions['type'], CronjobControllerEvents['type']>;
+ export declare const DAILY_TIMEOUT: number;
+@@ -71,6 +79,13 @@ declare const controllerName = "CronjobController";
+ export declare class CronjobController extends BaseController<typeof controllerName, CronjobControllerState, CronjobControllerMessenger> {
+     #private;
+     constructor({ messenger, state }: CronjobControllerArgs);
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init(): void;
+     /**
+      * Schedule a non-recurring background event.
+      *
 diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
 index e3f025c..b90b08f 100644
 --- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs

--- a/patches/@metamask+snaps-controllers+13.1.1.patch
+++ b/patches/@metamask+snaps-controllers+13.1.1.patch
@@ -1,0 +1,46 @@
+diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
+index 0e8feeb..2bf546a 100644
+--- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
++++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
+@@ -39,9 +39,18 @@ class CronjobController extends base_controller_1.BaseController {
+         this.messagingSystem.subscribe('SnapController:snapEnabled', this.#handleSnapEnabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapDisabled', this.#handleSnapDisabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapUpdated', this.#handleSnapUpdatedEvent);
++        this.messagingSystem.registerActionHandler(`${controllerName}:init`, (...args) => this.init(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:schedule`, (...args) => this.schedule(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:cancel`, (...args) => this.cancel(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:get`, (...args) => this.get(...args));
++    }
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init() {
+         this.#start();
+         this.#clear();
+         this.#reschedule();
+diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
+index e3f025c..b90b08f 100644
+--- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
++++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
+@@ -36,9 +36,18 @@ export class CronjobController extends BaseController {
+         this.messagingSystem.subscribe('SnapController:snapEnabled', this.#handleSnapEnabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapDisabled', this.#handleSnapDisabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapUpdated', this.#handleSnapUpdatedEvent);
++        this.messagingSystem.registerActionHandler(`${controllerName}:init`, (...args) => this.init(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:schedule`, (...args) => this.schedule(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:cancel`, (...args) => this.cancel(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:get`, (...args) => this.get(...args));
++    }
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init() {
+         this.#start();
+         this.#clear();
+         this.#reschedule();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent the `CronjobController` state from getting out of sync by initializing the controller before the `SnapController` allowing it to subscribe to the controller events. Additionally introduce a `init` function that handles the side-effects previously present in the `CronjobController` constructor.

Since this is a release blocker, this upstream change was patched in: https://github.com/MetaMask/snaps/commit/a9f0277aba928d9980f7ff827b1879535f2dda4b

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16700

## **Manual testing steps**

1. Downgrade Solana Snap to 1.30.3
2. Create a fresh MetaMask instance
3. Upgrade Solana Snap to 1.30.4 and reload the app
4. Wait a couple minutes
5. Notice that there are no errors in the console

