### PR TITLE
fix: cp-7.50.0 Hide simulations MM originated confirmations

### DIFF
--- a/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
@@ -15,6 +15,7 @@ import {
   generateContractInteractionState,
   getAppStateForConfirmation,
 } from '../../../util/test/confirm-data-helpers';
+import { MMM_ORIGIN } from '../../Views/confirmations/constants/confirmations';
 // eslint-disable-next-line import/no-namespace
 import * as BatchApprovalUtils from '../../Views/confirmations/hooks/7702/useBatchApproveBalanceChanges';
 import AnimatedSpinner from '../AnimatedSpinner';
@@ -166,6 +167,18 @@ describe('SimulationDetails', () => {
             enableMetrics={false}
           />,
           { state: generateContractInteractionState },
+        ).toJSON(),
+      ).toBeNull();
+    });
+
+    it('is not a dapp interaction', () => {
+      expect(
+        renderWithProvider(
+          <SimulationDetails transaction={{
+            id: mockTransactionId,
+            simulationData: simulationDataMock,
+            origin: MMM_ORIGIN,
+          } as TransactionMeta} enableMetrics={false} />,
         ).toJSON(),
       ).toBeNull();
     });

--- a/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.test.tsx
@@ -38,7 +38,7 @@ const approvalData = [
     nestedTransactionIndex: 0,
   },
 ];
-
+const DAPP_ORIGIN = 'https://dapp.com';
 const FIRST_PARTY_CONTRACT_ADDRESS_1_MOCK =
   '0x0439e60F02a8900a951603950d8D4527f400C3f1';
 const FIRST_PARTY_CONTRACT_ADDRESS_2_MOCK =
@@ -120,6 +120,7 @@ describe('SimulationDetails', () => {
           {
             id: mockTransactionId,
             simulationData: simulationDataMock,
+            origin: DAPP_ORIGIN,
           } as TransactionMeta
         }
         enableMetrics={false}
@@ -142,6 +143,7 @@ describe('SimulationDetails', () => {
                   ...simulationDataMock,
                   error: { code: SimulationErrorCode.ChainNotSupported },
                 },
+                origin: DAPP_ORIGIN,
               } as TransactionMeta
             }
             enableMetrics={false}
@@ -162,6 +164,7 @@ describe('SimulationDetails', () => {
                   ...simulationDataMock,
                   error: { code: SimulationErrorCode.Disabled },
                 },
+                origin: DAPP_ORIGIN,
               } as TransactionMeta
             }
             enableMetrics={false}
@@ -179,6 +182,7 @@ describe('SimulationDetails', () => {
             simulationData: simulationDataMock,
             origin: MMM_ORIGIN,
           } as TransactionMeta} enableMetrics={false} />,
+          { state: generateContractInteractionState },
         ).toJSON(),
       ).toBeNull();
     });
@@ -195,6 +199,7 @@ describe('SimulationDetails', () => {
                 ...simulationDataMock,
                 error: { code: SimulationErrorCode.Reverted },
               },
+              origin: DAPP_ORIGIN,
             } as TransactionMeta
           }
           enableMetrics={false}
@@ -215,6 +220,7 @@ describe('SimulationDetails', () => {
                 ...simulationDataMock,
                 error: { code: SimulationErrorCode.InvalidResponse },
               },
+              origin: DAPP_ORIGIN,
             } as TransactionMeta
           }
           enableMetrics={false}
