### PR TITLE
fix: cp-7.51.0 legacy swaps input amount small

### DIFF
--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -127,7 +127,7 @@ const createStyles = (colors) =>
       textAlignVertical: 'center',
       fontSize: Device.isIphone5() ? 30 : 40,
       height: Device.isIphone5() ? 40 : 50,
-      lineHeight: Device.isIphone5() ? 40 : 50,
+      lineHeight: Device.isIphone5() ? 33 : 44,
     },
     amountInvalid: {
       color: colors.error.default,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue in Legacy Swaps where the input amount was tiny in iOS.

## **Related issues**

Fixes: #17097 

## **Manual testing steps**

1. Go to Legacy Swaps
2. Observe that the font size is correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-18 at 11 15 13" src="https://github.com/user-attachments/assets/490398b7-2b1c-4034-a7c4-883d720fb2be" />

<img width="1080" height="2280" alt="Screenshot_1752833947" src="https://github.com/user-attachments/assets/e77991ed-d853-4592-99d6-ef80dceec2b9" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
