### PR TITLE
fix: in-app browser close button visibility

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1421,7 +1421,7 @@ export function getWebviewNavbar(navigation, route, themeColors) {
       elevation: 0,
     },
     headerIcon: {
-      color: themeColors.default,
+      color: themeColors.icon.default,
     },
   });
 


### PR DESCRIPTION
## **Description**

This PR fixes the header icon color in the webview navbar to properly display in dark mode. The issue was that the `headerIcon` style was using `themeColors.default` (which doesn't exist) instead of the correct `themeColors.icon.default` property.

[Slack Thread](https://consensys.slack.com/archives/C093A5JP3FS/p1752851827470759?thread_ts=1752851827.470759&cid=C093A5JP3FS)

## **Changelog**

CHANGELOG entry: Fixed header icon colors in browser webview to display correctly in dark mode

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the Browser tab in MetaMask mobile
2. Navigate to any website (e.g., https://google.com)
3. Switch to dark mode in device settings or MetaMask theme settings
4. Observe that the header navigation icons (back, forward, refresh, menu) now display with the correct dark mode icon color
5. Switch back to light mode and verify icons still display correctly
6. Test on different websites to ensure consistency

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img src="https://github.com/user-attachments/assets/4098cd83-5341-45cb-98ea-9749b668df70" width="250" />


### **After**

<img width="350" height="858" alt="Screenshot 2025-07-18 at 11 39 56 AM" src="https://github.com/user-attachments/assets/699df884-f22b-4c29-a4c8-2d264382c65b" /><img width="350" height="860" alt="Screenshot 2025-07-18 at 11 40 16 AM" src="https://github.com/user-attachments/assets/541e8eb7-a7c6-4cc5-b77b-c71195323486" />

https://github.com/user-attachments/assets/27e6a569-7e23-4249-b9ee-a1e515d7bfb7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.