### PR TITLE
fix: eth_sendTransaction proper validation

### DIFF
--- a/app/core/RPCMethods/eth_sendTransaction.test.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../core/Engine', () => ({
       usePPOM: jest.fn(),
     },
     NetworkController: {
+      getNetworkConfigurationByNetworkClientId: () => '0x1',
       getNetworkClientById: () => ({
         configuration: {
           chainId: '0x1',

--- a/app/core/RPCMethods/eth_sendTransaction.test.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.test.ts
@@ -25,7 +25,7 @@ jest.mock('../../core/Engine', () => ({
       usePPOM: jest.fn(),
     },
     NetworkController: {
-      getNetworkConfigurationByNetworkClientId: () => '0x1',
+      getNetworkConfigurationByNetworkClientId: () => ({ chainId: '0x1' }),
       getNetworkClientById: () => ({
         configuration: {
           chainId: '0x1',

--- a/app/core/RPCMethods/eth_sendTransaction.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.ts
@@ -11,6 +11,7 @@ import {
 } from '@metamask/transaction-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import ppomUtil, { PPOMRequest } from '../../lib/ppom/ppom-util';
+import Engine from '../Engine';
 
 /**
  * A JavaScript object that is not `null`, a function, or an array.
@@ -99,13 +100,19 @@ async function eth_sendTransaction({
       message: `Invalid parameters: expected the first parameter to be an object`,
     });
   }
+
+  const networkConfig =
+    Engine.context.NetworkController.getNetworkConfigurationByNetworkClientId(
+      req.networkClientId,
+    );
+
   // TODO: Normalize chainId to Hex string
-  const nChainId = parseInt(req.networkClientId, 16);
+  const nChainId = parseInt(networkConfig?.chainId || '0x0', 16);
+
   await validateAccountAndChainId({
     from: req.params[0].from,
     chainId: nChainId,
   });
-
 
   const { result, transactionMeta } = await sendTransaction(req.params[0], {
     deviceConfirmedOn: WalletDevice.MM_MOBILE,

--- a/app/core/RPCMethods/eth_sendTransaction.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.ts
@@ -100,14 +100,12 @@ async function eth_sendTransaction({
     });
   }
   // TODO: Normalize chainId to Hex string
-  const nChainId =
-    typeof req.params[0].chainId === 'number'
-      ? req.params[0].chainId
-      : parseInt(req.params[0].chainId || '0x0', 16);
+  const nChainId = parseInt(req.networkClientId, 16);
   await validateAccountAndChainId({
     from: req.params[0].from,
     chainId: nChainId,
   });
+
 
   const { result, transactionMeta } = await sendTransaction(req.params[0], {
     deviceConfirmedOn: WalletDevice.MM_MOBILE,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In the [following code](https://github.com/MetaMask/metamask-mobile/blob/60c955494345698d08d2d600e9a4b2bb4ae387e8/app/core/RPCMethods/eth_sendTransaction.ts#L106), `nChainId` will always resolve to '0x0' because no `chainId` property currently exists. So the suggested change retrieves the network client id from `req.networkClientId` and converts it into a valid `chainId`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4898

## **Manual testing steps**

1. Go to [Metamask Test Dapp](https://metamask.github.io/test-dapp/) via in app browser.
2. Connect to an EVM network.
3. Press send legacy transaction button (or any transaction button that calls `eth_sendTransaction`). Behaviour should stay the same functionally.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
