### PR TITLE
chore: add staking transaction confirmed traces

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
@@ -1426,7 +1426,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       });
     });
 
-    it('should call trace with EarnDepositTxConfirmed when transaction is submitted', async () => {
+    it('should call trace with EarnLendingDepositTxConfirmed when transaction is submitted', async () => {
       const transactionId = '123';
 
       mockExecuteLendingDeposit.mockResolvedValue({
@@ -1475,7 +1475,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       });
 
       expect(mockTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnDepositTxConfirmed,
+        name: TraceName.EarnLendingDepositTxConfirmed,
         data: {
           chainId: MOCK_USDC_MAINNET_ASSET.chainId,
           experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
@@ -1483,7 +1483,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       });
     });
 
-    it('should call endTrace with EarnDepositTxConfirmed when transaction is confirmed', async () => {
+    it('should call endTrace with EarnLendingDepositTxConfirmed when transaction is confirmed', async () => {
       const transactionId = '123';
 
       mockExecuteLendingDeposit.mockResolvedValue({
@@ -1546,7 +1546,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       });
 
       expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnDepositTxConfirmed,
+        name: TraceName.EarnLendingDepositTxConfirmed,
       });
     });
   });

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.test.tsx
@@ -1422,7 +1422,7 @@ describe('EarnLendingDepositConfirmationView', () => {
       });
 
       expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnDepositConfirmationScreen
+        name: TraceName.EarnDepositConfirmationScreen,
       });
     });
 

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -196,8 +196,7 @@ const EarnLendingDepositConfirmationView = () => {
   useEffect(() => {
     if (action === EARN_LENDING_ACTIONS.ALLOWANCE_INCREASE) {
       endTrace({ name: TraceName.EarnDepositSpendingCapScreen });
-    }
-    else {
+    } else {
       endTrace({ name: TraceName.EarnDepositReviewScreen });
     }
   }, [action]);
@@ -445,7 +444,13 @@ const EarnLendingDepositConfirmationView = () => {
         ({ transactionMeta }) => transactionMeta.id === transactionId,
       );
     },
-    [emitTxMetaMetric, navigation, outputToken, tokenSnapshot, earnToken?.chainId],
+    [
+      emitTxMetaMetric,
+      navigation,
+      outputToken,
+      tokenSnapshot,
+      earnToken?.chainId,
+    ],
   );
 
   const createTransactionEventListeners = useCallback(

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -394,7 +394,7 @@ const EarnLendingDepositConfirmationView = () => {
           emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_SUBMITTED);
           // start trace of time between tx submitted and tx confirmed
           trace({
-            name: TraceName.EarnDepositTxConfirmed,
+            name: TraceName.EarnLendingDepositTxConfirmed,
             data: {
               chainId: earnToken?.chainId || '',
               experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
@@ -412,7 +412,7 @@ const EarnLendingDepositConfirmationView = () => {
         'TransactionController:transactionConfirmed',
         () => {
           emitDepositTxMetaMetric(MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED);
-          endTrace({ name: TraceName.EarnDepositTxConfirmed });
+          endTrace({ name: TraceName.EarnLendingDepositTxConfirmed });
 
           if (!outputToken) {
             const networkClientId =

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
@@ -933,7 +933,7 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
       });
     });
 
-    it('should call trace with EarnWithdrawTxConfirmed when transaction is submitted', async () => {
+    it('should call trace with EarnLendingWithdrawTxConfirmed when transaction is submitted', async () => {
       const mockExecuteLendingWithdraw = Engine.context.EarnController
         .executeLendingWithdraw as jest.MockedFunction<
         typeof Engine.context.EarnController.executeLendingWithdraw
@@ -986,7 +986,7 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
       });
 
       expect(mockTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnWithdrawTxConfirmed,
+        name: TraceName.EarnLendingWithdrawTxConfirmed,
         data: {
           chainId: mockLineaAUsdc.chainId,
           experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
@@ -994,7 +994,7 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
       });
     });
 
-    it('should call endTrace with EarnWithdrawTxConfirmed when transaction is confirmed', async () => {
+    it('should call endTrace with EarnLendingWithdrawTxConfirmed when transaction is confirmed', async () => {
       const mockExecuteLendingWithdraw = Engine.context.EarnController
         .executeLendingWithdraw as jest.MockedFunction<
         typeof Engine.context.EarnController.executeLendingWithdraw
@@ -1061,7 +1061,7 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
       });
 
       expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnWithdrawTxConfirmed,
+        name: TraceName.EarnLendingWithdrawTxConfirmed,
       });
     });
   });

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
@@ -929,7 +929,7 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
       });
 
       expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.EarnWithdrawConfirmationScreen
