### PR TITLE
fix: Bump version of React-native-webview-mm to 14.2.2 to include fixes for Blob file downloading on both platforms

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1948,7 +1948,7 @@ PODS:
     - Yoga
   - react-native-view-shot (3.8.0):
     - React-Core
-  - react-native-webview-mm (14.2.0):
+  - react-native-webview-mm (14.2.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.10.14.00)
@@ -3210,7 +3210,7 @@ SPEC CHECKSUMS:
   react-native-slider: 3dd74f2a74332277a065428d64e0fdca7f5ac658
   react-native-video: 344080fe089178965dd1572ce5cb71b4bb207c33
   react-native-view-shot: d1a701eb0719c6dccbd20b4bb43b1069f304cb70
-  react-native-webview-mm: df0b41ef5f3557a2717460a8c0b2098469e90558
+  react-native-webview-mm: a1f93febab673185c4fd25aa946037a726bdaa1a
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: 2f4fd95d013b5f3f485b5e2ff267b45e4c7ffc25
   React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "@metamask/react-native-button": "^3.0.0",
     "@metamask/react-native-payments": "^2.0.0",
     "@metamask/react-native-search-api": "1.0.1",
-    "@metamask/react-native-webview": "^14.2.0",
+    "@metamask/react-native-webview": "^14.2.2",
     "@metamask/remote-feature-flag-controller": "^1.6.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/scure-bip39": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5773,10 +5773,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/react-native-search-api/-/react-native-search-api-1.0.1.tgz#b3a2069ff851b88e1fe64b86f1fab7088a4daceb"
   integrity sha512-ceCzyRZDZM0lpQSNUiFpo16nysTDIMUhkdyUcvBbkpiSUnYV+SjVMxYVn2Q+h7P9tce8wrb6zoxdlfK5BXtbAQ==
 
-"@metamask/react-native-webview@^14.2.0":
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/react-native-webview/-/react-native-webview-14.2.0.tgz#cbb4ac9a90f3370da77b5513607860b32a0235c5"
-  integrity sha512-Yv4tI6M9CMYp5tkKWAHwok2uOwqCGmalEeczy3QmEMLeaEaNPH93yxwCMCniNvHoloeJ4izTMa6/2/0k9N7Qaw==
+"@metamask/react-native-webview@^14.2.2":
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/@metamask/react-native-webview/-/react-native-webview-14.2.2.tgz#74b254ad89850e04d01f4a49f60d2e6b4a4e7193"
+  integrity sha512-0TzfMKthMCffrYvKTnsyU8vJ2wecPfx6h6bWj9TL1BnQZ91o/tf8t9kB4AHNpvneIZtbKGxR938NcZLntpqOtw==
   dependencies:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
I've made multiple fixes to the WebView Blob file downloading. They resolve release blockers below.

## **Related issues**

Fixes: 
iOS: https://github.com/MetaMask/metamask-mobile/issues/16690
Android: https://github.com/MetaMask/metamask-mobile/issues/16528

## **Manual testing steps**

1. On Android go to pancakeswap.finance
2. Make sure no Download file dialog is visible
3. On iOS go to Raydium.io/swap
4. Make sure no Download file dialog is visible

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
