### PR TITLE
feat: add a new PortAllocation strategy for E2E

### DIFF
--- a/e2e/framework/PortAllocator.test.ts
+++ b/e2e/framework/PortAllocator.test.ts
@@ -1,0 +1,97 @@
+import PortAllocator, {
+  PortAllocator as PortAllocatorClass,
+} from './PortAllocator';
+
+describe('PortAllocator', () => {
+  beforeEach(() => {
+    PortAllocator.reset();
+  });
+
+  it('should be a singleton', () => {
+    const instance1 = PortAllocatorClass.getInstance();
+    const instance2 = PortAllocatorClass.getInstance();
+    expect(instance1).toBe(instance2);
+  });
+
+  it('should allocate ports for resources', () => {
+    const port1 = PortAllocator.allocatePort('resource1');
+    const portRange = PortAllocator.getPortRange();
+
+    expect(port1).toBeGreaterThanOrEqual(portRange.min);
+    expect(port1).toBeLessThanOrEqual(portRange.max);
+
+    const port2 = PortAllocator.allocatePort('resource2');
+    expect(port2).not.toBe(port1);
+  });
+
+  it('should return the same port for the same resource', () => {
+    const port1 = PortAllocator.allocatePort('resource1');
+    const port2 = PortAllocator.allocatePort('resource1');
+    expect(port1).toBe(port2);
+  });
+
+  it('should honor preferred ports when available', () => {
+    const portRange = PortAllocator.getPortRange();
+    const preferredPort = portRange.min + 100; // Pick a port in the valid range
+    const port = PortAllocator.allocatePort('resource1', preferredPort);
+    expect(port).toBe(preferredPort);
+  });
+
+  it('should find another port when preferred port is not available', () => {
+    const portRange = PortAllocator.getPortRange();
+    const preferredPort = portRange.min + 100;
+    PortAllocator.allocatePort('resource1', preferredPort);
+
+    // Try to allocate the same port to another resource
+    const port = PortAllocator.allocatePort('resource2', preferredPort);
+    expect(port).not.toBe(preferredPort);
+  });
+
+  it('should release ports correctly', () => {
+    const port = PortAllocator.allocatePort('resource1');
+    expect(PortAllocator.getPort('resource1')).toBe(port);
+
+    PortAllocator.releasePort('resource1');
+    expect(PortAllocator.getPort('resource1')).toBeUndefined();
+
+    const newPort = PortAllocator.allocatePort('resource2', port);
+    expect(newPort).toBe(port);
+  });
+
+  it('should get all allocated ports', () => {
+    PortAllocator.allocatePort('resource1');
+    PortAllocator.allocatePort('resource2');
+
+    const allocatedPorts = PortAllocator.getAllocatedPorts();
+    expect(allocatedPorts.size).toBe(2);
+    expect(allocatedPorts.has('resource1')).toBe(true);
+    expect(allocatedPorts.has('resource2')).toBe(true);
+  });
+
+  it('should provide a valid port range', () => {
+    const portRange = PortAllocator.getPortRange();
+
+    expect(portRange.min).toBeDefined();
+    expect(portRange.max).toBeDefined();
+    expect(portRange.min).toBeLessThan(portRange.max);
+    expect(portRange.max - portRange.min).toBeGreaterThanOrEqual(999); // At least 1000 ports in range
+  });
+
+  it('should use different port ranges in CI environment', () => {
+    try {
+      // Force CI mode using the new method
+      PortAllocator.reinitializePortRange(true);
+
+      const ciPortRange = PortAllocator.getPortRange();
+
+      // CI port range should start at 10000 or higher
+      expect(ciPortRange.min).toBeGreaterThanOrEqual(10000);
+      expect(ciPortRange.max).toBeLessThanOrEqual(65535);
+      expect(ciPortRange.max - ciPortRange.min).toBeGreaterThanOrEqual(999);
+    } finally {
+      // Reset to default port range
+      PortAllocator.reinitializePortRange(false);
+      PortAllocator.reset();
+    }
+  });
+});

