### PR TITLE
perf: add cache layer for toFormattedAddress - cp-7.50.0

### DIFF
--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -22,6 +22,7 @@ import {
   renderAccountName,
   getTokenDetails,
   areAddressesEqual,
+  FORMATTED_EVM_ADDRESSES_CACHE,
 } from '.';
 import {
   mockHDKeyringAddress,
@@ -232,9 +233,23 @@ describe('formatAddress', () => {
 describe('toFormattedAddress', () => {
   describe('with EVM addresses', () => {
     it('returns checksummed address for lowercase input', () => {
-      const input = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
+      const address = '0xc4955c0d639d99699bfd7ec54d9fafee40e4d272';
       const expected = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
-      expect(toFormattedAddress(input)).toBe(expected);
+
+      expect(toFormattedAddress(address)).toBe(expected);
+    });
+
+    it('caches formatted addresses', () => {
+      const address = '0x8f8d5756179e229Dd344Ef9a83CF413CCD69053B';
+
+      const cacheSize = FORMATTED_EVM_ADDRESSES_CACHE.size;
+      const formattedAddress = toFormattedAddress(address);
+
+      // New formatted address, means new cache entry.
+      const cacheAddressKey = address.toLowerCase();
+      expect(FORMATTED_EVM_ADDRESSES_CACHE.size).toBe(cacheSize + 1);
+      expect(FORMATTED_EVM_ADDRESSES_CACHE.has(cacheAddressKey)).toBe(true);
+      expect(FORMATTED_EVM_ADDRESSES_CACHE.get(cacheAddressKey)).toStrictEqual(formattedAddress);
     });
   });
 
@@ -242,6 +257,16 @@ describe('toFormattedAddress', () => {
     it('returns original address without modification', () => {
       const address = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
       expect(toFormattedAddress(address)).toBe(address);
+    });
+
+    it('does not cache formatted addresses', () => {
+      const address = 'DphAa9aQdzRSacjh5czkapALbVDZS4Q4iMctE3wbr3c4';
+
+      const cacheSize = FORMATTED_EVM_ADDRESSES_CACHE.size;
+      toFormattedAddress(address);
+
+      expect(FORMATTED_EVM_ADDRESSES_CACHE.size).toBe(cacheSize); // No cache size change.
+      expect(FORMATTED_EVM_ADDRESSES_CACHE.has(address)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## **Description**

Simple cache logic to avoid re-computing the formatted EVM addresses every time. Computing it on my test device takes ~2.3ms. Once in cache, it only takes 0.01ms to get.

## **Related issues**

N/A

## **Manual testing steps**

1. Add this patch:

```diff
diff --git a/app/util/address/index.ts b/app/util/address/index.ts
index 9db7009fde..8fbfc28d6c 100644
--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -98,6 +98,8 @@ export const formatAddress = (rawAddress: string, type: FormatAddressType) => {
  */
 export function toFormattedAddress(address: string) {
   if (isEthAddress(address)) {
+    const tic = performance.now();
+
     // We only cache formatted address for Ethereum, cause all non-EVM address are left
     // untouched.

@@ -105,6 +107,10 @@ export function toFormattedAddress(address: string) {
     const cacheAddressKey = address.toLowerCase();
     const cachedFormattedAddress = FORMATTED_EVM_ADDRESSES_CACHE.get(cacheAddressKey);
     if (cachedFormattedAddress !== undefined) {
+      const toc = performance.now();
+      // eslint-disable-next-line no-console
+      console.log(`cache['${cacheAddressKey}'] -> ${(toc - tic).toFixed(2)}ms`);
+
       return cachedFormattedAddress; // No computation needed, just use the cache.
     }

@@ -115,6 +121,10 @@ export function toFormattedAddress(address: string) {
     const formattedAddress = toChecksumHexAddress(address);
     FORMATTED_EVM_ADDRESSES_CACHE.set(cacheAddressKey, formattedAddress);

+    const toc = performance.now();
+    // eslint-disable-next-line no-console
+    console.log(`toChecksumHexAddress('${address}') -> ${(toc - tic).toFixed(2)}ms`);
+
     return formattedAddress;
   }

```
2. Then just test the app and see how often we are computing this
3. The app should feel a little bit snappier, especially if you have a tons of accounts


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
