### PR TITLE
fix: cp-7.50.2 retrieving configured chains from NetworkController 

### DIFF
--- a/app/util/metrics/MultichainAPI/networkMetricUtils.ts
+++ b/app/util/metrics/MultichainAPI/networkMetricUtils.ts
@@ -40,31 +40,26 @@ export function getConfiguredCaipChainIds(): CaipChainId[] {
   // Issue described here: https://github.com/MetaMask/metamask-mobile/issues/17167
 
   const state = store.getState();
-  try {
-    const evmNetworkConfigurations =
-      state?.engine?.backgroundState?.NetworkController
-        ?.networkConfigurationsByChainId || {};
+  const evmNetworkConfigurations =
+    state?.engine?.backgroundState?.NetworkController
+      ?.networkConfigurationsByChainId || {};
 
-    const multichainNetworkController =
-      state?.engine?.backgroundState?.MultichainNetworkController;
+  const multichainNetworkController =
+    state?.engine?.backgroundState?.MultichainNetworkController;
 
-    const nonEvmNetworkConfigurations =
-      multichainNetworkController?.multichainNetworkConfigurationsByChainId ||
-      {};
+  const nonEvmNetworkConfigurations =
+    multichainNetworkController?.multichainNetworkConfigurationsByChainId || {};
 
-    const allNetworkConfigurations: Record<string, NetworkConfiguration> = {
-      ...evmNetworkConfigurations,
-      ...nonEvmNetworkConfigurations,
-    };
+  const allNetworkConfigurations: Record<string, NetworkConfiguration> = {
+    ...evmNetworkConfigurations,
+    ...nonEvmNetworkConfigurations,
+  };
 
-    const chainIds = Object.values(allNetworkConfigurations)
-      .filter((network) => network?.chainId)
-      .map((network) => caipifyChainId(network.chainId));
+  const chainIds = Object.values(allNetworkConfigurations)
+    .filter((network) => network?.chainId)
+    .map((network) => caipifyChainId(network.chainId));
 
-    return chainIds;
-  } catch (error) {
-    return [];
-  }
+  return chainIds;
 }
 
 /**

--- a/app/util/metrics/MultichainAPI/networkMetricUtils.ts
+++ b/app/util/metrics/MultichainAPI/networkMetricUtils.ts
@@ -35,9 +35,9 @@ function caipifyChainId(chainId: CaipChainId | string): CaipChainId {
  * @returns An array of CAIP chain IDs for all configured networks.
  */
 export function getConfiguredCaipChainIds(): CaipChainId[] {
-  // We're accessing state directly and safely here because there's a potential race condition
-  // that causes the state to be undefined where we access it.
-  // Issue described here: https://github.com/MetaMask/metamask-mobile/issues/17167
+  // We're accessing state with optional chaining here because there's a race condition
+  // that causes redux state to be undefined when we access it.
+  // Issue here: https://github.com/MetaMask/metamask-mobile/issues/17167
 
   const state = store.getState();
   const evmNetworkConfigurations =

--- a/app/util/metrics/MultichainAPI/networkMetricUtils.ts
+++ b/app/util/metrics/MultichainAPI/networkMetricUtils.ts
@@ -35,6 +35,10 @@ function caipifyChainId(chainId: CaipChainId | string): CaipChainId {
  * @returns An array of CAIP chain IDs for all configured networks.
  */
 export function getConfiguredCaipChainIds(): CaipChainId[] {
+  // We're accessing state directly and safely here because there's a potential race condition
+  // that causes the state to be undefined where we access it.
+  // Issue described here: https://github.com/MetaMask/metamask-mobile/issues/17167
+
   const state = store.getState();
   try {
     const evmNetworkConfigurations =
@@ -54,7 +58,7 @@ export function getConfiguredCaipChainIds(): CaipChainId[] {
     };
 
     const chainIds = Object.values(allNetworkConfigurations)
-      .filter((network) => network && network?.chainId)
+      .filter((network) => network?.chainId)
       .map((network) => caipifyChainId(network.chainId));
 
     return chainIds;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -17,21 +17,16 @@ jest.mock('../../../core/Analytics', () => ({
   },
 }));
 
-const mockSelectNetworkConfigurations = jest.fn();
-jest.mock('../../../selectors/networkController', () => ({
-  selectNetworkConfigurations: jest.fn(() => mockSelectNetworkConfigurations()),
+const mockGetConfiguredCaipChainIds = jest.fn();
+jest.mock('../MultichainAPI/networkMetricUtils', () => ({
+  getConfiguredCaipChainIds: jest.fn(() => mockGetConfiguredCaipChainIds()),
 }));
 
 describe('generateUserProfileAnalyticsMetaData', () => {
   beforeEach(() => {
     jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
 
-    mockSelectNetworkConfigurations.mockReturnValue({
-      '0x1': {
-        chainId: '0x1',
-        name: 'Ethereum Mainnet',
-      },
-    });
+    mockGetConfiguredCaipChainIds.mockReturnValue(['eip155:1']);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## **Description**

[This issue](https://github.com/MetaMask/metamask-mobile/issues/17167) shows the app crashing due to trying to access state for identity analytics that's not immediately available. This PR adds a safer way to access this state, returning gracefully in case it doesn't exist or we hit a race condition.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**
CHANGELOG entry: Fixes a bug that causes thee app to crash when accessing `NetworkController` and `MultichainNetworkController` state that is undefined.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17167

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
