### PR TITLE
feat: Bump react-native-webview to 14.4.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2028,7 +2028,7 @@ PODS:
     - Yoga
   - react-native-view-shot (3.8.0):
     - React-Core
-  - react-native-webview-mm (14.2.2):
+  - react-native-webview-mm (14.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3347,7 +3347,7 @@ SPEC CHECKSUMS:
   react-native-slider: e4b7f9d0616032ec2909ba073731eabcde242256
   react-native-video: 3bb92b90b2774144fac7d43d52d11b936e8a14ec
   react-native-view-shot: d1a701eb0719c6dccbd20b4bb43b1069f304cb70
-  react-native-webview-mm: 925bbab5d1599f504312a8959f85455d37533103
+  react-native-webview-mm: 0fbb0f4722fb1937065e9e1a84282584e632c8f6
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e
   React-perflogger: 72e653eb3aba9122f9e57cf012d22d2486f33358

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "@metamask/react-native-button": "^3.0.0",
     "@metamask/react-native-payments": "^2.0.0",
     "@metamask/react-native-search-api": "1.0.1",
-    "@metamask/react-native-webview": "^14.2.2",
+    "@metamask/react-native-webview": "^14.4.0",
     "@metamask/remote-feature-flag-controller": "^1.6.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/scure-bip39": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5912,10 +5912,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/react-native-search-api/-/react-native-search-api-1.0.1.tgz#b3a2069ff851b88e1fe64b86f1fab7088a4daceb"
   integrity sha512-ceCzyRZDZM0lpQSNUiFpo16nysTDIMUhkdyUcvBbkpiSUnYV+SjVMxYVn2Q+h7P9tce8wrb6zoxdlfK5BXtbAQ==
 
-"@metamask/react-native-webview@^14.2.2":
-  version "14.2.2"
-  resolved "https://registry.yarnpkg.com/@metamask/react-native-webview/-/react-native-webview-14.2.2.tgz#74b254ad89850e04d01f4a49f60d2e6b4a4e7193"
-  integrity sha512-0TzfMKthMCffrYvKTnsyU8vJ2wecPfx6h6bWj9TL1BnQZ91o/tf8t9kB4AHNpvneIZtbKGxR938NcZLntpqOtw==
+"@metamask/react-native-webview@^14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@metamask/react-native-webview/-/react-native-webview-14.4.0.tgz#a627aea5979cc3d75467e768d26b97021ff60497"
+  integrity sha512-inPUYTjokaeLUH3QfDngdLsW6yYbjeUprEIYsdZDqjsrEhodxaMKKx7kX1mIsFhQxmQZKojXbrGyMaNjOg6DmA==
   dependencies:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## **Description**
Fixed compilation of the project on arm64 architecture.
Added additional detection of iFrames on iOS

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
