### PR TITLE
fix(bridge): centralize Solana/CAIP address normalization for bridge tokens

### DIFF
--- a/app/components/UI/Bridge/hooks/useTokens.ts
+++ b/app/components/UI/Bridge/hooks/useTokens.ts
@@ -2,6 +2,8 @@ import { useTokensWithBalance } from './useTokensWithBalance';
 import { Hex, CaipChainId } from '@metamask/utils';
 import { useTopTokens } from './useTopTokens';
 import { BridgeToken } from '../types';
+import { isSolanaChainId } from '@metamask/bridge-controller';
+import { normalizeToCaipAssetType } from '../utils';
 
 interface UseTokensProps {
   topTokensChainId?: Hex | CaipChainId;
@@ -20,35 +22,50 @@ interface UseTokensProps {
 export function useTokens({
   topTokensChainId,
   balanceChainIds,
-  tokensToExclude
-}: UseTokensProps): { tokens: BridgeToken[], pending: boolean } {
+  tokensToExclude,
+}: UseTokensProps): { tokens: BridgeToken[]; pending: boolean } {
   const tokensWithBalance = useTokensWithBalance({
-    chainIds: balanceChainIds
+    chainIds: balanceChainIds,
   });
 
-  const { topTokens, remainingTokens, pending } = useTopTokens({ chainId: topTokensChainId });
+  const { topTokens, remainingTokens, pending } = useTopTokens({
+    chainId: topTokensChainId,
+  });
 
-  const getTokenKey = (token: { address: string; chainId: Hex | CaipChainId }) => `${token.address}-${token.chainId}`;
+  const getTokenKey = (token: {
+    address: string;
+    chainId: Hex | CaipChainId;
+  }) => {
+    // Use the shared utility for Solana normalization
+    const normalizedAddress = isSolanaChainId(token.chainId)
+      ? normalizeToCaipAssetType(token.address, token.chainId)
+      : token.address;
+    return `${normalizedAddress}-${token.chainId}`;
+  };
 
   // Create Sets for O(1) lookups
   const tokensWithBalanceSet = new Set(
-    tokensWithBalance.map(token => getTokenKey(token))
+    tokensWithBalance.map((token) => getTokenKey(token)),
   );
   const excludedTokensSet = new Set(
-    tokensToExclude?.map(token => getTokenKey(token)) ?? []
+    tokensToExclude?.map((token) => getTokenKey(token)) ?? [],
   );
 
   // Combine and filter tokens in a single pass
-  const tokensWithoutBalance = (topTokens ?? []).concat(remainingTokens ?? []).filter(token => {
-    const tokenKey = getTokenKey(token);
-    return !tokensWithBalanceSet.has(tokenKey);
-  });
+  const tokensWithoutBalance = (topTokens ?? [])
+    .concat(remainingTokens ?? [])
+    .filter((token) => {
+      const tokenKey = getTokenKey(token);
+      return !tokensWithBalanceSet.has(tokenKey);
+    });
 
   // Combine tokens with balance and filtered tokens and filter out excluded tokens
-  const tokens = tokensWithBalance.concat(tokensWithoutBalance).filter(token => {
-    const tokenKey = getTokenKey(token);
-    return !excludedTokensSet.has(tokenKey);
-  });
+  const tokens = tokensWithBalance
+    .concat(tokensWithoutBalance)
+    .filter((token) => {
+      const tokenKey = getTokenKey(token);
+      return !excludedTokensSet.has(tokenKey);
+    });
 
   return { tokens, pending };
 }

--- a/app/components/UI/Bridge/utils/index.test.ts
+++ b/app/components/UI/Bridge/utils/index.test.ts
@@ -1,5 +1,9 @@
 import '../_mocks_/initialState';
-import { isBridgeAllowed, wipeBridgeStatus } from './index';
+import {
+  isBridgeAllowed,
+  wipeBridgeStatus,
+  normalizeToCaipAssetType,
+} from './index';
 import AppConstants from '../../../../core/AppConstants';
 import {
   ARBITRUM_CHAIN_ID,
@@ -30,7 +34,10 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-const mockWipeBridgeStatus = Engine.context.BridgeStatusController.wipeBridgeStatus as jest.MockedFunction<typeof Engine.context.BridgeStatusController.wipeBridgeStatus>;
+const mockWipeBridgeStatus = Engine.context.BridgeStatusController
+  .wipeBridgeStatus as jest.MockedFunction<
+  typeof Engine.context.BridgeStatusController.wipeBridgeStatus
+>;
 
 describe('Bridge Utils', () => {
   beforeEach(() => {
@@ -116,6 +123,35 @@ describe('Bridge Utils', () => {
         address: testAddress,
         ignoreNetwork: false,
       });
+    });
+  });
+
+  describe('normalizeToCaipAssetType', () => {
+    it('should return CAIP format address as-is for Solana', () => {
+      const caipAddress =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const result = normalizeToCaipAssetType(caipAddress, SolScope.Mainnet);
+      expect(result).toBe(caipAddress);
+    });
+
+    it('should convert raw Solana address to CAIP format', () => {
+      const rawAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const result = normalizeToCaipAssetType(rawAddress, SolScope.Mainnet);
+      expect(result).toBe(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      );
+    });
+
+    it('should return EVM address as-is', () => {
+      const evmAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const result = normalizeToCaipAssetType(evmAddress, ETH_CHAIN_ID);
+      expect(result).toBe(evmAddress);
+    });
+
+    it('should handle different EVM chain IDs', () => {
+      const evmAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const result = normalizeToCaipAssetType(evmAddress, POLYGON_CHAIN_ID);
+      expect(result).toBe(evmAddress);
     });
   });
 });

--- a/app/components/UI/Bridge/utils/index.ts
+++ b/app/components/UI/Bridge/utils/index.ts
@@ -1,11 +1,11 @@
 import {
   CaipChainId,
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  SolScope
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  SolScope,
+  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 } from '@metamask/keyring-api';
 import AppConstants from '../../../../core/AppConstants';
