### PR TITLE
feat(sdk+wc): move sdk & wc init to saga

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -33,7 +33,6 @@ import { AccountDetailsIds } from '../../../../e2e/selectors/MultichainAccounts/
 import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
 import branch from 'react-native-branch';
 import { AppStateEventProcessor } from '../../../core/AppStateEventListener';
-import Logger from '../../../util/Logger';
 
 const initialState: DeepPartial<RootState> = {
   user: {
@@ -62,14 +61,7 @@ jest.mock('../../../core/DeeplinkManager/SharedDeeplinkManager', () => ({
   parse: jest.fn(),
 }));
 
-jest.mock('../../../core/SDKConnect/SDKConnect', () => ({
-  getInstance: () => ({
-    init: jest.fn().mockResolvedValue(undefined),
-    postInit: jest.fn().mockResolvedValue(undefined),
-  }),
-}));
-
-let mockIsWC2Enabled = true;
+const mockIsWC2Enabled = true;
 jest.mock('../../../../app/core/WalletConnect/WalletConnectV2', () => ({
   init: jest.fn().mockResolvedValue(undefined),
   get isWC2Enabled() {
@@ -84,9 +76,6 @@ jest.mock('../../hooks/useMetrics/useMetrics', () => ({
     getMetaMetricsId: jest.fn(),
   }),
 }));
-
-import WC2ManagerMock from '../../../../app/core/WalletConnect/WalletConnectV2';
-import { DevLogger as DevLoggerMock } from '../../../../app/core/SDKConnect/utils/DevLogger';
 
 jest.mock('../../../lib/ppom/PPOMView', () => ({ PPOMView: () => null }));
 
@@ -104,12 +93,6 @@ jest.mock('../../../core/AppStateEventListener', () => ({
 jest.mock('../../../core/NavigationService', () => ({
   navigation: {
     reset: jest.fn(),
-  },
-}));
-
-jest.mock('../../../../app/core/SDKConnect/utils/DevLogger', () => ({
-  DevLogger: {
-    log: jest.fn(),
   },
 }));
 
@@ -818,132 +801,6 @@ describe('App', () => {
         expect(AppStateEventProcessor.setCurrentDeeplink).toHaveBeenCalledWith(
           mockUri,
         );
-      });
-    });
-  });
-
-  describe('WalletConnect initialization', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockIsWC2Enabled = true;
-      (WC2ManagerMock.init as jest.Mock).mockClear();
-    });
-
-    it('initializes WalletConnect when isWC2Enabled is true', async () => {
-      mockIsWC2Enabled = true;
-      // Mock the user to be logged in so the component reaches the WalletConnect initialization
-      const loggedInState = {
-        ...initialState,
-        user: {
-          ...initialState.user,
-          existingUser: true,
-          userLoggedIn: true,
-        },
-      };
-      jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(true);
-      jest.spyOn(Authentication, 'appTriggeredAuth').mockResolvedValue();
-
-      renderScreen(App, { name: 'App' }, { state: loggedInState });
-      await waitFor(() => {
-        expect(WC2ManagerMock.init).toHaveBeenCalledWith({
-          navigation: expect.any(Object),
-        });
-      });
-    });
-
-    it('does not initialize WalletConnect when isWC2Enabled is false', async () => {
-      mockIsWC2Enabled = false;
-      (WC2ManagerMock.init as jest.Mock).mockClear();
-      // Mock the user to be logged in so the component reaches the WalletConnect initialization
-      const loggedInState = {
-        ...initialState,
-        user: {
-          ...initialState.user,
-          existingUser: true,
-          userLoggedIn: true,
-        },
-      };
-      jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(true);
-      jest.spyOn(Authentication, 'appTriggeredAuth').mockResolvedValue();
-
-      renderScreen(App, { name: 'App' }, { state: loggedInState });
-      await waitFor(() => {
-        expect(WC2ManagerMock.init).not.toHaveBeenCalled();
-      });
-    });
-
-    it('logs initialization message when WalletConnect is enabled', async () => {
-      const devLoggerSpy = jest
-        .spyOn(DevLoggerMock, 'log')
-        .mockImplementation();
-      mockIsWC2Enabled = true;
-      // Mock the user to be logged in so the component reaches the WalletConnect initialization
-      const loggedInState = {
-        ...initialState,
-        user: {
-          ...initialState.user,
-          existingUser: true,
-          userLoggedIn: true,
-        },
-      };
-      jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(true);
-      jest.spyOn(Authentication, 'appTriggeredAuth').mockResolvedValue();
-
-      renderScreen(App, { name: 'App' }, { state: loggedInState });
-      await waitFor(() => {
-        expect(devLoggerSpy).toHaveBeenCalledWith(
-          'WalletConnect: Initializing WalletConnect Manager',
-        );
-      });
-      devLoggerSpy.mockRestore();
-    });
-
-    it('handles WalletConnect initialization errors gracefully', async () => {
-      const loggerSpy = jest.spyOn(Logger, 'error').mockImplementation();
-      const mockError = new Error('WalletConnect initialization failed');
-      mockIsWC2Enabled = true;
-      (WC2ManagerMock.init as jest.Mock).mockRejectedValue(mockError);
-      // Mock the user to be logged in so the component reaches the WalletConnect initialization
-      const loggedInState = {
-        ...initialState,
-        user: {
-          ...initialState.user,
-          existingUser: true,
-          userLoggedIn: true,
-        },
-      };
-      jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(true);
-      jest.spyOn(Authentication, 'appTriggeredAuth').mockResolvedValue();
-
-      renderScreen(App, { name: 'App' }, { state: loggedInState });
-      await waitFor(() => {
-        expect(loggerSpy).toHaveBeenCalledWith(
-          mockError,
-          'Cannot initialize WalletConnect Manager.',
-        );
-      });
-      loggerSpy.mockRestore();
-    });
-
-    it('passes NavigationService.navigation to WalletConnect init', async () => {
-      mockIsWC2Enabled = true;
-      // Mock the user to be logged in so the component reaches the WalletConnect initialization
-      const loggedInState = {
-        ...initialState,
-        user: {
-          ...initialState.user,
-          existingUser: true,
-          userLoggedIn: true,
-        },
-      };
-      jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(true);
-      jest.spyOn(Authentication, 'appTriggeredAuth').mockResolvedValue();
-
-      renderScreen(App, { name: 'App' }, { state: loggedInState });
-      await waitFor(() => {
-        expect(WC2ManagerMock.init).toHaveBeenCalledWith({
-          navigation: expect.any(Object),
-        });
       });
     });
   });

--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -744,8 +744,6 @@ describe('App', () => {
     });
   });
 
