### PR TITLE
feat: cp-7.50.0 Hide 7702 feature behind env flag

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -134,3 +134,6 @@ export RAMP_INTERNAL_BUILD="true"
 
 # set seedless onboarding environment
 export WEB3AUTH_NETWORK="sapphire_devnet"
+
+# Enable 7702 locally
+export MM_SMART_ACCOUNT_UI_ENABLED="true"

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -770,7 +770,7 @@ const AppFlow = () => {
         name={Routes.CONFIRMATION_REQUEST_MODAL}
         component={ModalConfirmationRequest}
       />
-      {process.env.MM_SMART_ACCOUNT_UI_ENABLED && (
+      {process.env.MM_SMART_ACCOUNT_UI_ENABLED === 'true' && (
         <Stack.Screen
           name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
           component={ModalSwitchAccountType}

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -770,10 +770,12 @@ const AppFlow = () => {
         name={Routes.CONFIRMATION_REQUEST_MODAL}
         component={ModalConfirmationRequest}
       />
-      <Stack.Screen
-        name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
-        component={ModalSwitchAccountType}
-      />
+      {process.env.MM_SMART_ACCOUNT_UI_ENABLED && (
+        <Stack.Screen
+          name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
+          component={ModalSwitchAccountType}
+        />
+      )}
     </Stack.Navigator>
   );
 };

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -429,8 +429,9 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {(networkSupporting7702Present &&
-          !isHardwareAccount(selectedAddress)) && (
+        {process.env.MM_SMART_ACCOUNT_UI_ENABLED &&
+          networkSupporting7702Present &&
+          !isHardwareAccount(selectedAddress) && (
             <AccountAction
               actionTitle={strings('account_actions.switch_to_smart_account')}
               iconName={IconName.SwapHorizontal}

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -429,7 +429,7 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {process.env.MM_SMART_ACCOUNT_UI_ENABLED &&
+        {process.env.MM_SMART_ACCOUNT_UI_ENABLED === 'true' &&
           networkSupporting7702Present &&
           !isHardwareAccount(selectedAddress) && (
             <AccountAction

--- a/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
+++ b/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
@@ -38,7 +38,7 @@ export const useEIP7702Networks = (address: string) => {
   );
 
   const { pending, value } = useAsyncResultOrThrow(async () => {
-    if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+    if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
       return [];
     }
 

--- a/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
+++ b/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
@@ -38,6 +38,10 @@ export const useEIP7702Networks = (address: string) => {
   );
 
   const { pending, value } = useAsyncResultOrThrow(async () => {
+    if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+      return [];
+    }
+
     const chainIds = Object.keys(networkList) as Hex[];
 
     return await Engine.context.TransactionController.isAtomicBatchSupported({

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -195,7 +195,7 @@ async function getAlternateGasFeesCapability(
 }
 
 export async function getCapabilities(address: Hex, chainIds?: Hex[]) {
-  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
     return {};
   }
   const {
@@ -285,7 +285,7 @@ function getChainIdForNetworkClientId(networkClientId: string): Hex {
 }
 
 function validateSendCallsVersion(sendCalls: SendCalls) {
-  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
     throw rpcErrors.invalidParams('Functionality not available');
   }
 

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -49,6 +49,9 @@ export async function processSendCalls(
   params: SendCalls,
   req: JsonRpcRequest,
 ): Promise<SendCallsResult> {
+  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
+    throw rpcErrors.invalidParams('Functionality not available');
+  }
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;
   const { networkClientId, origin } = req as JsonRpcRequest & {
@@ -285,10 +288,6 @@ function getChainIdForNetworkClientId(networkClientId: string): Hex {
 }
 
 function validateSendCallsVersion(sendCalls: SendCalls) {
-  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
-    throw rpcErrors.invalidParams('Functionality not available');
-  }
-
   const { version } = sendCalls;
 
   if (version !== VERSION) {

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -49,10 +49,6 @@ export async function processSendCalls(
   params: SendCalls,
   req: JsonRpcRequest,
 ): Promise<SendCallsResult | void> {
-  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
-    return;
-  }
-
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;
   const { networkClientId, origin } = req as JsonRpcRequest & {
@@ -289,6 +285,10 @@ function getChainIdForNetworkClientId(networkClientId: string): Hex {
 }
 
 function validateSendCallsVersion(sendCalls: SendCalls) {
+  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+    throw rpcErrors.invalidParams('Functionality not available');
+  }
+
   const { version } = sendCalls;
 
   if (version !== VERSION) {

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -50,7 +50,7 @@ export async function processSendCalls(
   req: JsonRpcRequest,
 ): Promise<SendCallsResult> {
   if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
-    throw rpcErrors.invalidParams('Functionality not available');
+    throw rpcErrors.methodNotFound('Functionality not available');
   }
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -48,7 +48,7 @@ export const getAccounts = async () => {
 export async function processSendCalls(
   params: SendCalls,
   req: JsonRpcRequest,
-): Promise<SendCallsResult | void> {
+): Promise<SendCallsResult> {
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;
   const { networkClientId, origin } = req as JsonRpcRequest & {

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -48,7 +48,11 @@ export const getAccounts = async () => {
 export async function processSendCalls(
   params: SendCalls,
   req: JsonRpcRequest,
-): Promise<SendCallsResult> {
+): Promise<SendCallsResult | void> {
+  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+    return;
+  }
+
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;
   const { networkClientId, origin } = req as JsonRpcRequest & {
@@ -195,6 +199,9 @@ async function getAlternateGasFeesCapability(
 }
 
 export async function getCapabilities(address: Hex, chainIds?: Hex[]) {
+  if (!process.env.MM_SMART_ACCOUNT_UI_ENABLED) {
+    return {};
+  }
   const {
     controllerMessenger,
     context: { TransactionController },

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,8 @@ process.env.LAUNCH_DARKLY_URL =
 
 process.env.WEB3AUTH_NETWORK = 'sapphire_devnet';
 
+process.env.MM_SMART_ACCOUNT_UI_ENABLED = 'true';
+
 const config = {
   preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/app/util/test/testSetup.js'],


### PR DESCRIPTION
## **Description**

Hide 7702 feature behind env variable, this is being done only for release 7.50

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5294

## **Manual testing steps**

Ensure that none of 7702 functionality works.

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
