### PR TITLE
chore: Bump `react-native-quick-crypto`

### DIFF
--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -79,7 +79,7 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     );
   });
 
-  it.skip('can sign BIP-32 message using ed25519Bip32', async () => {
+  it('can sign BIP-32 message using ed25519Bip32', async () => {
     await TestSnaps.fillMessage('messageEd25519Bip32Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip32ed25519Bip32Button');
     await Assertions.checkIfTextIsDisplayed('Signature request');

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1745,7 +1745,7 @@ PODS:
     - Yoga
   - react-native-quick-base64 (2.0.8):
     - React-Core
-  - react-native-quick-crypto (0.7.13):
+  - react-native-quick-crypto (0.7.15):
     - DoubleConversion
     - glog
     - OpenSSL-Universal
@@ -3203,7 +3203,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 4418fa30e7906316026b5da0b50e6c1629433ed4
   react-native-performance: 6919b25d368968aeed6571d717d2c338f1f77bf5
   react-native-quick-base64: daf67f19ee076b77f0755bf4056f3425f164e1d8
-  react-native-quick-crypto: 8b0f34070629ef2c9da5ea5d68fc1549cb580591
+  react-native-quick-crypto: 6235df5ec2e2452e6dcd96763ff957ce96a45ee1
   react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
   react-native-safe-area-context: 8e56fd66d2848a7111f83831fddedb5472b60bd9

--- a/package.json
+++ b/package.json
@@ -386,7 +386,7 @@
     "react-native-progress": "3.5.0",
     "react-native-qrcode-svg": "5.1.2",
     "react-native-quick-base64": "^2.0.8",
-    "react-native-quick-crypto": "^0.7.13",
+    "react-native-quick-crypto": "^0.7.15",
     "react-native-randombytes": "^3.5.3",
     "react-native-reanimated": "^3.17.2",
     "react-native-render-html": "^6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27534,10 +27534,10 @@ react-native-quick-base64@^2.0.5, react-native-quick-base64@^2.0.8:
   dependencies:
     base64-js "^1.5.1"
 
-react-native-quick-crypto@^0.7.13:
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/react-native-quick-crypto/-/react-native-quick-crypto-0.7.13.tgz#e6ceacf84042cedcd0094f7cb72dbffb063c9b96"
-  integrity sha512-9EmXvvBW64gt/hUgeDUGl6KHjDVmtEdC/CbmlyLOTNXxvkOhNI/LhLK9ss6jDqRX3tYTM/DL0uk/+kXSTZQeKA==
+react-native-quick-crypto@^0.7.15:
+  version "0.7.15"
+  resolved "https://registry.yarnpkg.com/react-native-quick-crypto/-/react-native-quick-crypto-0.7.15.tgz#127b6958d74fd05964817f9313c674af523f24ee"
+  integrity sha512-7xtGusZr/5OYeiSJ/o1v52LhwlKNhK3E2/orS4UxIpowxE5//CC6BBlRZvkbpWGlx9/fSKukIhhZRQmAVBEjag==
   dependencies:
     "@craftzdog/react-native-buffer" "^6.0.5"
     events "^3.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bump `react-native-quick-crypto` to the latest `0.x` version, fixing an issue with deriving certain types of keys.

## **Manual testing steps**

1. Go to test-snaps
2. Install the BIP-32 Snap
3. Click "Sign ed25519Bip32 Message"