### PR TITLE
fix: use correct import/export for base64 in Sentry

### DIFF
--- a/patches/@sentry+react-native+6.10.0.patch
+++ b/patches/@sentry+react-native+6.10.0.patch
@@ -1,10 +1,10 @@
 diff --git a/node_modules/@sentry/react-native/dist/js/vendor/base64-js/index.js b/node_modules/@sentry/react-native/dist/js/vendor/base64-js/index.js
-index e3d0936..9974653 100644
+index e3d0936..5277051 100644
 --- a/node_modules/@sentry/react-native/dist/js/vendor/base64-js/index.js
 +++ b/node_modules/@sentry/react-native/dist/js/vendor/base64-js/index.js
 @@ -1,2 +1,2 @@
 -export { base64StringFromByteArray } from './fromByteArray';
-+export { base64StringFromByteArray } from 'react-native-quick-base64';
++export { fromByteArray as base64StringFromByteArray } from 'react-native-quick-base64';
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/node_modules/@sentry/react-native/dist/js/vendor/buffer/utf8ToBytes.js b/node_modules/@sentry/react-native/dist/js/vendor/buffer/utf8ToBytes.js


### PR DESCRIPTION
## **Description**

I was creating patch multiple times and did mistake with names in last attempt probably.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Sentry should report issues
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
