### PR TITLE
fix: re-fill missing explorer url for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base

### DIFF
--- a/app/store/migrations/089.test.ts
+++ b/app/store/migrations/089.test.ts
@@ -1,0 +1,304 @@
+import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+import {
+  NetworkConfiguration,
+} from '@metamask/network-controller';
+import { Hex } from '@metamask/utils';
+
+import { ensureValidState } from './util';
+import migrate from './089';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const createTestState = () => ({
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        selectedNetworkClientId: 'mainnet',
+        networksMetadata: {},
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: undefined,
+            blockExplorerUrls: [],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+          },
+          '0xaa36a7': {
+            chainId: '0xaa36a7',
+            rpcEndpoints: [
+              {
+                networkClientId: 'sepolia',
+                url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: undefined,
+            blockExplorerUrls: [],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Sepolia',
+            nativeCurrency: 'SepoliaETH',
+          },
+          '0xe705': {
+            chainId: '0xe705',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-sepolia',
+                url: 'https://linea-sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: undefined,
+            blockExplorerUrls: [],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Sepolia',
+            nativeCurrency: 'LineaETH',
+          },
+          '0xe708': {
+            chainId: '0xe708',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-mainnet',
+                url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: undefined,
+            blockExplorerUrls: [],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Mainnet',
+            nativeCurrency: 'ETH',
+          },
+          '0x2105': {
+            chainId: '0x2105',
+            rpcEndpoints: [
+              {
+                networkClientId: 'Base',
+                url: 'https://base-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: undefined,
+            blockExplorerUrls: [],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Base Mainnet',
+            nativeCurrency: 'ETH',
+          },
+        },
+      },
+    },
+  },
+});
+
+describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base.`', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('Re-fills BlockExploer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base.', () => {
+    const oldState = createTestState();
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              ['0x1'] : {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x1'],
+                blockExplorerUrls: [
+                  'https://etherscan.io/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0xaa36a7']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xaa36a7'],
+                blockExplorerUrls: [
+                  'https://sepolia.etherscan.io/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0xe705']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xe705'],
+                blockExplorerUrls: [
+                  'https://sepolia.lineascan.build/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0xe708']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xe708'],
+                blockExplorerUrls: [
+                  'https://lineascan.build/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0x2105']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x2105'],
+                blockExplorerUrls: [
+                  'https://basescan.org/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              }
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('Only re-fills BlockExploer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base if they are not present.', () => {
+    const oldState = createTestState();
+    const networkConfigurationsByChainId = oldState.engine.backgroundState.NetworkController.networkConfigurationsByChainId as unknown as Record<Hex, NetworkConfiguration>;
+    // Simulate there is a existing block explorer URL in Mainnet
+    networkConfigurationsByChainId['0x1'].blockExplorerUrls = [
+      'https://custom-etherscan.io/',
+    ];
+    networkConfigurationsByChainId['0x1'].defaultBlockExplorerUrlIndex = 0;
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    // Expecting the migration to only update Sepolia, Linea Mainnet, Linea Sepolia, and Base
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              ['0xaa36a7']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xaa36a7'],
+                blockExplorerUrls: [
+                  'https://sepolia.etherscan.io/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0xe705']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xe705'],
+                blockExplorerUrls: [
+                  'https://sepolia.lineascan.build/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0xe708']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0xe708'],
+                blockExplorerUrls: [
+                  'https://lineascan.build/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              },
+              ['0x2105']: {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x2105'],
+                blockExplorerUrls: [
+                  'https://basescan.org/',
+                ],
+                defaultBlockExplorerUrlIndex: 0,
+              }
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      state: {
+        engine: {},
+      },
+      test: 'empty engine state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      test: 'empty backgroundState',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      test: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      test: 'invalid networkConfigurationsByChainId state',
+    },
+  ])('does not modify state if the state is invalid - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        'Migration 89: NetworkController or networkConfigurationsByChainId not found in state',
+      ),
+    );
+  });
+});

--- a/app/store/migrations/089.test.ts
+++ b/app/store/migrations/089.test.ts
@@ -134,7 +134,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
             networkConfigurationsByChainId: {
               ...oldState.engine.backgroundState.NetworkController
                 .networkConfigurationsByChainId,
-              ['0x1'] : {
+              '0x1' : {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0x1'],
                 blockExplorerUrls: [
@@ -142,7 +142,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0xaa36a7']: {
+              '0xaa36a7': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xaa36a7'],
                 blockExplorerUrls: [
@@ -150,7 +150,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0xe705']: {
+              '0xe705': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xe705'],
                 blockExplorerUrls: [
@@ -158,7 +158,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0xe708']: {
+              '0xe708': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xe708'],
                 blockExplorerUrls: [
@@ -166,7 +166,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0x2105']: {
+              '0x2105': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0x2105'],
                 blockExplorerUrls: [
@@ -206,7 +206,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
             networkConfigurationsByChainId: {
               ...oldState.engine.backgroundState.NetworkController
                 .networkConfigurationsByChainId,
-              ['0xaa36a7']: {
+              '0xaa36a7': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xaa36a7'],
                 blockExplorerUrls: [
@@ -214,7 +214,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0xe705']: {
+              '0xe705': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xe705'],
                 blockExplorerUrls: [
@@ -222,7 +222,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0xe708']: {
+              '0xe708': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0xe708'],
                 blockExplorerUrls: [
@@ -230,7 +230,7 @@ describe('Migration 89: Re-Fill BlockExploer URLs for Mainnet, Sepolia, Linea Ma
                 ],
                 defaultBlockExplorerUrlIndex: 0,
               },
-              ['0x2105']: {
+              '0x2105': {
                 ...oldState.engine.backgroundState.NetworkController
                   .networkConfigurationsByChainId['0x2105'],
                 blockExplorerUrls: [

--- a/app/store/migrations/089.ts
+++ b/app/store/migrations/089.ts
@@ -1,0 +1,92 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, Hex, isObject } from '@metamask/utils';
+import {
+  type NetworkConfiguration,
+} from '@metamask/network-controller';
+
+import { ensureValidState } from './util';
+import { NETWORKS_CHAIN_ID } from '../../constants/network';
+
+// Default block explorer URLs for various networks
+// These URLs are aligned with MetaMask Extension 
+const MAINNET_DEFAULT_BLOCK_EXPLORER_URL = 'https://etherscan.io/';
+const LINEA_DEFAULT_BLOCK_EXPLORER_URL = 'https://lineascan.build/';
+const BASE_DEFAULT_BLOCK_EXPLORER_URL = 'https://basescan.org/';
+const SEPOLIA_DEFAULT_BLOCK_EXPLORER_URL = 'https://sepolia.etherscan.io/';
+const LINEA_SEPOLIA_DEFAULT_BLOCK_EXPLORER_URL = 'https://sepolia.lineascan.build/'
+
+export const CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP: Record<Hex, string> = {
+  [NETWORKS_CHAIN_ID.MAINNET]: MAINNET_DEFAULT_BLOCK_EXPLORER_URL,
+  [NETWORKS_CHAIN_ID.LINEA_MAINNET]: LINEA_DEFAULT_BLOCK_EXPLORER_URL,
+  [NETWORKS_CHAIN_ID.BASE]: BASE_DEFAULT_BLOCK_EXPLORER_URL,
+  [NETWORKS_CHAIN_ID.LINEA_SEPOLIA]: LINEA_SEPOLIA_DEFAULT_BLOCK_EXPLORER_URL,
+  [NETWORKS_CHAIN_ID.SEPOLIA]: SEPOLIA_DEFAULT_BLOCK_EXPLORER_URL,
+};
+
+/**
+ * Migration 89: Re-fill BlockExploer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base.
+ */
+const migration = (state: unknown): unknown => {
+  const migrationVersion = 89;
+
+  // Ensure the state is valid for migration
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    if (
+      hasProperty(state, 'engine') &&
+      hasProperty(state.engine, 'backgroundState') &&
+      hasProperty(state.engine.backgroundState, 'NetworkController') &&
+      isObject(state.engine.backgroundState.NetworkController) &&
+      isObject(
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId,
+      )
+    ) {
+        const networkConfigurationsByChainId = state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId as unknown as Record<Hex, NetworkConfiguration>;
+
+        // Re-fill the block explorer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base
+        Object.entries(CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP).forEach(
+          ([chainId, blockExplorerUrl]) => {
+            // Ensure the chainId is existing in the network configurations
+            if (
+              hasProperty(networkConfigurationsByChainId, chainId)
+            ) {  
+              const networkConfiguration = networkConfigurationsByChainId[chainId] as NetworkConfiguration;
+
+              // We only re-fill the block explorer URLs if they are not already set
+              if (
+                !networkConfiguration.blockExplorerUrls ||
+                (Array.isArray(networkConfiguration.blockExplorerUrls) &&
+                  networkConfiguration.blockExplorerUrls.length === 0)
+              ) {
+                networkConfiguration.blockExplorerUrls = [
+                  blockExplorerUrl,
+                ];
+                networkConfiguration.defaultBlockExplorerUrlIndex = 0;
+              }
+            }
+          },
+        );
+    } else {
+      captureException(
+        new Error(
+          `Migration ${migrationVersion}: NetworkController or networkConfigurationsByChainId not found in state`,
+        ),
+      );
+    }
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Re-fill BlockExploer URLs for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base failed with error: ${error}`,
+      ),
+    );
+    return state;
+  }
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -89,6 +89,7 @@ import migration85 from './085';
 import migration86 from './086';
 import migration87 from './087';
 import migration88 from './088';
