### PR TITLE
chore: adding cursor rule for ui development

### DIFF
--- a/.cursor/rules/ui-development-guidelines.mdc
+++ b/.cursor/rules/ui-development-guidelines.mdc
@@ -1,0 +1,158 @@
+---
+description: UI Development Guidelines
+globs: 'app/*.{tsx,ts,jsx,js}'
+alwaysApply: true
+---
+
+# MetaMask Mobile React Native UI Development Guidelines
+
+## Core Principle
+
+Always prioritize @metamask/design-system-react-native components and Tailwind CSS patterns over custom implementations.
+
+## Component Hierarchy (STRICT ORDER)
+
+1. **FIRST**: Use `@metamask/design-system-react-native` components
+2. **SECOND**: Use `app/component-library` components only if design system lacks the component
+3. **LAST RESORT**: Custom components with StyleSheet (avoid unless absolutely necessary)
+
+## Required Imports for React Native
+
+```tsx
+// ALWAYS prefer these imports
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  Button,
+  ButtonBase,
+  Icon,
+  TextVariant,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  // ... other design system components
+} from '@metamask/design-system-react-native';
+```
+
+## Styling Rules (ENFORCE STRICTLY)
+
+### ✅ ALWAYS DO:
+
+- Use `const tw = useTailwind();` hook instead of importing twrnc directly
+- Use `Box` component instead of `View`
+- Use `Text` component with variants instead of raw Text with styles
+- Use `twClassName` prop for static styles
+- Use `tw.style()` function for interactive/dynamic styles
+- Use design system color tokens: `bg-default`, `text-primary`, `border-muted`
+- Use component props first: `variant`, `color`, `size`, etc.
+
+### ❌ NEVER SUGGEST:
+
+- `import tw from 'twrnc'` (use useTailwind hook instead)
+- `StyleSheet.create()` (use Tailwind classes)
+- Raw `View` or `Text` components (use Box/Text from design system)
+- Arbitrary color values like `bg-[#3B82F6]` or `text-[#000000]`
+- Inline style objects unless for dynamic values
+- Mixing multiple styling approaches unnecessarily
+
+## Code Pattern Templates
+
+### Basic Container:
+
+```tsx
+const MyComponent = () => {
+  const tw = useTailwind();
+
+  return (
+    <Box twClassName="w-full bg-default p-4">
+      <Text variant={TextVariant.HeadingMd}>Title</Text>
+    </Box>
+  );
+};
+```
+
+### Flex Layout:
+
+```tsx
+<Box
+  flexDirection={BoxFlexDirection.Row}
+  alignItems={BoxAlignItems.Center}
+  justifyContent={BoxJustifyContent.Between}
+  twClassName="gap-3"
+>
+```
+
+### Interactive Element:
+
+```tsx
+<ButtonBase
+  twClassName="h-20 flex-1 rounded-lg bg-muted px-0 py-4"
+  style={({ pressed }) =>
+    tw.style(
+      'w-full flex-row items-center justify-center',
+      pressed && 'bg-pressed',
+    )
+  }
+>
+  <Text fontWeight={FontWeight.Medium}>Button Text</Text>
+</ButtonBase>
+```
+
+### Pressable with Tailwind:
+
+```tsx
+<Pressable
+  style={({ pressed }) =>
+    tw.style(
+      'w-full flex-row items-center justify-between px-4 py-2',
+      pressed && 'bg-pressed',
+    )
+  }
+>
+```
+
+## Component Conversion Guide
+
+| DON'T Use                            | USE Instead                            |
+| ------------------------------------ | -------------------------------------- |
+| `<View>`                             | `<Box>`                                |
+| `<Text style={...}>`                 | `<Text variant={TextVariant.BodyMd}>`  |
+| `StyleSheet.create()`                | `twClassName="..."`                    |
+| `style={{ backgroundColor: 'red' }}` | `twClassName="bg-error-default"`       |
+| `flexDirection: 'row'`               | `flexDirection={BoxFlexDirection.Row}` |
+| Manual padding/margin                | `twClassName="p-4 m-2"`                |
+
+## Error Prevention
+
+When you see these patterns, IMMEDIATELY suggest alternatives:
+
+- Any `import tw from 'twrnc'` → `import { useTailwind } from '@metamask/design-system-twrnc-preset'`
+- Any `View` component → `Box` from design system
+- Any `StyleSheet` usage → Tailwind classes
+- Any arbitrary color values → Design system tokens
+- Any manual flex properties → Box component props + twClassName
+
+## Design System Priority
+
+Before suggesting any UI solution:
+
+1. Check if `@metamask/design-system-react-native` has the component
+2. Use component's built-in props (variant, color, size)
+3. Add layout/spacing with `twClassName`
+4. Add interactions with `tw.style()`
+5. Only suggest component-library or custom components if design system lacks it
+
+## Reference Examples
+
+Always reference the patterns from `app/component-library/components/design-system.stories.tsx` for proper usage examples.
+
+## Enforcement
+
+- REJECT any code suggestions that use StyleSheet.create()
+- REJECT raw View/Text usage when Box/Text components exist
+- REQUIRE useTailwind hook for all Tailwind usage
+- REQUIRE design system components as first choice
+- ENFORCE design token usage over arbitrary values
+
+@app/component-library/components/design-system.stories.tsx


### PR DESCRIPTION
## **Description**

This PR adds a new Cursor rule file (`.cursor/rules/ui-development-guidelines.mdc`) that establishes comprehensive UI development guidelines for MetaMask Mobile React Native development. 

**Reason for change:** To enforce consistent usage of the `@metamask/design-system-react-native` components and Tailwind CSS patterns across the codebase, preventing inconsistent styling approaches and improving code maintainability.

**Improvement/solution:** The new rule file provides:
- Strict component hierarchy prioritizing design system components
- Comprehensive styling rules and code pattern templates
- Clear conversion guidelines from legacy patterns to design system patterns
- Automatic enforcement through Cursor's rule system for all TypeScript/JavaScript files in the app directory

## **Changelog**

CHANGELOG entry: null

*(This is a developer tooling improvement that doesn't affect end users)*

## **Related issues**

Fixes: *(No specific issue linked - this is a proactive improvement)*

## **Manual testing steps**

1. Open any existing React Native component file in the `app/` directory
2. Verify that Cursor now provides suggestions based on the new UI guidelines
3. Try typing patterns that violate the guidelines (e.g., `import tw from 'twrnc'`, using `<View>` instead of `<Box>`)
4. Confirm that Cursor suggests the correct alternatives as defined in the guidelines
5. Test that the rule applies to `.tsx`, `.ts`, `.jsx`, and `.js` files as specified in the `globs` pattern

## **Screenshots/Recordings**

*Not applicable for this rule file addition*

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable *(N/A for rule file)*
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable *(N/A for rule file)*
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.