### PR TITLE
docs: add expo e2e testing docs

### DIFF
--- a/.e2e.env.example
+++ b/.e2e.env.example
@@ -16,3 +16,8 @@ export USE_LOCAL_DAPP=true
 export MULTICHAIN_DAPP_URL="https://metamask.github.io/test-dapp-multichain/latest/"
 # Option 2: Use a custom remote URL
 # export MULTICHAIN_DAPP_URL="https://your-multichain-dapp.example.com/"
+
+# E2E prebuild paths
+export PREBUILT_IOS_APP_PATH='build/MetaMask.app'
+export PREBUILT_ANDROID_APK_PATH='build/MetaMask.apk'
+export PREBUILT_ANDROID_TEST_APK_PATH='build/MetaMask-Test.apk'

--- a/docs/readme/expo-e2e-testing.md
+++ b/docs/readme/expo-e2e-testing.md
@@ -155,3 +155,4 @@ This guide will help you set up and run end-to-end (E2E) tests using the Expo bu
 - **Build folder doesn't exist**: Run `mkdir build` in your project root
 - **Simulator/Emulator not found**: Ensure the device names match exactly as specified in prerequisites
 - **Android SDK not found**: Verify `$ANDROID_SDK_ROOT` is set correctly with `echo $ANDROID_SDK_ROOT`
+- **My Expo Application shows an error "Failed to connect to localhost/127.0.0.1:8081"**: The emulator may need to have the expo port forwarded. Try `adb reverse tcp:8081 tcp:8081` and rerun the test command.

--- a/docs/readme/expo-e2e-testing.md
+++ b/docs/readme/expo-e2e-testing.md
@@ -1,0 +1,143 @@
+# Expo E2E Testing
+
+This guide will help you set up and run end-to-end (E2E) tests using the Expo builds on both iOS and Android.
+
+## Prerequisites
+
+### Environment Setup
+
+1. Copy the E2E environment variables from the example file:
+
+   ```bash
+   cp .e2e.env.example .e2e.env
+   ```
+
+2. Ensure your `.e2e.env` file contains the following prebuild paths:
+
+   ```bash
+   # E2E prebuild paths
+   # These paths point to a gitignored root build folder, so you may need to create this folder.
+   export PREBUILT_IOS_APP_PATH='build/MetaMask.app'
+   export PREBUILT_ANDROID_APK_PATH='build/MetaMask.apk'
+   export PREBUILT_ANDROID_TEST_APK_PATH='build/MetaMask-Test.apk'
+   ```
+
+3. Create the build directory if it doesn't exist:
+
+   ```bash
+   # In root of project
+   mkdir build
+   ```
+
+### iOS Prerequisites
+
+- **Required Simulator**: iPhone 15 Pro
+- **Setup Instructions**:
+  1. Open Xcode
+  2. Go to **Window** → **Devices and Simulators**
+  3. Click the **+** button to add a new simulator
+  4. Select **iPhone 15 Pro** and create the simulator
+
+### Android Prerequisites
+
+- **Set up Android SDK path** by adding this to your shell profile (`.bashrc`, `.zshrc`, etc.):
+
+  ```bash
+  export ANDROID_SDK_ROOT="/Users/${USER}/Library/Android/sdk"
+  ```
+
+- **Required Emulator**: "Pixel 5 Pro API 34"
+  - Open Android Studio
+  - Go to **Tools** → **AVD Manager**
+  - Click **Create Virtual Device**
+  - Select a Pixel device (or similar)
+  - Choose API level 34
+  - **Important**: Name the emulator exactly "Pixel 5 Pro API 34" to match our configuration
+
+## iOS Testing Steps
+
+1. **Verify prerequisites** are completed (Environment Setup + iOS Prerequisites)
+
+2. **Download iOS simulator builds** from Runway/Bitrise
+
+3. **Copy and rename the build**: Copy your downloaded .app file to the prebuild path
+
+   ```bash
+   # Copy your downloaded .app file to the prebuild path
+   cp /path/to/your/downloaded/AAA.app build/MetaMask.app
+   ```
+
+4. **Start the E2E watcher**:
+
+   ```bash
+   source .e2e.env && yarn watch
+   ```
+
+5. **Launch the iPhone 15 Pro simulator** from Xcode or using:
+
+   ```bash
+   xcrun simctl boot "iPhone 15 Pro"
+   ```
+
+6. **Run the E2E tests**:
+
+   ```bash
+   # Run all tests
+   source .e2e.env && yarn test:e2e:ios:debug:run
+
+   # Run specific folder
+   source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/your-folder
+
+   # Run specific test file
+   source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/your-test-file.spec.ts
+   ```
+
+## Android Testing Steps
+
+1. **Verify prerequisites** are completed (Environment Setup + Android Prerequisites)
+
+2. **Download Android builds** from Runway/Bitrise
+
+   > ⚠️ **Important**: You need **both APK files** from the downloaded zip:
+   >
+   > - Main APK from `/prod/debug/` folder
+   > - Test APK from `/androidTest/` folder
+
+3. **Install the builds**:
+
+   ```bash
+   # Copy the main APK (from /prod/debug/ folder)
+   cp /path/to/downloaded/prod/debug/AAA.apk build/MetaMask.apk
+
+   # Copy the test APK (from /androidTest/ folder)
+   cp /path/to/downloaded/androidTest/prod/debug/BBB.apk build/MetaMask-Test.apk
+   ```
+
+4. **Start the E2E watcher**:
+
+   ```bash
+   source .e2e.env && yarn watch
+   ```
+
+5. **Launch the Android emulator**: through Android Studio
+
+6. **Run the E2E tests**:
+
+   ```bash
+   # Run all tests
+   source .e2e.env && yarn test:e2e:android:debug:run
+
+   # Run specific folder
+   source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/your-folder
+
+   # Run specific test file
+   source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/your-test-file.spec.ts
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+- **Build folder doesn't exist**: Run `mkdir build` in your project root
+- **Simulator/Emulator not found**: Ensure the device names match exactly as specified in prerequisites
+- **Android SDK not found**: Verify `$ANDROID_SDK_ROOT` is set correctly with `echo $ANDROID_SDK_ROOT`

--- a/docs/readme/expo-e2e-testing.md
+++ b/docs/readme/expo-e2e-testing.md
@@ -29,6 +29,13 @@ This guide will help you set up and run end-to-end (E2E) tests using the Expo bu
    mkdir build
    ```
 