-
-
   describe('Navigation hooks usage', () => {
     it('should use useNavigationState to check previous route and skip auth when coming from Settings', async () => {
       // Arrange: mock routes so previous route is SettingsView

--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -30,9 +30,6 @@ import { Authentication } from '../../../core';
 import { internalAccount1 as mockAccount } from '../../../util/test/accountsControllerTestUtils';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { AccountDetailsIds } from '../../../../e2e/selectors/MultichainAccounts/AccountDetails.selectors';
-import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
-import branch from 'react-native-branch';
-import { AppStateEventProcessor } from '../../../core/AppStateEventListener';
 
 const initialState: DeepPartial<RootState> = {
   user: {
@@ -747,63 +744,7 @@ describe('App', () => {
     });
   });
 
-  describe('Branch deeplink handling', () => {
-    it('initializes SharedDeeplinkManager with navigation and dispatch', async () => {
-      renderScreen(App, { name: 'App' }, { state: initialState });
-      await waitFor(() => {
-        expect(SharedDeeplinkManager.init).toHaveBeenCalledWith({
-          navigation: expect.any(Object),
-          dispatch: expect.any(Function),
-        });
-      });
-    });
-    it('calls getBranchDeeplink immediately for cold start deeplink check', async () => {
-      (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({});
-      renderScreen(App, { name: 'App' }, { state: initialState });
-      await waitFor(() => {
-        expect(branch.getLatestReferringParams).toHaveBeenCalledTimes(1);
-      });
-    });
-    it('processes cold start deeplink when non-branch link is found', async () => {
-      const mockDeeplink = 'https://link.metamask.io/home';
-      (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
-        '+non_branch_link': mockDeeplink,
-      });
-      renderScreen(App, { name: 'App' }, { state: initialState });
-      await waitFor(() => {
-        expect(branch.getLatestReferringParams).toHaveBeenCalledTimes(1);
-        expect(AppStateEventProcessor.setCurrentDeeplink).toHaveBeenCalledWith(
-          mockDeeplink,
-        );
-      });
-    });
 
-    it('subscribes to Branch deeplink events', async () => {
-      renderScreen(App, { name: 'App' }, { state: initialState });
-      await waitFor(() => {
-        expect(branch.subscribe).toHaveBeenCalled();
-      });
-    });
-    it('processes deeplink from subscription callback when uri is provided', async () => {
-      const mockUri = 'https://link.metamask.io/home';
-      const mockDeeplink = 'https://link.metamask.io/swap';
-      (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
-        '+non_branch_link': mockDeeplink,
-      });
-      renderScreen(App, { name: 'App' }, { state: initialState });
-      await waitFor(() => {
-        expect(branch.subscribe).toHaveBeenCalledWith(expect.any(Function));
-      });
-      const subscribeCallback = (branch.subscribe as jest.Mock).mock
-        .calls[0][0];
-      subscribeCallback({ uri: mockUri });
-      await waitFor(() => {
-        expect(AppStateEventProcessor.setCurrentDeeplink).toHaveBeenCalledWith(
-          mockUri,
-        );
-      });
-    });
-  });
 
   describe('Navigation hooks usage', () => {
     it('should use useNavigationState to check previous route and skip auth when coming from Settings', async () => {
@@ -939,16 +880,6 @@ describe('App', () => {
               },
             },
           ],
-        });
-      });
-    });
-
-    it('should no longer pass navigation object to SharedDeeplinkManager.init', async () => {
-      renderScreen(App, { name: 'App' }, { state: initialState });
-
-      await waitFor(() => {
-        expect(SharedDeeplinkManager.init).toHaveBeenCalledWith({
-
         });
       });
     });

--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -943,13 +943,12 @@ describe('App', () => {
       });
     });
 