+import migration89 from './089';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';
@@ -194,6 +195,7 @@ export const migrationList: MigrationsList = {
   86: migration86,
   87: migration87,
   88: migration88,
+  89: migration89,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adding a migration script `089` to add back the explorer URL for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base in NetworkConfiguration State

It only update the state if the network doesnt has an explorer URL yet

it also fixed the issue that the bridge tx does not display the explorer button when the tx is related to above chains

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix missing explorer url for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base

## **Related issues**


## **Manual testing steps**

1. Go to Network Selector Page
2. Edit the Network 
3. We should see the block explorer URL present (repeat all steps for Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="200" alt="Screenshot 2025-07-09 at 9 24 31 AM" src="https://github.com/user-attachments/assets/9be371b0-2582-4a40-8dc0-ca25b10e00b1" />
<img width="200" alt="Screenshot 2025-07-09 at 9 26 10 AM" src="https://github.com/user-attachments/assets/f24c802a-0b75-48ce-b011-82da3fc980ab" />

<!-- [screenshots/recordings] -->

### **After**
<img width="200" alt="Screenshot 2025-07-09 at 11 25 56 AM" src="https://github.com/user-attachments/assets/6a45da2c-cafc-41f2-8e55-184ca7d26d10" />
<img width="200" alt="Screenshot 2025-07-09 at 11 26 11 AM" src="https://github.com/user-attachments/assets/8b473439-b52c-4499-adfc-4553374e507d" />
<img width="200" alt="Screenshot 2025-07-09 at 11 26 29 AM" src="https://github.com/user-attachments/assets/2265b167-8d01-4282-a64b-256bb8369ca2" />
<img width="200" alt="Screenshot 2025-07-09 at 11 26 41 AM" src="https://github.com/user-attachments/assets/b7c04a45-27a0-4855-979b-c2c1b1f74d0a" />
<img width="200" alt="Screenshot 2025-07-09 at 11 27 00 AM" src="https://github.com/user-attachments/assets/528fd662-1d49-4354-9cdb-347ffb7cb506" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
