### PR TITLE
chore: fix scientific number display

### DIFF
--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -234,14 +234,11 @@ export function renderFromTokenMinimalUnit(
   decimalsToShow = 5,
 ) {
   const minimalUnit = fromTokenMinimalUnit(tokenValue || 0, decimals);
-  
   // Use BigNumber to handle very large numbers without scientific notation
   const minimalUnitBN = new BigNumber(minimalUnit);
-  
   if (minimalUnitBN.isLessThan(0.00001) && minimalUnitBN.isGreaterThan(0)) {
     return '< 0.00001';
   }
-  
   // Format the number with proper decimal places without scientific notation
   return minimalUnitBN.toFixed(decimalsToShow).replace(/\.?0+$/, '');
 }

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -234,17 +234,16 @@ export function renderFromTokenMinimalUnit(
   decimalsToShow = 5,
 ) {
   const minimalUnit = fromTokenMinimalUnit(tokenValue || 0, decimals);
-  const minimalUnitNumber = parseFloat(minimalUnit);
-  let renderMinimalUnit;
-  if (minimalUnitNumber < 0.00001 && minimalUnitNumber > 0) {
-    renderMinimalUnit = '< 0.00001';
-  } else {
-    const base = Math.pow(10, decimalsToShow);
-    renderMinimalUnit = (
-      Math.round(minimalUnitNumber * base) / base
-    ).toString();
+  
+  // Use BigNumber to handle very large numbers without scientific notation
+  const minimalUnitBN = new BigNumber(minimalUnit);
+  
+  if (minimalUnitBN.isLessThan(0.00001) && minimalUnitBN.isGreaterThan(0)) {
+    return '< 0.00001';
   }
-  return renderMinimalUnit;
+  
+  // Format the number with proper decimal places without scientific notation
+  return minimalUnitBN.toFixed(decimalsToShow).replace(/\.?0+$/, '');
 }
 
 /**


### PR DESCRIPTION
## **Description**

This PR fixes two UI issues in the MetaMask mobile app related to token approval displays

1. **Scientific Notation Issue**: Fixed the display of large token approval amounts that were showing in scientific notation (e.g., "1.157920892373162e+59") by improving the number formatting logic in the `renderFromTokenMinimalUnit` function.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17378
Slack thread: https://consensys.slack.com/archives/C093A5JP3FS/p1752852173738959

## **Manual testing steps**

1. Go to the Swaps feature in MetaMask mobile
2. Initiate a token swap that requires approval for a large token amount
3. Verify that the approval amount is displayed in standard decimal format (not scientific notation)

## **Screenshots/Recordings**

### **Before**

The approval amount was displayed as "1.157920892373162e+59"

### **After**

The approval amount now displays in readable decimal format

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.