### PR TITLE
fix: cp-7.51.0 missing explorer url in bridge tx

### DIFF
--- a/app/components/UI/Swaps/utils/useBlockExplorer.js
+++ b/app/components/UI/Swaps/utils/useBlockExplorer.js
@@ -52,7 +52,7 @@ function useBlockExplorer(networkConfigurations, providerConfigTokenExplorer) {
         name,
         value: blockExplorer,
         isValid: true,
-        isRPC: true,
+        isRPC: type === RPC,
         baseUrl: url.href,
       });
     } catch {

--- a/app/components/UI/Swaps/utils/useBlockExplorer.js
+++ b/app/components/UI/Swaps/utils/useBlockExplorer.js
@@ -29,11 +29,16 @@ function useBlockExplorer(networkConfigurations, providerConfigTokenExplorer) {
       const { rpcUrl , type } = definitiveProviderConfig;
 
       let blockExplorer;
+      let name;
 
-      if (type === RPC && rpcUrl) {
+      if (type === RPC) {
         blockExplorer = findBlockExplorerForRpc(rpcUrl, networkConfigurations)
+        name = 
+          getBlockExplorerName(blockExplorer) ||
+          strings('swaps.block_explorer');
       } else {
         blockExplorer = getEtherscanBaseUrl(type);
+        name = 'Etherscan';
       }
  
       if (!blockExplorer) {
@@ -43,15 +48,6 @@ function useBlockExplorer(networkConfigurations, providerConfigTokenExplorer) {
       const url = new URL(blockExplorer);
       if (!['http:', 'https:'].includes(url.protocol)) {
         throw new Error('Block explorer URL is not a valid http(s) protocol');
-      }
-
-      let name;
-      if (type === RPC) {
-        name = 
-          getBlockExplorerName(blockExplorer) ||
-          strings('swaps.block_explorer');
-      } else {
-        name = 'Etherscan';
       }
 
       setExplorer({

--- a/app/components/UI/Swaps/utils/useBlockExplorer.js
+++ b/app/components/UI/Swaps/utils/useBlockExplorer.js
@@ -45,9 +45,15 @@ function useBlockExplorer(networkConfigurations, providerConfigTokenExplorer) {
         throw new Error('Block explorer URL is not a valid http(s) protocol');
       }
 
-      const name =
-        getBlockExplorerName(blockExplorer) ||
-        strings('swaps.block_explorer');
+      let name;
+      if (type === RPC) {
+        name = 
+          getBlockExplorerName(blockExplorer) ||
+          strings('swaps.block_explorer');
+      } else {
+        name = 'Etherscan';
+      }
+
       setExplorer({
         name,
         value: blockExplorer,

--- a/app/components/UI/Swaps/utils/useBlockExplorer.js
+++ b/app/components/UI/Swaps/utils/useBlockExplorer.js
@@ -32,7 +32,7 @@ function useBlockExplorer(networkConfigurations, providerConfigTokenExplorer) {
       let name;
 
       if (type === RPC) {
-        blockExplorer = findBlockExplorerForRpc(rpcUrl, networkConfigurations)
+        blockExplorer = findBlockExplorerForRpc(rpcUrl, networkConfigurations);
         name = 
           getBlockExplorerName(blockExplorer) ||
           strings('swaps.block_explorer');

--- a/app/components/UI/Swaps/utils/useBlockExplorer.test.js
+++ b/app/components/UI/Swaps/utils/useBlockExplorer.test.js
@@ -1,0 +1,90 @@
+import {
+  RpcEndpointType,
+} from '@metamask/network-controller';
+
+import {
+  createProviderConfig,
+} from '../../../../selectors/networkController';
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { mockNetworkState } from '../../../../util/test/network';
+import useBlockExplorer from './useBlockExplorer';
+
+const renderUseBlockExplorerHook = (overrides) => {
+  // Prepare mock network state
+  const networkConfigurations = mockNetworkState(overrides);
+  const networkConfiguration = networkConfigurations.networkConfigurationsByChainId[overrides.chainId];
+  const rpcEndpoint =
+      networkConfiguration?.rpcEndpoints?.[networkConfiguration?.defaultRpcEndpointIndex];
+  const providerConfig = createProviderConfig(networkConfiguration, rpcEndpoint);
+
+  // Get the block explorer using the hook
+  const { result } = renderHookWithProvider(() => useBlockExplorer(
+    networkConfigurations.networkConfigurationsByChainId,
+    providerConfig
+  ));
+  return result.current;
+}
+
+describe('useBlockExplorer', () => {
+  it('returns a correct explorer object for a custom network', () => {
+    const explorer = renderUseBlockExplorerHook({
+        chainId: '0xa4b1',
+        id: 'arbitrum',
+        nickname: 'Arbitrum Mainnet',
+        ticker: 'ETH',
+        blockExplorerUrl: 'https://arbitrumscan.io',
+    });
+
+    expect(explorer).toStrictEqual({
+      name: 'Arbitrumscan',
+      value: 'https://arbitrumscan.io',
+      isValid: true,
+      isRPC: true,
+      baseUrl: 'https://arbitrumscan.io/',
+      token: expect.any(Function),
+      tx: expect.any(Function),
+      account: expect.any(Function),
+    });
+    expect(explorer.token('0x123')).toStrictEqual(
+      'https://arbitrumscan.io/token/0x123'
+    );
+    expect(explorer.tx('0x456')).toStrictEqual(
+      'https://arbitrumscan.io/tx/0x456'
+    );
+    expect(explorer.account('0x789')).toStrictEqual(
+      'https://arbitrumscan.io/address/0x789'
+    );
+  });
+  
+  it('returns a correct explorer object for build-in network', () => {
+    const explorer = renderUseBlockExplorerHook({
+        chainId: '0x1',
+        id: 'mainnet',
+        nickname: 'Ethereum Mainnet',
+        ticker: 'ETH',
+        blockExplorerUrl: 'https://etherscan.io',
+        rpcUrl: 'https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID',
+        type: RpcEndpointType.Infura
+    });
+    
+    expect(explorer).toStrictEqual({
+      name: 'Etherscan',
+      value: 'https://etherscan.io',
+      isValid: true,
+      isRPC: false,
+      baseUrl: 'https://etherscan.io/',
+      token: expect.any(Function),
+      tx: expect.any(Function),
+      account: expect.any(Function),
+    });
+    expect(explorer.token('0x123')).toStrictEqual(
+      'https://etherscan.io/token/0x123'
+    );
+    expect(explorer.tx('0x456')).toStrictEqual(
+      'https://etherscan.io/tx/0x456'
+    );
+    expect(explorer.account('0x789')).toStrictEqual(
+      'https://etherscan.io/address/0x789'
+    );
+  });
+});

--- a/app/constants/network.js
+++ b/app/constants/network.js
@@ -9,6 +9,7 @@ export const SEPOLIA = 'sepolia';
 export const LINEA_GOERLI = 'linea-goerli';
 export const LINEA_SEPOLIA = 'linea-sepolia';
 export const LINEA_MAINNET = 'linea-mainnet';
+export const BASE_MAINNET = 'base-mainnet';
 export const MEGAETH_TESTNET = 'megaeth-testnet';
 export const MONAD_TESTNET = 'monad-testnet';
 

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -52,6 +52,7 @@ export const LINEA_SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.lineascan.build';
 export const LINEA_MAINNET_BLOCK_EXPLORER = 'https://lineascan.build';
 export const MAINNET_BLOCK_EXPLORER = 'https://etherscan.io';
 export const SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.etherscan.io';
+export const BASE_MAINNET_BLOCK_EXPLORER_URL = 'https://basescan.org/';
 
 // Rpcs
 export const MAINNET_DEFAULT_RPC_URL = `https://mainnet.infura.io/v3/${infuraProjectId}`;

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -52,7 +52,7 @@ export const LINEA_SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.lineascan.build';
 export const LINEA_MAINNET_BLOCK_EXPLORER = 'https://lineascan.build';
 export const MAINNET_BLOCK_EXPLORER = 'https://etherscan.io';
 export const SEPOLIA_BLOCK_EXPLORER = 'https://sepolia.etherscan.io';
-export const BASE_MAINNET_BLOCK_EXPLORER_URL = 'https://basescan.org/';
+export const BASE_MAINNET_BLOCK_EXPLORER_URL = 'https://basescan.org';
 
 // Rpcs
 export const MAINNET_DEFAULT_RPC_URL = `https://mainnet.infura.io/v3/${infuraProjectId}`;

--- a/app/util/etherscan.js
+++ b/app/util/etherscan.js
@@ -1,13 +1,17 @@
 import {
+  BASE_MAINNET_BLOCK_EXPLORER_URL,
   LINEA_GOERLI_BLOCK_EXPLORER,
   LINEA_MAINNET_BLOCK_EXPLORER,
   LINEA_SEPOLIA_BLOCK_EXPLORER,
+  SEPOLIA_BLOCK_EXPLORER,
 } from '../constants/urls';
 import {
   LINEA_GOERLI,
   LINEA_MAINNET,
   LINEA_SEPOLIA,
+  BASE_MAINNET,
   MAINNET,
+  SEPOLIA,
 } from '../constants/network';
 
 /**
@@ -48,6 +52,8 @@ export function getEtherscanBaseUrl(networkType) {
   if (networkType === LINEA_GOERLI) return LINEA_GOERLI_BLOCK_EXPLORER;
   if (networkType === LINEA_SEPOLIA) return LINEA_SEPOLIA_BLOCK_EXPLORER;
   if (networkType === LINEA_MAINNET) return LINEA_MAINNET_BLOCK_EXPLORER;
+  if (networkType === BASE_MAINNET) return BASE_MAINNET_BLOCK_EXPLORER_URL;
+  if (networkType === SEPOLIA) return SEPOLIA_BLOCK_EXPLORER;
   const subdomain =
     networkType.toLowerCase() === MAINNET
       ? ''


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is fixed the block explorer URL doesnt not return correctly for bridge transaction

it is because the previous method is heavy depends on `etherscan-link` to get the URL

on the other hand, if the hashmap of network <> block explorer url is not up to date, there will be an issue (it only support 0x1)

In this fix, we copy the same behavior with `app/components/hooks/useBlockExplorer.ts` to have minimal change to fix the issue


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed missing explorer url in bridge transaction

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16109

## **Manual testing steps**

1. Make a bridge transaction from one the network - Mainnet, Sepolia, Linea Mainnet, Linea Sepolia, and Base
2. And check the tx histroy after the tx complete
3. We should see 2 explorer URL

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/594bc4be-5018-4e02-8a75-103066af77fc" />
<img width="200" alt="Screenshot 2025-07-09 at 4 01 52 PM" src="https://github.com/user-attachments/assets/dd7f25cd-eea3-40b1-b573-5d317b325bc7" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
