### PR TITLE
chore: bump @metamask/multichain-api-client to version 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "@metamask/logging-controller": "^6.0.4",
     "@metamask/message-signing-snap": "^1.1.2",
     "@metamask/metamask-eth-abis": "3.1.1",
-    "@metamask/multichain-api-client": "^0.6.3",
+    "@metamask/multichain-api-client": "^0.6.4",
     "@metamask/multichain-api-middleware": "^0.4.0",
     "@metamask/multichain-network-controller": "^0.8.0",
     "@metamask/multichain-transactions-controller": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5310,10 +5310,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/mobile-provider/-/mobile-provider-3.0.0.tgz#8a6a5a0874c8cbe4b468f63dfc57117d207f9595"
   integrity sha512-XwFJk0rd9lAZR5xS3VC7ypEhD7DvZR2gi2Ch6PHnODIqeS9Te3OdVKK5+jHI4his8v/zs6LWdFdlRtx5/jL96w==
 
-"@metamask/multichain-api-client@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@metamask/multichain-api-client/-/multichain-api-client-0.6.3.tgz#490438bd3d348bf44e954b0b85dd3c4c58c7457d"
-  integrity sha512-E7vKYnfCKRC/cGGnt/dFAJYrRm+wP3wT1hGK4ZFi1oY9VfHfyDOIdvZizDZwB36sqJPy3TdcnYOcqgSUucEwNg==
+"@metamask/multichain-api-client@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@metamask/multichain-api-client/-/multichain-api-client-0.6.4.tgz#417009a7f202fcbdf365f4041e388fe25da77e6c"
+  integrity sha512-UvyRWwJMb74mYsR5LSPT0v6pyDdSiJ9wRhQDfpqOaOvB8Nfy1IcHUrSd9eNeZa2epegdIXZNYEKAvr0pwmLkog==
 
 "@metamask/multichain-api-middleware@^0.4.0":
   version "0.4.0"


### PR DESCRIPTION
## **Description**

This PR bumps @metamask/multichain-api-client to version [v0.6.4](https://github.com/MetaMask/multichain-api-client/releases/tag/v0.6.4) to delay the first `wallet_getSession` call from Wallet Standard to the Multichain API. That call, when done too early, was breaking some E2E tests on MetaMask extension, so it's preferable to add it in Mobile as well.

## **Related issues**

Related extension PR: https://github.com/MetaMask/metamask-extension/pull/33904

## **Manual testing steps**

On a MetaMask fresh install:
1. Go to this page https://metamask.github.io/test-dapp-solana/latest/
2. Connect & reconnect should work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
