### PR TITLE
feat: add metametrics to backup and sync modal

### DIFF
--- a/app/components/Views/Identity/TurnOnBackupAndSync/TurnOnBackupAndSync.test.tsx
+++ b/app/components/Views/Identity/TurnOnBackupAndSync/TurnOnBackupAndSync.test.tsx
@@ -7,6 +7,25 @@ import renderWithProvider from '../../../../util/test/renderWithProvider';
 import Routes from '../../../../constants/navigation/Routes';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-storage';
+import { useMetrics } from '../../../hooks/useMetrics';
+import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
+
+const mockTrackEvent = jest.fn();
+jest.mock('../../../hooks/useMetrics');
+
+(useMetrics as jest.MockedFn<typeof useMetrics>).mockReturnValue({
+  trackEvent: mockTrackEvent,
+  createEventBuilder: MetricsEventBuilder.createEventBuilder,
+  enable: jest.fn(),
+  addTraitsToUser: jest.fn(),
+  createDataDeletionTask: jest.fn(),
+  checkDataDeleteStatus: jest.fn(),
+  getDeleteRegulationCreationDate: jest.fn(),
+  getDeleteRegulationId: jest.fn(),
+  isDataRecorded: jest.fn(),
+  isEnabled: jest.fn(),
+  getMetaMetricsId: jest.fn(),
+});
 
 const MOCK_STORE_STATE = {
   engine: {
@@ -37,6 +56,7 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       navigate: mockNavigate,
+      goBack: jest.fn(),
     }),
   };
 });
@@ -59,6 +79,25 @@ describe('TurnOnBackupAndSync', () => {
       state: MOCK_STORE_STATE,
     });
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('sends a MetaMetrics event when the modal is dismissed', () => {
+    const { getByTestId } = renderWithProvider(<TurnOnBackupAndSync />, {
+      state: MOCK_STORE_STATE,
+    });
+
+    const cancelButton = getByTestId(turnOnBackupAndSyncTestIds.cancelButton);
+    fireEvent.press(cancelButton);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Profile Activity Updated',
+        properties: expect.objectContaining({
+          feature_name: 'Backup And Sync Carousel Modal',
+          action: 'Modal Dismissed',
+        }),
+      }),
+    );
   });
 
   it('enables backup and sync when clicking on the cta if backup and sync is disabled, and navigates to backup and sync settings either way', async () => {
@@ -118,6 +157,27 @@ describe('TurnOnBackupAndSync', () => {
         enableBackupAndSync: expect.any(Function),
         trackEnableBackupAndSyncEvent: expect.any(Function),
       },
+    });
+  });
+
+  it('sends a MetaMetrics event when enabling backup and sync', async () => {
+    const { getByTestId } = renderWithProvider(<TurnOnBackupAndSync />, {
+      state: MOCK_STORE_STATE,
+    });
+
+    const switchElement = getByTestId(turnOnBackupAndSyncTestIds.enableButton);
+    fireEvent.press(switchElement);
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Profile Activity Updated',
+          properties: expect.objectContaining({
+            feature_name: 'Backup And Sync Carousel Modal',
+            action: 'Turned On',
+          }),
+        }),
+      );
     });
   });
 });

--- a/app/components/Views/Identity/TurnOnBackupAndSync/TurnOnBackupAndSync.tsx
+++ b/app/components/Views/Identity/TurnOnBackupAndSync/TurnOnBackupAndSync.tsx
@@ -65,10 +65,27 @@ const TurnOnBackupAndSync = () => {
   };
 
   const handleGoBack = () => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED)
+        .addProperties({
+          feature_name: 'Backup And Sync Carousel Modal',
+          action: 'Modal Dismissed',
+        })
+        .build(),
+    );
     navigation.goBack();
   };
 
   const handleEnableBackupAndSync = async () => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED)
+        .addProperties({
+          feature_name: 'Backup And Sync Carousel Modal',
+          action: 'Turned On',
+        })
+        .build(),
+    );
+
     if (!isBasicFunctionalityEnabled) {
       navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.SHEET.CONFIRM_TURN_ON_BACKUP_AND_SYNC,


### PR DESCRIPTION
## **Description**

This PR makes it so that MetaMetrics events are sent whenever a user either dismisses or turns on backup and sync from the carousel modal.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