@@ -235,6 +241,7 @@ describe('SimulationDetails', () => {
           {
             id: mockTransactionId,
             simulationData: simulationDataMock,
+            origin: DAPP_ORIGIN,
           } as TransactionMeta
         }
         enableMetrics={false}
@@ -283,6 +290,7 @@ describe('SimulationDetails', () => {
           {
             id: mockTransactionId,
             simulationData: simulationDataMock,
+            origin: DAPP_ORIGIN,
           } as TransactionMeta
         }
         enableMetrics={false}
@@ -334,6 +342,7 @@ describe('SimulationDetails', () => {
           {
             id: mockTransactionId,
             simulationData: simulationDataMock,
+            origin: DAPP_ORIGIN,
           } as TransactionMeta
         }
         enableMetrics={false}

--- a/app/components/UI/SimulationDetails/SimulationDetails.tsx
+++ b/app/components/UI/SimulationDetails/SimulationDetails.tsx
@@ -20,6 +20,7 @@ import Text, {
 import { useStyles } from '../../hooks/useStyles';
 import { TooltipModal } from '../../Views/confirmations/components/UI/Tooltip/Tooltip';
 import { use7702TransactionType } from '../../Views/confirmations/hooks/7702/use7702TransactionType';
+import { isDappOrigin } from '../../Views/confirmations/utils/origin';
 import AnimatedSpinner, { SpinnerSize } from '../AnimatedSpinner';
 import BalanceChangeList from './BalanceChangeList/BalanceChangeList';
 import BatchApprovalRow from './BatchApprovalRow/BatchApprovalRow';
@@ -171,6 +172,7 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
   });
   const { isBatched } = use7702TransactionType();
   const loading = !simulationData || balanceChangesResult.pending;
+  const isDappInteraction = isDappOrigin(transaction.origin);
 
   useSimulationMetrics({
     enableMetrics,
@@ -179,6 +181,10 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
     simulationData,
     transactionId,
   });
+
+  if (!isDappInteraction) {
+    return null;
+  }
 
   if (loading) {
     return (

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -208,7 +208,6 @@ describe('Confirm', () => {
     const { getByText } = renderWithProvider(<Confirm />, {
       state: stakingClaimConfirmationState,
     });
-    expect(getByText('Estimated changes')).toBeDefined();
     expect(getByText('Claiming to')).toBeDefined();
     expect(getByText('Interacting with')).toBeDefined();
     expect(getByText('Pooled Staking')).toBeDefined();

--- a/app/components/Views/confirmations/components/hero-token/hero-token.tsx
+++ b/app/components/Views/confirmations/components/hero-token/hero-token.tsx
@@ -48,13 +48,13 @@ export const HeroToken = ({ amountWei }: { amountWei?: string }) => {
 
   const { maxValueMode } = useSelector(selectTransactionState);
 
-  const { amountPrecise, amount, fiat } = useTokenAmount({ amountWei });
+  const { amountPrecise, amount, fiat, isNative } = useTokenAmount({ amountWei });
   const isRoundedAmount = amountPrecise !== amount;
 
   return (
     <AnimatedPulse
       isPulsing={isTransactionValueUpdating}
-      preventPulse={!maxValueMode}
+      preventPulse={!maxValueMode || isNative}
     >
       <Hero
         componentAsset={<AvatarTokenWithNetworkBadge />}

--- a/app/components/Views/confirmations/components/hero-token/hero-token.tsx
+++ b/app/components/Views/confirmations/components/hero-token/hero-token.tsx
@@ -54,7 +54,7 @@ export const HeroToken = ({ amountWei }: { amountWei?: string }) => {
   return (
     <AnimatedPulse
       isPulsing={isTransactionValueUpdating}
-      preventPulse={!maxValueMode || isNative}
+      preventPulse={!maxValueMode || !isNative}
     >
       <Hero
         componentAsset={<AvatarTokenWithNetworkBadge />}

--- a/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
@@ -135,15 +135,4 @@ describe('Transfer', () => {
       },
     });
   });
-
-  it('renders simulation details if transfer initiated by dapp', () => {
-    const state = cloneDeep(transferConfirmationState);
-    state.engine.backgroundState.TransactionController.transactions[0].origin =
-      'https://dapp.com';
-    const { getByText } = renderWithProvider(<Transfer />, {
-      state,
-    });
-
-    expect(getByText('Estimated changes')).toBeDefined();
-  });
 });

--- a/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { cloneDeep } from 'lodash';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { transferConfirmationState } from '../../../../../../util/test/confirm-data-helpers';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
@@ -67,6 +66,11 @@ jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+jest.mock('../../../components/UI/animated-pulse', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 const noop = () => undefined;

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -9,7 +9,6 @@ import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmat
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { ConfirmationInfoComponentIDs } from '../../../constants/info-ids';
 import useNavbar from '../../../hooks/ui/useNavbar';
-import { MMM_ORIGIN } from '../../../constants/confirmations';
 import { useMaxValueRefresher } from '../../../hooks/useMaxValueRefresher';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransferAssetType } from '../../../hooks/useTransferAssetType';
@@ -23,7 +22,6 @@ const Transfer = () => {
   // Set navbar as first to prevent Android navigation flickering
   useNavbar(strings('confirm.review'));
   const transactionMetadata = useTransactionMetadataRequest();
-  const isDappTransfer = transactionMetadata?.origin !== MMM_ORIGIN;
   const { usdValue } = useTokenAmount();
   const { assetType } = useTransferAssetType();
   const { trackPageViewedEvent, setConfirmationMetric } =
@@ -46,13 +44,11 @@ const Transfer = () => {
       <HeroRow />
       <FromToRow />
       <NetworkAndOriginRow />
-      {isDappTransfer && (
-        <SimulationDetails
-          transaction={transactionMetadata as TransactionMeta}
-          enableMetrics
-          isTransactionsRedesign
-        />
-      )}
+      <SimulationDetails
+        transaction={transactionMetadata as TransactionMeta}
+        enableMetrics
+        isTransactionsRedesign
+      />
       <GasFeesDetailsRow />
       <AdvancedDetailsRow />
     </View>

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -41,7 +41,7 @@ const Transfer = () => {
 
   return (
     <View testID={ConfirmationInfoComponentIDs.TRANSFER}>
-      <HeroRow />
+      {/* <HeroRow /> */}
       <FromToRow />
       <NetworkAndOriginRow />
       <SimulationDetails

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -41,7 +41,7 @@ const Transfer = () => {
 
   return (
     <View testID={ConfirmationInfoComponentIDs.TRANSFER}>
-      {/* <HeroRow /> */}
+      <HeroRow />
       <FromToRow />
       <NetworkAndOriginRow />
       <SimulationDetails

--- a/app/components/Views/confirmations/components/title/title.test.tsx
+++ b/app/components/Views/confirmations/components/title/title.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { merge } from 'lodash';
+import { TransactionType } from '@metamask/transaction-controller';
+
 import {
   generateContractInteractionState,
   personalSignatureConfirmationState,
@@ -126,4 +128,26 @@ describe('Confirm Title', () => {
     });
     expect(getByText('Approve request')).toBeTruthy();
   });
+
+  it.each([TransactionType.lendingDeposit, TransactionType.lendingWithdraw])(
+    'does not render subtitle for %s',
+    (transactionType) => {
+      const fakeLendingDepositState = merge(generateContractInteractionState, {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [{ type: transactionType }],
+            },
+          },
+        },
+      });
+      const { getByText, queryByText } = renderWithProvider(<Title />, {
+        state: fakeLendingDepositState,
+      });
+      expect(getByText('Transaction request')).toBeTruthy();
+      expect(
+        queryByText('Review request details before you confirm.'),
+      ).toBeNull();
+    },
+  );
 });

--- a/app/components/Views/confirmations/components/title/title.tsx
+++ b/app/components/Views/confirmations/components/title/title.tsx
@@ -12,6 +12,7 @@ import { strings } from '../../../../../../locales/i18n';
 import Text from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
+  EARN_CONTRACT_INTERACTION_TYPES,
   MMM_ORIGIN,
   REDESIGNED_APPROVE_TYPES,
   REDESIGNED_TRANSFER_TYPES,
@@ -96,7 +97,6 @@ const getTitleAndSubTitle = (
       };
     }
     case ApprovalType.Transaction: {
-      
       if (isDowngrade || isUpgradeOnly) {
         return {
           title: strings('confirm.title.switch_account_type'),
@@ -124,10 +124,12 @@ const getTitleAndSubTitle = (
       }
 
       // Default to contract interaction
+      const shouldHideSubTitle =
+        isBatched || EARN_CONTRACT_INTERACTION_TYPES.includes(transactionType);
       return {
         title: strings('confirm.title.contract_interaction'),
-        subTitle: isBatched
-          ? ''
+        subTitle: shouldHideSubTitle
+          ? undefined
           : strings('confirm.sub_title.contract_interaction'),
       };
     }

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -51,4 +51,9 @@ export const FULL_SCREEN_CONFIRMATIONS = [
   TransactionType.stakingUnstake,
   TransactionType.tokenMethodTransfer,
   TransactionType.tokenMethodTransferFrom,
-]
+];
+
+export const EARN_CONTRACT_INTERACTION_TYPES = [
+  TransactionType.lendingDeposit,
+  TransactionType.lendingWithdraw,
+];

--- a/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
@@ -80,7 +80,6 @@ describe('StakingClaim', () => {
         state: stakingClaimConfirmationState,
       },
     );
-    expect(getByText('Estimated changes')).toBeDefined();
     expect(getByText('Claiming to')).toBeDefined();
     expect(getByText('Interacting with')).toBeDefined();
     expect(getByText('Pooled Staking')).toBeDefined();

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -30,6 +30,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
+          isNative: true,
           usdValue: '0.36',
         });
       });
@@ -45,6 +46,7 @@ describe('useTokenAmount', () => {
           amount: '0.0001',
           amountPrecise: '0.0001',
           fiat: '$0.36',
+          isNative: true,
           usdValue: '0.36',
         });
       });
