### PR TITLE
chore: Check for free to use runners defined

### DIFF
--- a/.github/scripts/check-runners.sh
+++ b/.github/scripts/check-runners.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 # check-runners.sh
+
 ALLOWED_RUNNERS="ubuntu-latest|macos-latest|ubuntu-24.04|ubuntu-22.04|macos-13|macos-15"
 
-if grep -r "runs-on:" .github/workflows/ | grep -v -E "runs-on: (${ALLOWED_RUNNERS})" | grep -v "#"; then
-    echo "❌ Only ubuntu-latest and macos-latest runners are allowed"
+echo "Checking for non-compliant runners..."
+
+NON_COMPLIANT=$(find .github/workflows -name "*.yml" -o -name "*.yaml" | \
+  xargs grep -H "runs-on:" | \
+  grep -v -E "(${ALLOWED_RUNNERS})")
+
+if [ -n "$NON_COMPLIANT" ]; then
+    echo "❌ Found non-compliant runners:"
+    echo "$NON_COMPLIANT"
+    echo ""
+    echo "Only these runners are allowed: ubuntu-latest, macos-latest, ubuntu-24.04, ubuntu-22.04, macos-13, macos-15"
     exit 1
 else
     echo "✅ All runners are compliant"

--- a/.github/scripts/check-runners.sh
+++ b/.github/scripts/check-runners.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# check-runners.sh
+ALLOWED_RUNNERS="ubuntu-latest|macos-latest|ubuntu-24.04|ubuntu-22.04|macos-13|macos-15"
+
+if grep -r "runs-on:" .github/workflows/ | grep -v -E "runs-on: (${ALLOWED_RUNNERS})" | grep -v "#"; then
+    echo "❌ Only ubuntu-latest and macos-latest runners are allowed"
+    exit 1
+else
+    echo "✅ All runners are compliant"
+fi

--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -13,12 +13,12 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
             fetch-depth: 0 # This is needed to checkout all branches
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/bitrise-e2e-gate.yml
+++ b/.github/workflows/bitrise-e2e-gate.yml
@@ -21,10 +21,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,23 @@ on:
     types: [checks_requested]
 
 jobs:
+  check-workflows:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Check for Approved Runners
+        run: .github/scripts/check-runners.sh
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/62dc61a45fc95efe8c800af7a557ab0b9165d63b/scripts/download-actionlint.bash) 1.7.1
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        shell: bash
   check-diff:
     runs-on: macos-latest
+    needs: check-workflows
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -32,6 +47,7 @@ jobs:
           fi
   dedupe:
     runs-on: ubuntu-latest
+    needs: check-workflows
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -50,6 +66,7 @@ jobs:
           fi
   git-safe-dependencies:
     runs-on: ubuntu-latest
+    needs: check-workflows
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -61,6 +78,7 @@ jobs:
         run: yarn git-safe-dependencies
   scripts:
     runs-on: ubuntu-latest
+    needs: check-workflows
     strategy:
       matrix:
         scripts:
@@ -91,6 +109,7 @@ jobs:
           fi
   unit-tests:
     runs-on: ubuntu-latest
+    needs: check-workflows
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -126,7 +145,8 @@ jobs:
           fi
   merge-unit-tests:
     runs-on: ubuntu-latest
-    needs: unit-tests
+    needs:
+      - unit-tests
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -160,6 +180,7 @@ jobs:
 
   js-bundle-size-check:
     runs-on: ubuntu-latest
+    needs: check-workflows
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
@@ -183,7 +204,7 @@ jobs:
 
   ship-js-bundle-size-check:
     runs-on: ubuntu-latest
-    needs: [js-bundle-size-check]
+    needs: js-bundle-size-check
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
@@ -294,20 +315,6 @@ jobs:
               exit 1
             fi
           fi
