### PR TITLE
fix: cp-7.50.0 Mitigate flash of safe withdrawal limit message

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
@@ -31,6 +31,7 @@ import {
 } from './components/ConfirmationFooter';
 import { DEPOSIT_DETAILS_SECTION_TEST_ID } from './components/DepositInfoSection';
 import { DEPOSIT_RECEIVE_SECTION_TEST_ID } from './components/DepositReceiveSection';
+import Routes from '../../../../../constants/navigation/Routes';
 
 jest.mock('../../../../../selectors/accountsController', () => ({
   ...jest.requireActual('../../../../../selectors/accountsController'),
@@ -491,6 +492,8 @@ describe('EarnLendingDepositConfirmationView', () => {
           })
           .build(),
       );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
 
       // Clear and test confirmed status
       mockTrackEvent.mockClear();

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -276,6 +276,7 @@ const EarnLendingDepositConfirmationView = () => {
         'TransactionController:transactionSubmitted',
         () => {
           emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_SUBMITTED);
+          navigation.navigate(Routes.TRANSACTIONS_VIEW);
         },
         ({ transactionMeta }) => transactionMeta.id === transactionId,
       );
@@ -284,7 +285,6 @@ const EarnLendingDepositConfirmationView = () => {
         'TransactionController:transactionConfirmed',
         () => {
           emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED);
-          navigation.navigate(Routes.TRANSACTIONS_VIEW);
         },
         (transactionMeta) => transactionMeta.id === transactionId,
       );

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
@@ -29,6 +29,7 @@ import {
   CONFIRMATION_FOOTER_BUTTON_TEST_IDS,
   CONFIRMATION_FOOTER_LINK_TEST_IDS,
 } from '../EarnLendingDepositConfirmationView/components/ConfirmationFooter';
+import Routes from '../../../../../constants/navigation/Routes';
 
 expect.addSnapshotSerializer({
   // any is the expected type for the val parameter
@@ -40,6 +41,7 @@ expect.addSnapshotSerializer({
 const getStakingNavbarSpy = jest.spyOn(NavbarUtils, 'getStakingNavbar');
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -47,7 +49,7 @@ jest.mock('@react-navigation/native', () => {
     ...actual,
     useRoute: jest.fn(),
     useNavigation: () => ({
-      navigate: jest.fn(),
+      navigate: mockNavigate,
       goBack: mockGoBack,
       setOptions: jest.fn(),
     }),
@@ -834,6 +836,8 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
           },
         }),
       );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
 
       mockTrackEvent.mockClear();
 

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -364,6 +364,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
           emitWithdrawalTxMetaMetric(
             MetaMetricsEvents.EARN_TRANSACTION_SUBMITTED,
           );
+          navigation.navigate(Routes.TRANSACTIONS_VIEW);
         },
         ({ transactionMeta }) => transactionMeta.id === transactionId,
       );
@@ -374,7 +375,6 @@ const EarnLendingWithdrawalConfirmationView = () => {
           emitWithdrawalTxMetaMetric(
             MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED,
           );
-          navigation.navigate(Routes.TRANSACTIONS_VIEW);
         },
         (transactionMeta) => transactionMeta.id === transactionId,
       );

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
@@ -136,7 +136,7 @@ const EarnWithdrawInputView = () => {
   }, []);
 
   const [maxRiskAwareWithdrawalAmount, setMaxRiskAwareWithdrawalAmount] =
