### PR TITLE
test(deposit): refactor unsupported region

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/UnsupportedRegionModal.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/UnsupportedRegionModal.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import UnsupportedRegionModal from './UnsupportedRegionModal';
-import renderDepositTestComponent from '../../../utils/renderDepositTestComponent';
+import { renderScreen } from '../../../../../../../util/test/renderWithProvider';
+import { createBuyNavigationDetails } from '../../../../Aggregator/routes/utils';
+import { createRegionSelectorModalNavigationDetails } from '../RegionSelectorModal';
 import Routes from '../../../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
@@ -26,8 +28,13 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('../../../sdk', () => ({
   useDepositSDK: () => mockUseDepositSDK(),
-  DepositSDKProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
+
+function render(component: React.ComponentType) {
+  return renderScreen(component, {
+    name: Routes.DEPOSIT.MODALS.UNSUPPORTED_REGION,
+  });
+}
 
 describe('UnsupportedRegionModal', () => {
   beforeEach(() => {
@@ -50,10 +57,7 @@ describe('UnsupportedRegionModal', () => {
       },
     });
 
-    const { toJSON } = renderDepositTestComponent(
-      UnsupportedRegionModal,
-      Routes.DEPOSIT.MODALS.UNSUPPORTED_REGION,
-    );
+    const { toJSON } = render(UnsupportedRegionModal);
     expect(toJSON()).toMatchSnapshot();
   });
 
@@ -73,17 +77,14 @@ describe('UnsupportedRegionModal', () => {
       },
     });
 
-    const { getByText } = renderDepositTestComponent(
-      UnsupportedRegionModal,
-      Routes.DEPOSIT.MODALS.UNSUPPORTED_REGION,
-    );
+    const { getByText } = render(UnsupportedRegionModal);
 
     const buyCryptoButton = getByText('Buy Crypto');
     fireEvent.press(buyCryptoButton);
 
     expect(mockDangerouslyGetParent).toHaveBeenCalled();
     expect(mockPop).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith('RampBuy');
+    expect(mockNavigate).toHaveBeenCalledWith(...createBuyNavigationDetails());
   });
 
   it('navigates to region selector when Change region button is pressed', () => {
@@ -104,17 +105,14 @@ describe('UnsupportedRegionModal', () => {
       selectedRegion: mockSelectedRegion,
     });
 
-    const { getByText } = renderDepositTestComponent(
-      UnsupportedRegionModal,
-      Routes.DEPOSIT.MODALS.UNSUPPORTED_REGION,
-    );
+    const { getByText } = render(UnsupportedRegionModal);
 
     const changeRegionButton = getByText('Change region');
     fireEvent.press(changeRegionButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('DepositModals', {
-      screen: 'DepositRegionSelectorModal',
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ...createRegionSelectorModalNavigationDetails(),
+    );
   });
 
   it('handles missing region gracefully', () => {
@@ -122,10 +120,7 @@ describe('UnsupportedRegionModal', () => {
       selectedRegion: null,
     });
 
-    const { toJSON } = renderDepositTestComponent(
-      UnsupportedRegionModal,
-      Routes.DEPOSIT.MODALS.UNSUPPORTED_REGION,
-    );
+    const { toJSON } = render(UnsupportedRegionModal);
 
     expect(toJSON()).toMatchSnapshot();
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactor test to remove the use a unnecessary util

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
