### PR TITLE
fix: eth avatar logo change

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
@@ -23,7 +23,7 @@ import styleSheet from './DeFiPositionsListItem.styles';
 import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
 import { useStyles } from '../../hooks/useStyles';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
-import AppConstants from '../../../core/AppConstants';
+import { getTokenAvatarUrl } from './get-token-avatar-url';
 
 interface DeFiPositionsListItemProps {
   chainId: Hex;
@@ -101,10 +101,7 @@ const DeFiPositionsListItem: React.FC<DeFiPositionsListItemProps> = ({
         variant: AvatarVariant.Token,
         name: token.name,
         imageSource: {
-          uri:
-            token.address === AppConstants.ZERO_ADDRESS
-              ? token.iconUrl
-              : 'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/app/images/eth-logo-new.png',
+          uri: getTokenAvatarUrl(token),
         },
       })),
       tokenNames: tokenStr(),

--- a/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
@@ -23,6 +23,7 @@ import styleSheet from './DeFiPositionsListItem.styles';
 import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
 import { useStyles } from '../../hooks/useStyles';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
+import AppConstants from '../../../core/AppConstants';
 
 interface DeFiPositionsListItemProps {
   chainId: Hex;
@@ -100,7 +101,10 @@ const DeFiPositionsListItem: React.FC<DeFiPositionsListItemProps> = ({
         variant: AvatarVariant.Token,
         name: token.name,
         imageSource: {
-          uri: token.iconUrl,
+          uri:
+            token.address === AppConstants.ZERO_ADDRESS
+              ? token.iconUrl
+              : 'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/app/images/eth-logo-new.png',
         },
       })),
       tokenNames: tokenStr(),