+        name: TraceName.EarnWithdrawConfirmationScreen,
       });
     });
 

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -302,7 +302,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
           );
           // start trace of time between tx submitted and tx confirmed
           trace({
-            name: TraceName.EarnWithdrawTxConfirmed,
+            name: TraceName.EarnLendingWithdrawTxConfirmed,
             data: {
               chainId: outputToken?.chainId || '',
               experience: EARN_EXPERIENCES.STABLECOIN_LENDING,
@@ -322,7 +322,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
           emitWithdrawalTxMetaMetric(
             MetaMetricsEvents.EARN_TRANSACTION_CONFIRMED,
           );
-          endTrace({ name: TraceName.EarnWithdrawTxConfirmed });
+          endTrace({ name: TraceName.EarnLendingWithdrawTxConfirmed });
         },
         (transactionMeta) => transactionMeta.id === transactionId,
       );

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -351,7 +351,13 @@ const EarnLendingWithdrawalConfirmationView = () => {
         (transactionMeta) => transactionMeta.id === transactionId,
       );
     },
-    [emitTxMetaMetric, tokenSnapshot, earnToken, navigation, outputToken?.chainId],
+    [
+      emitTxMetaMetric,
+      tokenSnapshot,
+      earnToken,
+      navigation,
+      outputToken?.chainId,
+    ],
   );
 
   // Guards

