### PR TITLE
fix: correct RC build workflows to use RC configurations instead of prod

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1992,12 +1992,11 @@ workflows:
       bitrise.io:
         stack: linux-docker-android-22.04
         machine_type_id: elite-xl
-  # TODO: This is exactly the same as build_android_release_and_upload_sourcemaps, remove once consolidated
   build_android_rc_and_upload_sourcemaps:
     envs:
       - SENTRY_DISABLE_AUTO_UPLOAD: 'false'
     after_run:
-      - build_android_main_prod
+      - build_android_main_rc
     meta:
       bitrise.io:
         stack: linux-docker-android-22.04
@@ -2517,12 +2516,11 @@ workflows:
       - SENTRY_DISABLE_AUTO_UPLOAD: 'false'
     after_run:
       - build_ios_main_prod
-  # TODO: This is exactly the same as build_ios_release_and_upload_sourcemaps, remove once consolidated
   build_ios_rc_and_upload_sourcemaps:
     envs:
       - SENTRY_DISABLE_AUTO_UPLOAD: 'false'
     after_run:
-      - build_ios_main_prod
+      - build_ios_main_rc
   build_ios_beta:
     envs:
       - METAMASK_BUILD_TYPE: "beta"


### PR DESCRIPTION
## **Description**

This PR fixes the RC (Release Candidate) build workflows in bitrise.yml that were incorrectly using production build configurations instead of the appropriate RC configurations.

**What is the reason for the change?**
The RC build workflows  and  were calling production build steps ( and ) instead of the RC-specific build steps.

**What is the improvement/solution?**
Updated the workflows to use the correct RC build configurations:
-  now calls build_android_main_rc
-  now calls build_ios_main_rc

Also removed obsolete TODO comments that were no longer relevant.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Trigger an RC build via Bitrise
2. Verify that the RC build uses the correct RC configurations
3. Confirm that the generated apps have RC-specific settings

## **Screenshots/Recordings**

N/A - Build configuration changes only

### **Before**

RC builds were using production configurations

### **After**

RC builds now use the correct RC configurations

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.