### PR TITLE
feat: integrate ui settings from core PreferencesController

### DIFF
--- a/app/actions/preferencesController/index.ts
+++ b/app/actions/preferencesController/index.ts
@@ -1,0 +1,50 @@
+import Engine from '../../core/Engine';
+import { AppThemeKey } from '../../util/theme/models';
+
+/**
+ * Updates the theme setting in PreferencesController
+ */
+export const updateTheme = (theme: AppThemeKey) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setTheme(theme);
+};
+
+/**
+ * Updates the useBlockie setting in PreferencesController
+ */
+export const updateUseBlockie = (useBlockie: boolean) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setUseBlockie(useBlockie);
+};
+
+/**
+ * Updates the currentCurrency setting in PreferencesController
+ */
+export const updateCurrentCurrency = (currentCurrency: string) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setCurrentCurrency(currentCurrency);
+};
+
+/**
+ * Updates the hideZeroBalanceTokens setting in PreferencesController
+ */
+export const updateHideZeroBalanceTokens = (hideZeroBalanceTokens: boolean) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setHideZeroBalanceTokens(hideZeroBalanceTokens);
+};
+
+/**
+ * Updates the showNativeTokenAsMainBalance setting in PreferencesController
+ */
+export const updateShowNativeTokenAsMainBalance = (showNativeTokenAsMainBalance: boolean) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setShowNativeTokenAsMainBalance(showNativeTokenAsMainBalance);
+};
+
+/**
+ * Updates the currentLocale setting in PreferencesController
+ */
+export const updateCurrentLocale = (currentLocale: string) => {
+  const { PreferencesController } = Engine.context;
+  PreferencesController.setCurrentLocale(currentLocale);
+};

--- a/app/components/UI/AccountRightButton/index.tsx
+++ b/app/components/UI/AccountRightButton/index.tsx
@@ -32,6 +32,7 @@ import {
   selectNonEvmNetworkConfigurationsByChainId,
   selectSelectedNonEvmNetworkChainId,
 } from '../../../selectors/multichainNetworkController';
