### PR TITLE
fix: Dismiss Snap approvals immediately as a workaround for crashes

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -24,6 +24,7 @@ import {
 } from '@metamask/snaps-utils';
 import { isObject } from '@metamask/utils';
 import { PermissionConstraint } from '@metamask/permission-controller';
+import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import { RootState } from '../../../reducers';
 
 const InstallSnapApproval = () => {
@@ -39,7 +40,27 @@ const InstallSnapApproval = () => {
   );
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-  const { approvalRequest, onConfirm, onReject } = useApprovalRequest();
+  const {
+    approvalRequest,
+    onConfirm: rawOnConfirm,
+    onReject: rawOnReject,
+  } = useApprovalRequest();
+
+  const onReject = () => {
+    // There is a race condition when using modals and showing alerts in WebViews.
+    // We explicitly dismiss the modal here to prevent that race condition which causes a crash.
+    setInstallState(undefined);
+    rawOnReject(
+      serializeError(providerErrors.userRejectedRequest()) as unknown as Error,
+    );
+  };
+
+  const onConfirm = async (...args: Parameters<typeof rawOnConfirm>) => {
+    // There is a race condition when using modals and showing alerts in WebViews.
+    // We explicitly dismiss the modal here to prevent that race condition which causes a crash.
+    setInstallState(undefined);
+    await rawOnConfirm(...args);
+  };
 
   const currentPermissions = useSelector((state: RootState) =>
     getPermissions(state, approvalRequest?.origin),

--- a/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
@@ -212,7 +212,7 @@ describe('InstallSnapApprovalFlow', () => {
       throw new Error('Installation error');
     });
 
-    const { getByTestId, findByTestId } = render(<InstallSnapApproval />, {
+    const { getByTestId } = render(<InstallSnapApproval />, {
       wrapper: Wrapper,
     });
     const permissionsRequest = getByTestId(SNAP_INSTALL_PERMISSIONS_REQUEST);
@@ -221,9 +221,7 @@ describe('InstallSnapApprovalFlow', () => {
       SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE,
     );
     fireEvent.press(permissionsConfirmButton);
-    await waitFor(async () => {
-      expect(await findByTestId(SNAP_INSTALL_ERROR)).toBeDefined();
-    });
+    await waitFor(() => expect(getByTestId(SNAP_INSTALL_ERROR)).toBeDefined());
   });
 
   it('calls onCancel on cancel button click', async () => {

--- a/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
@@ -221,17 +221,17 @@ describe('InstallSnapApprovalFlow', () => {
       SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE,
     );
     fireEvent.press(permissionsConfirmButton);
-    await waitFor(() => {
-      expect(findByTestId(SNAP_INSTALL_ERROR)).toBeDefined();
+    await waitFor(async () => {
+      expect(await findByTestId(SNAP_INSTALL_ERROR)).toBeDefined();
     });
   });
 
-  it('calls onCancel on cancel button click', () => {
+  it('calls onCancel on cancel button click', async () => {
     mockApprovalRequest(installSnapData);
     const { getByTestId } = render(<InstallSnapApproval />, {
       wrapper: Wrapper,
     });
-    const cancelButton = getByTestId(SNAP_INSTALL_CANCEL);
+    const cancelButton = await getByTestId(SNAP_INSTALL_CANCEL);
     fireEvent.press(cancelButton);
     expect(onReject).toHaveBeenCalledTimes(1);
   });

--- a/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/test/InstallSnapApproval.test.tsx
@@ -224,12 +224,12 @@ describe('InstallSnapApprovalFlow', () => {
     await waitFor(() => expect(getByTestId(SNAP_INSTALL_ERROR)).toBeDefined());
   });
 
-  it('calls onCancel on cancel button click', async () => {
+  it('calls onCancel on cancel button click', () => {
     mockApprovalRequest(installSnapData);
     const { getByTestId } = render(<InstallSnapApproval />, {
       wrapper: Wrapper,
     });
-    const cancelButton = await getByTestId(SNAP_INSTALL_CANCEL);
+    const cancelButton = getByTestId(SNAP_INSTALL_CANCEL);
     fireEvent.press(cancelButton);
     expect(onReject).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Dismiss Snap approvals immediately as a workaround for a race condition that causes an app crash.

More details can be found here: https://github.com/MetaMask/metamask-mobile/issues/9890#issuecomment-3136026196

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17276

## **Manual testing steps**

1. Cancel an install of a Snap and see that it works
2. Confirm an install of a Snap and see that it fails correctly on the main flavor