@@ -63,6 +65,7 @@ describe('useTokenAmount', () => {
           amount: '0.001',
           amountPrecise: '0.001',
           fiat: '$3.60',
+          isNative: true,
           usdValue: '3.60',
         });
       });
@@ -114,6 +117,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$539.44', // 0.1 * 3596.25 * 1.5
+        isNative: false,
         usdValue: '539.44',
       });
     });
@@ -129,6 +133,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
+        isNative: false,
         usdValue: '0.00',
       });
     });
@@ -168,6 +173,7 @@ describe('ERC20 token transactions', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
+        isNative: false,
         usdValue: '0.00',
       });
     });
@@ -201,6 +207,7 @@ describe('ERC20 token transactions', () => {
       expect(result.current).toEqual({
         amount: '0.1',
         amountPrecise: '0.1',
+        isNative: false,
         fiat: '$719.25', // 0.1 * 3596.25 * 2.0
         usdValue: '719.25',
       });
@@ -257,6 +264,7 @@ describe('Edge cases', () => {
         amount: '0.0001',
         amountPrecise: '0.0001',
         fiat: '$0.36',
+        isNative: true,
         usdValue: '0.36',
       });
     });
@@ -294,6 +302,7 @@ describe('Edge cases', () => {
         amount: '0.1',
         amountPrecise: '0.1',
         fiat: '$0',
+        isNative: false,
         usdValue: '0.00',
       });
     });