--- a/app/components/UI/Stake/hooks/useStakingTransactionTracing.test.ts
+++ b/app/components/UI/Stake/hooks/useStakingTransactionTracing.test.ts
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react-native';
-import { TransactionStatus, TransactionType, TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import Engine from '../../../../core/Engine';
 import { trace, endTrace, TraceName } from '../../../../util/trace';
 import { useStakingTransactionTracing } from './useStakingTransactionTracing';
@@ -23,15 +27,22 @@ jest.mock('../../../Views/confirmations/utils/confirm', () => ({
   isStakingConfirmation: jest.fn(),
 }));
 
-jest.mock('../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest', () => ({
-  useTransactionMetadataRequest: jest.fn(),
-}));
+jest.mock(
+  '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest',
+  () => ({
+    useTransactionMetadataRequest: jest.fn(),
+  }),
+);
 
 const mockTrace = jest.mocked(trace);
 const mockEndTrace = jest.mocked(endTrace);
 const mockIsStakingConfirmation = jest.mocked(isStakingConfirmation);
-const mockUseTransactionMetadataRequest = jest.mocked(useTransactionMetadataRequest);
-const mockSubscribeOnceIf = jest.mocked(Engine.controllerMessenger.subscribeOnceIf);
+const mockUseTransactionMetadataRequest = jest.mocked(
+  useTransactionMetadataRequest,
+);
+const mockSubscribeOnceIf = jest.mocked(
+  Engine.controllerMessenger.subscribeOnceIf,
+);
 
 describe('useStakingTransactionTracing', () => {
   const mockStakingDepositTransaction: TransactionMeta = {
@@ -67,7 +78,9 @@ describe('useStakingTransactionTracing', () => {
   });
 
   it('should set up event listeners for staking deposit transactions', () => {
-    mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      mockStakingDepositTransaction,
+    );
     mockIsStakingConfirmation.mockReturnValue(true);
 
     renderHook(() => useStakingTransactionTracing());
@@ -88,7 +101,9 @@ describe('useStakingTransactionTracing', () => {
   });
 
   it('should not set up event listeners for non-staking transactions', () => {
-    mockUseTransactionMetadataRequest.mockReturnValue(mockNonStakingTransaction);
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      mockNonStakingTransaction,
+    );
     mockIsStakingConfirmation.mockReturnValue(false);
 
     renderHook(() => useStakingTransactionTracing());
@@ -106,21 +121,25 @@ describe('useStakingTransactionTracing', () => {
 
   describe('Transaction event handlers', () => {
     it('should start trace when transaction is submitted', () => {
-      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+      mockUseTransactionMetadataRequest.mockReturnValue(
+        mockStakingDepositTransaction,
+      );
       mockIsStakingConfirmation.mockReturnValue(true);
 
-      let transactionSubmittedCallback: 
+      let transactionSubmittedCallback:
         | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
         | undefined;
 
-      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
-        if (eventName === 'TransactionController:transactionSubmitted') {
-          transactionSubmittedCallback = callback as (event: {
-            transactionMeta: Partial<TransactionMeta>;
-          }) => void;
-        }
-        return jest.fn();
-      });
+      mockSubscribeOnceIf.mockImplementation(
+        (eventName: string, callback: unknown) => {
+          if (eventName === 'TransactionController:transactionSubmitted') {
+            transactionSubmittedCallback = callback as (event: {
+              transactionMeta: Partial<TransactionMeta>;
+            }) => void;
+          }
+          return jest.fn();
+        },
+      );
 
       renderHook(() => useStakingTransactionTracing());
 
@@ -145,21 +164,25 @@ describe('useStakingTransactionTracing', () => {
     });
 
     it('should end trace when transaction is confirmed', () => {
-      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+      mockUseTransactionMetadataRequest.mockReturnValue(
+        mockStakingDepositTransaction,
+      );
       mockIsStakingConfirmation.mockReturnValue(true);
 
-      let transactionConfirmedCallback: 
+      let transactionConfirmedCallback:
         | ((transactionMeta: Partial<TransactionMeta>) => void)
         | undefined;
 
-      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
-        if (eventName === 'TransactionController:transactionConfirmed') {
-          transactionConfirmedCallback = callback as (
-            transactionMeta: Partial<TransactionMeta>,
-          ) => void;
-        }
-        return jest.fn();
-      });
+      mockSubscribeOnceIf.mockImplementation(
+        (eventName: string, callback: unknown) => {
+          if (eventName === 'TransactionController:transactionConfirmed') {
+            transactionConfirmedCallback = callback as (
+              transactionMeta: Partial<TransactionMeta>,
+            ) => void;
+          }
+          return jest.fn();
+        },
+      );
 
       renderHook(() => useStakingTransactionTracing());
 
@@ -186,21 +209,25 @@ describe('useStakingTransactionTracing', () => {
         type: TransactionType.stakingUnstake,
       };
 
-      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingWithdrawalTransaction);
+      mockUseTransactionMetadataRequest.mockReturnValue(
+        mockStakingWithdrawalTransaction,
+      );
       mockIsStakingConfirmation.mockReturnValue(true);
 
-      let transactionSubmittedCallback: 
+      let transactionSubmittedCallback:
         | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
         | undefined;
 
-      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
-        if (eventName === 'TransactionController:transactionSubmitted') {
-          transactionSubmittedCallback = callback as (event: {
-            transactionMeta: Partial<TransactionMeta>;
-          }) => void;
-        }
-        return jest.fn();
-      });
+      mockSubscribeOnceIf.mockImplementation(
+        (eventName: string, callback: unknown) => {
+          if (eventName === 'TransactionController:transactionSubmitted') {
+            transactionSubmittedCallback = callback as (event: {
+              transactionMeta: Partial<TransactionMeta>;
+            }) => void;
+          }
+          return jest.fn();
+        },
+      );
 
       renderHook(() => useStakingTransactionTracing());
 
@@ -231,21 +258,25 @@ describe('useStakingTransactionTracing', () => {
         type: TransactionType.stakingClaim,
       };
 
-      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingClaimTransaction);
+      mockUseTransactionMetadataRequest.mockReturnValue(
+        mockStakingClaimTransaction,
+      );
       mockIsStakingConfirmation.mockReturnValue(true);
 
-      let transactionSubmittedCallback: 
+      let transactionSubmittedCallback:
         | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
         | undefined;
 
-      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
-        if (eventName === 'TransactionController:transactionSubmitted') {
-          transactionSubmittedCallback = callback as (event: {
-            transactionMeta: Partial<TransactionMeta>;
-          }) => void;
-        }
-        return jest.fn();
-      });
+      mockSubscribeOnceIf.mockImplementation(
+        (eventName: string, callback: unknown) => {
+          if (eventName === 'TransactionController:transactionSubmitted') {
+            transactionSubmittedCallback = callback as (event: {
+              transactionMeta: Partial<TransactionMeta>;
+            }) => void;
+          }
+          return jest.fn();
+        },
+      );
 
       renderHook(() => useStakingTransactionTracing());
 
@@ -269,4 +300,4 @@ describe('useStakingTransactionTracing', () => {
       });
     });
   });
-}); 
+});

