### PR TITLE
test(e2e): Add Snap JSON-RPC E2E test

### DIFF
--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -8,6 +8,7 @@ export const TestSnapViewSelectorWebIDS = {
   connectBip44Button: 'connectbip44',
   connectClientStatusSnapButton: 'connectclient-status',
   connectGetEntropyButton: 'connectGetEntropySnap',
+  connectJsonRpcButton: 'connectjson-rpc',
   connectManageStateButton: 'connectmanage-state',
   connectNetworkAccessButton: 'connectnetwork-access',
   connectEthereumProviderButton: 'connectethereum-provider',
@@ -25,6 +26,7 @@ export const TestSnapViewSelectorWebIDS = {
   sendGetUnencryptedStateButton: 'sendGetUnencryptedState',
   sendManageStateButton: 'sendManageState',
   sendNetworkAccessTestButton: 'sendNetworkAccessTest',
+  sendRpcButton: 'sendRpc',
   sendStateButton: 'sendState',
   sendUnencryptedManageStateButton: 'sendUnencryptedManageState',
   sendUnencryptedStateButton: 'sendUnencryptedState',
@@ -83,6 +85,7 @@ export const TestSnapResultSelectorWebIDS = {
   retrieveManageStateResultSpan: 'retrieveManageStateResult',
   retrieveManageStateUnencryptedResultSpan:
     'retrieveManageStateUnencryptedResult',
+  rpcResultSpan: 'rpcResult',
   sendManageStateResultSpan: 'sendManageStateResult',
   sendUnencryptedManageStateResultSpan: 'sendUnencryptedManageStateResult',
   signTypedDataResultSpan: 'signTypedDataResult',

--- a/e2e/specs/snaps/test-snap-rpc.spec.ts
+++ b/e2e/specs/snaps/test-snap-rpc.spec.ts
@@ -1,0 +1,53 @@
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  loadFixture,
+  startFixtureServer,
+  stopFixtureServer,
+} from '../../fixtures/fixture-helper';
+import FixtureServer from '../../fixtures/fixture-server';
+import { getFixturesServerPort } from '../../fixtures/utils';
+import TestHelpers from '../../helpers';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+
+const fixtureServer = new FixtureServer();
+
+describe(FlaskBuildTests('Snap RPC Tests'), () => {
+  beforeAll(async () => {
+    await TestHelpers.reverseServerPort();
+    const fixture = new FixtureBuilder()
+      .withMultiSRPKeyringController()
+      .build();
+    await startFixtureServer(fixtureServer);
+    await loadFixture(fixtureServer, { fixture });
+    await TestHelpers.launchApp({
+      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
+    });
+    await loginToApp();
+
+    // Navigate to test snaps URL once for all tests
+    await TabBarComponent.tapBrowser();
+    await TestSnaps.navigateToTestSnap();
+  });
+
+  afterAll(async () => {
+    await stopFixtureServer(fixtureServer);
+  });
+
+  beforeEach(() => {
+    jest.setTimeout(150_000);
+  });
+
+  it('can use the cross-snap RPC endowment and produce a public key', async () => {
+    await TestSnaps.installSnap('connectBip32Button');
+    await TestSnaps.installSnap('connectJsonRpcButton');
+
+    await TestSnaps.tapButton('sendRpcButton');
+    await TestSnaps.checkResultSpan(
+      'rpcResultSpan',
+      '"0x033e98d696ae15caef75fa8dd204a7c5c08d1272b2218ba3c20feeb4c691eec366"',
+    );
+  });
+});


### PR DESCRIPTION
## **Description**

This PR ports the JSON-RPC E2E test for Snaps from extension to mobile.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3492

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
