### PR TITLE
chore: moves notifications tests into quarantine

### DIFF
--- a/e2e/specs/quarantine/enable-notifications-after-onboarding.failing.ts
+++ b/e2e/specs/quarantine/enable-notifications-after-onboarding.failing.ts
@@ -12,12 +12,12 @@ import { getMockServerPort } from '../../fixtures/utils';
 import {
   NOTIFICATIONS_TEAM_PASSWORD,
   NOTIFICATIONS_TEAM_SEED_PHRASE,
-} from './utils/constants';
+} from '../notifications/utils/constants';
 import {
   getMockFeatureAnnouncementItemId,
   getMockWalletNotificationItemIds,
   mockNotificationServices,
-} from './utils/mocks';
+} from '../notifications/utils/mocks';
 
 const launchAppSettings = (port: number): DeviceLaunchAppConfig => ({
   newInstance: true,

--- a/e2e/specs/quarantine/notification-settings-flow.failing.ts
+++ b/e2e/specs/quarantine/notification-settings-flow.failing.ts
@@ -16,8 +16,8 @@ import {
   NOTIFICATION_WALLET_ACCOUNT_1,
   NOTIFICATIONS_TEAM_PASSWORD,
   NOTIFICATIONS_TEAM_SEED_PHRASE,
-} from './utils/constants';
-import { mockNotificationServices } from './utils/mocks';
+} from '../notifications/utils/constants';
+import { mockNotificationServices } from '../notifications/utils/mocks';
 
 const launchAppSettings = (port: number): DeviceLaunchAppConfig => ({
   newInstance: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Given the latest flakiness of the Notifications e2e tests we've decided to move these tests into quarantine.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