-import { Hex } from '@metamask/utils';
+import { Hex, isCaipAssetType } from '@metamask/utils';
 import {
   ARBITRUM_CHAIN_ID,
   AVALANCHE_CHAIN_ID,
@@ -44,8 +44,10 @@ export const isBridgeAllowed = (chainId: Hex | CaipChainId) => {
   return ALLOWED_CHAIN_IDS.includes(chainId);
 };
 
-
-export const wipeBridgeStatus = (address: string, chainId: Hex | CaipChainId) => {
+export const wipeBridgeStatus = (
+  address: string,
+  chainId: Hex | CaipChainId,
+) => {
   Engine.context.BridgeStatusController.wipeBridgeStatus({
     address,
     ignoreNetwork: false,
@@ -58,3 +60,23 @@ export const wipeBridgeStatus = (address: string, chainId: Hex | CaipChainId) =>
     });
   }
 };
+
+/**
+ * Normalizes a token address to CAIP format for non-EVM chains (e.g., Solana).
+ * If the address is already in CAIP format, returns it as-is.
+ * Otherwise, converts it to CAIP format using the provided chainId.
+ * For EVM chains, returns the address as-is.
+ */
+export function normalizeToCaipAssetType(
+  address: string,
+  chainId: Hex | CaipChainId,
+): string {
+  if (isSolanaChainId(chainId)) {
+    if (isCaipAssetType(address)) {
+      return address;
+    }
+    return `${chainId}/token:${address}`;
+  }
+  // For EVM, just return the address
+  return address;
+}

--- a/docs/readme/testing.md
+++ b/docs/readme/testing.md
@@ -403,6 +403,8 @@ Our CI/CD process is automated through various Bitrise pipelines, each designed 
   - **Faster Feedback**: Running a subset of tests on PRs provides quicker feedback, ensuring critical functionalities are validated without the overhead of executing all tests.
   - **Efficient Resource Use**: Limits resource consumption and test execution time, optimizing CI/CD pipeline performance.
 
-### Best Practices
+### Framework Documentation
 
-For more guidelines and best practices, refer to our [Best Practices Document](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/e2e-testing.md).
+For detailed E2E framework documentation, patterns, and best practices, see:
+- **[E2E Framework Guide](../../e2e/framework/README.md)** - Comprehensive guide to the TypeScript testing framework
+- **[General E2E Best Practices](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/e2e-testing.md)** - MetaMask-wide testing guidelines

--- a/e2e/framework/Assertions.ts
+++ b/e2e/framework/Assertions.ts
@@ -1,0 +1,622 @@
+import { waitFor } from 'detox';
+import Utilities, { BASE_DEFAULTS } from './Utilities';
+import { AssertionOptions } from './types';
+import Matchers from './Matchers';
+
+/**
+ * Assertions with auto-retry and better error messages
+ */
+export default class Assertions {
+  /**
+   * Assert element is visible with auto-retry
+   */
+  static async expectVisible(
+    detoxElement: DetoxElement | WebElement,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      description = 'element should be visible',
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = await detoxElement;
+        const isWebElement = Utilities.isWebElement(el);
+        if (isWebElement) {
+          // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+          await (expect(el) as any).toExist();
+        } else if (device.getPlatform() === 'ios') {
+          await waitFor(el).toExist().withTimeout(100);
+        } else {
+          await waitFor(el).toBeVisible().withTimeout(100);
+        }
+      },
+      {
+        timeout,
+        description: `Assert ${description}`,
+      },
+    );
+  }
+
+  /**
+   * Assert element is not visible with auto-retry
+   */
+  static async expectNotVisible(
+    detoxElement: DetoxElement | WebElement,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      description = 'element should not visible',
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = await detoxElement;
+        const isWebElement = Utilities.isWebElement(el);
+        if (isWebElement) {
+          // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+          await (expect(el) as any).not.toExist();
+        } else {
+          await waitFor(el).not.toBeVisible().withTimeout(100);
+        }
+      },
+      {
+        timeout,
+        description: `Assert ${description}`,
+      },
+    );
+  }
+
+  /**
+   * Assert element has specific text with auto-retry
+   */
+  static async expectText(
+    detoxElement: DetoxElement,
+    text: string,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      description = `element has text "${text}"`,
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).toHaveText(text).withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Assert ${description}`,
+      },
+    );
+  }
+
+  /**
+   * Assert element does not have specific text with auto-retry
+   */
+  static async expectNotToHaveText(
+    detoxElement: DetoxElement,
+    text: string,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      description = `element has text "${text}"`,
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).not.toHaveText(text).withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Assert ${description}`,
+      },
+    );
+  }
+
+  /**
+   * Assert element has specific label with auto-retry
+   */
+  static async expectLabel(
+    detoxElement: DetoxElement,
+    label: string,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      description = `element has label "${label}"`,
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).toHaveLabel(label).withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Assert ${description}`,
+      },
+    );
+  }
+
+  /**
+   * Assert text is displayed anywhere on screen with auto-retry
+   */
+  static async expectTextDisplayed(
+    text: string,
+    options: AssertionOptions & { allowDuplicates?: boolean } = {},
+  ): Promise<void> {
+    const { timeout = BASE_DEFAULTS.timeout, allowDuplicates = false } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const textElement = allowDuplicates
+          ? (await Matchers.getElementByText(text)).atIndex(0)
+          : await Matchers.getElementByText(text);
+        if (device.getPlatform() === 'ios') {
+          await waitFor(textElement).toExist().withTimeout(100);
+        } else {
+          await waitFor(textElement).toBeVisible().withTimeout(100);
+        }
+      },
+      {
+        timeout,
+        description: `Assert text "${text}" is displayed${allowDuplicates ? ' (allowing duplicates)' : ''}`,
+      },
+    );
+  }
+
+    /**
+   * Assert text is not displayed anywhere on screen with auto-retry
+   */
+  static async expectTextNotDisplayed(
+    text: string,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const { timeout = BASE_DEFAULTS.timeout } = options;
+    return Utilities.executeWithRetry(
+      async () => {
+        const textElement = await Matchers.getElementByText(text);
+        if (device.getPlatform() === 'ios') {
+          await waitFor(textElement).not.toExist().withTimeout(100);
+        } else {
+          await waitFor(textElement).not.toBeVisible().withTimeout(100);
+        }
+      },
+      {
+        timeout,
+        description: `expectTextNotDisplayed("${text}")`,
+      },
+    );
+  }
+
+  /**
+   * Assert toggle state with auto-retry
+   */
+  static async expectToggleState(
+    detoxElement: DetoxElement,
+    expectedState: 'on' | 'off' | boolean,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const { timeout = BASE_DEFAULTS.timeout } = options;
+
+    const expectedStateBoolean =
+      expectedState === 'on' || expectedState === true;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        const attributes = await el.getAttributes();
+        const isToggled =
+          ('text' in attributes && attributes.text === 'true') ||
+          ('label' in attributes && attributes.label === 'true') ||
+          ('value' in attributes && attributes.value === 'true');
+        if (isToggled !== expectedStateBoolean) {
+          throw new Error(
+            [
+              '🔄 Toggle state mismatch detected',
+              `   Expected: ${expectedStateBoolean ? 'on' : 'off'}`,
+              `   Actual:   ${isToggled}`,
+            ].join('\n'),
+          );
+        }
+      },
+      {
+        timeout,
+        description: `Assert toggle is ${expectedState ? 'on' : 'off'}`,
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Check if an element is visible (backwards compatibility)
+   * @deprecated Use expectVisible() instead for better error handling and retry mechanisms
+   */
+  static async checkIfVisible(
+    detoxElement: DetoxElement,
+    timeout = 15000,
+  ): Promise<void> {
+    return this.expectVisible(detoxElement, { timeout });
+  }
+
+  /**
+   * Legacy method: Check if a web element exists
+   * @deprecated Use expectVisible() instead for better error handling and retry mechanisms
+   */
+  static async webViewElementExists(
+    detoxElement: DetoxElement,
+  ): Promise<void> {
+    // For web elements, just use the basic expect assertion
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    // Use Detox's expect which has toExist method
+    // Use Detox's expect syntax for element existence
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
+    await (expect(el) as any).toExist();
+  }
+
+  /**
+   * Legacy method: Check if an element is not visible
+   * @deprecated Use expectNotVisible() instead for better error handling and retry mechanisms
+   */
+  static async checkIfNotVisible(
+    detoxElement: DetoxElement,
+    timeout = 15000,
+  ): Promise<void> {
+    return this.expectNotVisible(detoxElement as DetoxElement, { timeout });
+  }
+
+  /**
+   * Legacy method: Check if an element has specific text
+   * @deprecated Use expectText() instead for better error handling and retry mechanisms
+   */
+  static async checkIfElementToHaveText(
+    detoxElement: DetoxElement,
+    text: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return this.expectText(detoxElement as DetoxElement, text, { timeout });
+  }
+
+  /**
+   * Legacy method: Check if an element has specific label
+   * @deprecated Use expectLabel() instead for better error handling and retry mechanisms
+   */
+  static async checkIfElementHasLabel(
+    detoxElement: DetoxElement,
+    label: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return this.expectLabel(detoxElement, label, { timeout });
+  }
+
+  /**
+   * Legacy method: Check if text is displayed anywhere on screen
+   * @deprecated Use expectTextNotDisplayed() instead for better error handling and retry mechanisms
+   */
+  static async checkIfTextIsDisplayed(
+    text: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return this.expectTextDisplayed(text, { timeout });
+  }
+
+  /**
+   * Legacy method: Check if text is not displayed
+   * @deprecated Use expectNotVisible() or custom assertion instead for better error handling and retry mechanisms
+   */
+  static async checkIfTextIsNotDisplayed(
+    text: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const textElement = await Matchers.getElementByText(text);
+        await waitFor(textElement).not.toBeVisible().withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Text "${text}" is not displayed`,
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Check if an element does not have specific text
+   * @deprecated Use expectNotToHaveText() or custom assertion instead for better error handling and retry mechanisms
+   */
+  static async checkIfElementNotToHaveText(
+    detoxElement: DetoxElement,
+    text: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).not.toHaveText(text).withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Element does not have text "${text}"`,
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Check if an element does not have specific label
+   * @deprecated Use expectNotVisible() or custom assertion instead for better error handling and retry mechanisms
+   */
+  static async checkIfElementDoesNotHaveLabel(
+    detoxElement: DetoxElement,
+    label: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).not.toHaveLabel(label).withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Element does not have label "${label}"`,
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Check if toggle is in "on" state
+   * @deprecated Use expectToggleState() instead for better error handling and retry mechanisms
+   */
+  static async checkIfToggleIsOn(detoxElement: DetoxElement): Promise<void> {
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    // Use Detox's expect syntax for toggle values
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
+    await (expect(el) as any).toHaveToggleValue(true);
+  }
+
+  /**
+   * Legacy method: Check if toggle is in "off" state
+   * @deprecated Use expectToggleState() instead for better error handling and retry mechanisms
+   */
+  static async checkIfToggleIsOff(detoxElement: DetoxElement): Promise<void> {
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    // Use Detox's expect syntax for toggle values
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
+    await (expect(el) as any).toHaveToggleValue(false);
+  }
+
+  static async checkIfTextMatches(
+    actualText: string,
+    expectedText: string,
+  ): Promise<void> {
+    try {
+      if (!actualText || !expectedText) {
+        throw new Error('Both actual and expected text must be provided');
+      }
+
+      return expect(actualText).toBe(expectedText);
+    } catch (error) {
+      if (actualText !== expectedText) {
+        throw new Error(
+          `Text matching failed.\nExpected: "${expectedText}"\nActual: "${actualText}"`,
+        );
+      }
+    }
+  }
+
+  static async checkIfObjectsMatch(
+    actualObject: object,
+    expectedObject: object,
+  ): Promise<void> {
+    try {
+      if (!actualObject || !expectedObject) {
+        throw new Error('Both actual and expected objects must be provided');
+      }
+
+      return expect(actualObject).toEqual(expectedObject);
+    } catch (error) {
+      if (JSON.stringify(actualObject) !== JSON.stringify(expectedObject)) {
+        throw new Error(
+          `Object matching failed.\nExpected: ${JSON.stringify(
+            expectedObject,
+            null,
+            2,
+          )}\nActual: ${JSON.stringify(actualObject, null, 2)}`,
+        );
+      }
+    }
+  }
+
+  static async checkIfArrayHasLength(
+    array: unknown[],
+    expectedLength: number,
+  ): Promise<void> {
+    try {
+      if (!Array.isArray(array)) {
+        throw new Error('The provided value is not an array');
+      }
+
+      if (typeof expectedLength !== 'number') {
+        throw new Error('Expected length must be a number');
+      }
+
+      return expect(array.length).toBe(expectedLength);
+    } catch (error) {
+      if (array.length !== expectedLength) {
+        throw new Error(
+          `Array length assertion failed.\nExpected length: ${expectedLength}\nActual length: ${array.length}`,
+        );
+      }
+    }
+  }
+
+  static async checkIfValueIsDefined(value: unknown): Promise<void> {
+    // 0 evaluates to false, so we need to handle it separately
+    if (typeof value === 'number') {
+      return;
+    }
+
+    if (!value) {
+      throw new Error('Value is not present (falsy value)');
+    }
+  }
+
+  static async checkIfObjectContains(
+    actual: Record<string, unknown>,
+    partial: Record<string, unknown>,
+    deep = true,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const errors: string[] = [];
+
+      function check(
+        actualObj: Record<string, unknown>,
+        partialObj: Record<string, unknown>,
+        path = '',
+      ) {
+        if (
+          typeof actualObj !== 'object' ||
+          typeof partialObj !== 'object' ||
+          actualObj === null ||
+          partialObj === null
+        ) {
+          if (actualObj !== partialObj) {
+            errors.push(
+              `Value mismatch at "${path || 'root'}": expected ${JSON.stringify(
+                partialObj,
+              )}, got ${JSON.stringify(actualObj)}`,
+            );
+          }
+          return;
+        }
+
+        for (const key in partialObj) {
+          const currentPath = path ? `${path}.${key}` : key;
+          if (!Object.prototype.hasOwnProperty.call(actualObj, key)) {
+            errors.push(`Missing key at "${currentPath}" in actual object`);
+            continue;
+          }
+
+          if (
+            deep &&
+            typeof partialObj[key] === 'object' &&
+            partialObj[key] !== null
+          ) {
+            check(
+              actualObj[key] as Record<string, unknown>,
+              partialObj[key] as Record<string, unknown>,
+              currentPath,
+            );
+          } else if (actualObj[key] !== partialObj[key]) {
+            errors.push(
+              `Value mismatch at "${currentPath}": expected ${JSON.stringify(
+                partialObj[key],
+              )}, got ${JSON.stringify(actualObj[key])}`,
+            );
+          }
+        }
+      }
+
+      check(actual, partial);
+
+      if (errors.length > 0) {
+        reject(
+          new Error('Object contains assertion failed:\n' + errors.join('\n')),
+        );
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  /**
+   * Legacy method: Check if element is enabled
+   * @deprecated Use Utilities.waitForElementToBeEnabled() instead for better retry handling
+   */
+  static async checkIfEnabled(detoxElement: DetoxElement): Promise<boolean> {
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    const attributes = await el.getAttributes();
+    return 'enabled' in attributes ? !!attributes.enabled : false;
+  }
+
+  /**
+   * Legacy method: Check if element is disabled
+   * @deprecated Use Utilities.waitForElementToBeEnabled() with negated logic instead
+   */
+  static async checkIfDisabled(detoxElement: DetoxElement): Promise<boolean> {
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    const attributes = await el.getAttributes();
+    return 'enabled' in attributes ? !attributes.enabled : true;
+  }
+
+  /**
+   * Legacy method: Check if label contains text
+   * @deprecated Use expectLabel() with regex pattern instead for better error handling and retry mechanisms
+   */
+  static async checkIfLabelContainsText(
+    text: string,
+    timeout = 15000,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const labelMatcher = element(by.label(new RegExp(text)));
+        await waitFor(labelMatcher).toExist().withTimeout(100);
+      },
+      {
+        timeout,
+        description: `Label contains text "${text}"`,
+      },
+    );
+  }
+
+  /**
+   * Checks if the actual object contains all keys from the expected array
+   * @param actual - The object to check against
+   * @param validations - Object with keys and their expected values
+   */
+  static async checkIfObjectHasKeysAndValidValues(
+    actual: Record<string, unknown>,
+    validations: Record<string, string | ((value: unknown) => boolean)>,
+  ): Promise<void> {
+    const errors: string[] = [];
+
+    for (const [key, validation] of Object.entries(validations)) {
+      if (!Object.prototype.hasOwnProperty.call(actual, key)) {
+        errors.push(`Missing key: ${key}`);
+        continue;
+      }
+
+      const value = actual[key];
+
+      if (typeof validation === 'string') {
+        const actualType = typeof value;
+
+        if (Array.isArray(value) && validation === 'array') continue;
+        if (value === null && validation === 'null') continue;
+
+        // Check type
+        if (actualType !== validation && !(Array.isArray(value) && validation === 'array')) {
+          errors.push(`Type mismatch for key "${key}": expected "${validation}", got "${actualType}"`);
+        }
+      }
+      else if (typeof validation === 'function') {
+        try {
+          const valid = validation(value);
+          if (!valid) {
+            errors.push(`Validation failed for key "${key}": custom validator returned false`);
+          }
+        } catch (err) {
+          errors.push(`Validation error for key "${key}": ${(err as Error).message}`);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error('Object validation failed:\n' + errors.join('\n'));
+    }
+  }
+}

--- a/e2e/framework/Gestures.ts
+++ b/e2e/framework/Gestures.ts
@@ -1,0 +1,502 @@
+/* eslint-disable no-console */
+/* eslint-disable no-restricted-syntax */
+import { waitFor } from 'detox';
+import Utilities, { BASE_DEFAULTS } from './Utilities';
+import {
+  LongPressOptions,
+  TapOptions,
+  SwipeOptions,
+  ScrollOptions,
+  GestureOptions,
+  TypeTextOptions,
+} from './types';
+
+/**
+ * Gestures class with element stability and auto-retry
+ */
+export default class Gestures {
+  /**
+   * Tap an element with stability checking (internal method)
+   * @param detoxElement - The Detox element to tap
+   * @param options - Options for the tap action
+   */
+  private static tapWithChecks = async (
+    detoxElement: DetoxElement,
+    options: {
+      checkStability?: boolean;
+      checkVisibility?: boolean;
+      checkEnabled?: boolean;
+      elemDescription?: string;
+    },
+    point?: { x: number; y: number },
+  ) => {
+    const {
+      checkStability = false,
+      checkVisibility = true,
+      checkEnabled = true,
+      elemDescription,
+    } = options;
+
+    if (Utilities.isWebElement(await detoxElement)) {
+        // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+        await (expect(await detoxElement) as any).toExist();
+        await (await detoxElement).tap();
+        return;
+    }
+
+    const el = await Utilities.checkElementReadyState(detoxElement, {
+      checkStability,
+      checkVisibility,
+      checkEnabled,
+    });
+
+    await el.tap(point);
+    const successMessage = elemDescription
+      ? `✅ Successfully tapped element: ${elemDescription}`
+      : `✅ Successfully tapped element`;
+    console.log(successMessage);
+  };
+
+  /**
+   * Tap an element with stability checking and auto-retry
+   */
+  static async tap(
+    detoxElement: DetoxElement,
+    options: TapOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      checkStability = false,
+      checkVisibility = true,
+      checkEnabled = true,
+      elemDescription
+    } = options;
+
+    const fn = () => this.tapWithChecks(detoxElement, {
+      checkStability,
+      checkVisibility,
+      checkEnabled,
+      elemDescription
+    });
+    return Utilities.executeWithRetry(fn, {
+      timeout,
+      description: 'tap()',
+      elemDescription,
+    });
+  }
+
+  /**
+   * Wait for an element to be visible and then tap it with enhanced options
+   * This is the same as tap() - keeping it for backwards compatibility
+   */
+  static async waitAndTap(
+    detoxElement: DetoxElement,
+    options: TapOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      checkStability = false,
+      checkVisibility = true,
+      checkEnabled = true,
+      elemDescription
+    } = options;
+
+    const fn = () => this.tapWithChecks(detoxElement, {
+      checkStability,
+      checkVisibility,
+      checkEnabled,
+      elemDescription
+    });
+    return Utilities.executeWithRetry(fn, {
+      timeout,
+      description: 'waitAndTap()',
+      elemDescription,
+    });
+  }
+
+  /**
+   * Tap an element at specific point with stability checking
+   */
+  static async tapAtPoint(
+    detoxElement: DetoxElement,
+    point: { x: number; y: number },
+    options: TapOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      checkStability = false,
+      checkVisibility = true,
+      checkEnabled = true,
+      elemDescription
+    } = options;
+    const fn = () => this.tapWithChecks(detoxElement, {
+      checkStability,
+      checkVisibility,
+      checkEnabled,
+      elemDescription
+    }, point);
+    return Utilities.executeWithRetry(fn, {
+      timeout,
+      description: 'tapAtPoint()',
+      elemDescription,
+    });
+  }
+
+  /**
+   * Long press with stability checking
+   */
+  static async longPress(
+    detoxElement: DetoxElement,
+    options: LongPressOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      checkStability = false,
+      checkEnabled = true,
+      checkVisibility = true,
+      duration = 2000,
+      elemDescription
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await Utilities.checkElementReadyState(
+          detoxElement,
+          {
+            timeout,
+            checkStability,
+            checkEnabled,
+            checkVisibility,
+          },
+        )) as Detox.IndexableNativeElement;
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, BASE_DEFAULTS.actionDelay),
+        );
+        await el.longPress(duration);
+      },
+      {
+        timeout,
+        description: `longPress() for ${duration}ms`,
+        elemDescription,
+      },
+    );
+  }
+
+  /**
+   * Type text with automatic field clearing and retry
+   */
+  static async typeText(
+    detoxElement: DetoxElement,
+    text: string,
+    options: TypeTextOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      clearFirst = true,
+      hideKeyboard = false,
+      checkStability = false,
+      checkEnabled = true,
+      checkVisibility = true,
+      sensitive = false,
+      elemDescription
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await Utilities.checkElementReadyState(
+          detoxElement,
+          {
+            timeout,
+            checkStability,
+            checkVisibility,
+            checkEnabled,
+          },
+        )) as Detox.IndexableNativeElement;
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, BASE_DEFAULTS.actionDelay),
+        );
+
+        if (clearFirst) {
+          await el.replaceText('');
+        }
+
+        const textToType = hideKeyboard ? text + '\n' : text;
+        await el.typeText(textToType);
+
+        console.log(`✅ Successfully typed: "${sensitive ? '***' : text}" into element: ${elemDescription || 'unknown'}`);
+      },
+      {
+        timeout,
+        description: `typeText("${text}")`,
+        elemDescription,
+      },
+    );
+  }
+
+  /**
+   * Replace text in field with retry
+   */
+  static async replaceText(
+    detoxElement: DetoxElement,
+    text: string,
+    options: GestureOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      checkStability = false,
+      checkEnabled = true,
+      checkVisibility = true,
+      elemDescription
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await Utilities.checkElementReadyState(
+          detoxElement,
+          {
+            timeout,
+            checkStability,
+            checkEnabled,
+            checkVisibility,
+          },
+        )) as Detox.IndexableNativeElement;
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, BASE_DEFAULTS.actionDelay),
+        );
+        await el.replaceText(text);
+      },
+      {
+        timeout,
+        description: `replaceText("${text}")`,
+        elemDescription,
+      },
+    );
+  }
+
+  /**
+   * Swipe with element readiness checking
+   */
+  static async swipe(
+    detoxElement: DetoxElement,
+    direction: 'up' | 'down' | 'left' | 'right',
+    options: SwipeOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      speed = 'fast',
+      percentage = 0.75,
+      checkStability = false,
+      checkEnabled = true,
+      checkVisibility = true,
+      elemDescription
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await Utilities.checkElementReadyState(
+          detoxElement,
+          {
+            timeout,
+            checkStability,
+            checkEnabled,
+            checkVisibility,
+          },
+        )) as Detox.IndexableNativeElement;
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, BASE_DEFAULTS.actionDelay),
+        );
+        await el.swipe(direction, speed, percentage);
+      },
+      {
+        timeout,
+        description: `swipe(${direction})`,
+        elemDescription,
+      },
+    );
+  }
+
+  /**
+   * Scroll to element with dynamic retry
+   */
+  static async scrollToElement(
+    targetElement: DetoxElement,
+    scrollableContainer: Promise<Detox.NativeMatcher>,
+    options: ScrollOptions = {},
+  ): Promise<void> {
+    const {
+      timeout = BASE_DEFAULTS.timeout,
+      direction = 'down',
+      scrollAmount = 350,
+      elemDescription,
+    } = options;
+
+    return Utilities.executeWithRetry(
+      async () => {
+        const target = (await targetElement) as Detox.IndexableNativeElement;
+        const scrollable = (await scrollableContainer); // This is only working when it's awaited
+        await waitFor(target)
+          .toBeVisible()
+          .whileElement(scrollable)
+          .scroll(scrollAmount, direction);
+      },
+      {
+        timeout,
+        description: `scrollToElement(${direction})`,
+        elemDescription,
+      },
+    );
+  }
+
+  // Legacy methods for backwards compatibility
+
+  /**
+   * Legacy method: Tap and long press
+   * @deprecated Use longPress() instead for better error handling and retry mechanisms
+   */
+  static async tapAndLongPress(
+    detoxElement: DetoxElement,
+    timeout = 2000,
+  ): Promise<void> {
+    return this.longPress(detoxElement, { duration: timeout });
+  }
+
+  /**
+   * Legacy method: Tap element at a specific index
+   * @deprecated Use tap() with element.atIndex() instead for better error handling and retry mechanisms
+   */
+  static async tapAtIndex(
+    detoxElement: DetoxElement,
+    index: number,
+    timeout = 15000,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        const itemElementAtIndex = el.atIndex(index);
+        await waitFor(itemElementAtIndex).toBeVisible().withTimeout(timeout);
+        await itemElementAtIndex.tap();
+      },
+      {
+        timeout,
+        description: `Tapped element at index ${index}`,
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Tap web element
+   * @deprecated Use tap() with web elements instead for better error handling and retry mechanisms
+   */
+  static async tapWebElement(
+    detoxElement: Promise<Detox.IndexableWebElement>,
+    timeout = 15000,
+  ): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
+        await (expect(await detoxElement) as any).toExist();
+        await (await detoxElement).tap();
+        return;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    throw new Error('Web element not found or not tappable');
+  }
+
+  /**
+   * Legacy method: Double tap an element
+   * @deprecated Use tap() with multiTap(2) instead for better error handling and retry mechanisms
+   */
+  static async doubleTap(detoxElement: DetoxElement): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await el.multiTap(2);
+      },
+      {
+        description: 'Double tapped element',
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Clear the text field
+   * @deprecated Use typeText() with clearFirst option instead for better error handling and retry mechanisms
+   */
+  static async clearField(
+    detoxElement: DetoxElement,
+    timeout = 2500,
+  ): Promise<void> {
+    return Utilities.executeWithRetry(
+      async () => {
+        const el = (await detoxElement) as Detox.IndexableNativeElement;
+        await waitFor(el).toBeVisible().withTimeout(timeout);
+        await el.replaceText('');
+      },
+      {
+        timeout,
+        description: 'Cleared field',
+      },
+    );
+  }
+
+  /**
+   * Legacy method: Type text and hide keyboard
+   * @deprecated Use typeText() with hideKeyboard option instead for better error handling and retry mechanisms
+   */
+  static async typeTextAndHideKeyboard(
+    detoxElement: DetoxElement,
+    text: string,
+  ): Promise<void> {
+    return this.typeText(detoxElement, text, {
+      clearFirst: true,
+      hideKeyboard: true,
+    });
+  }
+
+  /**
+   * Legacy method: Type text without hiding keyboard
+   * @deprecated Use typeText() with hideKeyboard: false option instead for better error handling and retry mechanisms
+   */
+  static async typeTextWithoutKeyboard(
+    detoxElement: DetoxElement,
+    text: string,
+  ): Promise<void> {
+    return this.typeText(detoxElement, text, {
+      clearFirst: false,
+      hideKeyboard: false,
+    });
+  }
+
+  /**
+   * Legacy method: Replace text in field
+   * @deprecated Use replaceText() instead for better error handling and retry mechanisms
+   */
+  static async replaceTextInField(
+    detoxElement: DetoxElement,
+    text: string,
+    timeout = 10000,
+  ): Promise<void> {
+    return this.replaceText(detoxElement, text, { timeout });
+  }
+
+  static async scrollToWebViewPort(
+    detoxElement: WebElement,
+  ): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        await (await detoxElement).scrollToView();
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'scrollToWebViewPort()',
+      }
+    );
+  }
+}