-    useState('0');
+    useState<string | undefined>(undefined);
   const [
     isLoadingMaxSafeWithdrawalAmount,
     setIsLoadingMaxSafeWithdrawalAmount,
@@ -474,6 +474,10 @@ const EarnWithdrawInputView = () => {
     if (maxRiskAwareWithdrawalAmount === receiptToken?.balanceMinimalUnit)
       return;
 
+    if (!maxRiskAwareWithdrawalAmount) {
+      return;
+    }
+
     return renderFromTokenMinimalUnit(
       maxRiskAwareWithdrawalAmount,
       receiptToken?.decimals as number,
@@ -490,6 +494,10 @@ const EarnWithdrawInputView = () => {
     if (
       receiptToken?.experience?.type !== EARN_EXPERIENCES.STABLECOIN_LENDING
     ) {
+      return false;
+    }
+
+    if (!maxRiskAwareWithdrawalAmount) {
       return false;
     }
 

--- a/app/components/UI/Earn/hooks/useEarnInput.ts
+++ b/app/components/UI/Earn/hooks/useEarnInput.ts
@@ -29,7 +29,7 @@ const useEarnInputHandlers = ({
 
   const balanceMinimalUnit: BN4 = useMemo(
     () => new BN4(earnToken?.balanceMinimalUnit ?? '0'),
-    [earnToken.balanceMinimalUnit],
+    [earnToken?.balanceMinimalUnit],
   );
 
   const {
@@ -49,8 +49,8 @@ const useEarnInputHandlers = ({
     handleMaxInput,
   } = useInputHandler({
     balance: earnToken?.balanceMinimalUnit ?? '0',
-    decimals: earnToken.decimals,
-    ticker: earnToken.ticker ?? earnToken.symbol,
+    decimals: earnToken?.decimals ?? 0,
+    ticker: earnToken?.ticker ?? earnToken?.symbol,
     conversionRate,
     exchangeRate,
   });

--- a/app/components/UI/Earn/utils/tempLending.test.ts
+++ b/app/components/UI/Earn/utils/tempLending.test.ts
@@ -1,11 +1,11 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
-import { LendingProtocol } from '../types/lending.types';
 import {
   TransactionType,
   WalletDevice,
 } from '@metamask/transaction-controller';
 import { BigNumber, ethers } from 'ethers';
 import { EARN_EXPERIENCES } from '../constants/experiences';
+import { LendingProtocol } from '../types/lending.types';
 import {
   AAVE_V3_INFINITE_HEALTH_FACTOR,
   AAVE_WITHDRAWAL_RISKS,
@@ -16,7 +16,6 @@ import {
   getAaveReceiptTokenBalance,
   getAaveUserAccountData,
   getAaveV3MaxRiskAwareWithdrawalAmount,
-  getAaveV3MaxSafeWithdrawal,
   getErc20SpendingLimit,
   getLendingPoolLiquidity,
 } from './tempLending';
@@ -999,38 +998,6 @@ describe('Temp Lending Utils', () => {
       const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
         mockActiveAccountAddress,
         tokenWithoutMarket as unknown as typeof mockReceiptToken,
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    it('returns undefined when getLendingPoolLiquidity fails', async () => {
-      // Mock getLendingPoolLiquidity to throw an error
-      const mockGetLendingPoolLiquidity = jest.mocked(getLendingPoolLiquidity);
-      mockGetLendingPoolLiquidity.mockRejectedValueOnce(
-        new Error('Pool liquidity error'),
-      );
-
-      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
-        mockActiveAccountAddress,
-        mockReceiptToken,
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    it('returns undefined when getAaveV3MaxSafeWithdrawal fails', async () => {
-      // Mock getAaveV3MaxSafeWithdrawal to throw an error
-      const mockGetAaveV3MaxSafeWithdrawal = jest.mocked(
-        getAaveV3MaxSafeWithdrawal,
-      );
-      mockGetAaveV3MaxSafeWithdrawal.mockRejectedValueOnce(
-        new Error('Max safe withdrawal error'),
-      );
-
-      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
-        mockActiveAccountAddress,
-        mockReceiptToken,
       );
 
       expect(result).toBeUndefined();

--- a/app/components/UI/Earn/utils/tempLending.test.ts
+++ b/app/components/UI/Earn/utils/tempLending.test.ts
@@ -16,6 +16,7 @@ import {
   getAaveReceiptTokenBalance,
   getAaveUserAccountData,
   getAaveV3MaxRiskAwareWithdrawalAmount,
+  getAaveV3MaxSafeWithdrawal,
   getErc20SpendingLimit,
   getLendingPoolLiquidity,
 } from './tempLending';
@@ -122,6 +123,23 @@ describe('Temp Lending Utils', () => {
 
       expect(result).toBe(expectedAllowance);
     });
+
+    it('handles successful allowance check on BSC network', async () => {
+      const expectedAllowance = '3000000';
+      (ethers.Contract as unknown as jest.Mock).mockImplementation(() => ({
+        allowance: jest.fn().mockResolvedValue(expectedAllowance),
+      }));
+
+      const bscChainId = '0x38';
+
+      const result = await getErc20SpendingLimit(
+        mockAccount,
+        mockTokenAddress,
+        bscChainId,
+      );
+
+      expect(result).toBe(expectedAllowance);
+    });
   });
 
   describe('generateLendingDepositTransaction', () => {
@@ -175,6 +193,30 @@ describe('Temp Lending Utils', () => {
 
       expect(result?.txParams).toEqual({
         to: CHAIN_ID_TO_AAVE_V3_POOL_CONTRACT_ADDRESS[baseChainId],
+        from: mockActiveAccountAddress,
+        data: mockEncodedSupplyData,
+        value: '0',
+      });
+      expect(result?.txOptions).toEqual({
+        deviceConfirmedOn: WalletDevice.MM_MOBILE,
+        networkClientId: expect.any(String),
+        origin: ORIGIN_METAMASK,
+        type: 'lendingDeposit',
+      });
+    });
+
+    it('should generate valid deposit transaction parameters for BSC network', () => {
+      const bscChainId = '0x38';
+
+      const result = generateLendingDepositTransaction(
+        mockMinimalTokenAmount,
+        mockActiveAccountAddress,
+        mockTokenAddress,
+        bscChainId,
+      );
+
+      expect(result?.txParams).toEqual({
+        to: CHAIN_ID_TO_AAVE_V3_POOL_CONTRACT_ADDRESS[bscChainId],
         from: mockActiveAccountAddress,
         data: mockEncodedSupplyData,
         value: '0',
@@ -261,6 +303,25 @@ describe('Temp Lending Utils', () => {
       });
     });
 
+    it('should generate valid allowance increase transaction for BSC network', () => {
+      const bscChainId = '0x38';
+
+      const result = generateLendingAllowanceIncreaseTransaction(
+        mockMinimalTokenAmount,
+        mockSenderAddress,
+        mockTokenAddress,
+        bscChainId,
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.txParams).toEqual({
+        to: mockTokenAddress,
+        from: mockSenderAddress,
+        data: mockEncodedApprovalData,
+        value: '0',
+      });
+    });
+
     it('should return undefined for unsupported chain', () => {
       const unsupportedChainId = '0x999';
 
@@ -323,6 +384,22 @@ describe('Temp Lending Utils', () => {
       );
 
       expect(result).toBe('0');
+    });
+
+    it('handles successful liquidity check on BSC network', async () => {
+      const bscChainId = '0x38';
+      const expectedBalance = '2000000';
+      (ethers.Contract as unknown as jest.Mock).mockImplementation(() => ({
+        balanceOf: jest.fn().mockResolvedValue(expectedBalance),
+      }));
+
+      const result = await getLendingPoolLiquidity(
+        mockTokenAddress,
+        mockReceiptTokenAddress,
+        bscChainId,
+      );
+
+      expect(result).toBe(expectedBalance);
     });
   });
 
@@ -792,7 +869,7 @@ describe('Temp Lending Utils', () => {
       expect(result).toBe('1000000'); // Should be the minimum of the three values
     });
 
-    it('returns "0" when required token data is missing', async () => {
+    it('returns undefined when required token data is missing', async () => {
       const invalidToken = {
         chainId: '0x1',
         address: '0xabc789',
@@ -826,13 +903,15 @@ describe('Temp Lending Utils', () => {
         invalidToken,
       );
 
-      expect(result).toBe('0');
+      expect(result).toBeUndefined();
     });
 
-    it('returns "0" when API calls fail', async () => {
+    it('returns undefined when API calls fail', async () => {
       (ethers.Contract as unknown as jest.Mock).mockImplementation(() => ({
-        getUserAccountData: jest.fn().mockResolvedValue(mockUserData),
-        balanceOf: jest.fn().mockRejectedValue(new Error('Failed')),
+        getUserAccountData: jest
+          .fn()
+          .mockRejectedValue(new Error('Network error')),
+        balanceOf: jest.fn().mockResolvedValue('2000000'),
       }));
 
       const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
@@ -840,7 +919,151 @@ describe('Temp Lending Utils', () => {
         mockReceiptToken,
       );
 
-      expect(result).toBe('0');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when missing experience.market.underlying.address', async () => {
+      const tokenWithoutUnderlyingAddress = {
+        ...mockReceiptToken,
+        experience: {
+          ...mockReceiptToken.experience,
+          market: {
+            ...mockReceiptToken.experience.market,
+            underlying: {
+              ...mockReceiptToken.experience.market.underlying,
+              address: undefined,
+            },
+          },
+        },
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        tokenWithoutUnderlyingAddress as unknown as typeof mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when missing receiptToken.address', async () => {
+      const tokenWithoutAddress = {
+        ...mockReceiptToken,
+        address: undefined,
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        tokenWithoutAddress as unknown as typeof mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when missing receiptToken.chainId', async () => {
+      const tokenWithoutChainId = {
+        ...mockReceiptToken,
+        chainId: undefined,
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        tokenWithoutChainId as unknown as typeof mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when missing receiptToken.balanceMinimalUnit', async () => {
+      const tokenWithoutBalance = {
+        ...mockReceiptToken,
+        balanceMinimalUnit: undefined,
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        tokenWithoutBalance as unknown as typeof mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when missing experience.market', async () => {
+      const tokenWithoutMarket = {
+        ...mockReceiptToken,
+        experience: {
+          ...mockReceiptToken.experience,
+          market: undefined,
+        },
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        tokenWithoutMarket as unknown as typeof mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when getLendingPoolLiquidity fails', async () => {
+      // Mock getLendingPoolLiquidity to throw an error
+      const mockGetLendingPoolLiquidity = jest.mocked(getLendingPoolLiquidity);
+      mockGetLendingPoolLiquidity.mockRejectedValueOnce(
+        new Error('Pool liquidity error'),
+      );
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when getAaveV3MaxSafeWithdrawal fails', async () => {
+      // Mock getAaveV3MaxSafeWithdrawal to throw an error
+      const mockGetAaveV3MaxSafeWithdrawal = jest.mocked(
+        getAaveV3MaxSafeWithdrawal,
+      );
+      mockGetAaveV3MaxSafeWithdrawal.mockRejectedValueOnce(
+        new Error('Max safe withdrawal error'),
+      );
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when getAaveUserAccountData fails', async () => {
+      (ethers.Contract as unknown as jest.Mock).mockImplementation(() => ({
+        getUserAccountData: jest
+          .fn()
+          .mockRejectedValue(new Error('User account data error')),
+        balanceOf: jest.fn().mockResolvedValue('2000000'),
+      }));
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        mockReceiptToken,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('handles successful withdrawal amount calculation on BSC network', async () => {
+      const bscReceiptToken = {
+        ...mockReceiptToken,
+        chainId: '0x38',
+      };
+
+      const result = await getAaveV3MaxRiskAwareWithdrawalAmount(
+        mockActiveAccountAddress,
+        bscReceiptToken,
+      );
+
+      expect(result).toBe('1000000');
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR mitigates the flash of withdrawal limit message that appears on withdrawal forms for lending.

The improvement is to set the withdrawal limit value to undefined and do normal flow if it never becomes defined. If there is a failure, we fallback and do not stop the user from withdrawing as the default 0 withdrawal amount would be incorrect in this case.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1059
Fixes: https://github.com/MetaMask/metamask-mobile/issues/16749

## **Manual testing steps**

- Go to bsc chain with popular networks off (to avoid a diff bug)
- Attempt to withdraw, you should not see any flash of message
- You should be able to withdraw (if bsc rpc is not faulty) 
- If you cannot withdraw restart the app and try again to see if bsc issue is cleared
- Try linea withdraw as well it should work the same and have no flash of message

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
