### PR TITLE
fix: cp-7.50.0 wrong error passed to dapp when user rejects account upgrade

### DIFF
--- a/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
+++ b/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
@@ -91,8 +91,8 @@ export const SmartAccountUpdateSplash = () => {
 
   if (
     !transactionMetadata ||
-    acknowledged
-    // upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
+    acknowledged ||
+    upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
   ) {
     return null;
   }

--- a/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
+++ b/app/components/Views/confirmations/components/smart-account-update-splash/smart-account-update-splash.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useCallback, useState } from 'react';
 import { Image, Linking, View } from 'react-native';
-import { JsonRpcError, serializeError } from '@metamask/rpc-errors';
+import { providerErrors } from '@metamask/rpc-errors';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { strings } from '../../../../../../locales/i18n';
-import { EIP5792ErrorCode } from '../../../../../constants/transaction';
+import { UPGRADE_REJECTION_ERROR_MESSAGE } from '../../../../../constants/transaction';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -74,14 +74,11 @@ export const SmartAccountUpdateSplash = () => {
   const { onReject } = useConfirmActions();
 
   const onUpgradeReject = useCallback(() => {
-    const serializedError = serializeError(
-      new JsonRpcError(
-        EIP5792ErrorCode.RejectedUpgrade,
-        'User rejected account upgrade',
-      ),
+    onReject(
+      providerErrors.userRejectedRequest({
+        message: UPGRADE_REJECTION_ERROR_MESSAGE,
+      }),
     );
-
-    onReject(serializedError as unknown as Error);
   }, [onReject]);
 
   const onConfirm = useCallback(() => {
@@ -94,8 +91,8 @@ export const SmartAccountUpdateSplash = () => {
 
   if (
     !transactionMetadata ||
-    acknowledged ||
-    upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
+    acknowledged
+    // upgradeSplashPageAcknowledgedForAccounts.includes(from as string)
   ) {
     return null;
   }

--- a/app/constants/transaction.ts
+++ b/app/constants/transaction.ts
@@ -34,3 +34,5 @@ export enum EIP5792ErrorCode {
   UnknownBundleId = 5730,
   RejectedUpgrade = 5750,
 }
+
+export const UPGRADE_REJECTION_ERROR_MESSAGE = 'User rejected account upgrade';

--- a/app/core/Engine/controllers/transaction-controller/utils.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.test.ts
@@ -8,7 +8,7 @@ import {
   GasFeeEstimateLevel,
 } from '@metamask/transaction-controller';
 
-import { EIP5792ErrorCode } from '../../../../constants/transaction';
+import { UPGRADE_REJECTION_ERROR_MESSAGE } from '../../../../constants/transaction';
 import { MetaMetricsEvents } from '../../../Analytics';
 import { RootState } from '../../../../reducers';
 import {
@@ -576,7 +576,7 @@ describe('generateDefaultTransactionMetrics', () => {
           ...upgradeOnlyAccountConfirmation,
           status: TransactionStatus.rejected,
           error: {
-            code: EIP5792ErrorCode.RejectedUpgrade as unknown as string,
+            message: UPGRADE_REJECTION_ERROR_MESSAGE,
           } as TransactionError,
         },
         {

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -10,7 +10,7 @@ import {
 import { merge } from 'lodash';
 
 import type { RootState } from '../../../../reducers';
-import { EIP5792ErrorCode } from '../../../../constants/transaction';
+import { UPGRADE_REJECTION_ERROR_MESSAGE } from '../../../../constants/transaction';
 import { getMethodData } from '../../../../util/transactions';
 import { MetricsEventBuilder } from '../../../Analytics/MetricsEventBuilder';
 import {
@@ -148,10 +148,9 @@ async function getBatchProperties(transactionMeta: TransactionMeta) {
 
   if (transactionMeta.status === TransactionStatus.rejected) {
     const { error } = transactionMeta;
-
     properties.eip7702_upgrade_rejection =
       // @ts-expect-error Code has string type in controller
-      isUpgrade && error.code === EIP5792ErrorCode.RejectedUpgrade;
+      isUpgrade && error.message === UPGRADE_REJECTION_ERROR_MESSAGE;
   }
   properties.eip7702_upgrade_transaction = isUpgrade;
   properties.account_eip7702_upgraded = delegationAddress;


### PR DESCRIPTION
## **Description**

In case of pancake swap the error passed back to dapp is user rejects account upgrade was creating issue and resulting in weird confirmation submitted by pancake swap.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5278

## **Manual testing steps**

1. Go to pancake swap
2. Submit swap between tokens
3. Reject account upgrade
4. Submit request again, you should see same request page again

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/25280d9c-a0ad-48d7-a24c-6aa029591882

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