+import { selectUseBlockie } from '../../../selectors/preferencesController';
 
 const styles = StyleSheet.create({
   leftButton: {
@@ -63,13 +64,9 @@ const AccountRightButton = ({
   const { trackEvent, createEventBuilder } = useMetrics();
   const [isKeyboardVisible, setIsKeyboardVisible] = useState<boolean>(false);
 
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const accountAvatarType = useSelector((state: any) =>
-    state.settings.useBlockieIcon
-      ? AvatarAccountType.Blockies
-      : AvatarAccountType.JazzIcon,
-  );
+  const accountAvatarType = useSelector(selectUseBlockie)
+    ? AvatarAccountType.Blockies
+    : AvatarAccountType.JazzIcon;
   /**
    * Current network
    */

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -9,7 +9,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { KeyringTypes } from '@metamask/keyring-controller';
 
@@ -39,7 +39,7 @@ import { CaipAccountSelectorListProps } from './CaipAccountSelectorList.types';
 import styleSheet from './CaipAccountSelectorList.styles';
 import { AccountListBottomSheetSelectorsIDs } from '../../../../e2e/selectors/wallet/AccountListBottomSheet.selectors';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletView.selectors';
-import { RootState } from '../../../reducers';
+
 import { ACCOUNT_SELECTOR_LIST_TESTID } from './CaipAccountSelectorList.constants';
 import { toHex } from '@metamask/controller-utils';
 import AccountNetworkIndicator from '../AccountNetworkIndicator/AccountNetworkIndicator';
@@ -48,6 +48,7 @@ import {
   parseCaipAccountId,
   CaipChainId,
 } from '@metamask/utils';
+import { selectUseBlockie } from '../../../selectors/preferencesController';
 
 const CaipAccountSelectorList = ({
   onSelectAccount,
@@ -72,13 +73,9 @@ const CaipAccountSelectorList = ({
   const accountsLengthRef = useRef<number>(0);
   const { styles } = useStyles(styleSheet, {});
 
-  const accountAvatarType = useSelector(
-    (state: RootState) =>
-      state.settings.useBlockieIcon
-        ? AvatarAccountType.Blockies
-        : AvatarAccountType.JazzIcon,
-    shallowEqual,
-  );
+  const accountAvatarType = useSelector(selectUseBlockie)
+    ? AvatarAccountType.Blockies
+    : AvatarAccountType.JazzIcon;
   const getKeyExtractor = ({ caipAccountId }: Account) => caipAccountId;
 
   const renderAccountBalances = useCallback(

--- a/app/components/UI/Identicon/index.tsx
+++ b/app/components/UI/Identicon/index.tsx
@@ -5,8 +5,8 @@ import { toDataUrl } from '../../../util/blockies';
 import FadeIn from 'react-native-fade-in-image';
 import Jazzicon from 'react-native-jazzicon';
 import { useTheme } from '../../../util/theme';
-import { RootState } from '../../../reducers';
 import { useSelector } from 'react-redux';
+import { selectUseBlockie } from '../../../selectors/preferencesController';
 
 interface IdenticonProps {
   /**
@@ -46,9 +46,7 @@ const Identicon: React.FC<IdenticonProps> = ({
 }) => {
   const { colors } = useTheme();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const useBlockieIcon =
-    useSelector((state: RootState) => state.settings.useBlockieIcon) ?? true;
+  const useBlockieIcon = useSelector(selectUseBlockie) ?? true;
 
   if (!address && !imageUri) return null;
 

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -22,7 +22,8 @@ import { getSwapBridgeTxActivityTitle } from '../Bridge/utils/transaction-histor
 import BridgeActivityItemTxSegments from '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments';
 import Routes from '../../../constants/navigation/Routes';
 import { useSelector } from 'react-redux';
-import { RootState } from '../../../reducers';
+import { selectTheme } from '../../../selectors/preferencesController';
+import { AppThemeKey } from '../../../util/theme/models';
 
 const MultichainTransactionListItem = ({
   transaction,
@@ -39,7 +40,7 @@ const MultichainTransactionListItem = ({
 }) => {
   const { colors, typography } = useTheme();
   const osColorScheme = useColorScheme();
-  const appTheme = useSelector((state: RootState) => state.user.appTheme);
+  const appTheme = useSelector(selectTheme) as AppThemeKey;
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const { type, status, to, from, asset } = useMultichainTransactionDisplay({

--- a/app/components/UI/UrlAutocomplete/index.tsx
+++ b/app/components/UI/UrlAutocomplete/index.tsx
@@ -38,7 +38,8 @@ import { Result } from './Result';
 import useTokenSearchDiscovery from '../../hooks/TokenSearchDiscovery/useTokenSearch/useTokenSearch';
 import { Hex } from '@metamask/utils';
 import Engine from '../../../core/Engine';
-import { selectCurrentCurrency, selectUsdConversionRate } from '../../../selectors/currencyRateController';
+import { selectCurrentCurrency } from '../../../selectors/preferencesController';
+import { selectUsdConversionRate } from '../../../selectors/currencyRateController';
 import { SwapBridgeNavigationLocation, useSwapBridgeNavigation } from '../Bridge/hooks/useSwapBridgeNavigation';
 
 export * from './types';

--- a/app/components/UI/WalletAccount/WalletAccount.tsx
+++ b/app/components/UI/WalletAccount/WalletAccount.tsx
@@ -20,6 +20,7 @@ import { getLabelTextByAddress } from '../../../util/address';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import useEnsNameByAddress from '../../../components/hooks/useEnsNameByAddress';
 import Logger from '../../../util/Logger';
+import { selectUseBlockie } from '../../../selectors/preferencesController';
 
 // Internal dependencies
 import styleSheet from './WalletAccount.styles';
@@ -48,13 +49,9 @@ const WalletAccount = ({ style }: WalletAccountProps, ref: React.Ref<any>) => {
     accountActionsRef,
   }));
 
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const accountAvatarType = useSelector((state: any) =>
-    state.settings.useBlockieIcon
-      ? AvatarAccountType.Blockies
-      : AvatarAccountType.JazzIcon,
-  );
+  const accountAvatarType = useSelector(selectUseBlockie)
+    ? AvatarAccountType.Blockies
+    : AvatarAccountType.JazzIcon;
 
   const onNavigateToAccountActions = () => {
     navigate(Routes.MODAL.ROOT_MODAL_FLOW, {

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -29,7 +29,8 @@ import PickComponent from '../../PickComponent';
 import { toDataUrl } from '../../../../util/blockies.js';
 import Jazzicon from 'react-native-jazzicon';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
-import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
+import { selectCurrentCurrency, selectHideZeroBalanceTokens, selectUseBlockie } from '../../../../selectors/preferencesController';
+import { updateHideZeroBalanceTokens, updateUseBlockie } from '../../../../actions/preferencesController';
 import { withMetricsAwareness } from '../../../../components/hooks/useMetrics';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import Text, {
@@ -521,9 +522,9 @@ const mapStateToProps = (state) => ({
   currentCurrency: selectCurrentCurrency(state),
   searchEngine: state.settings.searchEngine,
   primaryCurrency: state.settings.primaryCurrency,
-  useBlockieIcon: state.settings.useBlockieIcon,
+  useBlockieIcon: selectUseBlockie(state),
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
-  hideZeroBalanceTokens: state.settings.hideZeroBalanceTokens,
+  hideZeroBalanceTokens: selectHideZeroBalanceTokens(state),
   // appTheme: state.user.appTheme,
 });
 
@@ -532,9 +533,9 @@ const mapDispatchToProps = (dispatch) => ({
   setPrimaryCurrency: (primaryCurrency) =>
     dispatch(setPrimaryCurrency(primaryCurrency)),
   setUseBlockieIcon: (useBlockieIcon) =>
-    dispatch(setUseBlockieIcon(useBlockieIcon)),
+    updateUseBlockie(useBlockieIcon),
   setHideZeroBalanceTokens: (hideZeroBalanceTokens) =>
-    dispatch(setHideZeroBalanceTokens(hideZeroBalanceTokens)),
+    updateHideZeroBalanceTokens(hideZeroBalanceTokens),
 });
 
 export default connect(

--- a/app/components/Views/ThemeSettings/index.tsx
+++ b/app/components/Views/ThemeSettings/index.tsx
@@ -2,9 +2,10 @@ import React, { useCallback, useRef } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
 import ReusableModal, { ReusableModalRef } from '../../UI/ReusableModal';
 import { useTheme } from '../../../util/theme';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppThemeKey } from '../../../util/theme/models';
-import { setAppTheme } from '../../../actions/user';
+import { updateTheme } from '../../../actions/preferencesController';
+import { selectTheme } from '../../../selectors/preferencesController';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { fontStyles } from '../../../styles/common';
@@ -52,14 +53,9 @@ const createStyles = (colors: any, safeAreaPaddingBottom: number) =>
 const ThemeSettings = () => {
   const safeAreaInsets = useSafeAreaInsets();
   const modalRef = useRef<ReusableModalRef>(null);
-  const dispatch = useDispatch();
   const triggerSetAppTheme = (theme: AppThemeKey) =>
-    dispatch(setAppTheme(theme));
-  const appTheme: AppThemeKey = useSelector(
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => state.user.appTheme,
-  );
+    updateTheme(theme);
+  const appTheme = useSelector(selectTheme) as AppThemeKey;
   const { colors } = useTheme();
   const styles = createStyles(colors, safeAreaInsets.bottom);
 

--- a/app/core/Engine/controllers/preferences-controller/index.ts
+++ b/app/core/Engine/controllers/preferences-controller/index.ts
@@ -1,0 +1,30 @@
+import {
+  PreferencesController,
+  type PreferencesControllerMessenger,
+  type PreferencesState,
+  getDefaultPreferencesState,
+} from '@metamask/preferences-controller';
+import type { ControllerInitFunction } from '../../types';
+
+/**
+ * Initialize the PreferencesController.
+ *
+ * @param request - The request object.
+ * @returns The PreferencesController.
+ */
+export const preferencesControllerInit: ControllerInitFunction<
+  PreferencesController,
+  PreferencesControllerMessenger
+> = (request) => {
+  const { controllerMessenger, persistedState } = request;
+
+  const preferencesControllerState = (persistedState.PreferencesController ??
+    getDefaultPreferencesState()) as PreferencesState;
+
+  const controller = new PreferencesController({
+    messenger: controllerMessenger,
+    state: preferencesControllerState,
+  });
+
+  return { controller };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -37,6 +37,7 @@ import { getSeedlessOnboardingControllerMessenger } from './seedless-onboarding-
 
 import { getApprovalControllerMessenger } from './approval-controller-messenger';
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
+import { getPreferencesControllerMessenger } from './preferences-controller-messenger';
 /**
  * The messengers for the controllers that have been.
  */
@@ -139,6 +140,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   PerpsController: {
     getMessenger: getPerpsControllerMessenger,
+    getInitMessenger: noop,
+  },
+  PreferencesController: {
+    getMessenger: getPreferencesControllerMessenger,
     getInitMessenger: noop,
   },
 } as const;

--- a/app/core/Engine/messengers/preferences-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/preferences-controller-messenger/index.ts
@@ -1,0 +1,21 @@
+import { BaseControllerMessenger } from '../../types';
+import { PreferencesControllerMessenger } from '@metamask/preferences-controller';
+
+// Export the types
+export * from './types';
+
+/**
+ * Get the PreferencesControllerMessenger for the PreferencesController.
+ *
+ * @param baseControllerMessenger - The base controller messenger.
+ * @returns The PreferencesControllerMessenger.
+ */
+export function getPreferencesControllerMessenger(
+  baseControllerMessenger: BaseControllerMessenger,
+): PreferencesControllerMessenger {
+  return baseControllerMessenger.getRestricted({
+    name: 'PreferencesController',
+    allowedEvents: [],
+    allowedActions: [],
+  });
+}

--- a/app/core/Engine/messengers/preferences-controller-messenger/types.ts
+++ b/app/core/Engine/messengers/preferences-controller-messenger/types.ts
@@ -1,0 +1,9 @@
+/**
+ * The actions that the PreferencesControllerMessenger can use.
+ */
+export type PreferencesControllerMessengerActions = never;
+
+/**
+ * The events that the PreferencesControllerMessenger can handle.
+ */
+export type PreferencesControllerMessengerEvents = never;

--- a/app/selectors/preferencesController.ts
+++ b/app/selectors/preferencesController.ts
@@ -172,3 +172,40 @@ export const selectSmartAccountOptIn = createSelector(
   (preferencesControllerState: PreferencesState) =>
     preferencesControllerState.smartAccountOptIn ?? false,
 );
+
+// General settings selectors
+export const selectCurrentLocale = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.currentLocale,
+);
+
+export const selectTheme = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.theme,
+);
+
+export const selectUseBlockie = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.useBlockie,
+);
+
+export const selectCurrentCurrency = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.currentCurrency,
+);
+
+export const selectHideZeroBalanceTokens = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.hideZeroBalanceTokens,
+);
+
+export const selectShowNativeTokenAsMainBalance = createSelector(
+  selectPreferencesControllerState,
+  (preferencesControllerState: PreferencesState) =>
+    preferencesControllerState.showNativeTokenAsMainBalance,
+);

--- a/app/store/migrations/089.test.ts
+++ b/app/store/migrations/089.test.ts
@@ -1,0 +1,226 @@
+import { captureException } from '@sentry/react-native';
+import { getDefaultPreferencesState } from '@metamask/preferences-controller';
+import migration from './089';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+const mockedCaptureException = captureException as jest.MockedFunction<typeof captureException>;
+
+interface MockStateOverrides {
+  engineBackgroundState?: Record<string, unknown>;
+  user?: Record<string, unknown>;
+  settings?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+describe('Migration 089', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockState = (overrides: MockStateOverrides = {}) => ({
+    'engine.backgroundState': {
+      CurrencyRateController: {
+        currentCurrency: 'usd',
+      },
+      ...overrides.engineBackgroundState,
+    },
+    user: {
+      currentLocale: 'en',
+      appTheme: 'light',
+      ...overrides.user,
+    },
+    settings: {
+      useBlockieIcon: false,
+      hideZeroBalanceTokens: false,
+      ...overrides.settings,
+    },
+    ...overrides,
+  });
+
+  describe('successful migration', () => {
+    it('should migrate all settings to PreferencesController with valid data', () => {
+      const mockState = createMockState({
+        user: {
+          currentLocale: 'es',
+          appTheme: 'dark',
+        },
+        settings: {
+          useBlockieIcon: true,
+          hideZeroBalanceTokens: true,
+        },
+        engineBackgroundState: {
+          CurrencyRateController: {
+            currentCurrency: 'eur',
+          },
+        },
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual({
+        ...mockState,
+        'engine.backgroundState': {
+          ...mockState['engine.backgroundState'],
+          PreferencesController: {
+            ...getDefaultPreferencesState(),
+            currentLocale: 'es',
+            theme: 'dark',
+            useBlockie: true,
+            currentCurrency: 'eur',
+            hideZeroBalanceTokens: true,
+            showNativeTokenAsMainBalance: false,
+          },
+        },
+      });
+    });
+
+    it('should use default values when settings are missing', () => {
+      const mockState = createMockState({
+        user: {},
+        settings: {},
+        engineBackgroundState: {
+          CurrencyRateController: {},
+        },
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual({
+        ...mockState,
+        'engine.backgroundState': {
+          ...mockState['engine.backgroundState'],
+          PreferencesController: {
+            ...getDefaultPreferencesState(),
+            currentLocale: 'en',
+            theme: 'light',
+            useBlockie: false,
+            currentCurrency: 'usd',
+            hideZeroBalanceTokens: false,
+            showNativeTokenAsMainBalance: false,
+          },
+        },
+      });
+    });
+
+    it('should handle missing user state', () => {
+      const mockState = createMockState({
+        user: undefined,
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual({
+        ...mockState,
+        'engine.backgroundState': {
+          ...mockState['engine.backgroundState'],
+          PreferencesController: {
+            ...getDefaultPreferencesState(),
+            currentLocale: 'en',
+            theme: 'light',
+            useBlockie: false,
+            currentCurrency: 'usd',
+            hideZeroBalanceTokens: false,
+            showNativeTokenAsMainBalance: false,
+          },
+        },
+      });
+    });
+
+    it('should handle missing settings state', () => {
+      const mockState = createMockState({
+        settings: undefined,
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual({
+        ...mockState,
+        'engine.backgroundState': {
+          ...mockState['engine.backgroundState'],
+          PreferencesController: {
+            ...getDefaultPreferencesState(),
+            currentLocale: 'en',
+            theme: 'light',
+            useBlockie: false,
+            currentCurrency: 'usd',
+            hideZeroBalanceTokens: false,
+            showNativeTokenAsMainBalance: false,
+          },
+        },
+      });
+    });
+
+    it('should handle missing CurrencyRateController', () => {
+      const mockState = createMockState({
+        engineBackgroundState: {
+          CurrencyRateController: undefined,
+        },
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual({
+        ...mockState,
+        'engine.backgroundState': {
+          ...mockState['engine.backgroundState'],
+          PreferencesController: {
+            ...getDefaultPreferencesState(),
+            currentLocale: 'en',
+            theme: 'light',
+            useBlockie: false,
+            currentCurrency: 'usd',
+            hideZeroBalanceTokens: false,
+            showNativeTokenAsMainBalance: false,
+          },
+        },
+      });
+    });
+  });
+
+  describe('idempotent migration', () => {
+    it('should skip migration if PreferencesController already exists', () => {
+      const existingPreferencesState = {
+        ...getDefaultPreferencesState(),
+        currentLocale: 'fr',
+        theme: 'auto',
+      };
+
+      const mockState = createMockState({
+        engineBackgroundState: {
+          PreferencesController: existingPreferencesState,
+        },
+      });
+
+      const result = migration(mockState);
+
+      expect(result).toEqual(mockState);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle invalid state and return original state', () => {
+      const invalidState = null;
+
+      const result = migration(invalidState);
+
+      expect(result).toEqual(invalidState);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        new Error(`Migration 089: Invalid state error: 'object' received.`),
+      );
+    });
+
+    it('should handle non-object state', () => {
+      const invalidState = 'invalid';
+
+      const result = migration(invalidState);
+
+      expect(result).toEqual(invalidState);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        new Error(`Migration 089: Invalid state error: 'string' received.`),
+      );
+    });
+  });
+});

--- a/app/store/migrations/089.ts
+++ b/app/store/migrations/089.ts
@@ -1,0 +1,138 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import { getDefaultPreferencesState, PreferencesState } from '@metamask/preferences-controller';
+
+interface MigrationState {
+  'engine.backgroundState'?: {
+    CurrencyRateController?: {
+      currentCurrency?: string;
+    };
+    PreferencesController?: unknown;
+    [key: string]: unknown;
+  };
+  user?: {
+    currentLocale?: string;
+    appTheme?: string;
+    [key: string]: unknown;
+  };
+  settings?: {
+    useBlockieIcon?: boolean;
+    hideZeroBalanceTokens?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export default function migrate(state: unknown) {
+  if (!isObject(state)) {
+    captureException(
+      new Error(
+        `Migration 089: Invalid state error: '${typeof state}' received.`,
+      ),
+    );
+    return state;
+  }
+
+  const migrationState = state as MigrationState;
+  const ENGINE_BACKGROUND_STATE = 'engine.backgroundState';
+  const PREFERENCES_CONTROLLER = 'PreferencesController';
+  const USER_STATE = 'user';
+  const SETTINGS_STATE = 'settings';
+
+  // Get references to state sections
+  const engineBackgroundState = migrationState[ENGINE_BACKGROUND_STATE];
+  const userState = migrationState[USER_STATE];
+  const settingsState = migrationState[SETTINGS_STATE];
+
+  // Check if PreferencesController already exists (idempotent migration)
+  if (
+    engineBackgroundState &&
+    hasProperty(engineBackgroundState, PREFERENCES_CONTROLLER) &&
+    isObject(engineBackgroundState[PREFERENCES_CONTROLLER])
+  ) {
+    return state;
+  }
+
+  try {
+    // Initialize PreferencesController with default state
+    const defaultPreferencesState = getDefaultPreferencesState();
+    const newPreferencesState = { ...defaultPreferencesState } as PreferencesState;
+
+    // Migrate currentLocale from user state or default to 'en'
+    if (
+      userState &&
+      hasProperty(userState, 'currentLocale') &&
+      typeof userState.currentLocale === 'string'
+    ) {
+      newPreferencesState.currentLocale = userState.currentLocale;
+    } else {
+      newPreferencesState.currentLocale = 'en';
+    }
+
+    // Migrate theme from user.appTheme
+    if (
+      userState &&
+      hasProperty(userState, 'appTheme') &&
+      typeof userState.appTheme === 'string'
+    ) {
+      newPreferencesState.theme = userState.appTheme;
+    } else {
+      newPreferencesState.theme = 'light';
+    }
+
+    // Migrate useBlockie from settings.useBlockieIcon
+    if (
+      settingsState &&
+      hasProperty(settingsState, 'useBlockieIcon') &&
+      typeof settingsState.useBlockieIcon === 'boolean'
+    ) {
+      newPreferencesState.useBlockie = settingsState.useBlockieIcon;
+    } else {
+      newPreferencesState.useBlockie = false;
+    }
+
+    // Migrate currentCurrency from CurrencyRateController
+    const currencyRateController = engineBackgroundState?.CurrencyRateController;
+    if (
+      currencyRateController &&
+      hasProperty(currencyRateController, 'currentCurrency') &&
+      typeof currencyRateController.currentCurrency === 'string'
+    ) {
+      newPreferencesState.currentCurrency = currencyRateController.currentCurrency;
+    } else {
+      newPreferencesState.currentCurrency = 'usd';
+    }
+
+    // Migrate hideZeroBalanceTokens from settings
+    if (
+      settingsState &&
+      hasProperty(settingsState, 'hideZeroBalanceTokens') &&
+      typeof settingsState.hideZeroBalanceTokens === 'boolean'
+    ) {
+      newPreferencesState.hideZeroBalanceTokens = settingsState.hideZeroBalanceTokens;
+    } else {
+      newPreferencesState.hideZeroBalanceTokens = false;
+    }
+
+    // Set showNativeTokenAsMainBalance to false (not implemented in mobile yet)
+    newPreferencesState.showNativeTokenAsMainBalance = false;
+
+    // Add PreferencesController to engine.backgroundState
+    const newEngineBackgroundState = {
+      ...engineBackgroundState,
+      [PREFERENCES_CONTROLLER]: newPreferencesState,
+    };
+
+    return {
+      ...state,
+      [ENGINE_BACKGROUND_STATE]: newEngineBackgroundState,
+    };
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration 089: Error migrating settings to PreferencesController: ${error}`,
+      ),
+    );
+    return state;
+  }
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -89,6 +89,7 @@ import migration85 from './085';
 import migration86 from './086';
 import migration87 from './087';
 import migration88 from './088';
+import migration89 from './089';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';
@@ -194,6 +195,7 @@ export const migrationList: MigrationsList = {
   86: migration86,
   87: migration87,
   88: migration88,
+  89: migration89,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/theme/index.ts
+++ b/app/util/theme/index.ts
@@ -11,6 +11,7 @@ import { AppThemeKey, Theme } from './models';
 import { useSelector } from 'react-redux';
 import { lightTheme, darkTheme, brandColor } from '@metamask/design-tokens';
 import Device from '../device';
+import { selectTheme } from '../../selectors/preferencesController';
 
 /**
  * This is needed to make our unit tests pass since Enzyme doesn't support contextType
@@ -104,11 +105,7 @@ const useColorSchemeCustom = (
 
 export const useAppTheme = (): Theme => {
   const osThemeName = useColorSchemeCustom();
-  const appTheme: AppThemeKey = useSelector(
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => state.user.appTheme,
-  );
+  const appTheme: AppThemeKey = useSelector(selectTheme) as AppThemeKey;
   const themeAppearance = getAssetFromTheme(
     appTheme,
     osThemeName,
@@ -203,9 +200,7 @@ export const useTheme = (): Theme => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useAssetFromTheme = (light: any, dark: any) => {
   const osColorScheme = useColorScheme();
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const appTheme = useSelector((state: any) => state.user.appTheme);
+  const appTheme = useSelector(selectTheme) as AppThemeKey;
   const asset = getAssetFromTheme(appTheme, osColorScheme, light, dark);
 
   return asset;

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@metamask/phishing-controller": "^12.5.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/ppom-validator": "0.36.0",
-    "@metamask/preferences-controller": "^18.4.0",
+    "@metamask/preferences-controller": "npm:@metamask-previews/preferences-controller@18.4.1-preview-32f9004a",
     "@metamask/profile-sync-controller": "^20.0.0",
     "@metamask/react-native-acm": "^1.0.1",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5733,13 +5733,13 @@
     eslint-plugin-n "^16.6.2"
     json-rpc-random-id "^1.0.1"
 
-"@metamask/preferences-controller@^18.4.0":
-  version "18.4.0"
-  resolved "https://registry.yarnpkg.com/@metamask/preferences-controller/-/preferences-controller-18.4.0.tgz#480daabce79b993a7d8e4c46af154d37218f75d3"
-  integrity sha512-mhtlt+yg2hu2BhENS5pwhB5ZwnFTcS/PdeivBUBKMyeZkMfVDU+xwQWnd66pjTbCz5mIlu6EjSuKd0vntqSBdQ==
+"@metamask/preferences-controller@npm:@metamask-previews/preferences-controller@18.4.1-preview-32f9004a":
+  version "18.4.1-preview-32f9004a"
+  resolved "https://registry.yarnpkg.com/@metamask-previews/preferences-controller/-/preferences-controller-18.4.1-preview-32f9004a.tgz#68cf839da737df44cde8e418ce57589778aa3543"
+  integrity sha512-o8wYx+J/zPvh2vUp3Ouec09TzkxlPb4rOFh5koPP1cHi0KYvkKIPYcf0tU257MEZTtJcXdKn2x6E/KQSCE4iiQ==
   dependencies:
     "@metamask/base-controller" "^8.0.1"
-    "@metamask/controller-utils" "^11.10.0"
+    "@metamask/controller-utils" "^11.11.0"
 
 "@metamask/profile-sync-controller@^20.0.0":
   version "20.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR completes the `PreferencesController` (core) integration for mobile to enable cross-platform syncing of general (aka UI) settings, in a future release. Following [the extension implementation](https://github.com/MetaMask/metamask-extension/pull/34327), this change migrates 6 general settings from scattered Redux locations to the centralized PreferencesController and updates all UI components to use the new architecture.

**What is the reason for the change?**
- Prepare the ground for cross-platform settings synchronization between extension and mobile
- Centralize general settings management under PreferencesController
- Remove dependencies on scattered Redux state locations for settings

**What is the improvement/solution?**
- Migration 089 moves 6 general settings (`currentLocale`, `theme`, `useBlockie`, `currentCurrency`, `hideZeroBalanceTokens`, `showNativeTokenAsMainBalance`) from various locations to the core (PreferencesController)
- All UI components now use new PreferencesController selectors and actions instead of old Redux state
- Created proper actions that use PreferencesController methods instead of Redux dispatches

## **Changelog**

### **Migration:**
- Migration 089 migrates 6 general settings to PreferencesController

### **UI Components Updated:**
- `ThemeSettings/index.tsx` - Uses `selectTheme` and `updateTheme`
- `MultichainTransactionListItem.tsx` - Uses `selectTheme` 
- `util/theme/index.ts` - Uses `selectTheme` in theme utilities
- `Identicon/index.tsx` - Uses `selectUseBlockie`
- `WalletAccount/WalletAccount.tsx` - Uses `selectUseBlockie`
- `AccountRightButton/index.tsx` - Uses `selectUseBlockie`
- `CaipAccountSelectorList.tsx` - Uses `selectUseBlockie`
- `GeneralSettings/index.js` - Uses new selectors and actions
- `UrlAutocomplete/index.tsx` - Uses PreferencesController `selectCurrentCurrency`

### **Actions Updated:**
All actions now use proper PreferencesController methods:
- `updateTheme` → `PreferencesController.setTheme`
- `updateUseBlockie` → `PreferencesController.setUseBlockie`
- `updateCurrentCurrency` → `PreferencesController.setCurrentCurrency`
- `updateHideZeroBalanceTokens` → `PreferencesController.setHideZeroBalanceTokens`

## **Related issues**

Related to: https://github.com/MetaMask/metamask-extension/pull/34327
Depends on: https://github.com/MetaMask/core/pull/6111

## **Manual testing steps**

1. Install the app and verify migration 089 runs successfully
2. Go to Settings > General Settings
3. Change theme setting and verify it persists after app restart
4. Toggle "Use Blockies" setting and verify avatar changes across the app
5. Change currency setting and verify it updates throughout the app
6. Toggle "Hide tokens with zero balance" and verify token list updates
7. Verify all settings are stored in PreferencesController state (not old Redux locations)
8. Test that settings work correctly in components like:
   - Theme selection modal
   - Account avatars/identicons
   - Currency displays
   - Token list filtering

## **Screenshots/Recordings**

### **Before**
TODO

### **After**
TODO 

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (migration tests already included)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.