### PR TITLE
feat: Enable 7702 in latest code

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -134,6 +134,3 @@ export RAMP_INTERNAL_BUILD="true"
 
 # set seedless onboarding environment
 export WEB3AUTH_NETWORK="sapphire_devnet"
-
-# Enable 7702 locally
-export MM_SMART_ACCOUNT_UI_ENABLED="true"

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -770,12 +770,10 @@ const AppFlow = () => {
         name={Routes.CONFIRMATION_REQUEST_MODAL}
         component={ModalConfirmationRequest}
       />
-      {process.env.MM_SMART_ACCOUNT_UI_ENABLED === 'true' && (
-        <Stack.Screen
-          name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
-          component={ModalSwitchAccountType}
-        />
-      )}
+      <Stack.Screen
+        name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
+        component={ModalSwitchAccountType}
+      />
     </Stack.Navigator>
   );
 };

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -429,9 +429,8 @@ const AccountActions = () => {
           )
           ///: END:ONLY_INCLUDE_IF
         }
-        {process.env.MM_SMART_ACCOUNT_UI_ENABLED === 'true' &&
-          networkSupporting7702Present &&
-          !isHardwareAccount(selectedAddress) && (
+        {(networkSupporting7702Present &&
+          !isHardwareAccount(selectedAddress)) && (
             <AccountAction
               actionTitle={strings('account_actions.switch_to_smart_account')}
               iconName={IconName.SwapHorizontal}

--- a/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
+++ b/app/components/Views/confirmations/hooks/7702/useEIP7702Networks.ts
@@ -38,10 +38,6 @@ export const useEIP7702Networks = (address: string) => {
   );
 
   const { pending, value } = useAsyncResultOrThrow(async () => {
-    if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
-      return [];
-    }
-
     const chainIds = Object.keys(networkList) as Hex[];
 
     return await Engine.context.TransactionController.isAtomicBatchSupported({

--- a/app/core/RPCMethods/eip5792.ts
+++ b/app/core/RPCMethods/eip5792.ts
@@ -49,9 +49,6 @@ export async function processSendCalls(
   params: SendCalls,
   req: JsonRpcRequest,
 ): Promise<SendCallsResult> {
-  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
-    throw rpcErrors.methodNotFound('Functionality not available');
-  }
   const { AccountsController } = Engine.context;
   const { calls, from: paramFrom } = params;
   const { networkClientId, origin } = req as JsonRpcRequest & {
@@ -198,9 +195,6 @@ async function getAlternateGasFeesCapability(
 }
 
 export async function getCapabilities(address: Hex, chainIds?: Hex[]) {
-  if (process.env.MM_SMART_ACCOUNT_UI_ENABLED !== 'true') {
-    return {};
-  }
   const {
     controllerMessenger,
     context: { TransactionController },

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,6 @@ process.env.LAUNCH_DARKLY_URL =
 
 process.env.WEB3AUTH_NETWORK = 'sapphire_devnet';
 
-process.env.MM_SMART_ACCOUNT_UI_ENABLED = 'true';
-
 const config = {
   preset: 'react-native',
   setupFilesAfterEnv: ['<rootDir>/app/util/test/testSetup.js'],


### PR DESCRIPTION
## **Description**

The [PR](https://github.com/MetaMask/metamask-mobile/pull/16836) has hidden 7702 behind env variable, this was needed to hide the feature in release 7.50, but since change has been cherry-picked we need to again enable the feature for release cut 7.51.

## **Related issues**
Ref: https://github.com/MetaMask/MetaMask-planning/issues/5294

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
