### PR TITLE
test: convert multiple dapp connect e2e files to typescript

### DIFF
--- a/e2e/pages/Browser/ConnectedAccountsModal.ts
+++ b/e2e/pages/Browser/ConnectedAccountsModal.ts
@@ -169,9 +169,9 @@ class ConnectedAccountsModal {
 
   async getNetworkName(): Promise<string> {
     const networkNameElement = this.navigateToEditNetworksPermissionsButton;
-    const element = await networkNameElement;
+    const elem = await networkNameElement;
     // Type assertion to access label property which exists on Detox elements
-    const attributes = await (element as IndexableNativeElement).getAttributes();
+    const attributes = await (elem as IndexableNativeElement).getAttributes();
     return (attributes as { label: string }).label;
   }
 }

--- a/e2e/pages/Browser/ConnectedAccountsModal.ts
+++ b/e2e/pages/Browser/ConnectedAccountsModal.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../types/detox.d.ts" />
-
 import {
   ConnectedAccountModalSelectorsText,
   ConnectedAccountsSelectorsIDs,
@@ -8,6 +6,9 @@ import { WalletViewSelectorsText } from '../../selectors/wallet/WalletView.selec
 import Matchers from '../../utils/Matchers';
 import Gestures from '../../utils/Gestures';
 import TestHelpers from '../../helpers';
+import type { IndexableNativeElement, NativeElement, IndexableSystemElement } from 'detox/detox';
+type DetoxElement = Promise<IndexableNativeElement | NativeElement | IndexableSystemElement>;
+
 
 class ConnectedAccountsModal {
   get container(): DetoxElement {
@@ -170,8 +171,8 @@ class ConnectedAccountsModal {
     const networkNameElement = this.navigateToEditNetworksPermissionsButton;
     const element = await networkNameElement;
     // Type assertion to access label property which exists on Detox elements
-    const attributes = await (element as any).getAttributes();
-    return attributes.label as string;
+    const attributes = await (element as IndexableNativeElement).getAttributes();
+    return (attributes as { label: string }).label;
   }
 }
 

--- a/e2e/pages/Browser/ConnectedAccountsModal.ts
+++ b/e2e/pages/Browser/ConnectedAccountsModal.ts
@@ -8,170 +8,169 @@ import Gestures from '../../utils/Gestures';
 import TestHelpers from '../../helpers';
 
 class ConnectedAccountsModal {
-  get container() {
+  get container(): DetoxElement {
     return Matchers.getElementByID(ConnectedAccountsSelectorsIDs.CONTAINER);
   }
 
-  get permissionsButton() {
+  get permissionsButton(): DetoxElement {
     return Matchers.getElementByText(
       ConnectedAccountModalSelectorsText.PERMISSION_LINK,
     );
   }
 
-  get networkPicker() {
+  get networkPicker(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.NETWORK_PICKER,
     );
   }
 
-  get disconnectAllButton() {
+  get disconnectAllButton(): DetoxElement {
     return Matchers.getElementByText(
       ConnectedAccountModalSelectorsText.DISCONNECT_ALL,
     );
   }
-  get disconnectButton() {
+
+  get disconnectButton(): DetoxElement {
     return Matchers.getElementByID(ConnectedAccountsSelectorsIDs.DISCONNECT);
   }
 
-  get disconnectAllAccountsAndNetworksButton() {
+  get disconnectAllAccountsAndNetworksButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS,
     );
   }
 
-  get navigateToEditNetworksPermissionsButton() {
+  get navigateToEditNetworksPermissionsButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
     );
   }
 
-  get connectAccountsButton() {
+  get connectAccountsButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.CONNECT_ACCOUNTS_BUTTON,
     );
   }
-  get managePermissionsButton() {
+
+  get managePermissionsButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.MANAGE_PERMISSIONS,
     );
   }
 
-  get permissionsSummaryTab() {
+  get permissionsSummaryTab(): DetoxElement {
     return Matchers.getElementByText(
       WalletViewSelectorsText.PERMISSIONS_SUMMARY_TAB,
     );
   }
 
-  get accountsSummaryTab() {
+  get accountsSummaryTab(): DetoxElement {
     return Matchers.getElementByText(
       WalletViewSelectorsText.ACCOUNTS_SUMMARY_TAB,
     );
   }
 
-  get accountListBottomSheet() {
+  get accountListBottomSheet(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.ACCOUNT_LIST_BOTTOM_SHEET,
     );
   }
 
-  get title() {
+  get title(): DetoxElement {
     return Matchers.getElementByText(ConnectedAccountModalSelectorsText.TITLE);
   }
 
-  get selectAllNetworksButton() {
+  get selectAllNetworksButton(): DetoxElement {
     return Matchers.getElementByText(
       ConnectedAccountModalSelectorsText.SELECT_ALL,
     );
-    // return Matchers.getElementByID(
-    //   ConnectedAccountsSelectorsIDs.SELECT_ALL_NETWORKS_BUTTON,
-    // );
   }
 
-  get disconnectNetworksButton() {
+  get disconnectNetworksButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.DISCONNECT_NETWORKS_BUTTON,
     );
   }
 
-  get confirmDisconnectNetworksButton() {
+  get confirmDisconnectNetworksButton(): DetoxElement {
     return Matchers.getElementByID(
       ConnectedAccountsSelectorsIDs.CONFIRM_DISCONNECT_NETWORKS_BUTTON,
     );
   }
 
-  async tapPermissionsButton() {
+  async tapPermissionsButton(): Promise<void> {
     await Gestures.waitAndTap(this.permissionsButton);
   }
 
-  async tapNetworksPicker() {
+  async tapNetworksPicker(): Promise<void> {
     await Gestures.waitAndTap(this.networkPicker);
   }
 
-  async tapDisconnectAllButton() {
+  async tapDisconnectAllButton(): Promise<void> {
     await Gestures.waitAndTap(this.disconnectAllButton);
   }
 
-  async tapManagePermissionsButton() {
+  async tapManagePermissionsButton(): Promise<void> {
     await TestHelpers.delay(4000);
     await Gestures.waitAndTap(this.managePermissionsButton);
   }
 
-  async tapPermissionsSummaryTab() {
+  async tapPermissionsSummaryTab(): Promise<void> {
     await Gestures.waitAndTap(this.permissionsSummaryTab);
   }
 
-  async tapAccountsSummaryTab() {
+  async tapAccountsSummaryTab(): Promise<void> {
     await TestHelpers.delay(1000);
     await Gestures.waitAndTap(this.accountsSummaryTab);
   }
 
-  async tapAccountListBottomSheet() {
+  async tapAccountListBottomSheet(): Promise<void> {
     await Gestures.waitAndTap(this.accountListBottomSheet);
   }
 
-  async tapDisconnectButton() {
+  async tapDisconnectButton(): Promise<void> {
     await Gestures.waitAndTap(this.disconnectButton);
   }
-  async tapDisconnectAllAccountsAndNetworksButton() {
+
+  async tapDisconnectAllAccountsAndNetworksButton(): Promise<void> {
     await Gestures.waitAndTap(this.disconnectAllAccountsAndNetworksButton);
   }
 
-  async tapNavigateToEditNetworksPermissionsButton() {
+  async tapNavigateToEditNetworksPermissionsButton(): Promise<void> {
     await Gestures.waitAndTap(this.navigateToEditNetworksPermissionsButton);
   }
 
-  async tapSelectAllNetworksButton() {
+  async tapSelectAllNetworksButton(): Promise<void> {
     await Gestures.waitAndTap(this.selectAllNetworksButton);
   }
 
-  async tapDeselectAllNetworksButton() {
+  async tapDeselectAllNetworksButton(): Promise<void> {
     await Gestures.waitAndTap(this.selectAllNetworksButton);
   }
 
-  async tapDisconnectNetworksButton() {
+  async tapDisconnectNetworksButton(): Promise<void> {
     await Gestures.waitAndTap(this.disconnectNetworksButton);
   }
 
-  async tapConfirmDisconnectNetworksButton() {
+  async tapConfirmDisconnectNetworksButton(): Promise<void> {
     await Gestures.waitAndTap(this.confirmDisconnectNetworksButton);
   }
 
-  //async tapToSetAsPrimaryAccount() {
-  // }
-
-  async scrollToBottomOfModal() {
-    await Gestures.swipe(this.title, 'down', 'fast');
+  async scrollToBottomOfModal(): Promise<void> {
+    await Gestures.swipe(this.title as Promise<IndexableNativeElement>, 'down', 'fast');
   }
 
-  async tapConnectMoreAccountsButton() {
+  async tapConnectMoreAccountsButton(): Promise<void> {
     await Gestures.waitAndTap(this.connectAccountsButton);
   }
-  async getNetworkName() {
 
-    const networkNameElement  = this.navigateToEditNetworksPermissionsButton
-    const attributes = await networkNameElement.label;
-    return attributes;
+  async getNetworkName(): Promise<string> {
+    const networkNameElement = this.navigateToEditNetworksPermissionsButton;
+    const element = await networkNameElement;
+    // Type assertion to access label property which exists on Detox elements
+    const attributes = await (element as any).getAttributes();
+    return attributes.label as string;
   }
 }
 
-export default new ConnectedAccountsModal();
+export default new ConnectedAccountsModal(); 

--- a/e2e/pages/Browser/ConnectedAccountsModal.ts
+++ b/e2e/pages/Browser/ConnectedAccountsModal.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../types/detox.d.ts" />
+
 import {
   ConnectedAccountModalSelectorsText,
   ConnectedAccountsSelectorsIDs,

--- a/e2e/selectors/Browser/ConnectedAccountModal.selectors.ts
+++ b/e2e/selectors/Browser/ConnectedAccountModal.selectors.ts
@@ -6,7 +6,7 @@ export const ConnectedAccountModalSelectorsText = {
   IMPORTED: enContent.accounts.imported,
   TITLE: enContent.accounts.connected_accounts_title,
   SELECT_ALL: enContent.networks.select_all,
-};
+} as const;
 
 export const ConnectedAccountsSelectorsIDs = {
   CONNECT_ACCOUNTS_BUTTON: 'connect-accounts-buttons',
@@ -23,9 +23,14 @@ export const ConnectedAccountsSelectorsIDs = {
   CONFIRM_DISCONNECT_NETWORKS_BUTTON: 'confirm_disconnect_networks',
   MANAGE_PERMISSIONS: 'manage_permissions',
   ACCOUNT_LIST_BOTTOM_SHEET: 'account-list-bottom-sheet',
-};
+} as const;
 
 export const PermissionsSummarySelectorsIDs = {
   ACCOUNTS_TAB: 'accounts-tab',
   PERMISSIONS_TAB: 'permissions-tab',
-};
+} as const;
+
+// Type definitions for the selectors
+export type ConnectedAccountModalSelectorsTextType = typeof ConnectedAccountModalSelectorsText;
+export type ConnectedAccountsSelectorsIDsType = typeof ConnectedAccountsSelectorsIDs;
+export type PermissionsSummarySelectorsIDsType = typeof PermissionsSummarySelectorsIDs; 

--- a/e2e/selectors/wallet/WalletView.selectors.ts
+++ b/e2e/selectors/wallet/WalletView.selectors.ts
@@ -63,19 +63,16 @@ export const WalletViewSelectorsIDs = {
     'profile-button-avatar-network-subtitle-icon',
   PROFILE_BUTTON_AVATAR_NETWORK_SUBTITLE_CONTAINER:
     'profile-button-avatar-network-subtitle-container',
-  // Carousel selectors
   CAROUSEL_CONTAINER: 'carousel-container',
-
   CAROUSEL_PROGRESS_DOTS: 'progress-dots',
-  CAROUSEL_SLIDE: (id) => `carousel-slide-${id}`,
-  CAROUSEL_SLIDE_TITLE: (id) => `carousel-slide-${id}-title`,
-  CAROUSEL_SLIDE_CLOSE_BUTTON: (id) => `carousel-slide-${id}-close-button`,
-
+  CAROUSEL_SLIDE: (id: string | number): string => `carousel-slide-${id}`,
+  CAROUSEL_SLIDE_TITLE: (id: string | number): string => `carousel-slide-${id}-title`,
+  CAROUSEL_SLIDE_CLOSE_BUTTON: (id: string | number): string => `carousel-slide-${id}-close-button`,
   DEFI_POSITIONS_CONTAINER: 'defi-positions-container',
   DEFI_POSITIONS_NETWORK_FILTER: 'defi-positions-network-filter',
   DEFI_POSITIONS_LIST: 'defi-positions-list',
   DEFI_POSITIONS_DETAILS_CONTAINER: 'defi-positions-details-container',
-};
+} as const;
 
 export const WalletViewSelectorsText = {
   IMPORT_TOKENS: `${enContent.wallet.no_available_tokens} ${enContent.wallet.add_tokens}`,
@@ -91,4 +88,8 @@ export const WalletViewSelectorsText = {
   DEFI_NO_POSITIONS: enContent.defi_positions.no_positions,
   DEFI_ERROR_CANNOT_LOAD_PAGE: enContent.defi_positions.error_cannot_load_page,
   DEFI_ERROR_VISIT_AGAIN: enContent.defi_positions.error_visit_again,
-};
+} as const;
+
+// Type definitions for the selectors
+export type WalletViewSelectorsIDsType = typeof WalletViewSelectorsIDs;
+export type WalletViewSelectorsTextType = typeof WalletViewSelectorsText; 

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.ts
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.ts
@@ -14,8 +14,29 @@ import WalletView from '../../../../pages/wallet/WalletView';
 import NetworkNonPemittedBottomSheet from '../../../../pages/Network/NetworkNonPemittedBottomSheet';
 import NetworkConnectMultiSelector from '../../../../pages/Browser/NetworkConnectMultiSelector';
 import NetworkEducationModal from '../../../../pages/Network/NetworkEducationModal';
-
 import PermissionSummaryBottomSheet from '../../../../pages/Browser/PermissionSummaryBottomSheet';
+
+// Define proper types for withFixtures options
+interface DappOptions {
+  numberOfDapps: number;
+}
+
+interface WithFixturesOptions {
+  fixture: any;
+  dapp?: boolean;
+  multichainDapp?: boolean;
+  dappOptions?: DappOptions;
+  dappPath?: string;
+  dappPaths?: string[];
+  ganacheOptions?: any;
+  languageAndLocale?: any;
+  launchArgs?: any;
+  restartDevice?: boolean;
+  smartContract?: any;
+  testSpecificMock?: any;
+  disableGanache?: boolean;
+  localNodeOptions?: any;
+}
 
 /*
 Test Steps:
@@ -28,13 +49,13 @@ Test Steps:
 7. Check Dapp 1 is still on Linea Sepolia
 8. Check Dapp 2 is still on ETH Mainnet
 */
-describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
-  beforeAll(async () => {
+describe(SmokeNetworkExpansion('Per Dapp Management'), (): void => {
+  beforeAll(async (): Promise<void> => {
     jest.setTimeout(300000);
     await TestHelpers.reverseServerPort();
   });
 
-  it('handles two dapps concurrently', async () => {
+  it('handles two dapps concurrently', async (): Promise<void> => {
     await withFixtures(
       {
         dapp: true,
@@ -45,8 +66,8 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
           .withSecondTestDappTab()
           .build(),
         restartDevice: true,
-      },
-      async () => {
+      } as WithFixturesOptions,
+      async (): Promise<void> => {
         // Step 1: Navigate to browser view
         await loginToApp();
         await TabBarComponent.tapBrowser();
@@ -85,7 +106,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await NetworkConnectMultiSelector.tapUpdateButton();
 
         await Assertions.checkIfElementHasLabel(
-          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton as TypableElement,
           'Use your enabled networks Linea Sepolia',
         );
 
@@ -112,7 +133,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
 
         await device.enableSynchronization(); // re-enabling synchronization
         await Assertions.checkIfElementHasLabel(
-          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton as TypableElement,
           'Use your enabled networks Sepolia',
         );
 
@@ -135,7 +156,7 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
 
         await Assertions.checkIfElementHasLabel(
-          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton as TypableElement,
           'Use your enabled networks Sepolia',
         );
 
@@ -157,10 +178,10 @@ describe(SmokeNetworkExpansion('Per Dapp Management'), () => {
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
 
         await Assertions.checkIfElementHasLabel(
-          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton,
+          ConnectedAccountsModal.navigateToEditNetworksPermissionsButton as TypableElement,
           'Use your enabled networks Linea Sepolia',
         );
       },
     );
   });
-});
+}); 

--- a/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.ts
+++ b/e2e/specs/multichain/permissions/chains/multiple-dapps.spec.ts
@@ -1,5 +1,4 @@
 'use strict';
-import { device } from 'detox';
 import TestHelpers from '../../../../helpers';
 import { SmokeNetworkExpansion } from '../../../../tags';
 import Browser from '../../../../pages/Browser/BrowserView';
@@ -22,20 +21,20 @@ interface DappOptions {
 }
 
 interface WithFixturesOptions {
-  fixture: any;
+  fixture: object;
   dapp?: boolean;
   multichainDapp?: boolean;
   dappOptions?: DappOptions;
   dappPath?: string;
   dappPaths?: string[];
-  ganacheOptions?: any;
-  languageAndLocale?: any;
-  launchArgs?: any;
+  ganacheOptions?: object;
+  languageAndLocale?: object;
+  launchArgs?: object;
   restartDevice?: boolean;
-  smartContract?: any;
-  testSpecificMock?: any;
+  smartContract?: object;
+  testSpecificMock?: object;
   disableGanache?: boolean;
-  localNodeOptions?: any;
+  localNodeOptions?: object;
 }
 
 /*


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This commit introduces the ConnectedAccountsModal class and its associated selectors, enabling users to manage connected accounts and their permissions within the application. The new modal includes various buttons for disconnecting accounts, managing permissions, and selecting networks. Additionally, it integrates with the WalletView selectors to provide a cohesive user experience for account management.

New files added:
- ConnectedAccountsModal.ts
- ConnectedAccountModal.selectors.ts
- WalletView.selectors.ts
- multiple-dapps.spec.ts for testing multi-dapp permissions management

This enhancement improves the user interface for managing connected accounts and streamlines the process of handling permissions across multiple dapps.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
