### PR TITLE
test: fix notification mock server clashing ports

### DIFF
--- a/e2e/specs/notifications/enable-notifications-after-onboarding.spec.ts
+++ b/e2e/specs/notifications/enable-notifications-after-onboarding.spec.ts
@@ -8,6 +8,7 @@ import WalletView from '../../pages/wallet/WalletView';
 import { SmokeNetworkAbstractions } from '../../tags';
 import Assertions from '../../utils/Assertions';
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
+import { getMockServerPort } from '../../fixtures/utils';
 import {
   NOTIFICATIONS_TEAM_PASSWORD,
   NOTIFICATIONS_TEAM_SEED_PHRASE,
@@ -31,11 +32,10 @@ describe(SmokeNetworkAbstractions('Notification Onboarding'), () => {
   let mockServer: Mockttp;
 
   beforeAll(async () => {
-    jest.setTimeout(200000);
     await TestHelpers.reverseServerPort();
 
     // Mock Server
-    mockServer = await startMockServer({});
+    mockServer = await startMockServer({}, getMockServerPort());
     await mockNotificationServices(mockServer);
 
     // Launch App

--- a/e2e/specs/notifications/notification-settings-flow.spec.ts
+++ b/e2e/specs/notifications/notification-settings-flow.spec.ts
@@ -11,6 +11,7 @@ import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import { SmokeNetworkAbstractions } from '../../tags';
 import Assertions from '../../utils/Assertions';
 import { importWalletWithRecoveryPhrase } from '../../viewHelper';
+import { getMockServerPort } from '../../fixtures/utils';
 import {
   NOTIFICATION_WALLET_ACCOUNT_1,
   NOTIFICATIONS_TEAM_PASSWORD,
@@ -31,11 +32,10 @@ describe(SmokeNetworkAbstractions('Notification Settings Flow'), () => {
   let mockServer: Mockttp;
 
   beforeAll(async () => {
-    jest.setTimeout(200000);
     await TestHelpers.reverseServerPort();
 
     // Mock Server
-    mockServer = await startMockServer({});
+    mockServer = await startMockServer({}, getMockServerPort());
     await mockNotificationServices(mockServer);
 
     // Launch App


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Some CI runs sometimes flakes due to not using the mock notification services - Example: https://app.bitrise.io/build/903cf5d6-c682-4689-8a8e-c2ceb504c687. By looking at the failure recording, you can see no notification mock APIs are being used.

(Hypothesis) CI runs tests in parallel, so using the default port (8000) will cause some mock servers to clash. We are now using the utility `getMockServerPort()` which will use port 8000 but also adds some "uniqueness" when ran in CI via the `transformToValidPort()` method.

## **Related issues**

Fixes: example CI failure https://app.bitrise.io/build/903cf5d6-c682-4689-8a8e-c2ceb504c687

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