+4. Install dependencies
+
+   ```bash
+   # In root of project
+   yarn setup:expo
+   ```
+
 ### iOS Prerequisites
 
 - **Required Simulator**: iPhone 15 Pro
@@ -90,6 +97,9 @@ This guide will help you set up and run end-to-end (E2E) tests using the Expo bu
 
    # Run specific test file
    source .e2e.env && yarn test:e2e:ios:debug:run e2e/specs/your-test-file.spec.ts
+
+   # Run specific tag
+   source .e2e.env && yarn test:e2e:ios:debug:run --testNamePattern="Smoke"
    ```
 
 ## Android Testing Steps
@@ -132,12 +142,16 @@ This guide will help you set up and run end-to-end (E2E) tests using the Expo bu
 
    # Run specific test file
    source .e2e.env && yarn test:e2e:android:debug:run e2e/specs/your-test-file.spec.ts
+
+   # Run specific tag
+   source .e2e.env && yarn test:e2e:android:debug:run --testNamePattern="Smoke"
    ```
 
 ## Troubleshooting
 
 ### Common Issues
 
+- **The application is not opening**: EXPO DOESN'T SUPPORT DETOX OUT OF THE BOX SO IT IS POSSIBLE THAT, IN SLOWER COMPUTERS, LOADING FROM THE BUNDLER TAKES TOO LONG WHICH MAKES THE VERY FIRST TEST FAIL. THE FAILED TEST WILL THEN AUTOMATICALLY RESTART AND IT SHOULD WORK FROM THEN ON.
 - **Build folder doesn't exist**: Run `mkdir build` in your project root
 - **Simulator/Emulator not found**: Ensure the device names match exactly as specified in prerequisites
 - **Android SDK not found**: Verify `$ANDROID_SDK_ROOT` is set correctly with `echo $ANDROID_SDK_ROOT`

--- a/docs/readme/testing.md
+++ b/docs/readme/testing.md
@@ -36,27 +36,7 @@ Ensure that these devices are set up. You can change the default devices at any 
 
 - **Option #1 - Using Expo prebuilds (recommended)**
 
-  **Install dependencies**
-
-  ```bash
-  yarn setup:expo
-  ```
-
-  **Start Metro Server**: Ensure the Metro server is running before executing tests:
-
-  ```bash
-  yarn watch:clean
-  ```
-
-  Instead of building apps localy, you can download prebuilt `.app`/`.ipa`/`.apk` files from [Runway buckets](../../README.md#download-and-install-the-development-build) and run the tests against them.
-
-  Use `.app` for the iOS simulator and `.ipa` for physical iOS devices.
-
-  After downloading the prebuilt apps, update your local environment variables so that the prebuilds are picked up in the [.detoxrc.js](../../.detoxrc.js) file:
-
-  - `PREBUILT_IOS_APP_PATH` for iOS
-  - `PREBUILT_ANDROID_APP_PATH` for Android APK
-  - `PREBUILT_ANDROID_TEST_APP_PATH` for Android test APK (needs to be set when using prebuilds)
+  Please follow the [Expo E2E Testing](./expo-e2e-testing.md) documentation
 
 - **Option #2 - Building locally**:
 
@@ -406,5 +386,6 @@ Our CI/CD process is automated through various Bitrise pipelines, each designed 
 ### Framework Documentation
 
 For detailed E2E framework documentation, patterns, and best practices, see:
+
 - **[E2E Framework Guide](../../e2e/framework/README.md)** - Comprehensive guide to the TypeScript testing framework
 - **[General E2E Best Practices](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/e2e-testing.md)** - MetaMask-wide testing guidelines


### PR DESCRIPTION
## **Description**

Added some comprehensive docs for e2e testing.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add expo e2e testing docs

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
