### PR TITLE
test(deposit): refactor enter address

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { fireEvent, screen, waitFor, act } from '@testing-library/react-native';
 import EnterAddress from './EnterAddress';
 import Routes from '../../../../../../constants/navigation/Routes';
-import renderDepositTestComponent from '../../utils/renderDepositTestComponent';
+
 import { BasicInfoFormData } from '../BasicInfo/BasicInfo';
 import { BuyQuote } from '@consensys/native-ramps-sdk';
+import { renderScreen } from '../../../../../../util/test/renderWithProvider';
+import initialRootState from '../../../../../../util/test/initial-root-state';
 
 const mockTrackEvent = jest.fn();
 
@@ -88,7 +90,6 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('../../sdk', () => ({
-  ...jest.requireActual('../../sdk'),
   useDepositSDK: () => mockUseDepositSDKReturnValue,
 }));
 
@@ -100,7 +101,15 @@ jest.mock('../../../../../../util/navigation/navUtils', () => ({
 jest.mock('../../../hooks/useAnalytics', () => () => mockTrackEvent);
 
 function render(Component: React.ComponentType) {
-  return renderDepositTestComponent(Component, Routes.DEPOSIT.ENTER_ADDRESS);
+  return renderScreen(
+    Component,
+    {
+      name: Routes.DEPOSIT.ENTER_ADDRESS,
+    },
+    {
+      state: initialRootState,
+    },
+  );
 }
 
 function fillFormAndSubmit({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR refactors a test to remove an unnecessary util



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
