### PR TITLE
fix: Potential fix for code scanning alert no. 10: Inefficient regular expression

### DIFF
--- a/app/util/regex/index.ts
+++ b/app/util/regex/index.ts
@@ -46,7 +46,7 @@ export const regex: RegexTypes = {
   trailingZero: /\.?0+$/,
   transactionNonce: /^#/,
   url: new RegExp(
-    /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!&',,=.+]+$/g,
+    /^(?:http(s)?:\/\/)?[a-zA-Z0-9]+(?:[-.][a-zA-Z0-9]+)*(?:\.[a-zA-Z0-9]+(?:[-.][a-zA-Z0-9]+)*)+[\w\-._~:/?#[\]@!&',,=.+]+$/g,
   ),
   urlHttpToHttps: /^http:\/\//,
   validChainId: /^[0-9]+$/u,


### PR DESCRIPTION
Potential fix for [https://github.com/MetaMask/metamask-mobile/security/code-scanning/10](https://github.com/MetaMask/metamask-mobile/security/code-scanning/10)

To fix the issue, we need to remove the ambiguity in the `[\w.-]+` sub-expression. This can be achieved by ensuring that the `.` and `-` characters are not treated as interchangeable with each other or with `\w`. A common approach is to use a negative lookahead or explicitly define the order of matching to avoid ambiguity.

For this specific case, we can rewrite the regular expression to separate the matching of word characters (`\w`), dots (`.`), and hyphens (`-`) into distinct groups. For example, we can use `[a-zA-Z0-9]+(?:[-.][a-zA-Z0-9]+)*` to ensure that dots and hyphens are only allowed between valid domain name pieces, and not as ambiguous repetitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens the URL validation regex to enforce clearer domain label structure and reduce ambiguity.
> 
> - **util/regex**:
>   - Update `regex.url` in `app/util/regex/index.ts` to a stricter pattern that enforces domain labels as alphanumeric segments separated by `.` or `-`, reducing ambiguity in the URL matcher.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b53eb9d8cc192b5c7009a69af9223f5cf1f307d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->