### PR TITLE
fix: cp-7.51.0 import token navigation

### DIFF
--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -257,28 +257,21 @@ class AddCustomToken extends PureComponent {
     }
 
     // Clear state before closing
-    this.setState(
-      {
-        address: '',
-        symbol: '',
-        decimals: '',
-        warningAddress: '',
-        warningSymbol: '',
-        warningDecimals: '',
-      },
-      () => {
-        InteractionManager.runAfterInteractions(() => {
-          this.props.navigation.goBack();
-          this.props.navigation.goBack();
-          NotificationManager.showSimpleNotification({
-            status: `import_success`,
-            duration: 5000,
-            title: strings('wallet.token_toast.token_imported_title'),
-            description: strings('wallet.token_toast.token_imported_desc_1'),
-          });
-        });
-      },
-    );
+    this.setState({
+      address: '',
+      symbol: '',
+      decimals: '',
+      warningAddress: '',
+      warningSymbol: '',
+      warningDecimals: '',
+    });
+
+    NotificationManager.showSimpleNotification({
+      status: `import_success`,
+      duration: 5000,
+      title: strings('wallet.token_toast.token_imported_title'),
+      description: strings('wallet.token_toast.token_imported_desc_1'),
+    });
   };
 
   cancelAddToken = () => {

--- a/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.test.tsx
+++ b/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.test.tsx
@@ -6,7 +6,7 @@ import renderWithProvider, {
 } from '../../../util/test/renderWithProvider';
 import useBalance from '../Ramp/Aggregator/hooks/useBalance';
 import { toTokenMinimalUnit } from '../../../util/number';
-import { fireEvent } from '@testing-library/react-native';
+import { userEvent } from '@testing-library/react-native';
 import BN4 from 'bnjs4';
 import { RootState } from '../../../reducers';
 import { mockNetworkState } from '../../../util/test/network';
@@ -14,6 +14,7 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useRoute } from '@react-navigation/native';
 import { useParams } from '../../../util/navigation/navUtils';
 import { TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT } from '../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.constants';
+import Routes from '../../../constants/navigation/Routes';
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
@@ -108,24 +109,24 @@ describe('ConfirmAddAsset', () => {
     const { getByText } = renderWithProvider(<ConfirmAddAsset />, {
       state: mockInitialState,
     });
-    expect(getByText('Tether USD')).toBeTruthy();
-    expect(getByText('USDT')).toBeTruthy();
-    expect(getByText('$27.02')).toBeTruthy();
+    expect(getByText('Tether USD')).toBeOnTheScreen();
+    expect(getByText('USDT')).toBeOnTheScreen();
+    expect(getByText('$27.02')).toBeOnTheScreen();
   });
 
-  it('handles cancel button click', () => {
+  it('handles cancel button click', async () => {
     const { getByText } = renderWithProvider(<ConfirmAddAsset />, {
       state: mockInitialState,
     });
     const cancelButton = getByText('Cancel');
-    fireEvent.press(cancelButton);
-    expect(getByText('Are you sure you want to exit?')).toBeTruthy();
+    await userEvent.press(cancelButton);
+    expect(getByText('Are you sure you want to exit?')).toBeOnTheScreen();
     expect(
       getByText('Your search information will not be saved.'),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('should call addTokenList when confirm button is pressed', () => {
+  it('should call addTokenList and navigate when confirm button is pressed', async () => {
     const mockAsset = {
       address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
       symbol: 'USDT',
@@ -163,8 +164,14 @@ describe('ConfirmAddAsset', () => {
     const confirmButton = getByTestId(
       TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT,
     );
-    fireEvent.press(confirmButton);
+    await userEvent.press(confirmButton);
 
     expect(mockAddTokenList).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
+      screen: Routes.WALLET.TAB_STACK_FLOW,
+      params: {
+        screen: Routes.WALLET_VIEW,
+      },
+    });
   });
 });

--- a/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.tsx
+++ b/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.tsx
@@ -219,8 +219,9 @@ const ConfirmAddAsset = () => {
               size: ButtonSize.Lg,
             },
             {
-              onPress: () => {
-                addTokenList();
+              onPress: async () => {
+                await addTokenList();
+                goToWalletPage();
               },
               label: strings('swaps.Import'),
               variant: ButtonVariants.Primary,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There was an issue on IOS after new re-architecture, where importing a token never navigated to the home screen. We have moved the navigation directly inside the modal rather than being invoked through a useParam callback.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed IOS bug where import tokens never navigated back to home screen

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17201

## **Manual testing steps**

See issue above and fix video below
1. Try to import a token
2. Click confirm
3. EXPECTED - to be navigated to the home screen and 1 toast is shown.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/cd4e6fa339c041edb9b4b727d81a8f83?sid=54c7d141-2147-4c79-a8d9-21e7d8403c30

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
