### PR TITLE
fix: smart account upgrade carousel should not be visible if solana account is selected

### DIFF
--- a/app/components/UI/Carousel/index.test.tsx
+++ b/app/components/UI/Carousel/index.test.tsx
@@ -10,7 +10,7 @@ import { Linking } from 'react-native';
 import Carousel from './';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletView.selectors';
 import { backgroundState } from '../../../util/test/initial-root-state';
-import { SolAccountType } from '@metamask/keyring-api';
+import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import Engine from '../../../core/Engine';
 import { PREDEFINED_SLIDES } from './constants';
 import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
@@ -341,6 +341,54 @@ describe('Carousel', () => {
     await userEvent.press(solanaBanner);
 
     expect(Engine.setSelectedAddress).toHaveBeenCalledWith('SomeSolanaAddress');
+  });
+
+  it('smart account upgrade banner should not be shown if solana account is selected', async () => {
+    const { mockState } = setupMocks();
+    mockState.engine.backgroundState.AccountsController = {
+      internalAccounts: {
+        selectedAccount: '1',
+        accounts: {
+          '1': {
+            address: 'SomeSolanaAddress',
+            type: SolAccountType.DataAccount,
+          },
+          '2': {
+            address: '0xSomeAddress',
+            type: EthAccountType.Eoa,
+          },
+        },
+      },
+    } as unknown as AccountsControllerState;
+
+    const { queryByTestId } = render(<Carousel />);
+    expect(
+      queryByTestId(WalletViewSelectorsIDs.CAROUSEL_SLIDE('smartAccount')),
+    ).toBeNull();
+  });
+
+  it('smart account upgrade banner should be shown if EVM account is selected', async () => {
+    const { mockState } = setupMocks();
+    mockState.engine.backgroundState.AccountsController = {
+      internalAccounts: {
+        selectedAccount: '2',
+        accounts: {
+          '1': {
+            address: 'SomeSolanaAddress',
+            type: SolAccountType.DataAccount,
+          },
+          '2': {
+            address: '0xSomeAddress',
+            type: EthAccountType.Eoa,
+          },
+        },
+      },
+    } as unknown as AccountsControllerState;
+
+    const { getByTestId } = render(<Carousel />);
+    expect(
+      getByTestId(WalletViewSelectorsIDs.CAROUSEL_SLIDE('smartAccount')),
+    ).toBeTruthy();
   });
 });
 

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -13,12 +13,19 @@ import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletV
 import { PREDEFINED_SLIDES, BANNER_IMAGES } from './constants';
 import { useStyles } from '../../../component-library/hooks';
 import { selectDismissedBanners } from '../../../selectors/banner';
