### PR TITLE
fix: cp-7.51.0 token fiat values not available in transaction list

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -41,8 +41,8 @@ import {
   selectConversionRateByChainId,
   selectCurrentCurrency,
 } from '../../../../selectors/currencyRateController';
-import { selectTokensByAddress } from '../../../../selectors/tokensController';
-import { selectContractExchangeRates } from '../../../../selectors/tokenRatesController';
+import { selectTokensByChainIdAndAddress } from '../../../../selectors/tokensController';
+import { selectContractExchangeRatesByChainId } from '../../../../selectors/tokenRatesController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { regex } from '../../../../../app/util/regex';
 import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
@@ -67,7 +67,6 @@ import {
   SEPOLIA_BLOCK_EXPLORER,
 } from '../../../../constants/urls';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import Tag from '../../../../component-library/components/Tags/Tag';
 import TagBase from '../../../../component-library/base-components/TagBase';
 
 const createStyles = (colors) =>
@@ -268,6 +267,7 @@ class TransactionDetails extends PureComponent {
         primaryCurrency,
         swapsTransactions,
         swapsTokens,
+        txChainId: transactionObject.chainId,
       });
       this.setState({ updatedTransactionDetails: decodedTx[1] });
     } catch (e) {
@@ -551,8 +551,14 @@ const mapStateToProps = (state, ownProps) => ({
   ticker: isPerDappSelectedNetworkEnabled()
     ? selectTickerByChainId(state, ownProps.transactionObject.chainId)
     : selectEvmTicker(state),
-  tokens: selectTokensByAddress(state),
-  contractExchangeRates: selectContractExchangeRates(state),
+  tokens: selectTokensByChainIdAndAddress(
+    state,
+    ownProps.transactionObject.chainId,
+  ),
+  contractExchangeRates: selectContractExchangeRatesByChainId(
+    state,
+    ownProps.transactionObject.chainId,
+  ),
   conversionRate: selectConversionRateByChainId(
     state,
     ownProps.transactionObject.chainId,

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -40,10 +40,7 @@ import {
   useBridgeTxHistoryData,
 } from '../../../util/bridge/hooks/useBridgeTxHistoryData';
 import BridgeActivityItemTxSegments from '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments';
-import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../constants/bridge';
 import { getSwapBridgeTxActivityTitle } from '../Bridge/utils/transaction-history';
-import { decimalToHex } from '../../../util/conversions';
-import { addHexPrefix } from '../../../util/number';
 import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
 import Badge, {
   BadgeVariant,
@@ -54,12 +51,9 @@ import {
   getFontFamily,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import {
-  formatChainIdToCaip,
-  formatChainIdToHex,
-  isSolanaChainId,
-} from '@metamask/bridge-controller';
 import { selectConversionRateByChainId } from '../../../selectors/currencyRateController';
+import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
+import { selectTokensByChainIdAndAddress } from '../../../selectors/tokensController';
 
 const createStyles = (colors, typography) =>
   StyleSheet.create({
@@ -707,6 +701,11 @@ const mapStateToProps = (state, ownProps) => ({
   swapsTokens: swapsControllerTokens(state),
   ticker: selectTickerByChainId(state, ownProps.txChainId),
   conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
+  contractExchangeRates: selectContractExchangeRatesByChainId(
+    state,
+    ownProps.txChainId,
+  ),
+  tokens: selectTokensByChainIdAndAddress(state, ownProps.txChainId),
 });
 
 TransactionElement.contextType = ThemeContext;

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -27,7 +27,6 @@ import {
   selectProviderType,
 } from '../../../selectors/networkController';
 import { selectPrimaryCurrency } from '../../../selectors/settings';
-import { selectTokensByAddress } from '../../../selectors/tokensController';
 import { selectGasFeeControllerEstimateType } from '../../../selectors/gasFeeController';
 import { baseStyles, fontStyles } from '../../../styles/common';
 import { isHardwareAccount } from '../../../util/address';
@@ -53,11 +52,7 @@ import PriceChartContext, {
   PriceChartProvider,
 } from '../AssetOverview/PriceChart/PriceChart.context';
 import { providerErrors } from '@metamask/rpc-errors';
-import {
-  selectConversionRate,
-  selectCurrentCurrency,
-} from '../../../selectors/currencyRateController';
-import { selectContractExchangeRates } from '../../../selectors/tokenRatesController';
+import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import {
@@ -130,10 +125,6 @@ class Transactions extends PureComponent {
      */
     close: PropTypes.func,
     /**
-     * Object containing token exchange rates in the format address => exchangeRate
-     */
-    contractExchangeRates: PropTypes.object,
-    /**
      * Network configurations
      */
     networkConfigurations: PropTypes.object,
@@ -150,10 +141,6 @@ class Transactions extends PureComponent {
      */
     collectibleContracts: PropTypes.array,
     /**
-     * An array that represents the user tokens
-     */
-    tokens: PropTypes.object,
-    /**
      * An array of transactions objects
      */
     transactions: PropTypes.array,
@@ -169,10 +156,6 @@ class Transactions extends PureComponent {
      * A string that represents the selected address
      */
     selectedAddress: PropTypes.string,
-    /**
-     * ETH to current currency conversion rate
-     */
-    conversionRate: PropTypes.number,
     /**
      * Currency code of the currently-active currency
      */
@@ -645,11 +628,8 @@ class Transactions extends PureComponent {
       onCancelAction={this.onCancelAction}
       onPressItem={this.toggleDetailsView}
       selectedAddress={this.props.selectedAddress}
-      tokens={this.props.tokens}
       collectibleContracts={this.props.collectibleContracts}
-      contractExchangeRates={this.props.contractExchangeRates}
       exchangeRate={this.props.exchangeRate}
-      conversionRate={this.props.conversionRate}
       currentCurrency={this.props.currentCurrency}
       navigation={this.props.navigation}
       txChainId={item.chainId}
@@ -910,15 +890,12 @@ const mapStateToProps = (state) => ({
   chainId: selectChainId(state),
   networkClientId: selectNetworkClientId(state),
   collectibleContracts: collectibleContractsSelector(state),
-  contractExchangeRates: selectContractExchangeRates(state),
-  conversionRate: selectConversionRate(state),
   currentCurrency: selectCurrentCurrency(state),
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
   networkConfigurations: selectNetworkConfigurations(state),
   providerConfig: selectProviderConfig(state),
   gasFeeEstimates: selectGasFeeEstimates(state),
   primaryCurrency: selectPrimaryCurrency(state),
-  tokens: selectTokensByAddress(state),
   gasEstimateType: selectGasFeeControllerEstimateType(state),
   networkType: selectProviderType(state),
 });

--- a/app/components/Views/ActivityView/index.test.tsx
+++ b/app/components/Views/ActivityView/index.test.tsx
@@ -19,6 +19,7 @@ jest.mock('../../../core/Engine', () => ({
 }));
 
 jest.mock('../../hooks/AssetPolling/useCurrencyRatePolling', () => jest.fn());
+jest.mock('../../hooks/AssetPolling/useTokenRatesPolling', () => jest.fn());
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -40,6 +40,7 @@ import { selectTokenNetworkFilter } from '../../../selectors/preferencesControll
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { PopularList } from '../../../util/networks/customNetworks';
 import useCurrencyRatePolling from '../../hooks/AssetPolling/useCurrencyRatePolling';
+import useTokenRatesPolling from '../../hooks/AssetPolling/useTokenRatesPolling';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -65,6 +66,7 @@ const TransactionsView = ({
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
 
   useCurrencyRatePolling();
+  useTokenRatesPolling();
 
   const selectedAddress = toChecksumHexAddress(
     selectedInternalAccount?.address,

--- a/app/components/Views/TransactionsView/index.test.tsx
+++ b/app/components/Views/TransactionsView/index.test.tsx
@@ -153,6 +153,7 @@ jest.mock('../../../core/Engine', () => ({
 }));
 
 jest.mock('../../hooks/AssetPolling/useCurrencyRatePolling', () => jest.fn());
+jest.mock('../../hooks/AssetPolling/useTokenRatesPolling', () => jest.fn());
 
 import TransactionsView from './index';
 import initialRootState from '../../../util/test/initial-root-state';

--- a/app/selectors/tokensController.test.ts
+++ b/app/selectors/tokensController.test.ts
@@ -320,14 +320,18 @@ describe('TokensController Selectors', () => {
   });
 
   describe('selectTokensByChainIdAndAddress', () => {
-    it('returns undefined if no tokens exist for chain ID and address', () => {
-      const tokensByChainAndAddress =
-        selectTokensByChainIdAndAddress.resultFunc(
-          mockTokensControllerState as unknown as TokensControllerState,
-          '0x1',
-          '0xNonExistentAddress',
-        );
-      expect(tokensByChainAndAddress).toBeUndefined();
+    it('returns mapped tokens for given chain ID', () => {
+      expect(
+        selectTokensByChainIdAndAddress(mockRootState, '0x1'),
+      ).toStrictEqual({
+        '0xToken1': mockToken,
+      });
+    });
+
+    it('returns undefined if no tokens exist for chain ID', () => {
+      expect(
+        selectTokensByChainIdAndAddress(mockRootState, '0x2'),
+      ).toBeUndefined();
     });
   });
 

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -31,13 +31,20 @@ export const selectTokens = createDeepEqualSelector(
 
 export const selectTokensByChainIdAndAddress = createDeepEqualSelector(
   selectTokensControllerState,
-  selectEvmChainId,
   selectSelectedInternalAccountAddress,
+  (_state, chainId: Hex) => chainId,
   (
     tokensControllerState: TokensControllerState,
-    chainId: Hex,
     selectedAddress: string | undefined,
-  ) => tokensControllerState?.allTokens[chainId]?.[selectedAddress as Hex],
+    chainId: Hex,
+  ) =>
+    tokensControllerState?.allTokens[chainId]?.[selectedAddress as Hex]?.reduce(
+      (tokensMap: { [address: string]: Token }, token: Token) => ({
+        ...tokensMap,
+        [token.address]: token,
+      }),
+      {},
+    ),
 );
 
 export const selectTokensByAddress = createSelector(


### PR DESCRIPTION
## **Description**

Fix `Not Available` in transaction list by ensuring chain specific `tokens` and `contractExchangeRates` selectors are used.

Also poll token rates while transaction view is visible.

## **Changelog**

CHANGELOG entry: Fixed a bug causing "Not Available" entries in transaction list

## **Related issues**

Fixes: #17102 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
