### PR TITLE
test(e2e): Add E2E tests for Snaps lifecycle hooks

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -120,6 +120,11 @@ const InstallSnapApproval = () => {
   const connectSnapIds = getConnectSnapIds(approvalRequest, currentPermissions);
 
   const snapId = installSnapId ?? connectSnapIds[0];
+
+  if (!snapId) {
+    return null;
+  }
+
   const snapName = getSnapMetadata(snapId).name;
 
   // TODO: This component should support connecting to multiple Snaps at once.

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -384,6 +384,10 @@ export default class TestHelpers {
     }
   }
 
+  static async terminateApp() {
+    return device.terminateApp();
+  }
+
   static async launchApp(launchOptions) {
     const config = await resolveConfig();
     const platform = device.getPlatform();

--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -10,6 +10,7 @@ export const TestSnapViewSelectorWebIDS = {
   connectGetEntropyButton: 'connectGetEntropySnap',
   connectGetPreferencesButton: 'connectpreferences',
   connectJsonRpcButton: 'connectjson-rpc',
+  connectLifeCycleButton: 'connectlifecycle-hooks',
   connectManageStateButton: 'connectmanage-state',
   connectNetworkAccessButton: 'connectnetwork-access',
   connectEthereumProviderButton: 'connectethereum-provider',

--- a/e2e/specs/snaps/test-snap-lifecycle.spec.ts
+++ b/e2e/specs/snaps/test-snap-lifecycle.spec.ts
@@ -1,0 +1,59 @@
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  loadFixture,
+  startFixtureServer,
+  stopFixtureServer,
+} from '../../fixtures/fixture-helper';
+import FixtureServer from '../../fixtures/fixture-server';
+import { getFixturesServerPort } from '../../fixtures/utils';
+import TestHelpers from '../../helpers';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import { FlaskBuildTests } from '../../tags';
+import Assertions from '../../utils/Assertions';
+import { loginToApp } from '../../viewHelper';
+
+const fixtureServer = new FixtureServer();
+
+describe(FlaskBuildTests('Lifecycle hooks Snap Tests'), () => {
+  beforeAll(async () => {
+    await TestHelpers.reverseServerPort();
+    const fixture = new FixtureBuilder().build();
+    await startFixtureServer(fixtureServer);
+    await loadFixture(fixtureServer, { fixture });
+  });
+
+  afterAll(async () => {
+    await stopFixtureServer(fixtureServer);
+  });
+
+  afterEach(async () => {
+    await TestHelpers.terminateApp();
+  });
+
+  beforeEach(async () => {
+    jest.setTimeout(150_000);
+
+    await TestHelpers.launchApp({
+      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
+    });
+    await loginToApp();
+  });
+
+  it('runs the `onInstall` lifecycle hook when the Snap is installed', async () => {
+    await TabBarComponent.tapBrowser();
+    await TestSnaps.navigateToTestSnap();
+
+    await TestSnaps.installSnap('connectLifeCycleButton');
+
+    await Assertions.checkIfTextIsDisplayed(
+      'The Snap was installed successfully, and the "onInstall" handler was called.',
+    );
+  });
+
+  it('runs the `onStart` lifecycle hook when the client is started', async () => {
+    await Assertions.checkIfTextIsDisplayed(
+      'The client was started successfully, and the "onStart" handler was called.',
+    );
+  });
+});

--- a/e2e/specs/snaps/test-snap-lifecycle.spec.ts
+++ b/e2e/specs/snaps/test-snap-lifecycle.spec.ts
@@ -21,23 +21,18 @@ describe(FlaskBuildTests('Lifecycle hooks Snap Tests'), () => {
     const fixture = new FixtureBuilder().build();
     await startFixtureServer(fixtureServer);
     await loadFixture(fixtureServer, { fixture });
+    await TestHelpers.launchApp({
+      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
+    });
+    await loginToApp();
   });
 
   afterAll(async () => {
     await stopFixtureServer(fixtureServer);
   });
 
-  afterEach(async () => {
-    await TestHelpers.terminateApp();
-  });
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.setTimeout(150_000);
-
-    await TestHelpers.launchApp({
-      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
-    });
-    await loginToApp();
   });
 
   it('runs the `onInstall` lifecycle hook when the Snap is installed', async () => {
@@ -52,6 +47,13 @@ describe(FlaskBuildTests('Lifecycle hooks Snap Tests'), () => {
   });
 
   it('runs the `onStart` lifecycle hook when the client is started', async () => {
+    TestHelpers.terminateApp();
+
+    await TestHelpers.launchApp({
+      launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },
+    });
+    await loginToApp();
+
     await Assertions.checkIfTextIsDisplayed(
       'The client was started successfully, and the "onStart" handler was called.',
     );

--- a/e2e/specs/snaps/test-snap-lifecycle.spec.ts
+++ b/e2e/specs/snaps/test-snap-lifecycle.spec.ts
@@ -47,7 +47,7 @@ describe(FlaskBuildTests('Lifecycle hooks Snap Tests'), () => {
   });
 
   it('runs the `onStart` lifecycle hook when the client is started', async () => {
-    TestHelpers.terminateApp();
+    await TestHelpers.terminateApp();
 
     await TestHelpers.launchApp({
       launchArgs: { fixtureServerPort: `${getFixturesServerPort()}` },


### PR DESCRIPTION
## **Description**

This PR ports the lifecycle hooks test from extension to mobile.

It adds a new helper to kill the app (necessary to trigger the `onStart` hook).

It also fixes a crash when installing a snap that renders a dialog right after install.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/3488

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="563" height="144" alt="Screenshot 2025-07-30 at 18 40 23" src="https://github.com/user-attachments/assets/d945914e-c77c-47b0-89bc-c450f4bd1831" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
