### PR TITLE
fix: export srp to go directly to quiz in account details

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
@@ -37,7 +37,13 @@ jest.mock('../../../../../../util/address', () => ({
   isPrivateKeyAccount: () => mockIsPrivateKeyAccount(),
 }));
 
-const mockAccount = createMockInternalAccount('0x123', 'Test Account');
+const mockKeyringId = 'keyring-1';
+const mockAccount = {
+  ...createMockInternalAccount('0x123', 'Test Account'),
+  options: {
+    entropySource: mockKeyringId,
+  },
+};
 const mockPrivateKeyAccount = createMockInternalAccount(
   '0x123',
   'Test Account',
@@ -50,7 +56,6 @@ const mockLedgerAccount = createMockInternalAccount(
   KeyringTypes.ledger,
   EthAccountType.Eoa,
 );
-const mockKeyringId = 'keyring-1';
 
 describe('ExportCredentials', () => {
   beforeEach(() => {
@@ -164,12 +169,10 @@ describe('ExportCredentials', () => {
     );
     fireEvent.press(mnemonicButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.REVEAL_SRP_CREDENTIAL,
-      {
-        account: mockAccount,
-      },
-    );
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+      keyringId: mockKeyringId,
+    });
   });
 
   it('navigates to reveal private credential when export private key is pressed', () => {

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
@@ -72,10 +72,13 @@ export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
   }, [seedphraseBackedUp, hdKeyringsWithSnapAccounts, account]);
 
   const onExportMnemonic = useCallback(() => {
-    navigate(Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.REVEAL_SRP_CREDENTIAL, {
-      account,
-    });
-  }, [navigate, account]);
+    if (account.options.entropySource) {
+      navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+        keyringId: account.options.entropySource,
+      });
+    }
+  }, [navigate, account.options.entropySource]);
 
   const onExportPrivateKey = useCallback(() => {
     navigate(

--- a/e2e/specs/multichain-accounts/export-credentials.spec.ts
+++ b/e2e/specs/multichain-accounts/export-credentials.spec.ts
@@ -31,9 +31,6 @@ const exportPrivateKey = async () => {
 
 const exportSrp = async () => {
   await AccountDetails.tapExportSrpButton();
-  await Assertions.checkIfVisible(ExportCredentials.srpInfoContainer);
-  await ExportCredentials.tapNextButton();
-  // this also checks the srp
   await completeSrpQuiz(defaultOptions.mnemonic);
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aligns the reveal SRP flow for the account details and wallet details screen. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: export srp goes directly to quiz from the account details. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-395?atlOrigin=eyJpIjoiOWQyY2M4OWFjMDA4NGUxZmI2ZTY4NTQ5ZmRmYWQ3NTIiLCJwIjoiaiJ9

## **Manual testing steps**

1. Enable multichain account designs
2. go to account details of a hd account
3. click on srp and see that the quiz is shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