--- a/e2e/framework/PortAllocator.ts
+++ b/e2e/framework/PortAllocator.ts
@@ -1,0 +1,193 @@
+import { createLogger } from './logger';
+
+/**
+ * PortAllocator - A singleton class for managing port allocation
+ * Keeps track of which resources are using which ports and ensures no port conflicts
+ * This prevents a test from failing because of port conflicts when the previous test crashed without proper cleanup
+ */
+export class PortAllocator {
+  private static instance: PortAllocator;
+  private portMap: Map<string, number> = new Map();
+  private usedPorts: Set<number> = new Set();
+  private MIN_PORT = 8000;
+  private MAX_PORT = 9000;
+  private readonly PORT_RANGE_SIZE = 1000;
+  private readonly RESERVED_PORTS: number[] = [8080, 8546];
+
+  private logger = createLogger({
+    name: 'PortAllocator',
+  });
+
+  private constructor() {
+    this.initializePortRange();
+    this.logger.debug(
+      `Port range initialized: ${this.MIN_PORT}-${this.MAX_PORT}`,
+    );
+  }
+
+  /**
+   * Initialize the port range based on environment
+   * In CI, use worker PID to calculate a unique port range
+   * Otherwise, use default port range
+   * @param forceCI Optional parameter to force CI mode (for testing)
+   */
+  private initializePortRange(forceCI?: boolean): void {
+    const isCI = forceCI || process.env.CI === 'true';
+
+    if (isCI) {
+      const pid = process.pid;
+      // Use PID to create a unique base port (keep within valid port range 1024-65535)
+      const pidOffset = (pid % 100) * this.PORT_RANGE_SIZE;
+      this.MIN_PORT = 10000 + pidOffset;
+      this.MAX_PORT = this.MIN_PORT + this.PORT_RANGE_SIZE - 1;
+
+      this.logger.debug(
+        `CI environment detected. Using PID ${pid} to calculate port range.`,
+      );
+    } else {
+      this.MIN_PORT = 8000;
+      this.MAX_PORT = 9000;
+    }
+  }
+
+  /**
+   * Get the singleton instance of PortAllocator
+   */
+  public static getInstance(): PortAllocator {
+    if (!PortAllocator.instance) {
+      PortAllocator.instance = new PortAllocator();
+    }
+    return PortAllocator.instance;
+  }
+
+  /**
+   * Allocate a port for a specific resource
+   * @param resourceId Unique identifier for the resource requesting a port
+   * @param preferredPort Optional preferred port to use if available
+   * @returns The allocated port number
+   */
+  public allocatePort(resourceId: string, preferredPort?: number): number {
+    if (this.portMap.has(resourceId)) {
+      return this.portMap.get(resourceId) as number;
+    }
+
+    if (preferredPort && this.isPortAvailable(preferredPort)) {
+      this.assignPort(resourceId, preferredPort);
+      return preferredPort;
+    }
+
+    const port = this.findAvailablePort();
+    if (port === -1) {
+      throw new Error('No available ports in the specified range');
+    }
+
+    this.assignPort(resourceId, port);
+    return port;
+  }
+
+  /**
+   * Release a port allocated to a specific resource
+   * @param resourceId Unique identifier for the resource
+   * @returns true if port was released, false if resource had no allocated port
+   */
+  public releasePort(resourceId: string): boolean {
+    const port = this.portMap.get(resourceId);
+    if (port === undefined) {
+      return false;
+    }
+
+    this.usedPorts.delete(port);
+    this.portMap.delete(resourceId);
+    return true;
+  }
+
+  /**
+   * Get the port allocated to a specific resource
+   * @param resourceId Unique identifier for the resource
+   * @returns The allocated port or undefined if none allocated
+   */
+  public getPort(resourceId: string): number | undefined {
+    return this.portMap.get(resourceId);
+  }
+
+  /**
+   * Get all allocated ports and their resources
+   * @returns A copy of the port map
+   */
+  public getAllocatedPorts(): Map<string, number> {
+    return new Map(this.portMap);
+  }
+
+  /**
+   * Check if a specific port is available
+   * @param port Port number to check
+   * @returns true if port is available, false otherwise
+   */
+  private isPortAvailable(port: number): boolean {
+    if (port < this.MIN_PORT || port > this.MAX_PORT) {
+      return false;
+    }
+
+    if (this.RESERVED_PORTS.includes(port)) {
+      return false;
+    }
+
+    return !this.usedPorts.has(port);
+  }
+
+  /**
+   * Find an available port in the allowed range
+   * @returns An available port number or -1 if none available
+   */
+  private findAvailablePort(): number {
+    for (let port = this.MIN_PORT; port <= this.MAX_PORT; port++) {
+      if (this.isPortAvailable(port)) {
+        return port;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Assign a port to a resource
+   * @param resourceId Unique identifier for the resource
+   * @param port Port number to assign
+   */
+  private assignPort(resourceId: string, port: number): void {
+    this.portMap.set(resourceId, port);
+    this.usedPorts.add(port);
+  }
+
+  /**
+   * Reset the port allocator (mainly for testing purposes)
+   */
+  public reset(): void {
+    this.portMap.clear();
+    this.usedPorts.clear();
+  }
+
+  /**
+   * Reinitialize the port range with specific settings
+   * This is primarily used for testing
+   * @param forceCI Force CI mode for port range calculation
+   */
+  public reinitializePortRange(forceCI: boolean = false): void {
+    this.initializePortRange(forceCI);
+    this.logger.debug(
+      `Port range reinitialized: ${this.MIN_PORT}-${this.MAX_PORT}`,
+    );
+  }
+
+  /**
+   * Get the current port range
+   * @returns Object containing min and max port values
+   */
+  public getPortRange(): { min: number; max: number } {
+    return {
+      min: this.MIN_PORT,
+      max: this.MAX_PORT,
+    };
+  }
+}
+
+export default PortAllocator.getInstance();

--- a/e2e/framework/fixtures/FixtureHelper.ts
+++ b/e2e/framework/fixtures/FixtureHelper.ts
@@ -165,6 +165,10 @@ async function handleSmartContracts(
  * Handles the local nodes by starting the servers and listening to the ports.
  * @param localNodeOptions - The local node options to use for the test.
  * @returns The local nodes.
+ * @throws {Error} If multiple nodes of the same type are specified.
+ *
+ * Note: Only one node of each type is allowed. For example, you can specify
+ * [anvil, ganache] but not [anvil, anvil].
  */
 async function handleLocalNodes(
   localNodeOptions: LocalNodeOptionsInput,
@@ -174,6 +178,27 @@ async function handleLocalNodes(
       .map((node) => node.type)
       .join(', ')}`,
   );
+
+  // Check for duplicate node types
+  const nodeTypes = localNodeOptions.map((node) => node.type);
+  const uniqueNodeTypes = new Set(nodeTypes);
+
+  if (nodeTypes.length !== uniqueNodeTypes.size) {
+    const counts = new Map<LocalNodeType, number>();
+    const duplicates = [];
+    for (const type of nodeTypes) {
+      counts.set(type, (counts.get(type) || 0) + 1);
+      if (counts.get(type) === 2) {
+        duplicates.push(type);
+      }
+    }
+    throw new Error(
+      `Multiple nodes of the same type detected: ${duplicates.join(
+        ', ',
+      )}. Only one node of each type is allowed.`,
+    );
+  }
+
   try {
     let localNode;
     let localNodeSpecificOptions;

--- a/e2e/framework/fixtures/FixtureHelper.ts
+++ b/e2e/framework/fixtures/FixtureHelper.ts
@@ -494,5 +494,6 @@ export async function withFixtures(
     }
 
     await stopFixtureServer(fixtureServer);
+    PortAllocator.getInstance().reset();
   }
 }

--- a/e2e/framework/fixtures/FixtureHelper.ts
+++ b/e2e/framework/fixtures/FixtureHelper.ts
@@ -226,12 +226,6 @@ async function handleLocalNodes(
           localNode = new Ganache();
           localNodeSpecificOptions = nodeOptions as GanacheNodeOptions;
 
-          // Allocate a port for the Ganache server
-          localNodeSpecificOptions.port =
-            PortAllocator.getInstance().allocatePort(
-              `test-${nodeType}`,
-              getGanachePort(),
-            );
           // Check if mnemonic and/or hardfork are provided, otherwise use defaultGanacheOptions
           if (
             (!localNodeSpecificOptions?.mnemonic &&
@@ -252,6 +246,13 @@ async function handleLocalNodes(
                 defaultGanacheOptions.hardfork;
             }
           }
+
+          // Allocate a port for the Ganache server
+          localNodeSpecificOptions.port =
+            PortAllocator.getInstance().allocatePort(
+              `test-${nodeType}`,
+              getGanachePort(),
+            );
           await localNode.start(localNodeSpecificOptions);
           localNodes.push(localNode);
           break;

--- a/e2e/framework/types.ts
+++ b/e2e/framework/types.ts
@@ -78,6 +78,7 @@ export enum LocalNodeType {
   anvil = 'anvil',
   ganache = 'ganache',
   bitcoin = 'bitcoin',
+  solana = 'solana',
 }
 
 export enum GanacheHardfork {
@@ -92,6 +93,7 @@ export interface LocalNodeConfig {
 export interface GanacheNodeOptions {
   hardfork: GanacheHardfork;
   mnemonic: string;
+  port?: number;
   [key: string]: unknown; // Allow additional properties of any type
 }
 export interface AnvilNodeOptions {

--- a/e2e/seeder/anvil-manager.ts
+++ b/e2e/seeder/anvil-manager.ts
@@ -97,11 +97,11 @@ class AnvilManager {
    * @throws {Error} If server fails to start
    */
   async start(opts: AnvilNodeOptions = {}): Promise<void> {
-    const options = { ...defaultOptions, ...opts, port: AnvilPort() };
+    const options = { ...defaultOptions, ...opts };
     const { port } = options;
 
     try {
-      logger.debug('Starting Anvil server...');
+      logger.debug(`Starting Anvil server on port ${port}`);
 
       // Create and start the server instance
       this.server = createAnvil({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to solve a flaky behavior that was causing tests to fail even before running. This is more noticeable in GHA or locally if for whatever reason test runs are excessively interrupted on purpose or by an app crash.

**Context**
In GHA (and rarely in Bitrise), if the runner times out even though it has a higher timeout than the global jest value, the final cleanup at the end of `withFixtures` wouldn't run causing ports to be occupied endlessly. The same would happen for tests that are not yet using `withFixtures` and fail to run any of the `after` hooks.
This ensures that we keep track of the used ports, store them in a singleton until the end of the test. If for whatever reason the test crashes a new port will be allocated for the next test in the same runner.

**Example trace observed:** 
```
19:07:11.594 detox[6332] i [E2E Framework] [ERROR] [AnvilManager] Failed to start server: Error: Anvil exited: Error: Address already in use (os error 48)
Location:
    /Users/runner/work/foundry/foundry/crates/anvil/src/lib.rs:229:28
    at EventEmitter.onExit (/Users/USER/metamask-mobile/node_modules/@viem/anvil/src/anvil/createAnvil.ts:420:23)
    at EventEmitter.emit (node:events:519:28)
    at EventEmitter.emit (node:domain:488:12)
    at ChildProcess.<anonymous> (/Users/USER/metamask-mobile/node_modules/@viem/anvil/src/anvil/createAnvil.ts:468:17)
    at ChildProcess.emit (node:events:531:35)
    at ChildProcess.emit (node:domain:488:12)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