--- a/app/components/UI/Stake/hooks/useStakingTransactionTracing.test.ts
+++ b/app/components/UI/Stake/hooks/useStakingTransactionTracing.test.ts
@@ -1,0 +1,272 @@
+import { renderHook } from '@testing-library/react-native';
+import { TransactionStatus, TransactionType, TransactionMeta } from '@metamask/transaction-controller';
+import Engine from '../../../../core/Engine';
+import { trace, endTrace, TraceName } from '../../../../util/trace';
+import { useStakingTransactionTracing } from './useStakingTransactionTracing';
+import { isStakingConfirmation } from '../../../Views/confirmations/utils/confirm';
+import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
+import { EARN_EXPERIENCES } from '../../Earn/constants/experiences';
+
+jest.mock('../../../../core/Engine', () => ({
+  controllerMessenger: {
+    subscribeOnceIf: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+jest.mock('../../../Views/confirmations/utils/confirm', () => ({
+  isStakingConfirmation: jest.fn(),
+}));
+
+jest.mock('../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest', () => ({
+  useTransactionMetadataRequest: jest.fn(),
+}));
+
+const mockTrace = jest.mocked(trace);
+const mockEndTrace = jest.mocked(endTrace);
+const mockIsStakingConfirmation = jest.mocked(isStakingConfirmation);
+const mockUseTransactionMetadataRequest = jest.mocked(useTransactionMetadataRequest);
+const mockSubscribeOnceIf = jest.mocked(Engine.controllerMessenger.subscribeOnceIf);
+
+describe('useStakingTransactionTracing', () => {
+  const mockStakingDepositTransaction: TransactionMeta = {
+    id: 'test-deposit-id',
+    type: TransactionType.stakingDeposit,
+    chainId: '0x1' as `0x${string}`,
+    networkClientId: 'test-network-client-id',
+    status: TransactionStatus.submitted,
+    time: 1000,
+    txParams: {
+      from: '0x2' as `0x${string}`,
+      to: '0x1' as `0x${string}`,
+      value: '1000000000000000000',
+    },
+  };
+
+  const mockNonStakingTransaction: TransactionMeta = {
+    id: 'test-send-id',
+    type: TransactionType.simpleSend,
+    chainId: '0x1' as `0x${string}`,
+    networkClientId: 'test-network-client-id',
+    status: TransactionStatus.submitted,
+    time: 1000,
+    txParams: {
+      from: '0x2' as `0x${string}`,
+      to: '0x1' as `0x${string}`,
+      value: '1000000000000000000',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set up event listeners for staking deposit transactions', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+    mockIsStakingConfirmation.mockReturnValue(true);
+
+    renderHook(() => useStakingTransactionTracing());
+
+    expect(mockSubscribeOnceIf).toHaveBeenCalledWith(
+      'TransactionController:transactionSubmitted',
+      expect.any(Function),
+      expect.any(Function),
+    );
+
+    expect(mockSubscribeOnceIf).toHaveBeenCalledWith(
+      'TransactionController:transactionConfirmed',
+      expect.any(Function),
+      expect.any(Function),
+    );
+
+    expect(mockSubscribeOnceIf).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not set up event listeners for non-staking transactions', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(mockNonStakingTransaction);
+    mockIsStakingConfirmation.mockReturnValue(false);
+
+    renderHook(() => useStakingTransactionTracing());
+
+    expect(mockSubscribeOnceIf).not.toHaveBeenCalled();
+  });
+
+  it('should not set up event listeners when transaction metadata is missing', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+
+    renderHook(() => useStakingTransactionTracing());
+
+    expect(mockSubscribeOnceIf).not.toHaveBeenCalled();
+  });
+
+  describe('Transaction event handlers', () => {
+    it('should start trace when transaction is submitted', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+      mockIsStakingConfirmation.mockReturnValue(true);
+
+      let transactionSubmittedCallback: 
+        | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
+        | undefined;
+
+      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
+        if (eventName === 'TransactionController:transactionSubmitted') {
+          transactionSubmittedCallback = callback as (event: {
+            transactionMeta: Partial<TransactionMeta>;
+          }) => void;
+        }
+        return jest.fn();
+      });
+
+      renderHook(() => useStakingTransactionTracing());
+
+      const transactionMeta = {
+        id: 'test-deposit-id',
+        type: TransactionType.stakingDeposit,
+        chainId: '0x1' as `0x${string}`,
+      };
+
+      if (transactionSubmittedCallback) {
+        transactionSubmittedCallback({ transactionMeta });
+      }
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.EarnPooledStakingDepositTxConfirmed,
+        id: 'test-deposit-id',
+        data: {
+          chainId: '0x1',
+          experience: EARN_EXPERIENCES.POOLED_STAKING,
+        },
+      });
+    });
+
+    it('should end trace when transaction is confirmed', () => {
+      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingDepositTransaction);
+      mockIsStakingConfirmation.mockReturnValue(true);
+
+      let transactionConfirmedCallback: 
+        | ((transactionMeta: Partial<TransactionMeta>) => void)
+        | undefined;
+
+      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
+        if (eventName === 'TransactionController:transactionConfirmed') {
+          transactionConfirmedCallback = callback as (
+            transactionMeta: Partial<TransactionMeta>,
+          ) => void;
+        }
+        return jest.fn();
+      });
+
+      renderHook(() => useStakingTransactionTracing());
+
+      const transactionMeta = {
+        id: 'test-deposit-id',
+        type: TransactionType.stakingDeposit,
+        chainId: '0x1' as `0x${string}`,
+      };
+
+      if (transactionConfirmedCallback) {
+        transactionConfirmedCallback(transactionMeta);
+      }
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.EarnPooledStakingDepositTxConfirmed,
+        id: 'test-deposit-id',
+      });
+    });
+
+    it('should handle staking withdrawal transactions', () => {
+      const mockStakingWithdrawalTransaction: TransactionMeta = {
+        ...mockStakingDepositTransaction,
+        id: 'test-withdrawal-id',
+        type: TransactionType.stakingUnstake,
+      };
+
+      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingWithdrawalTransaction);
+      mockIsStakingConfirmation.mockReturnValue(true);
+
+      let transactionSubmittedCallback: 
+        | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
+        | undefined;
+
+      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
+        if (eventName === 'TransactionController:transactionSubmitted') {
+          transactionSubmittedCallback = callback as (event: {
+            transactionMeta: Partial<TransactionMeta>;
+          }) => void;
+        }
+        return jest.fn();
+      });
+
+      renderHook(() => useStakingTransactionTracing());
+
+      const transactionMeta = {
+        id: 'test-withdrawal-id',
+        type: TransactionType.stakingUnstake,
+        chainId: '0x1' as `0x${string}`,
+      };
+
+      if (transactionSubmittedCallback) {
+        transactionSubmittedCallback({ transactionMeta });
+      }
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.EarnPooledStakingWithdrawTxConfirmed,
+        id: 'test-withdrawal-id',
+        data: {
+          chainId: '0x1',
+          experience: EARN_EXPERIENCES.POOLED_STAKING,
+        },
+      });
+    });
+
+    it('should handle staking claim rewards transactions', () => {
+      const mockStakingClaimTransaction: TransactionMeta = {
+        ...mockStakingDepositTransaction,
+        id: 'test-claim-id',
+        type: TransactionType.stakingClaim,
+      };
+
+      mockUseTransactionMetadataRequest.mockReturnValue(mockStakingClaimTransaction);
+      mockIsStakingConfirmation.mockReturnValue(true);
+
+      let transactionSubmittedCallback: 
+        | ((event: { transactionMeta: Partial<TransactionMeta> }) => void)
+        | undefined;
+
+      mockSubscribeOnceIf.mockImplementation((eventName: string, callback: unknown) => {
+        if (eventName === 'TransactionController:transactionSubmitted') {
+          transactionSubmittedCallback = callback as (event: {
+            transactionMeta: Partial<TransactionMeta>;
+          }) => void;
+        }
+        return jest.fn();
+      });
+
+      renderHook(() => useStakingTransactionTracing());
+
+      const transactionMeta = {
+        id: 'test-claim-id',
+        type: TransactionType.stakingClaim,
+        chainId: '0x1' as `0x${string}`,
+      };
+
+      if (transactionSubmittedCallback) {
+        transactionSubmittedCallback({ transactionMeta });
+      }
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.EarnPooledStakingClaimTxConfirmed,
+        id: 'test-claim-id',
+        data: {
+          chainId: '0x1',
+          experience: EARN_EXPERIENCES.POOLED_STAKING,
+        },
+      });
+    });
+  });
+}); 

