### PR TITLE
refactor: Remove password strength tracking from wallet events

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -515,7 +515,6 @@ class ChoosePassword extends PureComponent {
       }
       this.track(MetaMetricsEvents.WALLET_CREATED, {
         biometrics_enabled: Boolean(this.state.biometryType),
-        password_strength: getPasswordStrengthWord(this.state.passwordStrength),
       });
       this.track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
         wallet_setup_type: 'new',

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -615,7 +615,6 @@ const ImportFromSecretRecoveryPhrase = ({
         seedphraseBackedUp();
         track(MetaMetricsEvents.WALLET_IMPORTED, {
           biometrics_enabled: Boolean(biometryType),
-          password_strength: passwordStrengthWord,
         });
         track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
           wallet_setup_type: 'import',

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -534,13 +534,11 @@ class ResetPassword extends PureComponent {
 
       // Track password changed event
       const { biometryChoice, passwordStrength } = this.state;
-      const passwordStrengthWord = getPasswordStrengthWord(passwordStrength);
       const eventBuilder = MetricsEventBuilder.createEventBuilder(
         MetaMetricsEvents.PASSWORD_CHANGED,
       ).addProperties({
         biometry_type: this.state.biometryType,
         biometrics_enabled: Boolean(biometryChoice),
-        password_strength: passwordStrengthWord,
       });
       MetaMetrics.getInstance().trackEvent(eventBuilder.build());
 

--- a/e2e/specs/analytics/import-wallet.spec.ts
+++ b/e2e/specs/analytics/import-wallet.spec.ts
@@ -169,7 +169,6 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           () =>
             Assertions.checkIfObjectsMatch(walletImportedEvent.properties, {
               biometrics_enabled: false,
-              password_strength: 'good',
             }),
           'Wallet Imported event properties do not match expected values',
         );

--- a/e2e/specs/analytics/new-wallet.spec.ts
+++ b/e2e/specs/analytics/new-wallet.spec.ts
@@ -155,7 +155,6 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           Assertions.checkIfValueIsDefined(walletCreatedEvent);
           Assertions.checkIfObjectsMatch(walletCreatedEvent!.properties, {
             biometrics_enabled: false,
-            password_strength: 'weak',
           });
         }, 'Wallet Created: Should be present with correct properties');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes password strength analytics tracking from wallet setup flows. The password strength metric was being tracked in various events (WALLET_CREATED, WALLET_IMPORTED, PASSWORD_CHANGED) but is no longer needed, so this refactoring removes these analytics properties.

Changes include:
- Removed `password_strength` property from WALLET_CREATED analytics event
- Removed `password_strength` property from WALLET_IMPORTED analytics event  
- Removed `password_strength` property from PASSWORD_CHANGED analytics event
- Updated corresponding e2e tests to remove password strength assertions

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a new wallet and verify analytics events still fire correctly
2. Import a wallet and verify analytics events still fire correctly
3. Reset password and verify analytics events still fire correctly
4. Run e2e tests to ensure they pass with updated assertions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Analytics events included password_strength property -->

### **After**

<!-- Analytics events no longer include password_strength property -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.