### PR TITLE
feat: add preference for user to enable smart account opt-in

### DIFF
--- a/app/components/Views/Settings/AdvancedSettings/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/AdvancedSettings/__snapshots__/index.test.tsx.snap
@@ -174,6 +174,94 @@ exports[`AdvancedSettings should render correctly 1`] = `
                 }
               }
             >
+              Use smart account
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                }
+              }
+            >
+              <RCTSwitch
+                accessibilityLabel="Use smart account"
+                accessibilityRole="switch"
+                onChange={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                onTintColor="#4459ff"
+                style={
+                  [
+                    {
+                      "height": 31,
+                      "width": 51,
+                    },
+                    [
+                      {
+                        "alignSelf": "flex-start",
+                      },
+                      {
+                        "backgroundColor": "#b7bbc866",
+                        "borderRadius": 16,
+                      },
+                    ],
+                  ]
+                }
+                testID="smart_account_opt_in"
+                thumbTintColor="#ffffff"
+                tintColor="#b7bbc866"
+                value={true}
+              />
+            </View>
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "CentraNo1-Book",
+                "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 24,
+                "marginTop": 8,
+              }
+            }
+          >
+            Keep this on to automatically switch accounts created within MetaMask to smart accounts whenever relevant features are available, such as faster transactions, lower network fees and payment flexibility on payment for those.
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "marginTop": 32,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "flex": 1,
+                  "fontFamily": "CentraNo1-Medium",
+                  "fontSize": 18,
+                  "fontWeight": "500",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
               Dismiss "Switch to Smart Account" suggestion
             </Text>
             <View

--- a/app/components/Views/Settings/AdvancedSettings/index.js
+++ b/app/components/Views/Settings/AdvancedSettings/index.js
@@ -22,6 +22,7 @@ import { mockTheme, ThemeContext, useTheme } from '../../../../util/theme';
 import { selectChainId } from '../../../../selectors/networkController';
 import {
   selectDismissSmartAccountSuggestionEnabled,
+  selectSmartAccountOptIn,
   selectSmartTransactionsOptInStatus,
   selectUseTokenDetection,
 } from '../../../../selectors/preferencesController';
@@ -239,6 +240,10 @@ class AdvancedSettings extends PureComponent {
      * Boolean to disable smart account upgrade prompts
      */
     dismissSmartAccountSuggestionEnabled: PropTypes.bool,
+    /**
+     * Boolean for user to opt-in for smart account upgrade
+     */
+    smartAccountOptIn: PropTypes.bool,
   };
 
   scrollView = React.createRef();
@@ -330,6 +335,15 @@ class AdvancedSettings extends PureComponent {
     });
   };
 
+  toggleSmartAccountOptIn = (smartAccountOptIn) => {
+    const { PreferencesController } = Engine.context;
+    PreferencesController.setSmartAccountOptIn(smartAccountOptIn);
+
+    this.trackMetricsEvent(MetaMetricsEvents.SMART_ACCOUNT_OPT_IN, {
+      smart_account_opt_in: smartAccountOptIn,
+    });
+  };
+
   toggleDismissSmartAccountSuggestionEnabled = (
     dismissSmartAccountSuggestionEnabled,
   ) => {
@@ -359,6 +373,7 @@ class AdvancedSettings extends PureComponent {
       setShowHexData,
       setShowCustomNonce,
       setShowFiatOnTestnets,
+      smartAccountOptIn,
       smartTransactionsOptInStatus,
       dismissSmartAccountSuggestionEnabled,
     } = this.props;
@@ -402,6 +417,15 @@ class AdvancedSettings extends PureComponent {
                 style={styles.accessory}
               />
             </View>
+
+            <SettingsRow
+              heading={strings('app_settings.use_smart_account_heading')}
+              description={strings('app_settings.use_smart_account_desc')}
+              value={smartAccountOptIn}
+              onValueChange={this.toggleSmartAccountOptIn}
+              testId={AdvancedViewSelectorsIDs.SMART_ACCOUNT_OPT_IN}
+              styles={styles}
+            />
 
             <SettingsRow
               heading={strings(
@@ -518,6 +542,7 @@ const mapStateToProps = (state) => ({
   ),
   dismissSmartAccountSuggestionEnabled:
     selectDismissSmartAccountSuggestionEnabled(state),
+  smartAccountOptIn: selectSmartAccountOptIn(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/Settings/AdvancedSettings/index.test.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/index.test.tsx
@@ -18,6 +18,8 @@ const mockNavigate = jest.fn();
 let mockSetSmartTransactionsOptInStatus: jest.Mock<any, any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let mockDismissSmartAccountSuggestionEnabled: jest.Mock<any, any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockSmartAccountOptIn: jest.Mock<any, any>;
 
 beforeEach(() => {
   initialState = {
@@ -48,6 +50,7 @@ const mockEngine = Engine;
 jest.mock('../../../../core/Engine', () => {
   mockSetSmartTransactionsOptInStatus = jest.fn();
   mockDismissSmartAccountSuggestionEnabled = jest.fn();
+  mockSmartAccountOptIn = jest.fn();
   return {
     init: () => mockEngine.init({}),
     context: {
@@ -55,6 +58,7 @@ jest.mock('../../../../core/Engine', () => {
         setSmartTransactionsOptInStatus: mockSetSmartTransactionsOptInStatus,
         setDismissSmartAccountSuggestionEnabled:
           mockDismissSmartAccountSuggestionEnabled,
+        setSmartAccountOptIn: mockSmartAccountOptIn,
       },
     },
   };
@@ -114,6 +118,25 @@ describe('AdvancedSettings', () => {
       fireEvent(switchElement, 'onValueChange', false);
 
       expect(mockDismissSmartAccountSuggestionEnabled).toHaveBeenCalled();
+    });
+
+    it('should update smartAccountOptIn when dismiss upgrade opt in pressed', async () => {
+      const { findByLabelText } = renderWithProvider(
+        <AdvancedSettings
+          navigation={{ navigate: mockNavigate, setOptions: jest.fn() }}
+        />,
+        {
+          state: initialState,
+        },
+      );
+
+      const switchElement = await findByLabelText(
+        strings('app_settings.use_smart_account_heading'),
+      );
+
+      fireEvent(switchElement, 'onValueChange', false);
+
+      expect(mockSmartAccountOptIn).toHaveBeenCalled();
     });
 
     it('should render smart transactions opt in switch on by default', async () => {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -256,7 +256,9 @@ describe('Confirm', () => {
       .mockReturnValue({ isRedesignedEnabled: true });
 
     const { getByText } = renderWithProvider(<Confirm />, {
-      state: getAppStateForConfirmation(upgradeAccountConfirmation),
+      state: getAppStateForConfirmation(upgradeAccountConfirmation, {
+        PreferencesController: { smartAccountOptIn: false },
+      }),
     });
 
     await act(async () => {

--- a/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.test.tsx
+++ b/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.test.tsx
@@ -10,10 +10,10 @@ import {
 import * as ConfirmationReducerActions from '../../../../../actions/confirmations';
 // eslint-disable-next-line import/no-namespace
 import * as ConfirmationActions from '../../hooks/useConfirmActions';
+// eslint-disable-next-line import/no-namespace
+import * as AddressUtils from '../../../../../util/address';
 import { SmartAccountUpdateSplash } from './smart-account-update-splash';
 import { useDispatch } from 'react-redux';
-import { RootState } from '../../../../../reducers';
-import { DeepPartial } from 'redux';
 
 jest.mock('../../../../hooks/AssetPolling/AssetPollingProvider', () => ({
   AssetPollingProvider: () => null,
@@ -48,6 +48,10 @@ const renderComponent = (state?: Record<string, unknown>) =>
   });
 
 describe('SmartContractWithLogo', () => {
+  beforeEach(() => {
+    jest.spyOn(AddressUtils, 'isHardwareAccount').mockReturnValue(false);
+  });
+
   it('renders correctly', () => {
     const { getByText } = renderComponent();
     expect(getByText('Use smart account?')).toBeTruthy();
@@ -95,7 +99,7 @@ describe('SmartContractWithLogo', () => {
     expect(queryByText('Request for')).toBeNull();
   });
 
-  it('renders null if preference smartAccountOptIn is true', async () => {
+  it('renders null if preference smartAccountOptIn is true and account is not hardware account', async () => {
     const { queryByText } = renderComponent(
       getAppStateForConfirmation(upgradeAccountConfirmation, {
         PreferencesController: { smartAccountOptIn: true },
@@ -103,5 +107,17 @@ describe('SmartContractWithLogo', () => {
     );
 
     expect(queryByText('Request for')).toBeNull();
+  });
+
+  it('does not renders null if preference smartAccountOptIn is true and but account is hardware account', async () => {
+    jest.spyOn(AddressUtils, 'isHardwareAccount').mockReturnValue(true);
+    const { getByText } = renderComponent(
+      getAppStateForConfirmation(upgradeAccountConfirmation, {
+        PreferencesController: { smartAccountOptIn: true },
+      }),
+    );
+
+    expect(getByText('Use smart account?')).toBeTruthy();
+    expect(getByText('Request for')).toBeTruthy();
   });
 });

--- a/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
+++ b/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
@@ -15,10 +15,11 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import { selectSmartAccountOptIn } from '../../../../../selectors/preferencesController';
 import { upgradeSplashPageAcknowledgedForAccount } from '../../../../../actions/confirmations';
+import { useTheme } from '../../../../../util/theme';
 import Name from '../../../../UI/Name';
 import { NameType } from '../../../../UI/Name/Name.types';
-import { useTheme } from '../../../../../util/theme';
 import { useStyles } from '../../../../hooks/useStyles';
 import { selectUpgradeSplashPageAcknowledgedForAccounts } from '../../selectors/confirmation';
 import { useConfirmActions } from '../../hooks/useConfirmActions';
@@ -67,6 +68,7 @@ export const SmartAccountUpdateSplash = () => {
   const upgradeSplashPageAcknowledgedForAccounts = useSelector(
     selectUpgradeSplashPageAcknowledgedForAccounts,
   );
+  const startAccountOptIn = useSelector(selectSmartAccountOptIn);
   const {
     txParams: { from },
   } = transactionMetadata ?? { txParams: {} };
@@ -95,6 +97,7 @@ export const SmartAccountUpdateSplash = () => {
   if (
     !transactionMetadata ||
     acknowledged ||
+    startAccountOptIn ||
     upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
   ) {
     return null;

--- a/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
+++ b/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
@@ -16,6 +16,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { selectSmartAccountOptIn } from '../../../../../selectors/preferencesController';
+import { isHardwareAccount } from '../../../../../util/address';
 import { upgradeSplashPageAcknowledgedForAccount } from '../../../../../actions/confirmations';
 import { useTheme } from '../../../../../util/theme';
 import Name from '../../../../UI/Name';
@@ -68,7 +69,7 @@ export const SmartAccountUpdateSplash = () => {
   const upgradeSplashPageAcknowledgedForAccounts = useSelector(
     selectUpgradeSplashPageAcknowledgedForAccounts,
   );
-  const startAccountOptIn = useSelector(selectSmartAccountOptIn);
+  const smartAccountOptIn = useSelector(selectSmartAccountOptIn);
   const {
     txParams: { from },
   } = transactionMetadata ?? { txParams: {} };
@@ -97,7 +98,7 @@ export const SmartAccountUpdateSplash = () => {
   if (
     !transactionMetadata ||
     acknowledged ||
-    startAccountOptIn ||
+    (smartAccountOptIn && from && !isHardwareAccount(from)) ||
     upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
   ) {
     return null;

--- a/app/components/Views/confirmations/components/splash/splash.test.tsx
+++ b/app/components/Views/confirmations/components/splash/splash.test.tsx
@@ -61,7 +61,11 @@ describe('Splash', () => {
   });
 
   it('renders null for internal confirmation', async () => {
-    const { queryByText } = renderComponent();
+    const { queryByText } = renderComponent(
+      getAppStateForConfirmation(upgradeOnlyAccountConfirmation, {
+        PreferencesController: { smartAccountOptIn: false },
+      }),
+    );
 
     expect(queryByText('Use smart account?')).toBeNull();
   });

--- a/app/components/Views/confirmations/components/splash/splash.test.tsx
+++ b/app/components/Views/confirmations/components/splash/splash.test.tsx
@@ -19,6 +19,9 @@ jest.mock('../../../../../core/Engine', () => ({
     TransactionController: {
       getTransactions: jest.fn().mockReturnValue([]),
     },
+    KeyringController: {
+      state: { keyrings: [] },
+    },
   },
 }));
 
@@ -32,28 +35,33 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+const renderComponent = (state?: Record<string, unknown>) =>
+  renderWithProvider(<Splash />, {
+    state:
+      state ??
+      getAppStateForConfirmation(upgradeAccountConfirmation, {
+        PreferencesController: { smartAccountOptIn: false },
+      }),
+  });
+
 describe('Splash', () => {
   it('renders splash page if present', async () => {
-    const { getByText } = renderWithProvider(<Splash />, {
-      state: getAppStateForConfirmation(upgradeAccountConfirmation),
-    });
+    const { getByText } = renderComponent();
 
     expect(getByText('Use smart account?')).toBeTruthy();
     expect(getByText('Request for')).toBeTruthy();
   });
 
   it('renders null if confirmation is not of type upgrade', async () => {
-    const { queryByText } = renderWithProvider(<Splash />, {
-      state: getAppStateForConfirmation(downgradeAccountConfirmation),
-    });
+    const { queryByText } = renderComponent(
+      getAppStateForConfirmation(downgradeAccountConfirmation),
+    );
 
     expect(queryByText('Use smart account?')).toBeNull();
   });
 
   it('renders null for internal confirmation', async () => {
-    const { queryByText } = renderWithProvider(<Splash />, {
-      state: getAppStateForConfirmation(upgradeOnlyAccountConfirmation),
-    });
+    const { queryByText } = renderComponent();
 
     expect(queryByText('Use smart account?')).toBeNull();
   });

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -446,6 +446,9 @@ enum EVENT_NAME {
   // Smart transactions
   SMART_TRANSACTION_OPT_IN = 'Smart Transaction Opt In',
 
+  // Smart account opt in
+  SMART_ACCOUNT_OPT_IN = 'Smart Account Opt In',
+
   // Dismiss smart account upgrade suggestion
   DISMISS_SMART_ACCOUNT_SUGGESTION_ENABLED = 'Dismiss smart account suggestion enabled',
 
@@ -930,7 +933,7 @@ const events = {
   SEND_BUTTON_CLICKED: generateOpt(EVENT_NAME.SEND_BUTTON_CLICKED),
   EARN_BUTTON_CLICKED: generateOpt(EVENT_NAME.EARN_BUTTON_CLICKED),
   NETWORK_SELECTOR_PRESSED: generateOpt(EVENT_NAME.NETWORK_SELECTOR),
-  
+
   // Edit account name
   ACCOUNT_RENAMED: generateOpt(EVENT_NAME.ACCOUNT_RENAMED),
 
@@ -961,6 +964,9 @@ const events = {
 
   // Smart transactions
   SMART_TRANSACTION_OPT_IN: generateOpt(EVENT_NAME.SMART_TRANSACTION_OPT_IN),
+
+  // User opt in for smart account upgrade
+  SMART_ACCOUNT_OPT_IN: generateOpt(EVENT_NAME.SMART_ACCOUNT_OPT_IN),
 
   // Dismiss smart account upgrade suggestion
   DISMISS_SMART_ACCOUNT_SUGGESTION_ENABLED: generateOpt(

--- a/app/selectors/preferencesController.ts
+++ b/app/selectors/preferencesController.ts
@@ -166,3 +166,9 @@ export const selectDismissSmartAccountSuggestionEnabled = createSelector(
   (preferencesControllerState: PreferencesState) =>
     preferencesControllerState.dismissSmartAccountSuggestionEnabled ?? false,
 );
+
+export const selectSmartAccountOptIn = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.smartAccountOptIn ?? false,
+);

--- a/app/util/test/confirm-data-helpers.ts
+++ b/app/util/test/confirm-data-helpers.ts
@@ -564,20 +564,22 @@ const stakingConfirmationBaseState = {
       TokensController: {
         allTokens: {
           '0x1': {
-            '0x0000000000000000000000000000000000000000': [{
-              address: '0x0000000000000000000000000000000000000000',
-              aggregators: [],
-              balance: '0xde0b6b3a7640000',
-              chainId: '0x1',
-              decimals: 18,
-              isETH: true,
-              isNative: true,
-              name: 'Ethereum',
-              symbol: 'ETH',
-              ticker: 'ETH',
-            }]
-          }
-        }
+            '0x0000000000000000000000000000000000000000': [
+              {
+                address: '0x0000000000000000000000000000000000000000',
+                aggregators: [],
+                balance: '0xde0b6b3a7640000',
+                chainId: '0x1',
+                decimals: 18,
+                isETH: true,
+                isNative: true,
+                name: 'Ethereum',
+                symbol: 'ETH',
+                ticker: 'ETH',
+              },
+            ],
+          },
+        },
       },
       TransactionController: {
         transactions: [
@@ -906,13 +908,17 @@ export const mockTransaction = {
   origin: 'https://metamask.github.io',
 } as unknown as TransactionMeta;
 
-export const contractInteractionBaseState = merge({}, stakingConfirmationBaseState, {
-  engine: {
-    backgroundState: {
-      TransactionController: { transactions: [mockTransaction] },
+export const contractInteractionBaseState = merge(
+  {},
+  stakingConfirmationBaseState,
+  {
+    engine: {
+      backgroundState: {
+        TransactionController: { transactions: [mockTransaction] },
+      },
     },
   },
-});
+);
 
 export const generateContractInteractionState = {
   ...contractInteractionBaseState,
@@ -958,10 +964,14 @@ export const transferConfirmationState = merge(
   },
 );
 
-export const getAppStateForConfirmation = (confirmation: TransactionMeta) => ({
+export const getAppStateForConfirmation = (
+  confirmation: TransactionMeta,
+  backgroundStateArgs: Record<string, unknown> = {},
+) => ({
   engine: {
     backgroundState: {
       ...backgroundState,
+      ...backgroundStateArgs,
       ApprovalController: {
         pendingApprovals: {
           [confirmation.id]: {

--- a/e2e/selectors/Settings/AdvancedView.selectors.js
+++ b/e2e/selectors/Settings/AdvancedView.selectors.js
@@ -6,4 +6,5 @@ export const AdvancedViewSelectorsIDs = {
   ADVANCED_SETTINGS_SCROLLVIEW: 'advanced-settings-scrollview',
   STX_OPT_IN_SWITCH: 'smart_transactions_opt_in_switch',
   DISMISS_SMART_ACCOUNT_UPDATE: 'dismiss_smart_account_update',
+  SMART_ACCOUNT_OPT_IN: 'smart_account_opt_in',
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1442,6 +1442,8 @@
     "security_alerts_desc": "This feature alerts you to malicious activity by locally reviewing your transaction and signature requests. Always do your own due diligence before approving any requests. There's no guarantee that this feature will detect all malicious activity. By enabling this feature you agree to the provider's terms of use.",
     "dismiss_smart_account_update_heading": "Dismiss \"Switch to Smart Account\" suggestion",
     "dismiss_smart_account_update_desc": "Turn this on to no longer see the \"Switch to Smart Account\" suggestion on any account. Smart accounts unlocks faster transactions, lower network fees and more flexibility on payment for those.",
+    "use_smart_account_heading": "Use smart account",
+    "use_smart_account_desc": "Keep this on to automatically switch accounts created within MetaMask to smart accounts whenever relevant features are available, such as faster transactions, lower network fees and payment flexibility on payment for those.",
     "smart_transactions_opt_in_heading": "Smart Transactions",
     "smart_transactions_opt_in_desc_supported_networks": "Turn on Smart Transactions for more reliable and secure transactions on supported networks.",
     "smart_transactions_learn_more": "Learn more.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adding preference for user to opt in for smart account upgrade. It will be enabled by default for new users.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5235

## **Manual testing steps**

1. Go to advance settings and opt in for smart account upgrade
2. Splash pages should no longer be visible for the user when submitting batch request

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