--- a/app/components/UI/Stake/hooks/useStakingTransactionTracing.ts
+++ b/app/components/UI/Stake/hooks/useStakingTransactionTracing.ts
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
-import { TransactionType, type TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import Engine from '../../../../core/Engine';
 import { trace, endTrace, TraceName } from '../../../../util/trace';
 import { isStakingConfirmation } from '../../../Views/confirmations/utils/confirm';
@@ -10,8 +13,10 @@ import { EARN_EXPERIENCES } from '../../Earn/constants/experiences';
  * Maps pooled staking transaction types to their corresponding Earn trace names
  */
 const STAKING_TRACE_MAP: Record<string, TraceName> = {
-  [TransactionType.stakingDeposit]: TraceName.EarnPooledStakingDepositTxConfirmed,
-  [TransactionType.stakingUnstake]: TraceName.EarnPooledStakingWithdrawTxConfirmed,
+  [TransactionType.stakingDeposit]:
+    TraceName.EarnPooledStakingDepositTxConfirmed,
+  [TransactionType.stakingUnstake]:
+    TraceName.EarnPooledStakingWithdrawTxConfirmed,
   [TransactionType.stakingClaim]: TraceName.EarnPooledStakingClaimTxConfirmed,
 };
 
@@ -24,8 +29,12 @@ export const useStakingTransactionTracing = () => {
   useEffect(() => {
     const transactionType = transactionMetadata?.type;
     const transactionId = transactionMetadata?.id;
-    
-    if (!transactionType || !transactionId || !isStakingConfirmation(transactionType as string)) {
+
+    if (
+      !transactionType ||
+      !transactionId ||
+      !isStakingConfirmation(transactionType as string)
+    ) {
       return;
     }
 
@@ -42,12 +51,12 @@ export const useStakingTransactionTracing = () => {
           name: traceName,
           id: transactionMeta.id,
           data: {
-              chainId: transactionMeta.chainId,
-              experience: EARN_EXPERIENCES.POOLED_STAKING,
+            chainId: transactionMeta.chainId,
+            experience: EARN_EXPERIENCES.POOLED_STAKING,
           },
         });
       },
-      ({ transactionMeta }: { transactionMeta: TransactionMeta }) => 
+      ({ transactionMeta }: { transactionMeta: TransactionMeta }) =>
         transactionMeta.id === transactionId,
     );
 
@@ -60,8 +69,8 @@ export const useStakingTransactionTracing = () => {
           id: transactionMeta.id,
         });
       },
