### PR TITLE
fix: spelling of "steal" in private key warnings in English locale

### DIFF
--- a/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/index.test.tsx.snap
@@ -1286,7 +1286,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
                       }
                     }
                   >
-                    Anyone with your private key can stead any assets held in your account.
+                    Anyone with your private key can steal any assets held in your account.
                   </Text>
                 </View>
               </View>
@@ -1884,7 +1884,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
                       }
                     }
                   >
-                    Anyone with your private key can stead any assets held in your account.
+                    Anyone with your private key can steal any assets held in your account.
                   </Text>
                 </View>
               </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4449,7 +4449,7 @@
     "export_credentials": {
       "export_private_key": "Private key",
       "private_key_warning_title": "Never disclose this key.",
-      "private_key_warning_description": "Anyone with your private key can stead any assets held in your account.",
+      "private_key_warning_description": "Anyone with your private key can steal any assets held in your account.",
       "credential_as_text": "Text",
       "credential_as_qr": "QR code",
       "export_mnemonic": "Export mnemonic",
@@ -4458,7 +4458,7 @@
     "reveal_private_key": {
       "title": "Show private key",
       "banner_title": "Never disclose this key.",
-      "banner_description": "Anyone with your private key can stead any assets held in your account.",
+      "banner_description": "Anyone with your private key can steal any assets held in your account.",
       "enter_password": "Enter your password",
       "password_placeholder": "Password",
       "next": "Next",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a typo in the English localization file (en.json). The word "stead" was incorrectly used instead of "steal" in two warning messages related to private key security. The corrected messages now properly warn users that "Anyone with your private key can steal any assets held in your account." This change improves clarity and professionalism in the app's security warnings.

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-318
## **Manual testing steps**

1. Open MM
2. open account details
3. click reveal PK
4. Notice text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![image-20250626-202711](https://github.com/user-attachments/assets/1370a4fc-ce1a-4dfe-893a-11eb641d4359)

<!-- [screenshots/recordings] -->

### **After**
<img width="346" alt="Screenshot 2025-06-30 at 14 11 07" src="https://github.com/user-attachments/assets/14051388-1739-44dc-8d93-fcfcd45ff260" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
