### PR TITLE
fix: add padding to in-app browser text

### DIFF
--- a/app/components/UI/Tabs/index.js
+++ b/app/components/UI/Tabs/index.js
@@ -38,6 +38,7 @@ const createStyles = (colors, shadows) =>
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: colors.background.alternative,
+      paddingHorizontal: 16,
     },
     noTabsTitle: {
       ...fontStyles.normal,


### PR DESCRIPTION
## **Description**

This PR adds horizontal padding to the tab text in the Tabs component to improve text readability and visual spacing. The change specifically addresses the "browse the decentralized web" text that appears in the browser tab interface.


## **Changelog**

CHANGELOG entry: Added horizontal padding to browser tab text for improved readability

## **Related issues**

Fixes: [Slack Thread](https://consensys.slack.com/archives/C093A5JP3FS/p1752852169679619?thread_ts=1752852169.679619&cid=C093A5JP3FS)

## **Manual testing steps**

1. Go to the Browser tab in MetaMask mobile
2. Observe the "browse the decentralized web" text in the tab interface
3. Verify that the text now has appropriate horizontal spacing from the tab edges
4. Test on different screen sizes to ensure consistent spacing
5. Switch between light and dark modes to verify the padding works correctly in both themes

## **Screenshots/Recordings**

### **Before**

<img width="250" height="2622" alt="IMG_2424" src="https://github.com/user-attachments/assets/24235ef9-ec85-4bb5-a71b-859880f515b8" />

### **After**

<img width="250" height="854" alt="Screenshot 2025-07-18 at 12 03 24 PM" src="https://github.com/user-attachments/assets/0ed8587a-5009-400c-b2aa-40618be73ffb" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.