### PR TITLE
test: increase e2e run step timeout

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1024,7 +1024,7 @@ workflows:
       - wait-for-android-emulator@1: {}
       - script@1:
           title: Run detox test
-          timeout: 1200
+          timeout: 1800
           is_always_run: false
           inputs:
             - content: |-
@@ -1285,7 +1285,7 @@ workflows:
                 xcrun simctl list | grep Booted
       - script@1:
           title: Run detox test
-          timeout: 1200
+          timeout: 1800
           is_always_run: false
           inputs:
             - content: |-


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We’ve noticed that some workflows are failing due to timeouts, which can make it look like our e2e tests are flaky when they’re not. To fix this, the goal of this PR to extend the timeout for the "run detox e2e" step.

A good example is the wallet_platform workflow, which is currently hitting the timeout limit and failing.

![image](https://github.com/user-attachments/assets/dcd9818c-e872-475f-a740-c4db0f60053e)


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
