### PR TITLE
fix: avoid crash when there is no chain id passed to Network Controller

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -425,7 +425,7 @@ const EarnLendingDepositConfirmationView = () => {
                 address: tokenSnapshot?.token?.address || '',
                 name: tokenSnapshot?.token?.name || '',
                 networkClientId,
-              });
+              }).catch(console.error);
             } catch (error) {
               console.error(
                 error,

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -414,22 +414,26 @@ const EarnLendingDepositConfirmationView = () => {
           endTrace({ name: TraceName.EarnLendingDepositTxConfirmed });
 
           if (!outputToken) {
-            const networkClientId =
-              Engine.context.NetworkController.findNetworkClientIdByChainId(
-                tokenSnapshot?.chainId as Hex,
-              );
-            Engine.context.TokensController.addToken({
-              decimals: tokenSnapshot?.token?.decimals || 0,
-              symbol: tokenSnapshot?.token?.symbol || '',
-              address: tokenSnapshot?.token?.address || '',
-              name: tokenSnapshot?.token?.name || '',
-              networkClientId,
-            }).catch((error) => {
+            try {
+              const networkClientId =
+                Engine.context.NetworkController.findNetworkClientIdByChainId(
+                  tokenSnapshot?.chainId as Hex,
+                );
+              Engine.context.TokensController.addToken({
+                decimals: tokenSnapshot?.token?.decimals || 0,
+                symbol: tokenSnapshot?.token?.symbol || '',
+                address: tokenSnapshot?.token?.address || '',
+                name: tokenSnapshot?.token?.name || '',
+                networkClientId,
+              });
+            } catch (error) {
               console.error(
                 error,
-                'error adding counter-token on confirmation',
+                `error adding counter-token for ${
+                  earnToken?.symbol || earnToken?.ticker || ''
+                } on confirmation`,
               );
-            });
+            }
           }
         },
         (transactionMeta) => transactionMeta.id === transactionId,
@@ -444,13 +448,7 @@ const EarnLendingDepositConfirmationView = () => {
         ({ transactionMeta }) => transactionMeta.id === transactionId,
       );
     },
-    [
-      emitTxMetaMetric,
-      navigation,
-      outputToken,
-      tokenSnapshot,
-      earnToken?.chainId,
-    ],
+    [emitTxMetaMetric, navigation, outputToken, earnToken, tokenSnapshot],
   );
 
   const createTransactionEventListeners = useCallback(

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.test.tsx
@@ -447,6 +447,92 @@ describe('EarnLendingWithdrawalConfirmationView', () => {
     expect(Engine.context.TokensController.addToken).toHaveBeenCalledTimes(1);
   });
 
+  it('should handle error adding counter-token on confirmation', async () => {
+    // Update the mock to return no earnToken
+    (useEarnToken as jest.Mock).mockReturnValueOnce({
+      outputToken: mockLineaAUsdc,
+      earnToken: null,
+      getTokenSnapshot: jest.fn(),
+    });
+
+    (
+      Engine.context.NetworkController.findNetworkClientIdByChainId as jest.Mock
+    ).mockImplementationOnce(() => {
+      throw new Error('Invalid chain ID');
+    });
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {
+        // Do nothing
+      });
+
+    const { getByTestId } = renderWithProvider(
+      <EarnLendingWithdrawalConfirmationView />,
+      {
+        state: mockInitialState,
+      },
+    );
+
+    const footerConfirmationButton = getByTestId(
+      CONFIRMATION_FOOTER_BUTTON_TEST_IDS.CONFIRM_BUTTON,
+    );
+
+    // Mock the subscription callback
+    let subscriptionCallback:
+      | ((event: { transaction: { hash: string; status: string } }) => void)
+      | undefined;
+    (
+      Engine.controllerMessenger.subscribeOnceIf as jest.Mock
+    ).mockImplementation((event, callback) => {
+      if (event === 'TransactionController:transactionConfirmed') {
+        subscriptionCallback = callback;
+      }
+      return () => {
+        // Cleanup function
+      };
+    });
+
+    await act(async () => {
+      fireEvent.press(footerConfirmationButton);
+    });
+
+    // Simulate transaction submission
+    await act(async () => {
+      if (subscriptionCallback) {
+        subscriptionCallback({
+          transaction: {
+            hash: '0x123',
+            status: 'submitted',
+          },
+        });
+      }
+    });
+
+    // Verify the transaction was executed
+    expect(
+      Engine.context.EarnController.executeLendingWithdraw,
+    ).toHaveBeenCalledWith({
+      amount: '1000000',
+      gasOptions: {
+        gasLimit: 'none',
+      },
+      protocol: LendingProtocol.AAVE,
+      txOptions: {
+        deviceConfirmedOn: 'metamask_mobile',
+        networkClientId: 'linea-mainnet',
+        origin: 'metamask',
+        type: 'lendingWithdraw',
+      },
+      underlyingTokenAddress: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff',
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    // Clean up the spy
+    consoleErrorSpy.mockRestore();
+  });
+
   it('should use MaxUint256 when amountTokenMinimalUnit equals balanceMinimalUnit', async () => {
     // Mock the route params to have amountTokenMinimalUnit equal to balanceMinimalUnit
     (useRoute as jest.MockedFunction<typeof useRoute>).mockReturnValue({

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -330,34 +330,32 @@ const EarnLendingWithdrawalConfirmationView = () => {
         'TransactionController:transactionConfirmed',
         () => {
           if (!earnToken) {
-            const tokenNetworkClientId =
-              Engine.context.NetworkController.findNetworkClientIdByChainId(
-                tokenSnapshot?.chainId as Hex,
-              );
-            Engine.context.TokensController.addToken({
-              decimals: tokenSnapshot?.token?.decimals || 0,
-              symbol: tokenSnapshot?.token?.symbol || '',
-              address: tokenSnapshot?.token?.address || '',
-              name: tokenSnapshot?.token?.name || '',
-              networkClientId: tokenNetworkClientId,
-            }).catch((error) => {
+            try {
+              const tokenNetworkClientId =
+                Engine.context.NetworkController.findNetworkClientIdByChainId(
+                  tokenSnapshot?.chainId as Hex,
+                );
+              Engine.context.TokensController.addToken({
+                decimals: tokenSnapshot?.token?.decimals || 0,
+                symbol: tokenSnapshot?.token?.symbol || '',
+                address: tokenSnapshot?.token?.address || '',
+                name: tokenSnapshot?.token?.name || '',
+                networkClientId: tokenNetworkClientId,
+              });
+            } catch (error) {
               console.error(
                 error,
-                'error adding counter-token on confirmation',
+                `error adding counter-token for ${
+                  outputToken?.symbol || outputToken?.ticker || ''
+                } on confirmation`,
               );
-            });
+            }
           }
         },
         (transactionMeta) => transactionMeta.id === transactionId,
       );
     },
-    [
-      emitTxMetaMetric,
-      tokenSnapshot,
-      earnToken,
-      navigation,
-      outputToken?.chainId,
-    ],
+    [emitTxMetaMetric, tokenSnapshot, earnToken, outputToken, navigation],
   );
 
   // Guards

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -341,7 +341,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
                 address: tokenSnapshot?.token?.address || '',
                 name: tokenSnapshot?.token?.name || '',
                 networkClientId: tokenNetworkClientId,
-              });
+              }).catch(console.error);
             } catch (error) {
               console.error(
                 error,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
- At times there is a crash on 7.51.0 + when withdrawing a lending token on confirmation
3. What is the improvement/solution?
- Avoid this possible crash (does not look into why it is happening)

## **Changelog**
`CHANGELOG entry: Fixed a bug that was causing some lending withdrawals to crash`

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17534?reload=1

## **Manual testing steps**

1. Manually set the crash scenario and ensure that the app would not crash in the case
2. To do this, in the withdrawal confirmation view  app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx on line 332, remove the ` if (!earnToken) {` condition and pass undefined to `Engine.context.NetworkController.findNetworkClientIdByChainId(
                 undefined,
                );`
3. There should be no crash when withdrawing a lending token on confirmation, do the same on deposit confirmation view app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx lin 416 removing condition `if (!outputToken) {` and pass pass undefined to `Engine.context.NetworkController.findNetworkClientIdByChainId(
                 undefined,
                );`, there should be no crash when depositing on confirmation

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
