### PR TITLE
fix: remove identity E2Es test specific mock server ports

### DIFF
--- a/e2e/specs/identity/account-syncing/account-sync-settings-toggle.spec.ts
+++ b/e2e/specs/identity/account-syncing/account-sync-settings-toggle.spec.ts
@@ -28,14 +28,13 @@ describe(
   SmokeWalletPlatform('Sync and Backup settings - Account Sync toggle'),
   () => {
     const ADDED_ACCOUNT = 'Account 3';
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8004;
     let decryptedAccountNames: string[] = [];
     let mockServer: Mockttp;
 
     beforeAll(async () => {
       await TestHelpers.reverseServerPort();
 
-      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+      mockServer = await startMockServer({});
 
       const accountsSyncMockResponse = await getAccountsSyncMockResponse();
 
@@ -63,7 +62,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
     });
 
@@ -120,7 +119,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
 
       await importWalletWithRecoveryPhrase({

--- a/e2e/specs/identity/account-syncing/sync-after-adding-custom-name-account.spec.ts
+++ b/e2e/specs/identity/account-syncing/sync-after-adding-custom-name-account.spec.ts
@@ -32,7 +32,6 @@ describe(
   ),
   () => {
     const NEW_ACCOUNT_NAME = 'My third account';
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8000;
     let decryptedAccountNames: string[] = [];
     let mockServer: Mockttp;
     let userStorageMockttpController: UserStorageMockttpController;
@@ -40,7 +39,7 @@ describe(
     beforeAll(async () => {
       await TestHelpers.reverseServerPort();
 
-      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+      mockServer = await startMockServer({});
 
       const accountsSyncMockResponse = await getAccountsSyncMockResponse();
 
@@ -70,7 +69,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
     });
 
@@ -121,7 +120,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
 
       await importWalletWithRecoveryPhrase({

--- a/e2e/specs/identity/account-syncing/sync-after-onboarding.spec.ts
+++ b/e2e/specs/identity/account-syncing/sync-after-onboarding.spec.ts
@@ -25,7 +25,6 @@ import { MockttpServer } from 'mockttp';
 describe(
   SmokeWalletPlatform('Account syncing - syncs previously synced accounts'),
   () => {
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8001;
     let mockServer: MockttpServer;
 
     beforeAll(async () => {
@@ -33,10 +32,7 @@ describe(
         POST: [mockEvents.POST.segmentTrack],
       };
 
-      mockServer = await startMockServer(
-        segmentMock,
-        TEST_SPECIFIC_MOCK_SERVER_PORT,
-      );
+      mockServer = await startMockServer(segmentMock);
 
       const accountsSyncMockResponse = await getAccountsSyncMockResponse();
 
@@ -57,7 +53,7 @@ describe(
         newInstance: true,
         delete: true,
         launchArgs: {
-          mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT),
+          mockServerPort: mockServer.port,
         },
       });
     });

--- a/e2e/specs/identity/account-syncing/sync-with-account-balances.spec.ts
+++ b/e2e/specs/identity/account-syncing/sync-with-account-balances.spec.ts
@@ -31,7 +31,6 @@ describe(
     'Account syncing - user already has balances on multiple accounts',
   ),
   () => {
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8002;
     const unencryptedAccounts = accountsToMockForAccountsSync;
 
     const INITIAL_ACCOUNTS = [
@@ -77,7 +76,7 @@ describe(
     beforeAll(async () => {
       await TestHelpers.reverseServerPort();
 
-      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+      mockServer = await startMockServer({});
 
       const accountsSyncMockResponse = await getAccountsSyncMockResponse();
 
@@ -107,7 +106,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
 
       // PHASE 1: Initial setup and account creation
@@ -150,7 +149,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
 
       await importWalletWithRecoveryPhrase({

--- a/e2e/specs/identity/account-syncing/sync-with-multi-srp.spec.ts
+++ b/e2e/specs/identity/account-syncing/sync-with-multi-srp.spec.ts
@@ -31,7 +31,6 @@ import { MockttpServer } from 'mockttp';
 describe(
   SmokeWalletPlatform('Account syncing - syncs after adding a second SRP'),
   () => {
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8003;
     let mockServer: MockttpServer;
     let userStorageMockttpController: UserStorageMockttpController;
 
@@ -49,7 +48,7 @@ describe(
 
     beforeAll(async () => {
       jest.setTimeout(2500000);
-      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+      mockServer = await startMockServer({});
 
       const { userStorageMockttpControllerInstance } =
         await mockIdentityServices(mockServer);
@@ -67,7 +66,7 @@ describe(
         newInstance: true,
         delete: true,
         launchArgs: {
-          mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT),
+          mockServerPort: mockServer.port,
         },
       });
     });
@@ -143,7 +142,7 @@ describe(
         newInstance: true,
         delete: true,
         launchArgs: {
-          mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT),
+          mockServerPort: mockServer.port,
         },
       });
 

--- a/e2e/specs/identity/contact-syncing/backup-and-sync-settings.spec.ts
+++ b/e2e/specs/identity/contact-syncing/backup-and-sync-settings.spec.ts
@@ -28,14 +28,13 @@ describe(
   () => {
     const NEW_CONTACT_NAME = 'New Test Contact';
     const NEW_CONTACT_ADDRESS = '0x1234567890123456789012345678901234567890';
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8007;
     let mockServer: MockttpServer;
     let userStorageMockttpController: UserStorageMockttpController;
 
     beforeAll(async () => {
       await TestHelpers.reverseServerPort();
 
-      mockServer = await startMockServer({}, TEST_SPECIFIC_MOCK_SERVER_PORT);
+      mockServer = await startMockServer({});
 
       const contactsSyncMockResponse = await getContactsSyncMockResponse();
 
@@ -55,7 +54,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
     });
 
@@ -107,7 +106,7 @@ describe(
       await TestHelpers.launchApp({
         newInstance: true,
         delete: true,
-        launchArgs: { mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT) },
+        launchArgs: { mockServerPort: mockServer.port },
       });
 
       await importWalletWithRecoveryPhrase({

--- a/e2e/specs/identity/contact-syncing/sync-existing-user.spec.ts
+++ b/e2e/specs/identity/contact-syncing/sync-existing-user.spec.ts
@@ -26,7 +26,6 @@ import { UserStorageMockttpController } from '../utils/user-storage/userStorageM
 describe(
   SmokeWalletPlatform('Contact syncing - syncs previously synced contacts'),
   () => {
-    const TEST_SPECIFIC_MOCK_SERVER_PORT = 8005;
     let mockServer: MockttpServer;
     let userStorageMockttpController: UserStorageMockttpController;
 
@@ -37,10 +36,7 @@ describe(
 
       await TestHelpers.reverseServerPort();
 
-      mockServer = await startMockServer(
-        segmentMock,
-        TEST_SPECIFIC_MOCK_SERVER_PORT,
-      );
+      mockServer = await startMockServer(segmentMock);
 
       const contactsSyncMockResponse = await getContactsSyncMockResponse();
 
@@ -61,7 +57,7 @@ describe(
         newInstance: true,
         delete: true,
         launchArgs: {
-          mockServerPort: String(TEST_SPECIFIC_MOCK_SERVER_PORT),
+          mockServerPort: mockServer.port,
           sendMetaMetricsinE2E: true,
         },
       });


### PR DESCRIPTION
## **Description**

This PR removes all constant test specific mock server ports used in the @MetaMask/identity tests, in favor of passing `mockServer.port` instead.
This should fix the "Address already in use" error when starting the mock server.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-161

## **Manual testing steps**

1. No manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