-    it('should pass navigation object to SharedDeeplinkManager.init', async () => {
+    it('should no longer pass navigation object to SharedDeeplinkManager.init', async () => {
       renderScreen(App, { name: 'App' }, { state: initialState });
 
       await waitFor(() => {
         expect(SharedDeeplinkManager.init).toHaveBeenCalledWith({
-          navigation: expect.any(Object),
-          dispatch: expect.any(Function),
+
         });
       });
     });

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -985,12 +985,9 @@ const AppFlow = () => {
 
 const App: React.FC = () => {
   const navigation = useNavigation();
-  const userLoggedIn = useSelector(selectUserLoggedIn);
   const routes = useNavigationState((state) => state.routes);
-  const [onboarded, setOnboarded] = useState(false);
   const { toastRef } = useContext(ToastContext);
   const dispatch = useDispatch();
-  const sdkInit = useRef<boolean | undefined>(undefined);
   const isFirstRender = useRef(true);
 
   const { isEnabled: checkMetricsEnabled } = useMetrics();
@@ -1036,7 +1033,6 @@ const App: React.FC = () => {
 
   useEffect(() => {
     const appTriggeredAuth = async () => {
-      setOnboarded(!!existingUser);
       try {
         if (existingUser) {
           // Check if we came from Settings screen to skip auto-authentication
@@ -1181,45 +1177,6 @@ const App: React.FC = () => {
     initMetrics().catch((err) => {
       Logger.error(err, 'Error initializing MetaMetrics');
     });
-  }, []);
-
-  useEffect(() => {
-    // Init SDKConnect only if the navigator is ready, user is onboarded, and SDK is not initialized.
-    async function initSDKConnect() {
-      if (onboarded && sdkInit.current === undefined && userLoggedIn) {
-        sdkInit.current = false;
-        try {
-          const sdkConnect = SDKConnect.getInstance();
-          await sdkConnect.init({
-            context: 'Nav/App',
-            navigation: NavigationService.navigation,
-          });
-          await SDKConnect.getInstance().postInit();
-          sdkInit.current = true;
-        } catch (err) {
-          sdkInit.current = undefined;
-          Logger.error(err as Error, 'Cannot initialize SDKConnect');
-        }
-      }
-    }
-
-    initSDKConnect().catch((err) => {
-      Logger.error(err, 'Error initializing SDKConnect');
-    });
-  }, [onboarded, userLoggedIn]);
-
-  useEffect(() => {
-    if (isWC2Enabled) {
-      DevLogger.log(`WalletConnect: Initializing WalletConnect Manager`);
-      WC2Manager.init({ navigation: NavigationService.navigation }).catch(
-        (err) => {
-          Logger.error(
-            err as Error,
-            'Cannot initialize WalletConnect Manager.',
-          );
-        },
-      );
-    }
   }, []);
 
   useEffect(() => {

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import {
   useNavigation,
   useRoute,
   useNavigationState,
 } from '@react-navigation/native';
-import { Linking } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
 import Login from '../../Views/Login';
 import QRTabSwitcher from '../../Views/QRTabSwitcher';
@@ -22,10 +21,8 @@ import DeleteWalletModal from '../../../components/UI/DeleteWalletModal';
 import Main from '../Main';
 import OptinMetrics from '../../UI/OptinMetrics';
 import SimpleWebview from '../../Views/SimpleWebview';
-import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
-import branch from 'react-native-branch';
 import Logger from '../../../util/Logger';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   CURRENT_APP_VERSION,
   LAST_APP_VERSION,
@@ -108,7 +105,6 @@ import ChangeInSimulationModal from '../../Views/ChangeInSimulationModal/ChangeI
 import TooltipModal from '../../../components/Views/TooltipModal';
 import OptionsSheet from '../../UI/SelectOptionSheet/OptionsSheet';
 import FoxLoader from '../../../components/UI/FoxLoader';
-import { AppStateEventProcessor } from '../../../core/AppStateEventListener';
 import MultiRpcModal from '../../../components/Views/MultiRpcModal/MultiRpcModal';
 import Engine from '../../../core/Engine';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -144,7 +140,6 @@ import DeleteAccount from '../../Views/MultichainAccounts/sheets/DeleteAccount';
 import RevealPrivateKey from '../../Views/MultichainAccounts/sheets/RevealPrivateKey';
 import RevealSRP from '../../Views/MultichainAccounts/sheets/RevealSRP';
 import { DeepLinkModal } from '../../UI/DeepLinkModal';
-import { checkForDeeplink } from '../../../actions/user';
 import { WalletDetails } from '../../Views/MultichainAccounts/WalletDetails/WalletDetails';
 import { AddressList as MultichainAccountAddressList } from '../../Views/MultichainAccounts/AddressList';
 import { PrivateKeyList as MultichainAccountPrivateKeyList } from '../../Views/MultichainAccounts/PrivateKeyList';
@@ -975,7 +970,6 @@ const App: React.FC = () => {
   const navigation = useNavigation();
   const routes = useNavigationState((state) => state.routes);
   const { toastRef } = useContext(ToastContext);
-  const dispatch = useDispatch();
   const isFirstRender = useRef(true);
 
   const { isEnabled: checkMetricsEnabled } = useMetrics();
@@ -1088,74 +1082,6 @@ const App: React.FC = () => {
     });
     // existingUser and isMetaMetricsUISeen are not present in the dependency array because they are not needed to re-run the effect when they change and it will cause a bug.
   }, [navigation]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleDeeplink = useCallback(
-    ({ uri }: { uri?: string }) => {
-      try {
-        if (uri && typeof uri === 'string') {
-          AppStateEventProcessor.setCurrentDeeplink(uri);
-          dispatch(checkForDeeplink());
-        }
-      } catch (e) {
-        Logger.error(e as Error, `Deeplink: Error parsing deeplink`);
-      }
-    },
-    [dispatch],
-  );
-
-  // Subscribe to incoming deeplinks
-  // Ex. SDK and WalletConnect deeplinks will funnel through here when opening the app from the device's camera
-  useEffect(() => {
-    Linking.addEventListener('url', (params) => {
-      const { url } = params;
-      if (url) {
-        handleDeeplink({ uri: url });
-      }
-    });
-  }, [handleDeeplink]);
-
-  // Subscribe to incoming Branch deeplinks
-  // Branch.io documentation: https://help.branch.io/developers-hub/docs/react-native
-  // Ex. Branch links will funnel through here when opening the app from a Branch link
-  useEffect(() => {
-    // Initialize deep link manager
-    SharedDeeplinkManager.init({
-      navigation,
-      dispatch,
-    });
-
-    const getBranchDeeplink = async (uri?: string) => {
-      if (uri) {
-        handleDeeplink({ uri });
-        return;
-      }
-
-      try {
-        const latestParams = await branch.getLatestReferringParams();
-        const deeplink = latestParams?.['+non_branch_link'] as string;
-        if (deeplink) {
-          handleDeeplink({ uri: deeplink });
-        }
-      } catch (error) {
-        Logger.error(error as Error, 'Error getting Branch deeplink');
-      }
-    };
-
-    // branch.subscribe is not called for iOS cold start after the new RN architecture upgrade.
-    // This is a workaround to ensure that the deeplink is processed for iOS cold start.
-    // TODO: Remove this once branch.subscribe is called for iOS cold start.
-    getBranchDeeplink();
-
-    branch.subscribe((opts) => {
-      const { error } = opts;
-
-      if (error) {
-        trackErrorAsAnalytics(error, 'Branch:');
-      }
-
-      getBranchDeeplink(opts.uri);
-    });
-  }, [dispatch, handleDeeplink, navigation]);
 
   useEffect(() => {
     const initMetrics = async () => {

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import {
   useNavigation,
   useRoute,
@@ -39,7 +33,6 @@ import {
 } from '../../../constants/storage';
 import { getVersion } from 'react-native-device-info';
 import { Authentication } from '../../../core/';
-import SDKConnect from '../../../core/SDKConnect/SDKConnect';
 import { colors as importedColors } from '../../../styles/common';
 import Routes from '../../../constants/navigation/Routes';
 import ModalConfirmation from '../../../component-library/components/Modals/ModalConfirmation';
@@ -85,10 +78,6 @@ import NetworkSelector from '../../../components/Views/NetworkSelector';
 import ReturnToAppModal from '../../Views/ReturnToAppModal';
 import EditAccountName from '../../Views/EditAccountName/EditAccountName';
 import MultichainEditAccountName from '../../Views/MultichainAccounts/sheets/EditAccountName';
-import WC2Manager, {
-  isWC2Enabled,
-} from '../../../../app/core/WalletConnect/WalletConnectV2';
-import { DevLogger } from '../../../../app/core/SDKConnect/utils/DevLogger';
 import { PPOMView } from '../../../lib/ppom/PPOMView';
 import LockScreen from '../../Views/LockScreen';
 import StorageWrapper from '../../../store/storage-wrapper';
@@ -139,7 +128,6 @@ import {
 import { Confirm } from '../../Views/confirmations/components/confirm';
 import ImportNewSecretRecoveryPhrase from '../../Views/ImportNewSecretRecoveryPhrase';
 import { SelectSRPBottomSheet } from '../../Views/SelectSRP/SelectSRPBottomSheet';
-import NavigationService from '../../../core/NavigationService';
 import AccountStatus from '../../Views/AccountStatus';
 import OnboardingSheet from '../../Views/OnboardingSheet';
 import SeedphraseModal from '../../UI/SeedphraseModal';

--- a/app/core/DeeplinkManager/DeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.test.ts
@@ -26,21 +26,13 @@ const mockNavigation = {
   navigate: jest.fn(),
 } as unknown as NavigationProp<ParamListBase>;
 
-const mockDispatch = jest.fn();
-
 describe('DeeplinkManager', () => {
-  let deeplinkManager = new DeeplinkManager({
-    navigation: mockNavigation,
-    dispatch: mockDispatch,
-  });
+  let deeplinkManager = new DeeplinkManager();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    deeplinkManager = new DeeplinkManager({
-      navigation: mockNavigation,
-      dispatch: mockDispatch,
-    });
+    deeplinkManager = new DeeplinkManager();
   });
 
   it('should set, get, and expire a deeplink correctly', () => {

--- a/app/core/DeeplinkManager/DeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.test.ts
@@ -1,4 +1,5 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import NavigationService from '../NavigationService';
 import DeeplinkManager from './DeeplinkManager';
 import handleBrowserUrl from './Handlers/handleBrowserUrl';
 import handleEthereumUrl from './Handlers/handleEthereumUrl';
@@ -27,11 +28,13 @@ const mockNavigation = {
 } as unknown as NavigationProp<ParamListBase>;
 
 describe('DeeplinkManager', () => {
-  let deeplinkManager = new DeeplinkManager();
+  let deeplinkManager: DeeplinkManager;
 
   beforeEach(() => {
     jest.clearAllMocks();
-
+    // Ensure navigation is available before DeeplinkManager is constructed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    NavigationService.navigation = mockNavigation as any;
     deeplinkManager = new DeeplinkManager();
   });
 

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -1,8 +1,7 @@
 'use strict';
 
-import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { ParseOutput } from 'eth-url-parser';
-import { AnyAction, Dispatch, Store } from 'redux';
+import { Dispatch } from 'redux';
 import handleBrowserUrl from './Handlers/handleBrowserUrl';
 import handleEthereumUrl from './Handlers/handleEthereumUrl';
 import handleRampUrl from './Handlers/handleRampUrl';
@@ -14,23 +13,26 @@ import { handleSwapUrl } from './Handlers/handleSwapUrl';
 import Routes from '../../constants/navigation/Routes';
 import { handleCreateAccountUrl } from './Handlers/handleCreateAccountUrl';
 import { handlePerpsUrl, handlePerpsAssetUrl } from './Handlers/handlePerpsUrl';
+import { store } from '../../store';
+import NavigationService from '../NavigationService';
+import branch from 'react-native-branch';
+import { Linking } from 'react-native';
+import Logger from '../../util/Logger';
+import { handleDeeplink } from './Handlers/handleDeeplink';
+import SharedDeeplinkManager from './SharedDeeplinkManager';
 
 class DeeplinkManager {
-  public navigation: NavigationProp<ParamListBase>;
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public navigation: any;
   public pendingDeeplink: string | null;
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public dispatch: Dispatch<any>;
 
-  constructor({
-    navigation,
-    dispatch,
-  }: {
-    navigation: NavigationProp<ParamListBase>;
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dispatch: Store<any, AnyAction>['dispatch'];
-  }) {
+  constructor() {
+    const navigation = NavigationService.navigation;
+    const dispatch = store.dispatch;
     this.navigation = navigation;
     this.pendingDeeplink = null;
     this.dispatch = dispatch;
@@ -146,6 +148,59 @@ class DeeplinkManager {
       origin,
       browserCallBack,
       onHandled,
+    });
+  }
+
+  static start() {
+    SharedDeeplinkManager.init();
+
+    const getBranchDeeplink = async (uri?: string) => {
+      if (uri) {
+        handleDeeplink({ uri });
+        return;
+      }
+
+      try {
+        const latestParams = await branch.getLatestReferringParams();
+        const deeplink = latestParams?.['+non_branch_link'] as string;
+        if (deeplink) {
+          handleDeeplink({ uri: deeplink });
+        }
+      } catch (error) {
+        Logger.error(error as Error, 'Error getting Branch deeplink');
+      }
+    };
+
+    Linking.getInitialURL().then((url) => {
+      if (!url) {
+        return;
+      }
+      Logger.log(`handleDeeplink:: got initial URL ${url}`);
+      handleDeeplink({ uri: url });
+    });
+
+    Linking.addEventListener('url', (params) => {
+      const { url } = params;
+      handleDeeplink({ uri: url });
+    });
+
+    // branch.subscribe is not called for iOS cold start after the new RN architecture upgrade.
+    // This is a workaround to ensure that the deeplink is processed for iOS cold start.
+    // TODO: Remove this once branch.subscribe is called for iOS cold start.
+    getBranchDeeplink();
+
+    branch.subscribe((opts) => {
+      const { error } = opts;
+      if (error) {
+        const branchError = new Error(error);
+        Logger.error(branchError, 'Error subscribing to branch.');
+      }
+      getBranchDeeplink(opts.uri);
+      //TODO: that async call in the subscribe doesn't look good to me
+      branch.getLatestReferringParams().then((val) => {
+        const deeplink = opts.uri || (val['+non_branch_link'] as string);
+        handleDeeplink({ uri: deeplink });
+      });
     });
   }
 }

--- a/app/core/DeeplinkManager/Handlers/handleDeeplink.test.ts
+++ b/app/core/DeeplinkManager/Handlers/handleDeeplink.test.ts
@@ -1,0 +1,128 @@
+import { handleDeeplink } from './handleDeeplink';
+import { checkForDeeplink } from '../../../actions/user';
+import ReduxService from '../../redux';
+import Logger from '../../../util/Logger';
+import { AppStateEventProcessor } from '../../AppStateEventListener';
+
+jest.mock('../../../actions/user', () => ({
+  checkForDeeplink: jest.fn(() => ({ type: 'CHECK_FOR_DEEPLINK' })),
+}));
+
+jest.mock('../../redux', () => ({
+  __esModule: true,
+  default: {
+    store: {
+      dispatch: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+jest.mock('../../AppStateEventListener', () => ({
+  AppStateEventProcessor: {
+    setCurrentDeeplink: jest.fn(),
+  },
+}));
+
+describe('handleDeeplink', () => {
+  const mockDispatch = ReduxService.store.dispatch as jest.Mock;
+  const mockCheckForDeeplink = checkForDeeplink as jest.Mock;
+  const mockLoggerError = Logger.error as jest.Mock;
+  const mockSetCurrentDeeplink =
+    AppStateEventProcessor.setCurrentDeeplink as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should process valid URI and dispatch checkForDeeplink', () => {
+    const testUri = 'metamask://test-deeplink';
+
+    handleDeeplink({ uri: testUri });
+
+    expect(mockSetCurrentDeeplink).toHaveBeenCalledWith(testUri);
+    expect(mockCheckForDeeplink).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'CHECK_FOR_DEEPLINK' });
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it('should handle undefined URI without processing', () => {
+    handleDeeplink({ uri: undefined });
+
+    expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockCheckForDeeplink).not.toHaveBeenCalled();
+  });
+
+  it('should handle empty string URI without processing', () => {
+    handleDeeplink({ uri: '' });
+
+    expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockCheckForDeeplink).not.toHaveBeenCalled();
+  });
+
+  it('should handle non-string URI without processing', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - Testing runtime behavior with invalid type
+    handleDeeplink({ uri: 123 });
+
+    expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockCheckForDeeplink).not.toHaveBeenCalled();
+  });
+
+  it('should handle complex URI schemes', () => {
+    const complexUri =
+      'metamask://dapp/connect?url=https://example.com&chainId=1';
+
+    handleDeeplink({ uri: complexUri });
+
+    expect(mockSetCurrentDeeplink).toHaveBeenCalledWith(complexUri);
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'CHECK_FOR_DEEPLINK' });
+  });
+
+  it('should handle errors gracefully and log them', () => {
+    const testUri = 'metamask://test';
+    const mockError = new Error('Test error');
+
+    mockSetCurrentDeeplink.mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    handleDeeplink({ uri: testUri });
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      mockError,
+      'Deeplink: Error parsing deeplink',
+    );
+  });
+
+  it('should handle dispatch errors gracefully', () => {
+    const testUri = 'metamask://test';
+    const mockError = new Error('Dispatch error');
+
+    mockDispatch.mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    handleDeeplink({ uri: testUri });
+
+    expect(mockSetCurrentDeeplink).toHaveBeenCalledWith(testUri);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      mockError,
+      'Deeplink: Error parsing deeplink',
+    );
+  });
+
+  it('should handle options object without uri parameter', () => {
+    handleDeeplink({});
+
+    expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockCheckForDeeplink).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/DeeplinkManager/Handlers/handleDeeplink.ts
+++ b/app/core/DeeplinkManager/Handlers/handleDeeplink.ts
@@ -1,0 +1,17 @@
+import { checkForDeeplink } from '../../../actions/user';
+import Logger from '../../../util/Logger';
+import { AppStateEventProcessor } from '../../AppStateEventListener';
+import ReduxService from '../../redux';
+
+export function handleDeeplink(opts: { uri?: string }) {
+  const { dispatch } = ReduxService.store;
+  const { uri } = opts;
+  try {
+    if (uri && typeof uri === 'string') {
+      AppStateEventProcessor.setCurrentDeeplink(uri);
+      dispatch(checkForDeeplink());
+    }
+  } catch (e) {
+    Logger.error(e as Error, `Deeplink: Error parsing deeplink`);
+  }
+}

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
@@ -1,4 +1,3 @@
-import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import SharedDeeplinkManager from './SharedDeeplinkManager';
 import DeeplinkManager from './DeeplinkManager';
 import { store } from '../../store';
@@ -31,23 +30,6 @@ describe('SharedDeeplinkManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('should call init method on the DeeplinkManager instance after initialization', () => {
-    const spyInit = jest.spyOn(SharedDeeplinkManager, 'init');
-
-    const navigation = {
-      navigate: jest.fn(),
-    } as unknown as NavigationProp<ParamListBase>;
-
-    const dispatch = jest.fn();
-
-    SharedDeeplinkManager.init();
-
-    expect(spyInit).toHaveBeenCalledWith({
-      navigation,
-      dispatch,
-    });
   });
 
   it('should return instance of DeeplinkManager when calling getInstance', () => {

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
@@ -17,9 +17,7 @@ jest.mock('../../core/NavigationService', () => ({
 }));
 
 describe('SharedDeeplinkManager', () => {
-  const mockDispatch = jest.fn();
   const mockStore = store as jest.Mocked<typeof store>;
-  const mockNavigate = jest.fn() as unknown as NavigationProp<ParamListBase>;
 
   beforeEach(() => {
     const mockedState = {

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.test.ts
@@ -28,10 +28,7 @@ describe('SharedDeeplinkManager', () => {
 
     mockStore.getState.mockReturnValue(mockedState);
 
-    SharedDeeplinkManager.init({
-      navigation: mockNavigate,
-      dispatch: mockDispatch,
-    });
+    SharedDeeplinkManager.init();
   });
 
   beforeEach(() => {
@@ -47,10 +44,7 @@ describe('SharedDeeplinkManager', () => {
 
     const dispatch = jest.fn();
 
-    SharedDeeplinkManager.init({
-      navigation,
-      dispatch,
-    });
+    SharedDeeplinkManager.init();
 
     expect(spyInit).toHaveBeenCalledWith({
       navigation,

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.ts
@@ -9,7 +9,7 @@ const SharedDeeplinkManager = {
     if (instance) {
       return;
     }
-    instance = new DeeplinkManager();
+    instance ??= new DeeplinkManager();
     DevLogger.log(`DeeplinkManager initialized`);
   },
   parse: (
@@ -19,7 +19,11 @@ const SharedDeeplinkManager = {
       origin: string;
       onHandled?: () => void;
     },
-  ) => instance.parse(url, args),
+  ) => {
+    // Always try initialize, but instance will only be assigned once
+    SharedDeeplinkManager.init();
+    return instance.parse(url, args);
+  },
   setDeeplink: (url: string) => instance.setDeeplink(url),
   getPendingDeeplink: () => instance.getPendingDeeplink(),
   expireDeeplink: () => instance.expireDeeplink(),

--- a/app/core/DeeplinkManager/SharedDeeplinkManager.ts
+++ b/app/core/DeeplinkManager/SharedDeeplinkManager.ts
@@ -1,5 +1,3 @@
-import { NavigationProp, ParamListBase } from '@react-navigation/native';
-import { Dispatch } from 'redux';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 import DeeplinkManager from './DeeplinkManager';
 
@@ -7,22 +5,11 @@ let instance: DeeplinkManager;
 
 const SharedDeeplinkManager = {
   getInstance: () => instance,
-  init: ({
-    navigation,
-    dispatch,
-  }: {
-    navigation: NavigationProp<ParamListBase>;
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dispatch: Dispatch<any>;
-  }) => {
+  init: () => {
     if (instance) {
       return;
     }
-    instance = new DeeplinkManager({
-      navigation,
-      dispatch,
-    });
+    instance = new DeeplinkManager();
     DevLogger.log(`DeeplinkManager initialized`);
   },
   parse: (

--- a/app/core/SDKConnect/InitializationManagement/postInit.ts
+++ b/app/core/SDKConnect/InitializationManagement/postInit.ts
@@ -7,7 +7,7 @@ import DevLogger from '../utils/DevLogger';
 import { waitForCondition, waitForKeychainUnlocked } from '../utils/wait.util';
 import { isE2E } from '../../../util/test/utils';
 
-async function postInit(instance: SDKConnect, callback?: () => void) {
+async function postInit(instance: SDKConnect) {
   if (!instance.state._initialized) {
     throw new Error(`SDKConnect::postInit() - not initialized`);
   }
@@ -78,8 +78,6 @@ async function postInit(instance: SDKConnect, callback?: () => void) {
 
   instance.state._postInitialized = true;
   DevLogger.log(`SDKConnect::postInit() - done`);
-
-  callback?.();
 }
 
 export default postInit;

--- a/app/core/SDKConnect/SDKConnect.test.ts
+++ b/app/core/SDKConnect/SDKConnect.test.ts
@@ -1,5 +1,4 @@
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
-import { NavigationContainerRef } from '@react-navigation/native';
 import AppConstants from '../AppConstants';
 import addDappConnection from './AndroidSDK/addDappConnection';
 import bindAndroidSDK from './AndroidSDK/bindAndroidSDK';
@@ -33,6 +32,23 @@ import {
   updateSDKLoadingState,
 } from './StateManagement';
 import Engine from '../../core/Engine';
+
+const mockNavigation = {
+  getCurrentRoute: jest.fn().mockReturnValue({ name: 'Home' }),
+  navigate: jest.fn(),
+};
+
+jest.mock('../NavigationService', () => ({
+  __esModule: true,
+  default: {
+    get navigation() {
+      return mockNavigation;
+    },
+    set navigation(value) {
+      // Mock setter - does nothing but prevents errors
+    },
+  },
+}));
 
 jest.mock('./Connection');
 jest.mock('@react-navigation/native');
@@ -123,21 +139,25 @@ describe('SDKConnect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sdkConnect = SDKConnect.getInstance();
+    // Reset SDK state for test isolation
+    sdkConnect.state._initialized = false;
+    sdkConnect.state._initializing = undefined;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('Initialization Management', () => {
     describe('init', () => {
       it('should initialize the SDKConnect instance', async () => {
-        const testNavigation = {} as NavigationContainerRef;
-
-        await sdkConnect.init({
-          navigation: testNavigation,
+        await SDKConnect.init({
           context: 'testContext',
         });
 
         expect(mockInit).toHaveBeenCalledTimes(1);
         expect(mockInit).toHaveBeenCalledWith({
-          navigation: testNavigation,
+          navigation: mockNavigation,
           context: 'testContext',
           instance: sdkConnect,
         });

--- a/app/core/SDKConnect/SDKConnect.test.ts
+++ b/app/core/SDKConnect/SDKConnect.test.ts
@@ -15,7 +15,7 @@ import {
   removeChannel,
   watchConnection,
 } from './ConnectionManagement';
-import { init, postInit } from './InitializationManagement';
+import { init } from './InitializationManagement';
 import {
   ApprovedHosts,
   ConnectedSessions,
@@ -83,8 +83,6 @@ describe('SDKConnect', () => {
 
   const mockInit = init as jest.MockedFunction<typeof init>;
 
-  const mockPostInit = postInit as jest.MockedFunction<typeof postInit>;
-
   const mockPause = pause as jest.MockedFunction<typeof pause>;
 
   const mockResume = resume as jest.MockedFunction<typeof resume>;
@@ -151,9 +149,7 @@ describe('SDKConnect', () => {
   describe('Initialization Management', () => {
     describe('init', () => {
       it('should initialize the SDKConnect instance', async () => {
-        await SDKConnect.init({
-          context: 'testContext',
-        });
+        await SDKConnect.init({ context: 'testContext' });
 
         expect(mockInit).toHaveBeenCalledTimes(1);
         expect(mockInit).toHaveBeenCalledWith({
@@ -162,12 +158,10 @@ describe('SDKConnect', () => {
           instance: sdkConnect,
         });
       });
-    });
 
-    describe('postInit', () => {
-      it('should perform post-initialization tasks', async () => {
-        await sdkConnect.postInit();
-
+      it('should call postInit and execute provided callback', async () => {
+        const mockPostInit = jest.spyOn(sdkConnect, 'postInit');
+        await SDKConnect.init({ context: 'testContext' });
         expect(mockPostInit).toHaveBeenCalledTimes(1);
       });
     });

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -364,7 +364,7 @@ export class SDKConnect {
   }) {
     const navigation = NavigationService.navigation;
     const instance = SDKConnect.getInstance();
-    
+
     analytics.setGlobalProperty('platform', 'mobile');
     analytics.enable();
     await init({ navigation, context, instance });

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -34,6 +34,7 @@ import {
   updateSDKLoadingState,
 } from './StateManagement';
 import DevLogger from './utils/DevLogger';
+import NavigationService from '../NavigationService';
 
 export interface ConnectedSessions {
   [id: string]: Connection;
@@ -354,16 +355,20 @@ export class SDKConnect {
     return this.state.connections;
   }
 
-  public async init({
-    navigation,
+  public static async init({
     context,
+    postInitCallback,
   }: {
-    navigation: NavigationContainerRef;
     context?: string;
+    postInitCallback?: () => void;
   }) {
+    const navigation = NavigationService.navigation;
+    const instance = SDKConnect.getInstance();
+    
     analytics.setGlobalProperty('platform', 'mobile');
     analytics.enable();
-    return init({ navigation, context, instance: this });
+    await init({ navigation, context, instance });
+    await instance.postInit(postInitCallback);
   }
 
   async postInit(callback?: () => void) {

--- a/app/core/SDKConnect/SDKConnect.ts
+++ b/app/core/SDKConnect/SDKConnect.ts
@@ -355,24 +355,18 @@ export class SDKConnect {
     return this.state.connections;
   }
 
-  public static async init({
-    context,
-    postInitCallback,
-  }: {
-    context?: string;
-    postInitCallback?: () => void;
-  }) {
+  public static async init({ context }: { context?: string }) {
     const navigation = NavigationService.navigation;
     const instance = SDKConnect.getInstance();
 
     analytics.setGlobalProperty('platform', 'mobile');
     analytics.enable();
     await init({ navigation, context, instance });
-    await instance.postInit(postInitCallback);
+    await instance.postInit();
   }
 
-  async postInit(callback?: () => void) {
-    return postInit(this, callback);
+  async postInit() {
+    return postInit(this);
   }
 
   hasInitialized() {

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -209,6 +209,8 @@ export class WC2Manager {
     sessions?: { [topic: string]: WalletConnect2Session };
   }) {
     if (!isWC2Enabled) {
+      console.warn(`WC2::init WC2 is not enabled --- SKIP INIT`);
+
       //If WC is not enabled, we don't need to initialize it
       return;
     }

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -234,6 +234,7 @@ export class WC2Manager {
     const keyringController = (
       Engine.context as { KeyringController: KeyringController }
     ).KeyringController;
+
     await waitForKeychainUnlocked({
       keyringController,
       context: 'WalletConnectV2::init',

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -39,6 +39,7 @@ import {
 } from '@metamask/chain-agnostic-permission';
 import WalletConnect2Session from './WalletConnect2Session';
 import { CaipChainId } from '@metamask/utils';
+import NavigationService from '../NavigationService';
 const { PROJECT_ID } = AppConstants.WALLET_CONNECT;
 export const isWC2Enabled =
   typeof PROJECT_ID === 'string' && PROJECT_ID?.length > 0;
@@ -203,12 +204,17 @@ export class WC2Manager {
   }
 
   public static async init({
-    navigation,
     sessions = {},
   }: {
-    navigation: NavigationContainerRef;
     sessions?: { [topic: string]: WalletConnect2Session };
   }) {
+    if (!isWC2Enabled) {
+      //If WC is not enabled, we don't need to initialize it
+      return;
+    }
+
+    const navigation = NavigationService.navigation;
+
     if (!navigation) {
       console.warn(`WC2::init missing navigation --- SKIP INIT`);
       return;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -195,11 +195,19 @@ export function* startAppServices() {
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
 
-  // Initialize WalletConnect
-  WC2Manager.init({});
+  try {
+    // Initialize WalletConnect
+    WC2Manager.init({});
+  } catch (e) {
+    Logger.log('Failed to initialize WalletConnect', e);
+  }
 
-  // Initialize SDKConnect
-  SDKConnect.init({ context: 'Nav/App' });
+  try {
+    // Initialize SDKConnect
+    SDKConnect.init({ context: 'Nav/App' });
+  } catch (e) {
+    Logger.log('Failed to initialize SDKConnect', e);
+  }
 
   // Unblock the ControllersGate
   yield put(setAppServicesReady());

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -178,24 +178,6 @@ export function* handleDeeplinkSaga() {
   }
 }
 
-function* initialiseWC() {
-  try {
-    // Initialize WalletConnect
-    yield call(WC2Manager.init, {});
-  } catch (e) {
-    Logger.log('Failed to initialize WalletConnect', e);
-  }
-}
-
-function* initialiseSDKConnect() {
-  try {
-    // Initialize SDKConnect
-    yield call(SDKConnect.init, { context: 'Nav/App' });
-  } catch (e) {
-    Logger.log('Failed to initialize SDKConnect', e);
-  }
-}
-
 /**
  * Handles initializing app services on start up
  */
@@ -213,8 +195,13 @@ export function* startAppServices() {
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
 
-  yield all([call(initialiseWC), call(initialiseSDKConnect)]);
-
+  try {
+    // Initialize WalletConnect
+    yield call(WC2Manager.init, {});
+    yield call(SDKConnect.init, { context: 'Nav/App' });
+  } catch (e) {
+    Logger.log('Failed to initialize services', e);
+  }
   // Unblock the ControllersGate
   yield put(setAppServicesReady());
 }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -196,9 +196,10 @@ export function* startAppServices() {
   yield call(applyVaultInitialization);
 
   try {
-    // Initialize WalletConnect
-    yield call(WC2Manager.init, {});
-    yield call(SDKConnect.init, { context: 'Nav/App' });
+    yield all([
+      call(WC2Manager.init, {}),
+      call(SDKConnect.init, { context: 'Nav/App' }),
+    ]);
   } catch (e) {
     Logger.log('Failed to initialize services', e);
   }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -32,6 +32,7 @@ import { selectCompletedOnboarding } from '../../selectors/onboarding';
 import { applyVaultInitialization } from '../../util/generateSkipOnboardingState';
 import SDKConnect from '../../core/SDKConnect/SDKConnect';
 import WC2Manager from '../../core/WalletConnect/WalletConnectV2';
+import DeeplinkManager from '../../core/DeeplinkManager/DeeplinkManager';
 
 export function* appLockStateMachine() {
   let biometricsListenerTask: Task<void> | undefined;
@@ -152,7 +153,7 @@ export function* initializeSDKServices() {
 export function* handleDeeplinkSaga() {
   // TODO: This is only needed because SDKConnect does some weird stuff when it's initialized.
   // Once that's refactored and the singleton is simply initialized, we should be able to remove this.
-  let hasInitializedSDKServices = false;
+  const hasInitializedSDKServices = false;
 
   while (true) {
     // Handle parsing deeplinks after login or when the lock manager is resolved
@@ -210,6 +211,9 @@ export function* startAppServices() {
 
   // Start Engine service
   yield call(EngineService.start);
+
+  // Start DeeplinkManager and process branch deeplinks
+  DeeplinkManager.start();
 
   // Start AppStateEventProcessor
   AppStateEventProcessor.start();

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -195,12 +195,11 @@ export function* startAppServices() {
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
 
-  yield all([
-    // Initialize WalletConnect v2 Manager
-    call(WC2Manager.init, {}),
-    // Initialize SDKConnect
-    call(SDKConnect.init, { context: 'Nav/App' }),
-  ]);
+  // Initialize WalletConnect
+  WC2Manager.init({});
+
+  // Initialize SDKConnect
+  SDKConnect.init({ context: 'Nav/App' });
 
   // Unblock the ControllersGate
   yield put(setAppServicesReady());

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -142,6 +142,7 @@ export function* handleSDKInit() {
   // Initialize SDKConnect
   while (true) {
     const action = (yield take([
+      NavigationActionType.ON_NAVIGATION_READY,
       UserActionType.LOGIN,
       SET_COMPLETED_ONBOARDING,
     ])) as LoginAction | SetCompletedOnboardingAction;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -142,9 +142,9 @@ export function* basicFunctionalityToggle() {
 export function* initializeSDKServices() {
   try {
     // Initialize WalletConnect
-    yield call(WC2Manager.init, {});
+    yield call(() => WC2Manager.init({}));
     // Initialize SDKConnect
-    yield call(SDKConnect.init, { context: 'Nav/App' });
+    yield call(() => SDKConnect.init({ context: 'Nav/App' }));
   } catch (e) {
     Logger.log('Failed to initialize services', e);
   }
@@ -153,7 +153,7 @@ export function* initializeSDKServices() {
 export function* handleDeeplinkSaga() {
   // TODO: This is only needed because SDKConnect does some weird stuff when it's initialized.
   // Once that's refactored and the singleton is simply initialized, we should be able to remove this.
-  const hasInitializedSDKServices = false;
+  let hasInitializedSDKServices = false;
 
   while (true) {
     // Handle parsing deeplinks after login or when the lock manager is resolved
@@ -183,6 +183,7 @@ export function* handleDeeplinkSaga() {
     // Initialize SDK services
     if (!hasInitializedSDKServices) {
       yield call(initializeSDKServices);
+      hasInitializedSDKServices = true;
     }
 
     const deeplink = AppStateEventProcessor.pendingDeeplink;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -199,8 +199,8 @@ export function* startAppServices() {
     // Initialize WalletConnect v2 Manager
     call(WC2Manager.init, {}),
     // Initialize SDKConnect
-    call(SDKConnect.init, { context: 'Nav/App' })
-  ])
+    call(SDKConnect.init, { context: 'Nav/App' }),
+  ]);
 
   // Unblock the ControllersGate
   yield put(setAppServicesReady());

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -30,6 +30,8 @@ import {
 } from '../../actions/onboarding';
 import { selectCompletedOnboarding } from '../../selectors/onboarding';
 import { applyVaultInitialization } from '../../util/generateSkipOnboardingState';
+import SDKConnect from '../../core/SDKConnect/SDKConnect';
+import WC2Manager from '../../core/WalletConnect/WalletConnectV2';
 
 export function* appLockStateMachine() {
   let biometricsListenerTask: Task<void> | undefined;
@@ -192,6 +194,14 @@ export function* startAppServices() {
   // Start AppStateEventProcessor
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
+
+  yield all([
+    // Initialize WalletConnect v2 Manager
+    call(WC2Manager.init, {}),
+    // Initialize SDKConnect
+    call(SDKConnect.init, { context: 'Nav/App' })
+  ])
+
   // Unblock the ControllersGate
   yield put(setAppServicesReady());
 }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -138,6 +138,45 @@ export function* basicFunctionalityToggle() {
   }
 }
 
+export function* handleSDKInit() {
+  // Initialize SDKConnect
+  while (true) {
+    const action = (yield take([
+      UserActionType.LOGIN,
+      SET_COMPLETED_ONBOARDING,
+    ])) as LoginAction | SetCompletedOnboardingAction;
+
+    let completedOnboarding: boolean;
+    if (action.type === SET_COMPLETED_ONBOARDING) {
+      completedOnboarding = action.completedOnboarding;
+    } else {
+      completedOnboarding = yield select(selectCompletedOnboarding);
+    }
+
+    const { KeyringController } = Engine.context;
+    const isUnlocked = KeyringController.isUnlocked();
+
+    if (
+      action.type === UserActionType.LOGIN ||
+      (completedOnboarding && isUnlocked)
+    ) {
+      try {
+        yield call(SDKConnect.init, { context: 'Nav/App' });
+      } catch (e) {
+        Logger.log('Failed to initialize SDKConnect', e);
+      }
+      break;
+    }
+  }
+
+  // Initialize WalletConnect V2
+  try {
+    yield call(WC2Manager.init, {});
+  } catch (e) {
+    Logger.log('Failed to initialize services', e);
+  }
+}
+
 export function* handleDeeplinkSaga() {
   while (true) {
     // Handle parsing deeplinks after login or when the lock manager is resolved
@@ -195,14 +234,6 @@ export function* startAppServices() {
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
 
-  try {
-    yield all([
-      call(WC2Manager.init, {}),
-      call(SDKConnect.init, { context: 'Nav/App' }),
-    ]);
-  } catch (e) {
-    Logger.log('Failed to initialize services', e);
-  }
   // Unblock the ControllersGate
   yield put(setAppServicesReady());
 }
@@ -212,5 +243,6 @@ export function* rootSaga() {
   yield fork(startAppServices);
   yield fork(authStateMachine);
   yield fork(basicFunctionalityToggle);
+  yield fork(handleSDKInit);
   yield fork(handleDeeplinkSaga);
 }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -139,10 +139,11 @@ export function* basicFunctionalityToggle() {
 }
 
 export function* handleSDKInit() {
+  yield take([NavigationActionType.ON_NAVIGATION_READY]);
+
   // Initialize SDKConnect
   while (true) {
     const action = (yield take([
-      NavigationActionType.ON_NAVIGATION_READY,
       UserActionType.LOGIN,
       SET_COMPLETED_ONBOARDING,
     ])) as LoginAction | SetCompletedOnboardingAction;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -178,6 +178,24 @@ export function* handleDeeplinkSaga() {
   }
 }
 
+function* initialiseWC() {
+  try {
+    // Initialize WalletConnect
+    yield call(WC2Manager.init, {});
+  } catch (e) {
+    Logger.log('Failed to initialize WalletConnect', e);
+  }
+}
+
+function* initialiseSDKConnect() {
+  try {
+    // Initialize SDKConnect
+    yield call(SDKConnect.init, { context: 'Nav/App' });
+  } catch (e) {
+    Logger.log('Failed to initialize SDKConnect', e);
+  }
+}
+
 /**
  * Handles initializing app services on start up
  */
@@ -195,19 +213,7 @@ export function* startAppServices() {
   AppStateEventProcessor.start();
   yield call(applyVaultInitialization);
 
-  try {
-    // Initialize WalletConnect
-    WC2Manager.init({});
-  } catch (e) {
-    Logger.log('Failed to initialize WalletConnect', e);
-  }
-
-  try {
-    // Initialize SDKConnect
-    SDKConnect.init({ context: 'Nav/App' });
-  } catch (e) {
-    Logger.log('Failed to initialize SDKConnect', e);
-  }
+  yield all([call(initialiseWC), call(initialiseSDKConnect)]);
 
   // Unblock the ControllersGate
   yield put(setAppServicesReady());

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -23,6 +23,9 @@ import EngineService from '../../core/EngineService';
 import { AppStateEventProcessor } from '../../core/AppStateEventListener';
 import SharedDeeplinkManager from '../../core/DeeplinkManager/SharedDeeplinkManager';
 import Engine from '../../core/Engine';
+import DeeplinkManager from '../../core/DeeplinkManager/DeeplinkManager';
+import branch from 'react-native-branch';
+import { handleDeeplink } from '../../core/DeeplinkManager/Handlers/handleDeeplink';
 import { setCompletedOnboarding } from '../../actions/onboarding';
 import SDKConnect from '../../core/SDKConnect/SDKConnect';
 import WC2Manager from '../../core/WalletConnect/WalletConnectV2';
@@ -49,6 +52,8 @@ jest.mock('../../core/EngineService', () => ({
 jest.mock('../../core/AppStateEventListener', () => ({
   AppStateEventProcessor: {
     start: jest.fn(),
+    pendingDeeplink: null,
+    clearPendingDeeplink: jest.fn(),
   },
 }));
 
@@ -84,20 +89,28 @@ jest.mock('../../core/DeeplinkManager/SharedDeeplinkManager', () => ({
   },
 }));
 
-jest.mock('../../core/DeeplinkManager/DeeplinkManager', () => ({
+// Use real DeeplinkManager to verify Branch/linking behavior triggered by startAppServices
+
+// Branch and Linking mocks for DeeplinkManager.start tests
+jest.mock('react-native-branch', () => ({
   __esModule: true,
   default: {
-    start: jest.fn(),
+    subscribe: jest.fn(),
+    getLatestReferringParams: jest.fn(),
   },
 }));
 
-jest.mock('../../core/AppStateEventListener', () => ({
-  AppStateEventProcessor: {
-    start: jest.fn(),
-    pendingDeeplink: null,
-    clearPendingDeeplink: jest.fn(),
-  },
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  getInitialURL: jest.fn().mockResolvedValue(null),
 }));
+
+jest.mock('../../core/DeeplinkManager/Handlers/handleDeeplink', () => ({
+  handleDeeplink: jest.fn(),
+}));
+
+// (AppStateEventListener mock defined above)
 
 jest.mock('../../core/SDKConnect/SDKConnect', () => ({
   __esModule: true,
@@ -448,5 +461,48 @@ describe('handleDeeplinkSaga', () => {
         });
       });
     });
+  });
+});
+
+describe('DeeplinkManager.start Branch deeplink handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes SharedDeeplinkManager', async () => {
+    DeeplinkManager.start();
+    expect(SharedDeeplinkManager.init).toHaveBeenCalled();
+  });
+
+  it('calls getLatestReferringParams immediately for cold start deeplink check', async () => {
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({});
+    DeeplinkManager.start();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(branch.getLatestReferringParams).toHaveBeenCalledTimes(1);
+  });
+
+  it('processes cold start deeplink when non-branch link is found', async () => {
+    const mockDeeplink = 'https://link.metamask.io/home';
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
+      '+non_branch_link': mockDeeplink,
+    });
+    DeeplinkManager.start();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDeeplink).toHaveBeenCalledWith({ uri: mockDeeplink });
+  });
+
+  it('subscribes to Branch deeplink events', async () => {
+    DeeplinkManager.start();
+    expect(branch.subscribe).toHaveBeenCalled();
+  });
+
+  it('processes deeplink from subscription callback when uri is provided', async () => {
+    DeeplinkManager.start();
+    expect(branch.subscribe).toHaveBeenCalledWith(expect.any(Function));
+    const callback = (branch.subscribe as jest.Mock).mock.calls[0][0];
+    const mockUri = 'https://link.metamask.io/home';
+    callback({ uri: mockUri });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDeeplink).toHaveBeenCalledWith({ uri: mockUri });
   });
 });

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -23,6 +23,8 @@ import { AppStateEventProcessor } from '../../core/AppStateEventListener';
 import SharedDeeplinkManager from '../../core/DeeplinkManager/SharedDeeplinkManager';
 import Engine from '../../core/Engine';
 import { setCompletedOnboarding } from '../../actions/onboarding';
+import SDKConnect from '../../core/SDKConnect/SDKConnect';
+import WC2Manager from '../../core/WalletConnect/WalletConnectV2';
 
 const mockBioStateMachineId = '123';
 
@@ -82,6 +84,28 @@ jest.mock('../../core/AppStateEventListener', () => ({
     start: jest.fn(),
     pendingDeeplink: null,
     clearPendingDeeplink: jest.fn(),
+  },
+}));
+
+jest.mock('../../core/SDKConnect/SDKConnect', () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn().mockResolvedValue(undefined),
+    getInstance: jest.fn().mockReturnValue({
+      postInit: jest.fn().mockResolvedValue(undefined),
+      state: {
+        _initialized: true,
+        _postInitialized: true,
+      },
+    }),
+  },
+}));
+
+jest.mock('../../core/WalletConnect/WalletConnectV2', () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn().mockResolvedValue(undefined),
+    getInstance: jest.fn().mockReturnValue({}),
   },
 }));
 
@@ -202,6 +226,8 @@ describe('startAppServices', () => {
     // Verify services are started
     expect(EngineService.start).toHaveBeenCalled();
     expect(AppStateEventProcessor.start).toHaveBeenCalled();
+    expect(WC2Manager.init).toHaveBeenCalledWith({});
+    expect(SDKConnect.init).toHaveBeenCalledWith({ context: 'Nav/App' });
   });
 
   it('should not start app services if navigation is not ready', async () => {
@@ -213,6 +239,8 @@ describe('startAppServices', () => {
     // Verify services are not started
     expect(EngineService.start).not.toHaveBeenCalled();
     expect(AppStateEventProcessor.start).not.toHaveBeenCalled();
+    expect(WC2Manager.init).not.toHaveBeenCalled();
+    expect(SDKConnect.init).not.toHaveBeenCalled();
   });
 
   it('should not start app services if persisted data is not loaded', async () => {
@@ -224,6 +252,8 @@ describe('startAppServices', () => {
     // Verify services are not started
     expect(EngineService.start).not.toHaveBeenCalled();
     expect(AppStateEventProcessor.start).not.toHaveBeenCalled();
+    expect(WC2Manager.init).not.toHaveBeenCalled();
+    expect(SDKConnect.init).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## **Description**

This PR updates the SDK and WalletConnect init code to occur alongside other app service initializations inside `sagas`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #13225 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