--- a/e2e/framework/Matchers.ts
+++ b/e2e/framework/Matchers.ts
@@ -1,0 +1,162 @@
+import { web, system } from 'detox';
+
+/**
+ * Utility class for matching (locating) UI elements
+ */
+export default class Matchers {
+  /**
+   * Get element by ID with optional index
+   */
+  static async getElementByID(
+    elementId: string | RegExp,
+    index?: number,
+  ): Promise<Detox.IndexableNativeElement> {
+    const el = element(by.id(elementId));
+    if (index !== undefined) {
+      return el.atIndex(index) as Detox.IndexableNativeElement;
+    }
+    return el as Detox.IndexableNativeElement;
+  }
+
+  /**
+   * Get element by text with optional index
+   */
+  static async getElementByText(
+    text: string,
+    index = 0,
+  ): Promise<Detox.IndexableNativeElement> {
+    return element(by.text(text)).atIndex(
+      index,
+    ) as Detox.IndexableNativeElement;
+  }
+
+  /**
+   * Get element that matches by id and label
+   * This strategy matches elements by combining 2 matchers together.
+   * Elements returned match the provided ID and Label at the same time.
+   */
+  static async getElementByIDAndLabel(
+    id: string,
+    label: string | RegExp,
+    index = 0,
+  ): Promise<Detox.IndexableNativeElement> {
+    return element(by.id(id).and(by.label(label))).atIndex(
+      index,
+    ) as Detox.IndexableNativeElement;
+  }
+
+  /**
+   * Get element by label (accessibility label on iOS, content description on Android)
+   */
+  static async getElementByLabel(
+    label: string,
+    index = 0,
+  ): Promise<Detox.IndexableNativeElement> {
+    return element(by.label(label)).atIndex(
+      index,
+    ) as Detox.IndexableNativeElement;
+  }
+
+  /**
+   * Get element by descendant relationship
+   */
+  static async getElementByDescendant(
+    parentElement: string,
+    childElement: string,
+  ): Promise<Detox.IndexableNativeElement> {
+    return element(by.id(parentElement).withDescendant(by.id(childElement)));
+  }
+
+  /**
+   * Get element with ancestor relationship
+   */
+  static async getElementIDWithAncestor(
+    childElement: string,
+    parentElement: string,
+  ): Promise<Detox.IndexableNativeElement> {
+    return element(by.id(childElement).withAncestor(by.id(parentElement)));
+  }
+
+  /**
+   * Get Native WebView instance by elementId
+   * Because Android Webview might have more that one WebView instance present on the main activity,
+   * the correct element is selected based on its parent element id.
+   */
+  static getWebViewByID(elementId: string): Detox.WebViewElement {
+    if (process.env.CI) {
+      return device.getPlatform() === 'ios'
+        ? web(by.id(elementId))
+        : web(by.type('android.webkit.WebView').withAncestor(by.id(elementId)));
+    }
+    return web(by.id(elementId));
+  }
+
+  /**
+   * Get element by web ID within a webview
+   */
+  static async getElementByWebID(
+    webviewID: string,
+    innerID: string,
+  ): WebElement {
+    const myWebView = this.getWebViewByID(webviewID);
+    return myWebView.element(by.web.id(innerID));
+  }
+
+  /**
+   * Get element by CSS selector within a webview
+   */
+  static async getElementByCSS(
+    webviewID: string,
+    selector: string,
+  ): Promise<Detox.IndexableWebElement> {
+    const myWebView = this.getWebViewByID(webviewID);
+    return myWebView
+      .element(by.web.cssSelector(selector))
+      .atIndex(0) as unknown as Detox.IndexableWebElement;
+  }
+
+  /**
+   * Get element by XPath within a webview
+   */
+  static async getElementByXPath(
+    webviewID: string,
+    xpath: string,
+  ): Promise<Detox.IndexableWebElement | Detox.SecuredWebElementFacade> {
+    const myWebView = this.getWebViewByID(webviewID);
+    return myWebView.element(by.web.xpath(xpath));
+  }
+
+  /**
+   * Get element by href within a webview
+   */
+  static async getElementByHref(
+    webviewID: string,
+    url: string,
+  ): Promise<Detox.IndexableWebElement> {
+    const myWebView = this.getWebViewByID(webviewID);
+    return myWebView
+      .element(by.web.href(url))
+      .atIndex(0) as unknown as Detox.IndexableWebElement;
+  }
+
+  /**
+   * Creates a Detox matcher for identifying an element by its ID
+   * This method does not create an element but instead generates only a matcher.
+   * The purpose is to create a matcher that can be used for identification purposes,
+   * without performing any actions on the element.
+   */
+  static async getIdentifier(
+    selectorString: string,
+  ): Promise<Detox.NativeMatcher> {
+    return by.id(selectorString);
+  }
+
+  /**
+   * Get system dialogs in the system-level (e.g. permissions, alerts, etc.), by text
+   */
+  static async getSystemElementByText(
+    text: string,
+  ): Promise<Detox.IndexableSystemElement> {
+    return system.element(by.system.label(text));
+  }
+}