-      (transactionMeta: TransactionMeta) => 
+      (transactionMeta: TransactionMeta) =>
         transactionMeta.id === transactionId,
     );
   }, [transactionMetadata?.type, transactionMetadata?.id]);
-}; 
+};

--- a/app/components/UI/Stake/hooks/useStakingTransactionTracing.ts
+++ b/app/components/UI/Stake/hooks/useStakingTransactionTracing.ts
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { TransactionType, type TransactionMeta } from '@metamask/transaction-controller';
+import Engine from '../../../../core/Engine';
+import { trace, endTrace, TraceName } from '../../../../util/trace';
+import { isStakingConfirmation } from '../../../Views/confirmations/utils/confirm';
+import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
+import { EARN_EXPERIENCES } from '../../Earn/constants/experiences';
+
+/**
+ * Maps pooled staking transaction types to their corresponding Earn trace names
+ */
+const STAKING_TRACE_MAP: Record<string, TraceName> = {
+  [TransactionType.stakingDeposit]: TraceName.EarnPooledStakingDepositTxConfirmed,
+  [TransactionType.stakingUnstake]: TraceName.EarnPooledStakingWithdrawTxConfirmed,
+  [TransactionType.stakingClaim]: TraceName.EarnPooledStakingClaimTxConfirmed,
+};
+
+/**
+ * Hook that adds tracing for pooled staking transactions (submitted and confirmed)
+ */
+export const useStakingTransactionTracing = () => {
+  const transactionMetadata = useTransactionMetadataRequest();
+
+  useEffect(() => {
+    const transactionType = transactionMetadata?.type;
+    const transactionId = transactionMetadata?.id;
+    
+    if (!transactionType || !transactionId || !isStakingConfirmation(transactionType as string)) {
+      return;
+    }
+
+    const traceName = STAKING_TRACE_MAP[transactionType as string];
+    if (!traceName) {
+      return;
+    }
+
+    // Start the trace on submission
+    Engine.controllerMessenger.subscribeOnceIf(
+      'TransactionController:transactionSubmitted',
+      ({ transactionMeta }: { transactionMeta: TransactionMeta }) => {
+        trace({
+          name: traceName,
+          id: transactionMeta.id,
+          data: {
+              chainId: transactionMeta.chainId,
+              experience: EARN_EXPERIENCES.POOLED_STAKING,
+          },
+        });
+      },
+      ({ transactionMeta }: { transactionMeta: TransactionMeta }) => 
+        transactionMeta.id === transactionId,
+    );
+
+    // End the trace on confirmation
+    Engine.controllerMessenger.subscribeOnceIf(
+      'TransactionController:transactionConfirmed',
+      (transactionMeta: TransactionMeta) => {
+        endTrace({
+          name: traceName,
+          id: transactionMeta.id,
+        });
+      },
+      (transactionMeta: TransactionMeta) => 
+        transactionMeta.id === transactionId,
+    );
+  }, [transactionMetadata?.type, transactionMetadata?.id]);
+}; 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -130,6 +130,7 @@ jest.mock('../../../../../core/Engine', () => ({
   controllerMessenger: {
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
+    subscribeOnceIf: jest.fn(),
   },
 }));
 

