### PR TITLE
test(e2e): Disable broken Snaps E2E tests because of regression

### DIFF
--- a/e2e/specs/snaps/test-snap-bip-32.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-32.spec.ts
@@ -110,7 +110,9 @@ describe(FlaskBuildTests('BIP-32 Snap Tests'), () => {
     );
   });
 
-  it('fails when choosing the invalid entropy source', async () => {
+  // This test is skipped because of a bug causing the app to crash when the
+  // alert is displayed.
+  it.skip('fails when choosing the invalid entropy source', async () => {
     await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
     await TestSnaps.tapButton('signMessageBip32Secp256k1Button');

--- a/e2e/specs/snaps/test-snap-bip-44.spec.ts
+++ b/e2e/specs/snaps/test-snap-bip-44.spec.ts
@@ -85,7 +85,9 @@ describe(FlaskBuildTests('BIP-44 Snap Tests'), () => {
     );
   });
 
-  it('fails when choosing the invalid entropy source', async () => {
+  // This test is skipped because of a bug causing the app to crash when the
+  // alert is displayed.
+  it.skip('fails when choosing the invalid entropy source', async () => {
     await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'Invalid');
     await TestSnaps.fillMessage('messageBip44Input', 'foo bar');
     await TestSnaps.tapButton('signMessageBip44Button');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

These tests are broken because of a regression in the app, likely related to #17276.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