--- a/app/components/UI/DeFiPositions/DeFiProtocolPositionGroupTokens.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiProtocolPositionGroupTokens.test.tsx
@@ -12,6 +12,7 @@ const mockInitialState = {
 const mockTokens = [
   {
     key: 'token1',
+    address: '0x1',
     name: 'Token 1',
     symbol: 'TKN1',
     iconUrl: 'https://example.com/tkn1.png',
@@ -20,6 +21,7 @@ const mockTokens = [
   },
   {
     key: 'token2',
+    address: '0x2',
     name: 'Token 2',
     symbol: 'TKN2',
     iconUrl: 'https://example.com/tkn2.png',

--- a/app/components/UI/DeFiPositions/DeFiProtocolPositionGroupTokens.tsx
+++ b/app/components/UI/DeFiPositions/DeFiProtocolPositionGroupTokens.tsx
@@ -13,11 +13,13 @@ import DeFiAvatarWithBadge from './DeFiAvatarWithBadge';
 import styleSheet from './DeFiProtocolPositionGroupTokens.styles';
 import { PositionType } from './position-types';
 import { useStyles } from '../../hooks/useStyles';
+import { getTokenAvatarUrl } from './get-token-avatar-url';
 
 interface DeFiProtocolPositionGroupTokensProps {
   positionType: PositionType;
   tokens: {
     key: string;
+    address: string;
     name: string;
     symbol: string;
     iconUrl: string;
@@ -53,7 +55,7 @@ const DeFiProtocolPositionGroupTokens: React.FC<
             <DeFiAvatarWithBadge
               networkIconAvatar={networkIconAvatar}
               avatarName={token.name}
-              avatarIconUrl={token.iconUrl}
+              avatarIconUrl={getTokenAvatarUrl(token)}
             />
           </View>
 

--- a/app/components/UI/DeFiPositions/DeFiProtocolPositionGroups.tsx
+++ b/app/components/UI/DeFiPositions/DeFiProtocolPositionGroups.tsx
@@ -43,6 +43,7 @@ const DeFiProtocolPositionGroups: React.FC<
                 )
                 .map((underlyingToken, index) => ({
                   key: `${protocolToken.address}-${underlyingToken.address}-${index}`,
+                  address: underlyingToken.address,
                   name: underlyingToken.name,
                   symbol: underlyingToken.symbol,
                   iconUrl: underlyingToken.iconUrl,
@@ -56,6 +57,7 @@ const DeFiProtocolPositionGroups: React.FC<
                 )
                 .map((underlyingToken, index) => ({
                   key: `${protocolToken.address}-${underlyingToken.address}-${index}`,
+                  address: underlyingToken.address,
                   name: underlyingToken.name,
                   symbol: underlyingToken.symbol,
                   iconUrl: underlyingToken.iconUrl,

--- a/app/components/UI/DeFiPositions/get-token-avatar-url.test.ts
+++ b/app/components/UI/DeFiPositions/get-token-avatar-url.test.ts
@@ -7,6 +7,7 @@ describe('getTokenAvatarUrl', () => {
   it('returns ETH logo URL when token address is zero address', () => {
     const token = {
       address: AppConstants.ZERO_ADDRESS,
+      symbol: 'ETH',
       iconUrl: customIconUrl,
     };
 
@@ -20,6 +21,31 @@ describe('getTokenAvatarUrl', () => {
   it('returns token iconUrl when token address is not zero address', () => {
     const token = {
       address: '0x1234567890123456789012345678901234567890',
+      symbol: 'USDC',
+      iconUrl: customIconUrl,
+    };
+
+    const result = getTokenAvatarUrl(token);
+
+    expect(result).toBe(customIconUrl);
+  });
+
+  it('returns token iconUrl when token address is zero address and symbol is not ETH', () => {
+    const token = {
+      address: AppConstants.ZERO_ADDRESS,
+      symbol: 'BNB',
+      iconUrl: customIconUrl,
+    };
+
+    const result = getTokenAvatarUrl(token);
+
+    expect(result).toBe(customIconUrl);
+  });
+
+  it('returns token iconUrl when token address is not zero address and symbol is ETH', () => {
+    const token = {
+      address: '0x1234567890123456789012345678901234567890',
+      symbol: 'ETH',
       iconUrl: customIconUrl,
     };
 

--- a/app/components/UI/DeFiPositions/get-token-avatar-url.test.ts
+++ b/app/components/UI/DeFiPositions/get-token-avatar-url.test.ts
@@ -1,0 +1,30 @@
+import { getTokenAvatarUrl } from './get-token-avatar-url';
+import AppConstants from '../../../core/AppConstants';
+
+describe('getTokenAvatarUrl', () => {
+  const customIconUrl = 'https://example.com/custom-token-icon.png';
+
+  it('returns ETH logo URL when token address is zero address', () => {
+    const token = {
+      address: AppConstants.ZERO_ADDRESS,
+      iconUrl: customIconUrl,
+    };
+
+    const result = getTokenAvatarUrl(token);
+
+    expect(result).toBe(
+      'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/app/images/eth-logo-new.png',
+    );
+  });
+
+  it('returns token iconUrl when token address is not zero address', () => {
+    const token = {
+      address: '0x1234567890123456789012345678901234567890',
+      iconUrl: customIconUrl,
+    };
+
+    const result = getTokenAvatarUrl(token);
+
+    expect(result).toBe(customIconUrl);
+  });
+});

--- a/app/components/UI/DeFiPositions/get-token-avatar-url.ts
+++ b/app/components/UI/DeFiPositions/get-token-avatar-url.ts
@@ -1,7 +1,11 @@
 import AppConstants from '../../../core/AppConstants';
 
-export function getTokenAvatarUrl(token: { address: string; iconUrl: string }) {
-  return token.address === AppConstants.ZERO_ADDRESS
+export function getTokenAvatarUrl(token: {
+  address: string;
+  symbol: string;
+  iconUrl: string;
+}) {
+  return token.address === AppConstants.ZERO_ADDRESS && token.symbol === 'ETH'
     ? 'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/app/images/eth-logo-new.png'
     : token.iconUrl;
 }

--- a/app/components/UI/DeFiPositions/get-token-avatar-url.ts
+++ b/app/components/UI/DeFiPositions/get-token-avatar-url.ts
@@ -1,0 +1,7 @@
+import AppConstants from '../../../core/AppConstants';
+
+export function getTokenAvatarUrl(token: { address: string; iconUrl: string }) {
+  return token.address === AppConstants.ZERO_ADDRESS
+    ? 'https://raw.githubusercontent.com/MetaMask/metamask-mobile/main/app/images/eth-logo-new.png'
+    : token.iconUrl;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Overwrites ETH native logo to use the one with blue background.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed that native eth logo icon in the DeFi tab

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open DeFi tab
2. Check that positions with ETH as an underlying token display the correct logo

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="828" height="1792" alt="image" src="https://github.com/user-attachments/assets/0b445adb-a539-4f07-829a-13e633daa4b5" />
<img width="828" height="1792" alt="image" src="https://github.com/user-attachments/assets/f8bca656-4fe7-4c88-8660-66e3278caa4e" />


### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/f1f9123f-1f1d-45f7-958d-4fa56ea350ab" />
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/753ce2da-d293-470e-90cc-4f12758b7617" />


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
