### PR TITLE
fix: custom token input height

### DIFF
--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
@@ -243,8 +243,10 @@ exports[`AddCustomToken render correctly 1`] = `
               "color": "#121314",
               "fontFamily": "CentraNo1-Book",
               "fontWeight": "400",
+              "minHeight": 48,
               "paddingHorizontal": 16,
               "paddingVertical": 12,
+              "textAlignVertical": "center",
             }
           }
           testID="input-token-address"

--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -78,6 +78,8 @@ const createStyles = (colors) =>
       borderColor: colors.border.default,
       paddingHorizontal: 16,
       paddingVertical: 12,
+      minHeight: 48,
+      textAlignVertical: 'center',
       ...fontStyles.normal,
       color: colors.text.default,
     },

--- a/app/components/UI/AddCustomToken/index.js
+++ b/app/components/UI/AddCustomToken/index.js
@@ -92,6 +92,8 @@ const createStyles = (colors) =>
       borderWidth: 2,
       paddingHorizontal: 16,
       paddingVertical: 12,
+      minHeight: 48,
+      textAlignVertical: 'center',
       ...fontStyles.normal,
     },
     textInputDisabled: {


### PR DESCRIPTION
## **Description**

This PR improves the styling of text input fields in the AddCustomToken component by adding a minimum height and proper text vertical alignment. These changes ensure consistent input field sizing and better text positioning for improved user experience.

**Changes made:**
- Added `minHeight: 48` to ensure consistent input field height
- Added `textAlignVertical: 'center'` for proper text positioning within the input field

## **Changelog**

CHANGELOG entry: Improved text input styling in add custom token screen with consistent height and centered text alignment

## **Related issues**

Fixes: N/A
Reference: https://consensys.slack.com/archives/C093A5JP3FS/p1752248663988069

## **Manual testing steps**

1. Go to Wallet → Settings → Advanced → Add Custom Token
2. Observe the text input fields for token contract address, symbol, and decimals
3. Verify that input fields have consistent height (48px minimum)
4. Verify that text appears vertically centered within each input field
5. Test on both light and dark themes
6. Test on different screen sizes to ensure responsive behavior

## **Screenshots/Recordings**

<!-- Screenshots would show before/after comparison of the input field styling -->

### **Before**

<img src="https://github.com/user-attachments/assets/b59afd83-967f-41a4-95bd-bae684647792" width="250" />

### **After**

<!-- Input fields have consistent 48px minimum height with centered text -->

https://github.com/user-attachments/assets/ec13363a-898c-457d-9ffb-1d88c9d18385

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.