-///: BEGIN:ONLY_INCLUDE_IF(solana)
 import {
   selectSelectedInternalAccount,
+  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   selectLastSelectedSolanaAccount,
+  ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors/accountsController';
-import { isEvmAccountType, SolAccountType } from '@metamask/keyring-api';
+import {
+  isEvmAccountType,
+  ///: BEGIN:ONLY_INCLUDE_IF(solana)
+  SolAccountType,
+  ///: END:ONLY_INCLUDE_IF
+} from '@metamask/keyring-api';
+///: BEGIN:ONLY_INCLUDE_IF(solana)
 import Engine from '../../../core/Engine';
 ///: END:ONLY_INCLUDE_IF
 import { selectAddressHasTokenBalances } from '../../../selectors/tokenBalancesController';

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -13,19 +13,12 @@ import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletV
 import { PREDEFINED_SLIDES, BANNER_IMAGES } from './constants';
 import { useStyles } from '../../../component-library/hooks';
 import { selectDismissedBanners } from '../../../selectors/banner';
+///: BEGIN:ONLY_INCLUDE_IF(solana)
 import {
   selectSelectedInternalAccount,
-  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   selectLastSelectedSolanaAccount,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors/accountsController';
-import {
-  isEvmAccountType,
-  ///: BEGIN:ONLY_INCLUDE_IF(solana)
-  SolAccountType,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
-///: BEGIN:ONLY_INCLUDE_IF(solana)
+import { isEvmAccountType, SolAccountType } from '@metamask/keyring-api';
 import Engine from '../../../core/Engine';
 ///: END:ONLY_INCLUDE_IF
 import { selectAddressHasTokenBalances } from '../../../selectors/tokenBalancesController';
@@ -59,8 +52,8 @@ const CarouselComponent: FC<CarouselProps> = ({ style }) => {
   const { navigate } = useNavigation();
   const { styles } = useStyles(styleSheet, { style });
   const dismissedBanners = useSelector(selectDismissedBanners);
-  const selectedAccount = useSelector(selectSelectedInternalAccount);
   ///: BEGIN:ONLY_INCLUDE_IF(solana)
+  const selectedAccount = useSelector(selectSelectedInternalAccount);
   const lastSelectedSolanaAccount = useSelector(
     selectLastSelectedSolanaAccount,
   );
@@ -120,18 +113,17 @@ const CarouselComponent: FC<CarouselProps> = ({ style }) => {
       ) {
         return false;
       }
-      ///: END:ONLY_INCLUDE_IF
-
-      if (slide.id === 'fund' && isZeroBalance) {
-        return true;
-      }
-
       if (
         slide.id === 'smartAccount' &&
         selectedAccount?.type &&
         !isEvmAccountType(selectedAccount.type)
       ) {
         return false;
+      }
+      ///: END:ONLY_INCLUDE_IF
+
+      if (slide.id === 'fund' && isZeroBalance) {
+        return true;
       }
 
       return isCurrentlyActive && !dismissedBanners.includes(slide.id);

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -120,7 +120,7 @@ const CarouselComponent: FC<CarouselProps> = ({ style }) => {
       }
 
       if (
-        slide.id === 'fund' &&
+        slide.id === 'smartAccount' &&
         selectedAccount?.type &&
         !isEvmAccountType(selectedAccount.type)
       ) {

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -18,7 +18,7 @@ import {
   selectSelectedInternalAccount,
   selectLastSelectedSolanaAccount,
 } from '../../../selectors/accountsController';
-import { SolAccountType } from '@metamask/keyring-api';
+import { isEvmAccountType, SolAccountType } from '@metamask/keyring-api';
 import Engine from '../../../core/Engine';
 ///: END:ONLY_INCLUDE_IF
 import { selectAddressHasTokenBalances } from '../../../selectors/tokenBalancesController';
@@ -52,8 +52,8 @@ const CarouselComponent: FC<CarouselProps> = ({ style }) => {
   const { navigate } = useNavigation();
   const { styles } = useStyles(styleSheet, { style });
   const dismissedBanners = useSelector(selectDismissedBanners);
-  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   const selectedAccount = useSelector(selectSelectedInternalAccount);
+  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   const lastSelectedSolanaAccount = useSelector(
     selectLastSelectedSolanaAccount,
   );
@@ -117,6 +117,14 @@ const CarouselComponent: FC<CarouselProps> = ({ style }) => {
 
       if (slide.id === 'fund' && isZeroBalance) {
         return true;
+      }
+
+      if (
+        slide.id === 'fund' &&
+        selectedAccount?.type &&
+        !isEvmAccountType(selectedAccount.type)
+      ) {
+        return false;
       }
 
       return isCurrentlyActive && !dismissedBanners.includes(slide.id);


### PR DESCRIPTION
## **Description**

Smart acocunt upgrade carousel should not be visible if solana account is selected

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5460

## **Manual testing steps**

1. Switch to solana account
2. Ensure that switch to smart account banner is not visible

## **Screenshots/Recordings**
<img width="396" height="841" alt="Screenshot 2025-07-30 at 3 18 38 PM" src="https://github.com/user-attachments/assets/fd998a0b-4c95-41ae-9a17-d1ec8e1e4d3e" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