--- a/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.test.tsx
@@ -13,6 +13,9 @@ jest.mock('../../../../../../hooks/AssetPolling/AssetPollingProvider', () => ({
 
 jest.mock('../../../../../../../core/Engine', () => ({
   getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
+  controllerMessenger: {
+    subscribeOnceIf: jest.fn(),
+  },
   context: {
     NetworkController: {
       getNetworkConfigurationByNetworkClientId: jest.fn(),

--- a/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-claim/staking-claim.tsx
@@ -18,6 +18,7 @@ import GasFeesDetailsRow from '../../../../components/rows/transactions/gas-fee-
 import { ConfirmationInfoComponentIDs } from '../../../../constants/info-ids';
 import useEndTraceOnMount from '../../../../../../hooks/useEndTraceOnMount';
 import { TraceName } from '../../../../../../../util/trace';
+import { useStakingTransactionTracing } from '../../../../../../UI/Stake/hooks/useStakingTransactionTracing';
 
 const StakingClaim = ({
   route,
@@ -48,6 +49,7 @@ const StakingClaim = ({
 
   useEffect(trackPageViewedEvent, [trackPageViewedEvent]);
   useEndTraceOnMount(TraceName.EarnClaimConfirmationScreen);
+  useStakingTransactionTracing();
 
   return (
     <View testID={ConfirmationInfoComponentIDs.STAKING_CLAIM}>

--- a/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.test.tsx
@@ -25,6 +25,9 @@ jest.mock('../../../../../../../core/Engine', () => ({
       stopPollingByPollingToken: jest.fn(),
     },
   },
+  controllerMessenger: {
+    subscribeOnceIf: jest.fn(),
+  },
 }));
 
 jest.mock('../../../../hooks/useConfirmActions', () => ({

--- a/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-deposit/staking-deposit.tsx
@@ -14,6 +14,7 @@ import { HeroRow } from '../../../../components/rows/transactions/hero-row';
 import GasFeesDetailsRow from '../../../../components/rows/transactions/gas-fee-details-row';
 import useEndTraceOnMount from '../../../../../../hooks/useEndTraceOnMount';
 import { TraceName } from '../../../../../../../util/trace';
+import { useStakingTransactionTracing } from '../../../../../../UI/Stake/hooks/useStakingTransactionTracing';
 
 const StakingDeposit = () => {
   useNavbar(strings('stake.stake'));
@@ -48,6 +49,7 @@ const StakingDeposit = () => {
   }, [trackPageViewedEvent, setConfirmationMetric]);
 
   useEndTraceOnMount(TraceName.EarnDepositConfirmationScreen);
+  useStakingTransactionTracing();
 
   const handleAdvancedDetailsToggledEvent = (isExpanded: boolean) => {
     trackAdvancedDetailsToggledEvent({ isExpanded });

--- a/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.test.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.test.tsx
@@ -24,6 +24,9 @@ jest.mock('../../../../../../../core/Engine', () => ({
       stopPollingByPollingToken: jest.fn(),
     },
   },
+  controllerMessenger: {
+    subscribeOnceIf: jest.fn(),
+  },
 }));
 
 jest.mock('../../../../hooks/metrics/useConfirmationMetricEvents', () => ({

--- a/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.tsx
@@ -25,7 +25,7 @@ const StakingWithdrawal = ({ route }: UnstakeConfirmationViewProps) => {
   useClearConfirmationOnBackSwipe();
 
   const { trackPageViewedEvent, setConfirmationMetric } =
-  useConfirmationMetricEvents();
+    useConfirmationMetricEvents();
   const { amount } = useTokenAmount({ amountWei });
 
   useEffect(() => {

--- a/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.tsx
+++ b/app/components/Views/confirmations/external/staking/info/staking-withdrawal/staking-withdrawal.tsx
@@ -16,6 +16,7 @@ import UnstakingTimeSection from '../../components/unstaking-time/unstaking-time
 import GasFeesDetailsRow from '../../../../components/rows/transactions/gas-fee-details-row';
 import useEndTraceOnMount from '../../../../../../hooks/useEndTraceOnMount';
 import { TraceName } from '../../../../../../../util/trace';
+import { useStakingTransactionTracing } from '../../../../../../UI/Stake/hooks/useStakingTransactionTracing';
 
 const StakingWithdrawal = ({ route }: UnstakeConfirmationViewProps) => {
   const amountWei = route?.params?.amountWei;
@@ -42,6 +43,7 @@ const StakingWithdrawal = ({ route }: UnstakeConfirmationViewProps) => {
 
   useEffect(trackPageViewedEvent, [trackPageViewedEvent]);
   useEndTraceOnMount(TraceName.EarnWithdrawConfirmationScreen);
+  useStakingTransactionTracing();
 
   return (
     <View testID={ConfirmationInfoComponentIDs.STAKING_WITHDRAWAL}>

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -107,7 +107,7 @@ export enum TraceOperation {
   CreateAccount = 'create.account',
   CreateSnapAccount = 'create.snap.account',
   RevealPrivateCredential = 'reveal.private.credential',
-  DiscoverAccounts = 'discover.accounts'
+  DiscoverAccounts = 'discover.accounts',
 }
 
 const ID_DEFAULT = 'default';

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -73,16 +73,19 @@ export enum TraceName {
   EarnDepositSpendingCapScreen = 'Earn Deposit Spending Cap Screen',
   EarnDepositReviewScreen = 'Earn Deposit Review Screen',
   EarnDepositConfirmationScreen = 'Earn Deposit Confirmation Screen',
-  EarnDepositTxConfirmed = 'Earn Deposit Tx Confirmed',
+  EarnLendingDepositTxConfirmed = 'Earn Lending Deposit Tx Confirmed',
+  EarnPooledStakingDepositTxConfirmed = 'Earn Pooled Staking Deposit Tx Confirmed',
   EarnWithdrawScreen = 'Earn Withdraw Screen',
   EarnWithdrawReviewScreen = 'Earn Withdraw Review Screen',
   EarnWithdrawConfirmationScreen = 'Earn Withdraw Confirmation Screen',
-  EarnWithdrawTxConfirmed = 'Earn Withdraw Tx Confirmed',
+  EarnLendingWithdrawTxConfirmed = 'Earn Lending Withdraw Tx Confirmed',
+  EarnPooledStakingWithdrawTxConfirmed = 'Earn Pooled Staking Withdraw Tx Confirmed',
   EarnEarnings = 'Earn Earnings',
   EarnFaq = 'Earn FAQ',
   EarnFaqApys = 'Earn FAQ APYs',
   EarnTokenList = 'Earn Token List',
   EarnClaimConfirmationScreen = 'Earn Claim Confirmation Screen',
+  EarnPooledStakingClaimTxConfirmed = 'Earn Pooled Staking Claim Tx Confirmed',
 }
 
 export enum TraceOperation {


### PR DESCRIPTION
## **Description**

Follows on from [this](https://github.com/MetaMask/metamask-mobile/pull/17025) PR.

This PR adds more Sentry traces for Earn metrics following the guidelines for [Performance Tracing](https://github.com/MetaMask/contributor-docs/blob/main/docs/performance-tracing.md):

- Earn Pooled Staking Deposit Tx Confirmed
- Earn Pooled Staking Withdraw Tx Confirmed
- Earn Pooled Staking Claim Tx Confirmed

This is by way of a new hook `useStakingTransactionTracing` which is used inside the Pooled Staking confirmation screens to track the submitted and confirmed transaction events and measure the trace between the two.

Renames the following to make the creation of different dashboards easier:
- Earn Deposit Tx Confirmed -> Earn Lending Deposit Tx Confirmed
- Earn Withdraw Tx Confirmed -> Earn Lending Withdraw Tx Confirmed

Also runs prettier on these files so you'll see a few unrelated formatting changes. 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-574

## **Manual testing steps**

- First get permissions to https://metamask.sentry.io/ and the metamask team within that
- Ensure you have the MM_SENTRY_DSN_DEV key in your .js.env
- Check out this branch and run the app on iPhone. Ensure metametrics are enabled.
- Go through the full flow to stake some ETH
- See on the console that Sentry Logger is called for the Earn Pooled Staking Tx Confirmed trace
- See on the Sentry [dashboard](https://metamask.sentry.io/dashboard/137081) for Earn Pooled Staking Tx Confirmed that a new trace has appeared
- Repeat for ETH withdrawal and claim

## **Screenshots/Recordings**

Dashboards are here:
https://metamask.sentry.io/dashboard/137081/?statsPeriod=24h
https://metamask.sentry.io/dashboard/138761/?statsPeriod=24h

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