--- a/e2e/framework/README.md
+++ b/e2e/framework/README.md
@@ -1,0 +1,539 @@
+# 🚧 Migration Notice (Still In Progress)
+
+**TypeScript Framework Utils is NOT YET READY**: The updated TypeScript framework is still in progress.
+
+- **Current Framework Utils**: `/e2e/utils/` (JavaScript - existing tests)
+- **New Framework Utils**: `/e2e/framework/` (TypeScript - new tests and migrations)
+
+**Migration Status**: 
+- ⏳ Phase 0: TypeScript framework foundation
+- ⏳ Phase 1: ESLint for E2E tests
+- ⏳ Phase 2: Legacy framework replacement
+- ⏳ Phase 3: Gradual test migration
+
+---
+
+# 🚨 **USAGE NOTICE** 🚨
+
+## **Continue using the current JS framework utilities for new tests. We'll transition to this new approach once it's fully validated.**
+> ⏰ **IMPORTANT:** Stick with existing testing tools until this implementation is proven stable
+
+```typescript
+// New framework usage
+import { Assertions, Gestures, Matchers } from '../framework';
+
+await Assertions.expectVisible(element, { description: 'element should be visible' });
+await Gestures.tap(element, { description: 'tap element' });
+```
+
+# MetaMask Mobile E2E Testing Framework
+
+This directory contains the End-to-End (E2E) testing framework for MetaMask Mobile, built with Detox and enhanced with TypeScript for better reliability and developer experience.
+
+## 🚀 Quick Start
+
+### Prerequisites
+- Node.js and Yarn installed
+- iOS Simulator or Android Emulator set up
+- MetaMask Mobile development environment configured
+- **📖 [Testing Setup Guide](../../docs/readme/testing.md)** - Essential reading for:
+  - Local environment setup and configuration
+  - Test wallet setup with testnet/mainnet access
+  - Environment variables configuration (`.e2e.env`, `.js.env`)
+  - Device setup instructions (iPhone 15 Pro, Pixel 5 API 34)
+  - Building apps locally vs using prebuilt apps from Runway
+  - Bitrise CI/CD pipeline information
+  - Appium testing setup and BrowserStack configuration
+
+### Running Tests
+```bash
+# Setup E2E dependencies
+yarn setup:e2e
+
+# iOS Tests
+yarn test:e2e:ios:debug:build    # Build iOS app for testing
+yarn test:e2e:ios:debug:run      # Run all iOS tests
+
+# Android Tests  
+yarn test:e2e:android:debug:build    # Build Android app for testing
+yarn test:e2e:android:debug:run      # Run all Android tests
+
+# Run specific test
+yarn test:e2e:ios:debug:run e2e/specs/onboarding/create-wallet.spec.js
+
+# Run tests by tag
+yarn test:e2e:ios:debug:run --testNamePattern="Smoke"
+```
+
+## 📁 Directory Structure
+
+```
+e2e/
+├── FRAMEWORK.md                 # This file - framework overview
+├── specs/                      # All test files organized by feature
+│   ├── onboarding/             # Onboarding flow tests
+│   ├── wallet/                 # Wallet functionality tests
+│   ├── swaps/                  # Token swap tests
+│   └── ...                     # Other feature areas
+├── utils/                      # Framework utilities (TypeScript)
+│   ├── Assertions.ts           # Enhanced assertions with auto-retry
+│   ├── Gestures.ts             # Robust user interactions
+│   ├── Matchers.ts             # Type-safe element selectors
+│   ├── Utilities.ts            # Core utilities and configuration
+│   ├── types.ts                # TypeScript type definitions
+│   ├── Assertions.js           # Legacy assertions (⚠️ deprecated - use .ts)
+│   ├── Gestures.js             # Legacy gestures (⚠️ deprecated - use .ts)
+│   ├── Matchers.js             # Legacy matchers (⚠️ deprecated - use .ts)
+│   └── Utilities.js            # Legacy utilities (⚠️ deprecated - use .ts)
+├── ESLINT-RULES.md             # Documentation for ESLint rules and best practices
+├── pages/                      # Page Object classes
+│   ├── BasePage.ts             # Base page with common functionality
+│   ├── onboarding/             # Onboarding-related pages
+│   ├── wallet/                 # Wallet-related pages
+│   └── ...                     # Other page objects
+├── resources/                  # Test data and configuration files
+└── types/                      # TypeScript type definitions
+```
+
+## 🔧 Framework Architecture
+
+### TypeScript Framework (Recommended)
+
+The new TypeScript framework utilities provides enhanced reliability, better error messages, and type safety:
+
+#### Core Classes:
+- **`Assertions.ts`** - Enhanced assertions with auto-retry and detailed error messages
+  - Modern methods: `expectVisible()`, `expectText()`, `expectLabel()`, `expectTextDisplayed()`
+  - Legacy methods marked `@deprecated` - use modern equivalents
+- **`Gestures.ts`** - Robust user interactions with configurable element state checking
+  - Modern methods: `tap()`, `typeText()`, `longPress()`, `swipe()`, `scrollToElement()`
+  - **Element state flags**: `checkVisibility` (default: true), `checkEnabled` (default: true), `checkStability` (default: false)
+  - **Performance optimization**: Stability checking disabled by default for better performance
+  - Legacy methods marked `@deprecated` - use modern equivalents
+- **`Matchers.ts`** - Type-safe element selectors with flexible options
+  - Methods: `getElementByID()`, `getElementByText()`, `getElementByLabel()`, `getWebViewByID()`
+- **`Utilities.ts`** - Core utilities with specialised element state checking
+  - **State checking methods**: `checkElementReadyState()`, `checkElementEnabled()`, `checkElementStable()`
+  - **Retry mechanisms**: `executeWithRetry()`, `waitForElementToBeEnabled()`, `waitForElementToStopMoving()`
+  - **Configuration**: Flexible timeout and retry configuration
+- **`types.ts`** - TypeScript type definitions including `GestureOptions` with element state flags
+
+#### Key Features:
+- ✅ **Auto-retry** - Handles flaky network/UI conditions
+- ✅ **Configurable element state checking** - Control visibility, enabled, and stability checks per interaction
+- ✅ **Performance optimization** - Stability checking disabled by default for better performance
+- ✅ **Better error messages** - Descriptive errors with retry context and timing
+- ✅ **Type safety** - Full TypeScript support with IntelliSense
+- ✅ **Flexible configuration** - Adjustable timeouts, retry intervals, and element state validation
+- ✅ **Backwards compatibility** - Works alongside existing JavaScript framework
+
+#### Basic Usage:
+```typescript
+import Assertions from '../utils/Assertions';
+import Gestures from '../utils/Gestures';
+import Matchers from '../utils/Matchers';
+
+// Configurable element state checking
+const button = Matchers.getElementByID('my-button');
+await Assertions.expectVisible(button, { description: 'button should be visible' });
+
+// Default behavior: checkVisibility=true, checkEnabled=true, checkStability=false
+await Gestures.tap(button, { description: 'tap button' });
+
+// Enable stability checking for animated elements
+await Gestures.tap(animatedButton, { 
+  checkStability: true,
+  description: 'tap animated button' 
+});
+
+// Skip visibility/enabled checks for special cases
+await Gestures.tap(loadingButton, { 
+  checkVisibility: false,
+  checkEnabled: false,
+  description: 'tap loading button' 
+});
+```
+
+### Legacy JavaScript Framework (Backwards Compatible)
+
+The original JavaScript framework continues to work but legacy methods are deprecated:
+
+```javascript
+// ❌ DON'T: Use deprecated methods
+await Assertions.checkIfVisible(element(by.id('my-element')), 15000);
+
+// ✅ DO: Use modern methods instead
+await Assertions.expectVisible(element, { description: 'element should be visible' });
+```
+
+## 📋 Page Object Pattern Best Practices
+
+### Page Object Structure
+```typescript
+class LoginPage {
+  // Getter pattern for elements
+  get emailInput() { return Matchers.getElementByID('email-input'); }
+  get passwordInput() { return Matchers.getElementByID('password-input'); }
+  get loginButton() { return Matchers.getElementByID('login-button'); }
+  
+  // Public methods for actions
+  async login(email: string, password: string): Promise<void> {
+    await Gestures.typeText(this.emailInput, email, { description: 'enter email' });
+    await Gestures.typeText(this.passwordInput, password, { description: 'enter password' });
+    await Gestures.tap(this.loginButton, { description: 'tap login button' });
+  }
+  
+  // Public methods for verifications
+  async verifyLoginError(expectedError: string): Promise<void> {
+    await Assertions.expectTextDisplayed(expectedError, {
+      description: 'login error should be displayed'
+    });
+  }
+}
+
+export default new LoginPage();
+```
+
+### ✅ Page Object Best Practices
+- Use getter pattern for element references (lazy evaluation)
+- Export as singleton instance (`export default new LoginPage()`)
+- Provide public methods for user actions and verifications
+- Use descriptive method names that reflect user intent
+- Include workflow methods for common multi-step actions
+- Add verification methods for page state validation
+
+## 🔧 Configuration
+
+```typescript
+// Per-operation timeout override
+await Assertions.expectVisible(element, {
+  timeout: 30000,
+  description: 'slow loading element'
+});
+```
+
+## 🔍 ESLint Rules and Code Quality
+
+The framework includes custom ESLint rules to automatically warn against anti-patterns and encourage best practices:
+
+- **📖 [ESLint Rules Documentation](./ESLINT-RULES.md)** - Complete guide to the custom linting rules
+- **🚨 Automatic Warnings** for `TestHelpers.delay()`, deprecated methods, and poor patterns
+- **💡 Suggestions** for descriptive error messages and modern framework usage
+- **🔧 Configurable** - Currently warnings, can be upgraded to errors for enforcement
+
+### Quick Examples:
+```javascript
+// ❌ ESLint will warn about these patterns
+await TestHelpers.delay(5000);                    // Use proper waiting instead
+await Assertions.checkIfVisible(element);         // Deprecated method
+await Gestures.tap(button);                       // Missing description
+
+// ✅ ESLint approves these patterns  
+await Assertions.expectVisible(element, { description: 'button should appear' });
+await Gestures.tap(button, { description: 'tap submit button' });
+```
+
+## ✅ E2E Testing Best Practices
+
+### Test Structure Best Practices
+```typescript
+import LoginPage from '../pages/LoginPage';
+
+describe('Feature: User Login', () => {
+  beforeAll(() => {
+    Utilities.configure({ timeout: 20000 });
+  });
+  
+  it('should login successfully with valid credentials', async () => {
+    await LoginPage.login('user@test.com', 'password123');
+    await LoginPage.verifyLoginSuccess();
+  });
+});
+```
+
+### ✅ DO - Follow These Patterns
+- Use modern TypeScript framework with descriptive messages
+- Use Page Object pattern for maintainable tests  
+- Let framework handle element stability and retries
+- Configure appropriate timeouts for operations
+- Handle expected failures gracefully with try/catch
+
+### ❌ DON'T - Avoid These Anti-Patterns  
+- **No arbitrary delays**: Replace `TestHelpers.delay()` with proper waiting
+- **No deprecated methods**: Use modern equivalents (check `@deprecated` tags)
+- **No magic numbers**: Use descriptive constants for timeouts
+- **No repeated selectors**: Define elements once, reuse everywhere
+- **No generic descriptions**: Use specific, helpful error messages
+
+### Migration from Legacy Patterns
+
+| Legacy Pattern | Modern Replacement |
+|----------------|-------------------|
+| `TestHelpers.delay(5000)` | `Assertions.expectVisible(element, {timeout: 5000})` |
+| `checkIfVisible(element, 15000)` | `expectVisible(element, {timeout: 15000, description: '...'})` |
+| `waitFor(element).toBeVisible()` | `expectVisible(element, {description: '...'})` |
+| `element.tap()` | `Gestures.tap(element, {description: '...'})` |
+| `clearField(element); typeText(element, text)` | `typeText(element, text, {clearFirst: true})` |
+| Manual retry loops | `executeWithRetry()` with proper configuration |
+
+### Code Review Checklist
+
+Before submitting E2E tests, ensure:
+
+- [ ] No usage of `TestHelpers.delay()` or `setTimeout()`
+- [ ] No deprecated legacy methods (marked with `@deprecated`)
+- [ ] All assertions have descriptive `description` parameters
+- [ ] All gestures have descriptive `description` parameters
+- [ ] Appropriate timeouts for operations (not magic numbers)
+- [ ] Page Object pattern used for complex interactions
+- [ ] Element selectors defined once and reused
+- [ ] Framework configuration used appropriately
+- [ ] Error handling for expected failure scenarios
+- [ ] Tests work on both iOS and Android platforms
+
+## 🧪 Testing Patterns
+
+## 🔄 Migration from Legacy Framework
+
+The new TypeScript framework is fully backwards compatible. You can:
+
+1. **Start with new tests** - Use TypeScript framework for all new tests
+2. **Gradual migration** - Migrate existing tests one at a time  
+3. **Mixed usage** - Use both frameworks in the same test file
+4. **No breaking changes** - All existing tests continue to work
+
+### Deprecated Legacy Methods
+
+The following legacy methods are marked `@deprecated` and should be replaced:
+
+#### Assertions.ts Legacy Methods:
+- `checkIfVisible()` → Use `expectVisible()`
+- `checkIfTextIsDisplayed()` → Use `expectTextDisplayed()`
+- `checkIfElementToHaveText()` → Use `expectText()`
+- `checkIfElementHasLabel()` → Use `expectLabel()`
+- And many more... (see `@deprecated` tags in code)
+
+#### Gestures.ts Legacy Methods:
+- `tapAndLongPress()` → Use `longPress()`
+- `typeTextAndHideKeyboard()` → Use `typeText({hideKeyboard: true})`
+- `clearField()` → Use `typeText({clearFirst: true})`
+- `tapAtIndex()` → Use `tap()` with `element.atIndex()`
+- And many more... (see `@deprecated` tags in code)
+
+#### Common Anti-Pattern Replacements:
+- `TestHelpers.delay()` → Use proper waiting with `expectVisible()` or similar
+- Manual retry loops → Use `executeWithRetry()` or built-in framework retries
+- Raw Detox assertions → Use framework assertions with descriptions
+
+See the Migration section above for detailed migration instructions.
+
+## 🛠 Framework Development
+
+### Adding New Framework Features
+
+1. **Core utilities** - Add to appropriate class in `utils/`
+2. **Type definitions** - Update TypeScript interfaces
+3. **Documentation** - Add examples to `examples/`
+4. **Tests** - Verify functionality works correctly
+
+### Framework Architecture
+
+```
+utils/Utilities.ts     - Core configuration and helper functions
+utils/Assertions.ts    - Element state verification with retry
+utils/Gestures.ts      - User interactions with stability checking  
+utils/Matchers.ts      - Element selection and identification
+utils/types.ts         - TypeScript type definitions
+```
+
+### Best Practices for Framework Development
+
+- **Type safety** - Use proper TypeScript types
+- **Error messages** - Provide descriptive, actionable error messages
+- **Retry logic** - Handle transient failures gracefully
+- **Documentation** - Include usage examples in README
+- **Backwards compatibility** - Don't break existing functionality
+
+## 🔗 Related Documentation
+
+- **[Main README](../README.md)** - Project overview and setup instructions
+- **[Architecture Overview](../README.md#architecture-overview)** - App architecture details
+- **[Development Commands](../README.md#common-development-commands)** - Build and test commands
+
+## 🤝 Contributing
+
+When adding new tests or modifying the framework:
+
+1. **Use TypeScript framework** for new tests and page objects
+2. **Follow page object pattern** for complex UI interactions
+3. **Include descriptive messages** in all assertions and gestures
+4. **Configure appropriate timeouts** for your test environment
+5. **Add examples** for new framework features
+6. **Test on both iOS and Android** platforms
+7. **Avoid deprecated methods** - Use modern equivalents marked in `@deprecated` tags
+8. **No arbitrary delays** - Replace `TestHelpers.delay()` with proper waiting
+9. **Follow best practices** - See the Best Practices section above
+10. **Code review checklist** - Ensure all items are addressed before submitting
+
+## 📞 Support
+
+For framework questions or issues:
+
+1. Review Best Practices section for common patterns and anti-patterns
+2. Check migration guide above for legacy equivalents
+3. Examine TypeScript types for available options
+4. Look at existing tests for usage patterns
+5. Check `@deprecated` tags in legacy methods for modern replacements
+6. Review the comprehensive examples in this README
+
+The framework is designed to be self-documenting through TypeScript types and comprehensive error messages.
+
+## 🚨 Troubleshooting
+
+### Performance Issues
+
+#### **Element State Checking Configuration**
+- **Default behavior**: `checkVisibility: true`, `checkEnabled: true`, `checkStability: false`
+- **Performance optimization**: Stability checking disabled by default for better performance
+- **When to enable stability**: Complex animations, moving screens, carousel components
+- **When to disable checks**: Loading states, temporarily disabled elements
+- **Examples**:
+  ```typescript
+  // Default: checks visibility + enabled, skips stability
+  await Gestures.tap(button, { description: 'tap button' });
+  
+  // Enable stability for animated elements
+  await Gestures.tap(carouselItem, { 
+    checkStability: true,
+    description: 'tap carousel item'
+  });
+  
+  // Skip checks for loading/processing elements
+  await Gestures.tap(processingButton, { 
+    checkVisibility: false,
+    checkEnabled: false,
+    description: 'tap processing button'
+  });
+  ```
+
+### Retry Mechanism Best Practices
+
+#### **Framework vs Manual Retries**
+- **Use framework retries**: `Gestures.tap()`, `Assertions.expectVisible()` have built-in retries
+- **Avoid manual retries**: Don't wrap framework methods in additional retry loops
+- **Example**:
+  ```typescript
+  // ❌ DON'T: Manual retry around framework method
+  let attempts = 0;
+  while (attempts < 5) {
+    try {
+      await Gestures.tap(button); // Already has retry logic
+      break;
+    } catch {
+      attempts++;
+    }
+  }
+  
+  // ✅ DO: Use framework retry with proper configuration
+  await Gestures.tap(button, { 
+    timeout: 10000, 
+    description: 'tap submit button' 
+  });
+  ```
+
+#### **Timeout Configuration Strategy**
+- **Quick operations**: Use default timeouts (15s)
+- **Slow operations**: Increase timeout, don't add delays
+- **Example**:
+  ```typescript
+  // ❌ DON'T: Add arbitrary delays
+  await TestHelpers.delay(5000);
+  await Gestures.tap(button);
+  
+  // ✅ DO: Use appropriate timeout for slow-loading elements
+  await Gestures.tap(slowLoadingButton, { timeout: 30000 });
+  ```
+
+#### **"Element not enabled" Errors**
+- **Cause**: Element exists but is not interactive (disabled/loading state)
+- **Root cause**: Framework checks element is both visible AND enabled before interaction by default
+- **Solution**: Use `checkEnabled: false` to bypass enabled state validation
+- **When to use**: Elements that are temporarily disabled during processing, loading states, or elements that appear disabled but should still be interactable (i.e Account List item which is not yet selected)
+- **Example**:
+  ```typescript
+  // Default: checks visibility + enabled + stability (if enabled)
+  await Gestures.tap(element, { description: 'tap interactive element' });
+  
+  // Skip enabled check for temporarily disabled elements
+  await Gestures.tap(loadingButton, { 
+    checkEnabled: false,
+    description: 'tap button during loading' 
+  });
+  
+  // Skip all checks for special cases
+  await Gestures.tap(processingButton, { 
+    checkVisibility: false,
+    checkEnabled: false,
+    description: 'tap button during processing' 
+  });
+  ```
+  
+#### **"Element moving/animating" Errors**
+- **Cause**: UI animations interfering with interactions
+- **Solution**: Enable stability checking for that specific interaction
+- **Example**:
+  ```typescript
+  await Gestures.tap(animatedButton, {
+    checkStability: true,  // Wait for animations to complete
+    description: 'tap animated button'
+  });
+  ```
+
+### Common Issues and Solutions:
+
+- **"Test is flaky"** → Remove `TestHelpers.delay()`, use proper assertions with timeouts
+- **"Element not found"** → Use framework retry mechanisms and proper element selectors  
+- **"Deprecated method warning"** → Check `@deprecated` tag for modern replacement
+- **"Test is slow"** → Avoid nested retries, use appropriate timeouts, use `checkStability: true` only when needed
+- **"Hard to maintain"** → Implement Page Object pattern, avoid repeated selectors
+- **"Timeouts not working as expected"** → Check for nested retry patterns, use single-level framework retries
+
+#### **Handling Flaky Navigation/Tap Issues**
+
+**Problem**: Element tap succeeds but doesn't trigger navigation or expected action (common with buttons that sometimes don't respond to taps due to obscuration or timing issues).
+
+**Solution**: Use higher-level retry pattern that wraps both the action and verification:
+
+```typescript
+// ✅ DO: Wrap tap + verification in single retry operation
+async tapOpenAllTabsButton(): Promise<void> {
+  return Utilities.executeWithRetry(
+    async () => {
+      await Gestures.waitAndTap(this.tabsButton, {
+        timeout: 2000  // Short timeout for individual action
+      });
+
+      await Assertions.expectVisible(this.tabsNumber, {
+        timeout: 2000  // Short timeout for verification
+      });
+    },
+    {
+      timeout: 30000,  // Longer overall timeout for retries
+      description: 'tap open all tabs button and verify navigation',
+      elemDescription: 'Open All Tabs Button',
+    }
+  );
+}
+```
+
+**Why this works**:
+- **Fast inner timeouts (2s)** - Prevents long waits when tap doesn't trigger navigation
+- **Outer retry logic** - Handles the flaky tap scenario by retrying the entire flow
+- **Total timeout control** - 30s outer timeout gives reasonable overall time limit
+- **Clear failure modes** - Each step fails fast, allowing quick retry of the whole operation
+
+**When to use this pattern**:
+- Buttons that sometimes don't respond (obscuration issues)
+- Navigation taps that may fail silently
+- Actions that require verification of success (screen transitions)
+- Complex interactions where multiple steps must succeed together

--- a/e2e/framework/Utilities.ts
+++ b/e2e/framework/Utilities.ts
@@ -1,0 +1,378 @@
+/* eslint-disable no-console */
+import { blacklistURLs } from '../resources/blacklistURLs.json';
+import { RetryOptions, StabilityOptions } from './types';
+
+const TEST_CONFIG_DEFAULTS = {
+  timeout: 15000,
+  retryInterval: 500,
+  actionDelay: 100,
+  stabilityCheckInterval: 200,
+  stabilityCheckCount: 3,
+};
+
+/**
+ * Enhanced Utilities class with retry mechanisms and stability checking
+ */
+export default class Utilities {
+  /**
+   * Formats an array of strings into a regex pattern string for exact matching.
+   */
+  static formatForExactMatchGroup(regexstrings: string[]): string {
+    return `\\("${regexstrings.join('","')}"\\)`;
+  }
+
+  /**
+   * A getter method that returns a formatted string of blacklisted URLs for exact matching in a regex pattern.
+   */
+  static get BlacklistURLs(): string {
+    return this.formatForExactMatchGroup(blacklistURLs);
+  }
+
+  /**
+   * Check if element is enabled (non-retry version)
+   */
+  static async checkElementEnabled(
+    detoxElement: DetoxElement,
+  ): Promise<void> {
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    const attributes = await el.getAttributes();
+    if (!('enabled' in attributes) || !attributes.enabled) {
+      throw new Error(
+        [
+          '🚫 Element is not enabled.',
+          '',
+          '💡 If this element might be disabled in some situations,',
+          '   consider using the {checkEnabled: false} option.',
+          '',
+          '📝 Example:',
+          '   await Gestures.waitAndTap(element, {checkEnabled: false})',
+        ].join('\n'),
+      );
+    }
+  }
+
+  /**
+   * Wait for element to be enabled with retry mechanism
+   */
+  static async waitForElementToBeEnabled(
+    detoxElement: DetoxElement,
+    timeout = 3500,
+    interval = 100,
+  ): Promise<void> {
+    return this.executeWithRetry(
+      () => this.checkElementEnabled(detoxElement),
+      {
+        timeout,
+        interval,
+        description: 'Element to be enabled',
+      },
+    );
+  }
+
+  /**
+   * Check if element is actually tappable (not obscured by other elements)
+   * Android-specific check for element obscuration
+   */
+  static async checkElementNotObscured(
+    detoxElement: DetoxElement,
+  ): Promise<void> {
+    try {
+      const el = (await detoxElement) as Detox.IndexableNativeElement;
+      const attributes = await el.getAttributes();
+
+      // Check if element has proper frame/bounds
+      if (!('frame' in attributes) || !attributes.frame) {
+        throw new Error('🚫 Element does not have valid frame bounds - may be obscured');
+      }
+
+      // Additional Android-specific checks could be added here
+      // For now, we rely on the basic frame check and visibility
+      try {
+        // Try to get element center point to ensure it's accessible
+        const centerX = attributes.frame.x + attributes.frame.width / 2;
+        const centerY = attributes.frame.y + attributes.frame.height / 2;
+
+        if (centerX <= 0 || centerY <= 0) {
+          throw new Error('🚫 Element center point is not accessible - may be obscured');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`🚫 Element appears to be obscured or not tappable: ${errorMessage}`);
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes('window focus') || errorMessage.includes('window-focus') || errorMessage.includes('has-window-focus=false')) {
+        console.warn('⚠️ Skipping obscuration check - window has no focus (common in CI environments)');
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Check if element is stable (non-retry version)
+   */
+  static async checkElementStable(
+    detoxElement: DetoxElement,
+    options: StabilityOptions = {},
+  ): Promise<void> {
+    const { timeout = 2000, interval = 200, stableCount = 3 } = options;
+    let lastPosition: { x: number; y: number } | null = null;
+    let stableChecks = 0;
+    const fallBackTimeout = 2000;
+    const start = Date.now();
+
+    const getPosition = async (el: Detox.IndexableNativeElement) => {
+      try {
+        const attributes = await el.getAttributes();
+        if (
+          'frame' in attributes &&
+          attributes.frame &&
+          typeof attributes.frame.x === 'number' &&
+          typeof attributes.frame.y === 'number'
+        ) {
+          return { x: attributes.frame.x, y: attributes.frame.y };
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    };
+
+    while (Date.now() - start < timeout) {
+      const el = (await detoxElement) as Detox.IndexableNativeElement;
+      const position = await getPosition(el);
+
+      if (!position) {
+        await new Promise((resolve) =>
+          // eslint-disable-next-line no-restricted-syntax
+          setTimeout(resolve, fallBackTimeout),
+        );
+        return; // Return early if position is not available
+      }
+
+      if (
+        lastPosition &&
+        position.x === lastPosition.x &&
+        position.y === lastPosition.y
+      ) {
+        stableChecks += 1;
+        if (stableChecks >= stableCount) return;
+      } else {
+        lastPosition = position;
+        stableChecks = 1;
+      }
+
+      // eslint-disable-next-line no-restricted-syntax
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+
+    throw new Error('⏱️ Element did not become stable in time');
+  }
+
+  /**
+   * Waits for an element to become stable (not moving) by checking its position multiple times.
+   */
+  static async waitForElementToStopMoving(
+    detoxElement: DetoxElement,
+    options: StabilityOptions = {},
+  ): Promise<void> {
+    const { timeout = 5000 } = options;
+    return this.executeWithRetry(
+      () => this.checkElementStable(detoxElement, options),
+      {
+        timeout,
+        description: 'Element stability',
+      },
+    );
+  }
+
+  /**
+   * Check element ready state (non-retry version)
+   */
+  static async checkElementReadyState(
+    detoxElement: DetoxElement,
+    options: {
+      timeout?: number;
+      checkStability?: boolean;
+      checkVisibility?: boolean;
+      checkEnabled?: boolean;
+    } = {},
+  ): DetoxElement {
+    const {
+      timeout,
+      checkStability = false,
+      checkVisibility = true,
+      checkEnabled = true,
+    } = options;
+
+    const el = (await detoxElement) as Detox.IndexableNativeElement;
+    /**
+     * IMPORTANT: Default timeout behavior
+     *
+     * When no timeout is provided, we use fallback defaults to ensure compatibility
+     * with the retry mechanism in executeWithRetry(). This method can be used in two ways:
+     *
+     * 1. Direct usage: Always provide explicit timeout values for predictable behavior
+     * 2. Via executeWithRetry(): Timeout defaults are handled automatically
+     *
+     * Default fallbacks:
+     * - Visibility check: 100ms (minimal check)
+     * - Enabled check: No timeout (immediate check)
+     * - Stability check: 2000ms (allows time for UI to settle)
+     */
+
+    if (checkVisibility) {
+      const visibilityTimeout = timeout || 100; // If no timeout is provided, default to 100ms
+      if (device.getPlatform() === 'ios') {
+        await waitFor(el).toExist().withTimeout(visibilityTimeout);
+      } else {
+        await waitFor(el).toBeVisible().withTimeout(visibilityTimeout);
+        await this.checkElementNotObscured(Promise.resolve(el)); // Ensure element is not obscured
+      }
+    }
+
+    if (checkEnabled) {
+      await this.checkElementEnabled(Promise.resolve(el));
+    }
+
+
+    if (checkStability) {
+      const stabilityTimeout = timeout || 2000; // If no timeout is provided, default to 2000ms
+      const stabilityCheckInterval = timeout ? timeout / 10 : 200; // Default to 200ms if no timeout is provided
+      await this.checkElementStable(Promise.resolve(el), {
+        timeout: stabilityTimeout,
+        interval: stabilityCheckInterval,
+      });
+    }
+
+    return el;
+  }
+
+  /**
+   * Wait for element to be in a ready state (visible, enabled, stable)
+   */
+  static async waitForReadyState(
+    detoxElement: DetoxElement,
+    options: {
+      timeout?: number;
+      checkStability?: boolean;
+      skipVisibilityCheck?: boolean;
+      elemDescription?: string;
+    } = {},
+  ): DetoxElement {
+    const { timeout = TEST_CONFIG_DEFAULTS.timeout, elemDescription } = options;
+
+    return this.executeWithRetry(
+      () => this.checkElementReadyState(detoxElement, options),
+      {
+        timeout,
+        description: 'Element ready state check',
+        elemDescription,
+      },
+    );
+  }
+
+  /**
+   * Check if an element is a WebElement
+   */
+  static isWebElement(el: unknown): boolean {
+    if (!el || typeof el !== 'object') {
+      return false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const webEl = el as any;
+    return !!(
+      webEl?.webViewElement ||
+      (typeof webEl?.runScript === 'function') ||
+      (webEl?.constructor?.name && (
+        webEl.constructor.name.includes('IndexableWebElement') ||
+        webEl.constructor.name.includes('SecuredWebElementFacade') ||
+        webEl.constructor.name.includes('WebElement')
+      ))
+    );
+  }
+
+  static async executeWithRetry<T>(
+    operation: () => Promise<T>,
+    options: RetryOptions,
+  ): Promise<T> {
+    const {
+      timeout = TEST_CONFIG_DEFAULTS.timeout,
+      interval = TEST_CONFIG_DEFAULTS.retryInterval,
+      maxRetries = Math.floor(timeout / interval),
+      elemDescription = '',
+      description,
+    } = options;
+
+    let lastError: Error | undefined;
+    let attempt = 0;
+    const startTime = Date.now();
+
+    const action = description || operation.name;
+
+    while (true) {
+      try {
+        const result = await operation();
+
+        if (attempt > 0) {
+          const successMessage = [
+            `✅ ${action} succeeded after ${attempt}`,
+            ` ${attempt === 1 ? 'retry' : 'retries'}`,
+            elemDescription ? ` for ${elemDescription}` : '',
+            '.',
+          ].join('');
+
+          console.log(successMessage);
+        }
+
+        return result;
+      } catch (error) {
+        lastError = error as Error;
+        attempt++;
+
+        const elapsedTime = Date.now() - startTime;
+        const timeoutExceeded = elapsedTime >= timeout;
+        const maxRetriesReached = attempt >= maxRetries;
+
+        if (timeoutExceeded || maxRetriesReached) {
+          break;
+        }
+
+        if (attempt === 1) {
+          const retryMessage = [
+            `⚠️  ${action} failed (attempt ${attempt})`,
+            ` on element`,
+            elemDescription ? `: ${elemDescription}` : '',
+            `. Retrying... (timeout: ${timeout}ms)`,
+          ].join('');
+
+          console.log(retryMessage);
+          console.log(`🔍 Error: ${lastError.message}`);
+        }
+
+        // eslint-disable-next-line no-restricted-syntax
+        await new Promise((resolve) => setTimeout(resolve, interval));
+      }
+    }
+
+    const elapsedTime = Date.now() - startTime;
+
+    const errorMessage = [
+      `❌ ${action} failed after ${attempt} attempt(s) over ${elapsedTime}ms`,
+      `📍 Element Description: ${
+        elemDescription || 'Description not provided'
+      }`,
+      `🔍 Last error: ${lastError?.message || 'Unknown error'}`,
+    ].join('\n');
+
+    const enhancedError = new Error(errorMessage);
+    if (lastError?.stack) {
+      enhancedError.stack = `${errorMessage}\n\nOriginal error stack:\n${lastError.stack}`;
+    }
+    throw enhancedError;
+  }
+}
+
+export { TEST_CONFIG_DEFAULTS as BASE_DEFAULTS };

--- a/e2e/framework/index.ts
+++ b/e2e/framework/index.ts
@@ -1,0 +1,9 @@
+// Main framework exports for easy importing
+export { default as Assertions } from './Assertions';
+export { default as Gestures } from './Gestures';
+export { default as Matchers } from './Matchers';
+export { default as Utilities, BASE_DEFAULTS } from './Utilities';
+export * from './types';
+
+// Example usage:
+// import { Assertions, Gestures, Matchers } from '../framework';

--- a/e2e/framework/types.ts
+++ b/e2e/framework/types.ts
@@ -1,0 +1,54 @@
+
+// Gestures
+
+export interface GestureOptions {
+  timeout?: number;
+  checkStability?: boolean;
+  checkVisibility?: boolean;
+  checkEnabled?: boolean;
+  elemDescription?: string; // For better error messages - i.e "Get Started button"
+}
+
+export interface TapOptions extends GestureOptions {
+}
+
+export interface TypeTextOptions extends GestureOptions {
+  clearFirst?: boolean;
+  hideKeyboard?: boolean;
+  sensitive?: boolean; // If true, the text will not be logged in the test report
+}
+
+export interface SwipeOptions extends GestureOptions {
+  speed?: 'fast' | 'slow';
+  percentage?: number;
+}
+
+export interface LongPressOptions extends GestureOptions {
+  duration?: number;
+}
+
+export interface ScrollOptions extends GestureOptions {
+  direction?: 'up' | 'down' | 'left' | 'right';
+  scrollAmount?: number;
+}
+
+// Assertions
+
+export interface AssertionOptions extends RetryOptions {
+  timeout?: number;
+  description?: string; // Description for the assertion, e.g. "The Wallet View should be visible"
+}
+
+export interface RetryOptions {
+  timeout?: number;
+  interval?: number;
+  description?: string; // Description for the retry operation, e.g. "tap() or "waitForReadyState()"
+  elemDescription?: string;
+  maxRetries?: number;
+}
+
+export interface StabilityOptions {
+  timeout?: number;
+  interval?: number;
+  stableCount?: number;
+}


### PR DESCRIPTION
### Description

This PR centralizes Solana/CAIP address normalization for bridge tokens in MetaMask Mobile.

- Adds a `normalizeToCaipAssetType` utility to Bridge utils
- Refactors `useTokens` and `useTopTokens` to use the shared normalization utility
- Removes duplicated normalization logic
- Adds unit tests for the normalization utility

This prevents duplicate tokens in the destination selector and ensures consistent CAIP/raw handling across the Bridge feature.

---

**Why:**
Bridge API and wallet tokens may use different address formats (raw vs CAIP), causing deduplication and highlighting issues. All normalization now uses a single utility, ensuring robust, maintainable, and future-proof handling.

---

### Manual Testing Steps

1. Go to the Bridge feature
2. Select Solana as source or destination chain
3. Verify no duplicate tokens in the destination selector
4. Verify the default token is correctly highlighted
5. Test with EVM chains to confirm no regression

### QA

- [x] Run Smoke E2E
- [x] QA Passed

### Related Issues

- Fixes #16734
- Fixes SWAPS-2525

### Labels

- Run Smoke E2E
- QA Passed
- no-changelog

---

**Reviewer Checklist**

- [x] Manual testing completed
- [x] All unit tests pass
- [x] PR description and title follow project rules
- [x] No duplicate or temporary files

---

**Screenshots/Recordings**
N/A (no UI changes)
