### PR TITLE
fix: URL spoofing on iOS with a redirect to http website. 

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -1058,6 +1058,22 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
           ...webStates.current[nativeEvent.url],
           started: true,
         };
+        if (nativeEvent.url.startsWith('http://')) {
+          /*
+            If the user is initially redirected to the page using the HTTP protocol,
+            which then automatically redirects to HTTPS, we receive `onLoadStart` for the HTTP URL
+            and `onLoadEnd` for the HTTPS URL. In this case, the URL bar will not be updated.
+            To fix this, we also mark the HTTPS version of the URL as started.
+          */
+          const urlWithHttps = nativeEvent.url.replace(
+            regex.urlHttpToHttps,
+            'https://',
+          );
+          webStates.current[urlWithHttps] = {
+            ...webStates.current[urlWithHttps],
+            started: true,
+          };
+        }
 
         // Cancel loading the page if we detect its a phishing page
         const isAllowed = await isAllowedOrigin(urlOrigin);


### PR DESCRIPTION
If you open a website that redirects to a HTTP website, this website will also redirect you to HTTPS version of this website. Client on iOS cannot handle such situations and displays a url of the original website which opened HTTP one.

## **Description**

In current code we update URL of the webpage if it's the same URL on start of the loading and end of the loading. In this case protocols are different between start and end, so the URL is not updated in the bar.

## **Related issues**

Fixes: https://github.com/MetaMask/pm-security/issues/462

## **Manual testing steps**

1. On iOS open URL https://tyschenko.github.io/address_bar_spoof.html
2. Click "Redirect to MetaMask"
3. URL bar will display https://tyschenko.github.io/address_bar_spoof.html instead of portfolio.metamask.io

## **Screenshots/Recordings**

### **Before**
https://github.com/user-attachments/assets/4698e5cc-db64-440a-82dd-dc4c0daafaef

### **After**
https://github.com/user-attachments/assets/7611e1a5-4ce2-443d-82b2-0474201e4036

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
