### PR TITLE
fix: qr code address width

### DIFF
--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.styles.ts
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.styles.ts
@@ -8,6 +8,9 @@ const styleSheet = () =>
       paddingLeft: 24,
       paddingRight: 24,
     },
+    addressContainer: {
+      width: 200,
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -101,7 +101,10 @@ export const ShareAddress = () => {
           logo={PNG_MM_LOGO_PATH}
           logoSize={40}
         />
-        <QRAccountDisplay accountAddress={formattedAddress} />
+        <QRAccountDisplay
+          accountAddress={formattedAddress}
+          addressContainerStyle={styles.addressContainer}
+        />
       </Box>
       <BottomSheetFooter
         buttonsAlignment={ButtonsAlignment.Horizontal}

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.styles.ts
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.styles.ts
@@ -1,8 +1,13 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, ViewStyle } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+const styleSheet = (params: {
+  theme: Theme;
+  vars: { addressContainerStyle?: ViewStyle };
+}) => {
+  const { theme, vars } = params;
+  const { addressContainerStyle } = vars;
+
   return StyleSheet.create({
     wrapper: {
       backgroundColor: theme.colors.background.default,
@@ -15,6 +20,7 @@ const styleSheet = (params: { theme: Theme }) => {
     addressContainer: {
       width: 185,
       textAlign: 'center',
+      ...(addressContainerStyle ?? {}),
     },
     copyButton: {
       alignSelf: 'center',

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
@@ -4,7 +4,7 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import { SafeAreaView, StyleProp, ViewStyle } from 'react-native';
+import { SafeAreaView, ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import { IconName } from '../../../component-library/components/Icons/Icon';

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
@@ -4,7 +4,7 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import { SafeAreaView } from 'react-native';
+import { SafeAreaView, StyleProp, ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import { IconName } from '../../../component-library/components/Icons/Icon';
@@ -25,8 +25,13 @@ import { renderAccountName } from '../../../util/address';
 const ADDRESS_PREFIX_LENGTH = 6;
 const ADDRESS_SUFFIX_LENGTH = 5;
 
-const QRAccountDisplay = (props: { accountAddress: string }) => {
-  const { styles } = useStyles(styleSheet, {});
+const QRAccountDisplay = (props: {
+  accountAddress: string;
+  addressContainerStyle?: ViewStyle;
+}) => {
+  const { styles } = useStyles(styleSheet, {
+    addressContainerStyle: props.addressContainerStyle,
+  });
   const addr = props.accountAddress;
   const accounts = useSelector(selectInternalAccounts);
   const accountLabel = renderAccountName(addr, accounts);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR allows additional props to style the QR code address. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-314?atlOrigin=eyJpIjoiZWJiYjBjNTgxNTk1NDNhMGJjYTkxNjdmYWQyMjEyNmYiLCJwIjoiaiJ9

## **Manual testing steps**

1. Enable multichain account designs
2. Go to account details
3. Go to share address
4. See that the address only uses 2 lines. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
