### PR TITLE
Intercom-SDK

### DIFF
--- a/ios/MetaMask/AppDelegate.m
+++ b/ios/MetaMask/AppDelegate.m
@@ -5,6 +5,7 @@
 
 #import <RNBranch/RNBranch.h>
 #import <Firebase.h>
+#import <IntercomModule.h>
 
 
 @implementation AppDelegate
@@ -26,6 +27,10 @@
  // Uncomment this line to use the test key instead of the live one.
   // [RNBranch useTestInstance];
   [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
+  
+  // Initialize Intercom
+  [IntercomModule initialize:@"KEY_HERE" withAppId:@"KEY_HERE"];
+  
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{@"foxCode": foxCode};


### PR DESCRIPTION
Changes Made
Configuration Files:
-app.config.js: Added Intercom plugin to the Expo configuration with placeholder API keys
-android/app/src/main/java/io/metamask/MainApplication.kt: Added Intercom import and initialization for Android platform
-ios/MetaMask/AppDelegate.m: Added Intercom import and initialization for iOS platform

Setup Instructions
1.Install the Intercom React Native package:
   npm install @intercom/intercom-react-native
2. Replace "KEY_HERE" placeholders in the following files with actual Intercom credentials ( I will provide them ):
    - app.config.js: Replace androidApiKey and iosApiKey values
    - android/app/src/main/java/io/metamask/MainApplication.kt: Replace Intercom initialization keys
    - ios/MetaMask/AppDelegate.m: Replace Intercom initialization keys
