### PR TITLE
chore: Add old flags to the legacy e2e tests

### DIFF
--- a/e2e/api-mocking/mock-config/mock-events.js
+++ b/e2e/api-mocking/mock-config/mock-events.js
@@ -54,6 +54,7 @@ export const mockEvents = {
             contract_deployment: false,
             contract_interaction: false,
             transfer: false,
+            approve: false,
           },
         },
       ],

--- a/e2e/specs/confirmations/approve-custom-erc20.spec.ts
+++ b/e2e/specs/confirmations/approve-custom-erc20.spec.ts
@@ -30,7 +30,8 @@ describe(SmokeConfirmations('ERC20 tokens'), () => {
   it('approve custom ERC20 token amount from a dapp', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/approve-default-erc20.spec.ts
+++ b/e2e/specs/confirmations/approve-default-erc20.spec.ts
@@ -33,7 +33,8 @@ describe(SmokeConfirmations('ERC20 tokens'), () => {
   it('approve default ERC20 token amount from a dapp', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/approve-erc721.spec.ts
+++ b/e2e/specs/confirmations/approve-erc721.spec.ts
@@ -28,7 +28,8 @@ describe(SmokeConfirmations('ERC721 tokens'), () => {
   it('approve an ERC721 token from a dapp', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/batch-transfer-erc1155.spec.ts
+++ b/e2e/specs/confirmations/batch-transfer-erc1155.spec.ts
@@ -29,7 +29,8 @@ describe(SmokeConfirmations('ERC1155 token'), () => {
   it('batch transfer ERC1155 tokens', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/increase-allowance-erc20.spec.ts
+++ b/e2e/specs/confirmations/increase-allowance-erc20.spec.ts
@@ -29,7 +29,8 @@ describe(SmokeConfirmations('ERC20 - Increase Allowance'), () => {
   it('from a dApp', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/send-erc721.spec.ts
+++ b/e2e/specs/confirmations/send-erc721.spec.ts
@@ -28,7 +28,8 @@ describe(SmokeConfirmations('ERC721 tokens'), () => {
   it('send an ERC721 token from a dapp', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/send-failing-contract.spec.ts
+++ b/e2e/specs/confirmations/send-failing-contract.spec.ts
@@ -28,7 +28,8 @@ describe(SmokeConfirmations('Failing contracts'), () => {
   it('sends a failing contract transaction', async () => {
     const testSpecificMock  = {
         GET: [
-          mockEvents.GET.suggestedGasFeesApiGanache
+          mockEvents.GET.suggestedGasFeesApiGanache,
+          mockEvents.GET.remoteFeatureFlagsOldConfirmations,
         ],
       };
     await withFixtures(

--- a/e2e/specs/confirmations/set-approval-for-all-erc1155.spec.ts
+++ b/e2e/specs/confirmations/set-approval-for-all-erc1155.spec.ts
@@ -29,7 +29,8 @@ describe(SmokeConfirmations('ERC1155 token'), () => {
   it('approve all ERC1155 tokens', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 

--- a/e2e/specs/confirmations/set-approve-for-all-erc721.spec.ts
+++ b/e2e/specs/confirmations/set-approve-for-all-erc721.spec.ts
@@ -29,7 +29,8 @@ describe(SmokeConfirmations('ERC721 token'), () => {
   it('approve all ERC721 tokens', async () => {
     const testSpecificMock  = {
       GET: [
-        mockEvents.GET.suggestedGasFeesApiGanache
+        mockEvents.GET.suggestedGasFeesApiGanache,
+        mockEvents.GET.remoteFeatureFlagsOldConfirmations,
       ],
     };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Legacy confirmation e2e tests are still relying on the feature flags and should be mocked to get legacy confirmations. As confirmation feature flags work like a true "kill switch" ( https://github.com/MetaMask/metamask-mobile/blob/main/app/selectors/featureFlagController/confirmations/index.ts#L81 )it will eventually be enabled for some confirmations until it finds explicit `false` from feature flags.

Some e2e tests were lacking these flags - so changes in the LD caused e2e test to fail.

With this PR - we ensure all flags turned off properly on legacy tests.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16901

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
