### PR TITLE
fix: Improve address formatting for CAIP asset types

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -81,9 +81,7 @@ export enum TokenInputAreaType {
   Destination = 'destination',
 }
 
-const shortAddress = (address?: string) => {
-  return address ? `${address.slice(0, 6)}...${address.slice(-4)}` : undefined;
-}
+const shortAddress = (address?: string) => address ? `${address.slice(0, 6)}...${address.slice(-4)}` : undefined;
 
 const formatAddress = (address?: string) => {
   if (isCaipAssetType(address)) {
@@ -92,7 +90,7 @@ const formatAddress = (address?: string) => {
   }
 
   return shortAddress(address);
-}
+};
 
 export const getDisplayAmount = (
   amount?: string,

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -36,6 +36,7 @@ import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
 import parseAmount from '../../../Ramp/Aggregator/utils/parseAmount';
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 
 const MAX_DECIMALS = 5;
 export const MAX_INPUT_LENGTH = 18;
@@ -80,8 +81,18 @@ export enum TokenInputAreaType {
   Destination = 'destination',
 }
 
-const formatAddress = (address?: string) =>
-  address ? `${address.slice(0, 6)}...${address.slice(-4)}` : undefined;
+const shortAddress = (address?: string) => {
+  return address ? `${address.slice(0, 6)}...${address.slice(-4)}` : undefined;
+}
+
+const formatAddress = (address?: string) => {
+  if (isCaipAssetType(address)) {
+    const { assetReference } = parseCaipAssetType(address);
+    return shortAddress(assetReference);
+  }
+
+  return shortAddress(address);
+}
 
 export const getDisplayAmount = (
   amount?: string,

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -37,6 +37,7 @@ import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
 import parseAmount from '../../../Ramp/Aggregator/utils/parseAmount';
 import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import { renderShortAddress } from '../../../../../util/address';
 
 const MAX_DECIMALS = 5;
 export const MAX_INPUT_LENGTH = 18;
@@ -81,15 +82,14 @@ export enum TokenInputAreaType {
   Destination = 'destination',
 }
 
-const shortAddress = (address?: string) => address ? `${address.slice(0, 6)}...${address.slice(-4)}` : undefined;
-
 const formatAddress = (address?: string) => {
+  if (!address) return undefined;
+
   if (isCaipAssetType(address)) {
     const { assetReference } = parseCaipAssetType(address);
-    return shortAddress(assetReference);
+    return renderShortAddress(assetReference, 4);
   }
-
-  return shortAddress(address);
+  return renderShortAddress(address, 4);
 };
 
 export const getDisplayAmount = (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated the formatAddress function to handle CAIP asset types by extracting and shortening the asset reference. Introduced a shortAddress helper for consistent address shortening.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/16129

## **Manual testing steps**

1. Go to swaps on Solana
2. See destination token address does not include chain identifier

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![image](https://github.com/user-attachments/assets/04ac6d57-81ee-47f0-a7d0-546c2e6fb200)

<!-- [screenshots/recordings] -->

### **After**
<img width="344" alt="Screenshot 2025-07-09 at 15 52 21" src="https://github.com/user-attachments/assets/163b0bb3-14db-4530-8183-c5dfce4bc43b" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