@@ -326,6 +335,7 @@ describe('Edge cases', () => {
         amount: '0.0001',
         amountPrecise: '0.0001',
         fiat: '$0.36',
+        isNative: true,
         usdValue: null,
       });
     });

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -30,6 +30,7 @@ interface TokenAmountProps {
 interface TokenAmount {
   amountPrecise: string | undefined;
   amount: string | undefined;
+  isNative: boolean | undefined;
   fiat: string | undefined;
   usdValue: string | null;
 }
@@ -71,6 +72,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       amountPrecise: undefined,
       amount: undefined,
       fiat: undefined,
+      isNative: undefined,
       usdValue: null,
     };
   }
@@ -84,6 +86,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
 
   let fiat;
   let usdValue = null;
+  let isNative = false;
 
   switch (transactionType) {
     case TransactionType.simpleSend:
@@ -94,6 +97,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
       fiat = amount.times(nativeConversionRate);
       const usdAmount = amount.times(usdConversionRate);
       usdValue = usdConversionRateFromCurrencyRates ? usdAmount.toFixed(2): null;
+      isNative = true;
       break;
     }
     case TransactionType.contractInteraction:
@@ -115,6 +119,7 @@ export const useTokenAmount = ({ amountWei }: TokenAmountProps = {}): TokenAmoun
     amountPrecise: formatAmountMaxPrecision(I18n.locale, amount),
     amount: formatAmount(I18n.locale, amount),
     fiat: fiat ? fiatFormatter(fiat) : undefined,
+    isNative,
     usdValue,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to hide simulations when transaction is MM originated. (Basically for `lending` and `withdraw` transactions for Earn flow)

Also aims to remove subtitle from those confirmations.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5266

## **Manual testing steps**

1. Go to two step lending screens
2. See that there is no simulations on the second step.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