-  check-workflows:
-    name: Check workflows
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - name: Check for Approved Runners
-        run: .github/scripts/check-runners.sh
-      - name: Download actionlint
-        id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/62dc61a45fc95efe8c800af7a557ab0b9165d63b/scripts/download-actionlint.bash) 1.7.1
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.download-actionlint.outputs.executable }} -color
-        shell: bash
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-latest
@@ -317,7 +324,6 @@ jobs:
         dedupe,
         scripts,
         unit-tests,
-        check-workflows,
         js-bundle-size-check,
         sonar-cloud-quality-gate-status,
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   check-diff:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -33,8 +33,8 @@ jobs:
   dedupe:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -51,8 +51,8 @@ jobs:
   git-safe-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -71,10 +71,10 @@ jobs:
           - test:depcheck
           - test:tgz-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -95,8 +95,8 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -128,8 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -161,8 +161,8 @@ jobs:
   js-bundle-size-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -186,7 +186,7 @@ jobs:
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Download iOS bundle
         uses: actions/download-artifact@v4
@@ -204,10 +204,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: merge-unit-tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0 # SonarCloud needs a full checkout to perform necessary analysis
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
       - uses: actions/download-artifact@v4
@@ -245,7 +245,7 @@ jobs:
     needs: sonar-cloud
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: SonarCloud Quality Gate Status
         id: sonar-status
         env:
@@ -298,7 +298,9 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Check for Approved Runners
+        run: .github/scripts/check-runners.sh
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/62dc61a45fc95efe8c800af7a557ab0b9165d63b/scripts/download-actionlint.bash) 1.7.1

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -6,19 +6,19 @@ on:
       - stable
     types:
       - closed
-    
+
 jobs:
   close-bug-report:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.extract_version.outputs.version
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Set up Node.js
         if: steps.extract_version.outputs.version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ vars.branch_name }}
@@ -27,7 +27,7 @@ jobs:
       - name: Get Node.js version
         id: nvm
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Create Cherry Pick PR

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: ${{ github.ref }}  # Explicitly specifies the tag ref
 

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: crowdin action
       uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build and load
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -23,10 +23,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/run-bitrise-flask-e2e-check.yml
+++ b/.github/workflows/run-bitrise-flask-e2e-check.yml
@@ -21,10 +21,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: '.nvmrc'
 
@@ -41,4 +41,4 @@ jobs:
         # The status check created under this workflow may be bucketed under another check suite in Github actions. This is a result of workflows with the same triggers.
         # For example, the status check may show as `CLA Signature Bot / Bitrise Flask E2E Status`. This is a bug on Github's UI. https://github.com/orgs/community/discussions/24616
         run: yarn run run-bitrise-e2e-check
-        working-directory: '.github/scripts' 
+        working-directory: '.github/scripts'

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -28,7 +28,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: React to the comment
         run: |
           gh api \
@@ -52,7 +52,7 @@ jobs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -79,7 +79,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -110,7 +110,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.ACTIONS_WRITE_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
       - is-fork-pull-request
       - check-status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post comment if the update failed

--- a/.github/workflows/update-latest-build-version.yml
+++ b/.github/workflows/update-latest-build-version.yml
@@ -27,12 +27,12 @@ jobs:
           contents: write
           id-token: write
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
           with:
             fetch-depth: 0
             ref: ${{ inputs.base-branch }}
             token: ${{ secrets.PR_TOKEN }}
-            
+
         - name: Bump script
           env:
             HEAD_REF: ${{ inputs.base-branch }}
@@ -47,5 +47,4 @@ jobs:
             git add android/app/build.gradle
             git commit -m "Bump version number to ${{ needs.generate-build-version.outputs.build-version }}"
             git push origin HEAD:"$HEAD_REF" --force
-            
-  
+


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
Public Repos get free actions minutes when using the standard size runners. Take advantage of free compute.
2. What is the improvement/solution?
Add a new script that scans workflows for supported runners prior to deploying workflows