### PR TITLE
fix(snaps): Patch `CronjobController`

### DIFF
--- a/patches/@metamask+snaps-controllers+13.0.0.patch
+++ b/patches/@metamask+snaps-controllers+13.0.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
-index 0e8feeb..2bf546a 100644
+index 0e8feeb..5eae8f9 100644
 --- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
 +++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.cjs
 @@ -39,9 +39,18 @@ class CronjobController extends base_controller_1.BaseController {
@@ -21,6 +21,28 @@ index 0e8feeb..2bf546a 100644
          this.#start();
          this.#clear();
          this.#reschedule();
+@@ -182,6 +191,12 @@ class CronjobController extends base_controller_1.BaseController {
+         if (ms > exports.DAILY_TIMEOUT) {
+             return;
+         }
++        // When an event is supposed to be scheduled close to the current time
++        // we may end up needing to execute immediately instead.
++        if (ms <= 0) {
++            this.#execute(event);
++            return;
++        }
+         const timer = new Timer_1.Timer(ms);
+         timer.start(() => {
+             this.#execute(event);
+@@ -262,6 +277,8 @@ class CronjobController extends base_controller_1.BaseController {
+      * @param snap - Basic Snap information.
+      */
+     #handleSnapInstalledEvent = (snap) => {
++        // In case of local Snaps, they may already have cronjobs that should be cleared.
++        this.unregister(snap.id);
+         this.register(snap.id);
+     };
+     /**
 diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts
 index 99f72dd..bac97d5 100644
 --- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.d.cts
@@ -106,7 +128,7 @@ index 40ba2e1..ae0fb31 100644
       * Schedule a non-recurring background event.
       *
 diff --git a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
-index e3f025c..b90b08f 100644
+index e3f025c..421ecb8 100644
 --- a/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
 +++ b/node_modules/@metamask/snaps-controllers/dist/cronjob/CronjobController.mjs
 @@ -36,9 +36,18 @@ export class CronjobController extends BaseController {
@@ -128,3 +150,25 @@ index e3f025c..b90b08f 100644
          this.#start();
          this.#clear();
          this.#reschedule();
+@@ -179,6 +188,12 @@ export class CronjobController extends BaseController {
+         if (ms > DAILY_TIMEOUT) {
+             return;
+         }
++        // When an event is supposed to be scheduled close to the current time
++        // we may end up needing to execute immediately instead.
++        if (ms <= 0) {
++            this.#execute(event);
++            return;
++        }
+         const timer = new Timer(ms);
+         timer.start(() => {
+             this.#execute(event);
+@@ -259,6 +274,8 @@ export class CronjobController extends BaseController {
+      * @param snap - Basic Snap information.
+      */
+     #handleSnapInstalledEvent = (snap) => {
++        // In case of local Snaps, they may already have cronjobs that should be cleared.
++        this.unregister(snap.id);
+         this.register(snap.id);
+     };
+     /**


### PR DESCRIPTION
## **Description**

This PR fixes a regression in the `7.50.1` release by patching temporarily in the new release the `CronjobController` with a fix that exists in a higher version of the package.

This fix is only applied to this release as the next releases already contains the fix with the actual version of the package.

Fixes: #17183
