### PR TITLE
style: cp-7.51.0 fix padding issues with asset detail buttons

### DIFF
--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -368,7 +368,7 @@ exports[`AssetOverview should render correctly 1`] = `
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-evenly",
-          "padding": 16,
+          "paddingVertical": 16,
         }
       }
     >
@@ -1523,7 +1523,7 @@ exports[`AssetOverview should render native balances even if there are no accoun
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-evenly",
-          "padding": 16,
+          "paddingVertical": 16,
         }
       }
     >
@@ -2684,7 +2684,7 @@ exports[`AssetOverview should render native balances when non evm network is sel
           "display": "flex",
           "flexDirection": "row",
           "justifyContent": "space-evenly",
-          "padding": 16,
+          "paddingVertical": 16,
         }
       }
     >

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -1026,7 +1026,7 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -3022,7 +3022,7 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -5018,7 +5018,7 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -7053,7 +7053,7 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -9049,7 +9049,7 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -11045,7 +11045,7 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -13513,7 +13513,7 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >
@@ -15509,7 +15509,7 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                             "display": "flex",
                                             "flexDirection": "row",
                                             "justifyContent": "space-evenly",
-                                            "padding": 16,
+                                            "paddingVertical": 16,
                                           }
                                         }
                                       >

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.styles.ts
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.styles.ts
@@ -8,7 +8,7 @@ const styleSheet = (params: { theme: Theme }) => {
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'space-evenly',
-      padding: 16,
+      paddingVertical: 16,
     },
     buttonWrapper: {
       display: 'flex',

--- a/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
       "display": "flex",
       "flexDirection": "row",
       "justifyContent": "space-evenly",
-      "padding": 16,
+      "paddingVertical": 16,
     }
   }
 >


### PR DESCRIPTION
## **Description**

Styling issue with the asset details buttons. Unsure how/when this was introduced.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove asset details button group padding

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-974

## **Manual testing steps**

1. Open Asset Details Page
2. View Asset Details Buttons Group - is the buttons in centre with no weird padding?

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image-20250714-145823" src="https://github.com/user-attachments/assets/92e25364-6a09-48a6-97f1-30bf27b193c0" />

### **After**

IOS
<img width="469" height="967" alt="Screenshot 2025-07-15 at 17 33 44" src="https://github.com/user-attachments/assets/8bf5588a-f764-49f0-ba9f-0a1b83457fcf" />

Android
<img width="407" height="914" alt="Screenshot 2025-07-15 at 17 53 27" src="https://github.com/user-attachments/assets/5c22d786-7615-4372-bce1-1b6db9456b80" />



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
