### PR TITLE
fix: cp-7.50.2 Fix undefined formatNetworkRpcUrl

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -104,6 +104,10 @@ import {
   removeItemFromChainIdList,
 } from '../../../../../util/metrics/MultichainAPI/networkMetricUtils';
 
+const formatNetworkRpcUrl = (rpcUrl) => {
+  return stripProtocol(stripKeyFromInfuraUrl(rpcUrl));
+};
+
 const createStyles = (colors) =>
   StyleSheet.create({
     base: {
@@ -1677,9 +1681,6 @@ export class NetworkSettings extends PureComponent {
       this.context.themeAppearance || themeAppearanceLight;
     const styles = createStyles(colors);
 
-    const formatNetworkRpcUrl = (rpcUrl) => {
-      return stripProtocol(stripKeyFromInfuraUrl(rpcUrl));
-    };
     const inputStyle = [
       styles.input,
       inputWidth,

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1914,4 +1914,52 @@ describe('NetworkSettings', () => {
       expect(result).toEqual([]);
     });
   });
+
 });
+
+describe('NetworkSettings - showNetworkModal', () => {
+  it('should not crash', () => {
+    const networkConfiguration = {
+      blockExplorerUrls: ['https://etherscan.io'],
+      defaultBlockExplorerUrlIndex: 0,
+      defaultRpcEndpointIndex: 0,
+      chainId: '0x1',
+      rpcEndpoints: [
+        {
+          networkClientId: 'mainnet',
+          type: 'Infura',
+          url: 'https://mainnet.infura.io/v3/',
+        },
+      ],
+      name: 'Ethereum Main Network',
+      nativeCurrency: 'ETH',
+    };
+    const props = {
+      route: {
+        params: {
+          network: 'mainnet',
+        },
+      },
+      navigation: {
+        setOptions: jest.fn(),
+        navigate: jest.fn(),
+        goBack: jest.fn(),
+      },
+      networkConfigurations: {
+        '0x1': networkConfiguration,
+      },
+    };
+
+    const wrapper = shallow(
+      <Provider store={store}>
+        <NetworkSettings {...props} />
+      </Provider>,
+    )
+      .find(NetworkSettings)
+      .dive();
+
+    const instance = wrapper.instance() as NetworkSettings;
+
+    expect(() => instance.showNetworkModal(networkConfiguration)).not.toThrow();
+  });
+})

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1914,7 +1914,6 @@ describe('NetworkSettings', () => {
       expect(result).toEqual([]);
     });
   });
-
 });
 
 describe('NetworkSettings - showNetworkModal', () => {
@@ -1962,4 +1961,4 @@ describe('NetworkSettings - showNetworkModal', () => {
 
     expect(() => instance.showNetworkModal(networkConfiguration)).not.toThrow();
   });
-})
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In certain code branches within the NetworkSettings component, we call `showNetworkModal`. This crashes because the `formatNetworkRpcUrl` function does not exist there. This function is used in another part of the component, so moving it up fixes the problem.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed crash when opening modal to add a popular or custom network

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17240

## **Manual testing steps**

Unfortunately, I haven't been able to reproduce the Sentry error linked above, but adding a popular or custom network should work.

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
