### PR TITLE
fix: cp-7.51.2 scroll behaviour on Solana New Feature view

### DIFF
--- a/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.styles.ts
+++ b/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.styles.ts
@@ -1,16 +1,18 @@
 import { StyleSheet } from 'react-native';
-import Device from '../../../util/device';
 import { colors as importedColors } from '../../../styles/common';
+import Device from '../../../util/device';
 
 const createStyles = () =>
   StyleSheet.create({
     scroll: {
-      flex: 1,
+      flexGrow: 1,
+      minHeight: '100%',
     },
     wrapper: {
       flex: 1,
       alignItems: 'center',
-      paddingVertical: 30,
+      paddingTop: 30,
+      minHeight: '100%',
     },
     largeFoxWrapper: {
       alignItems: 'center',

--- a/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.tsx
+++ b/app/components/UI/SolanaNewFeatureContent/SolanaNewFeatureContent.tsx
@@ -1,28 +1,28 @@
+import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { Image, Linking, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import { ScrollView } from 'react-native-gesture-handler';
 
-import FoxVipers from '../../../images/Fox_Vipers.png';
-import { baseStyles, colors as importedColors } from '../../../styles/common';
+import { SolanaNewFeatureSheetSelectorsIDs } from '../../../../e2e/selectors/wallet/SolanaNewFeatureSheet.selectors';
+import { strings } from '../../../../locales/i18n';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../component-library/components/Buttons/Button';
 import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../component-library/components/Buttons/Button';
-import { strings } from '../../../../locales/i18n';
 import { useMetrics } from '../../../components/hooks/useMetrics';
-import createStyles from './SolanaNewFeatureContent.styles';
-import StorageWrapper from '../../../store/storage-wrapper';
+import Routes from '../../../constants/navigation/Routes';
 import { SOLANA_FEATURE_MODAL_SHOWN } from '../../../constants/storage';
 import { SOLANA_NEW_FEATURE_CONTENT_LEARN_MORE } from '../../../constants/urls';
-import Routes from '../../../constants/navigation/Routes';
-import { SolanaNewFeatureSheetSelectorsIDs } from '../../../../e2e/selectors/wallet/SolanaNewFeatureSheet.selectors';
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import FoxVipers from '../../../images/Fox_Vipers.png';
+import StorageWrapper from '../../../store/storage-wrapper';
+import { baseStyles, colors as importedColors } from '../../../styles/common';
 import generateDeviceAnalyticsMetaData from '../../../util/metrics';
+import createStyles from './SolanaNewFeatureContent.styles';
 
 const SolanaNewFeatureContent = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
@@ -80,6 +80,9 @@ const SolanaNewFeatureContent = () => {
       <ScrollView
         style={baseStyles.flexGrow}
         contentContainerStyle={styles.scroll}
+        bounces
+        scrollEnabled
+        keyboardShouldPersistTaps="handled"
       >
         <View style={styles.wrapper}>
           <Text


### PR DESCRIPTION
## **Description**

This PR fixes the iOS-specific scrolling issue with the Solana feature popup that was preventing users from accessing the bottom buttons. The problem occurred when the title text spans multiple lines (particularly in non-English languages), causing the "Not now" button to appear below the visible screen area. While users could scroll down to reach the button, the ScrollView would automatically snap back to the top, making the buttons inaccessible and effectively blocking app usage.

**Root Cause:** The issue was caused by conflicting flex layouts where `contentContainerStyle` with `flex: 1` forced the ScrollView content to always try to fill the full height, creating layout calculation conflicts on iOS that resulted in the automatic scroll-back behavior.

**Solution:** 
- Replaced `flex: 1` with `flexGrow: 1` and `minHeight: '100%'` to allow proper content expansion without forcing full height
- Enhanced ScrollView configuration for better iOS compatibility

## **Changelog**

CHANGELOG entry: Fixed Solana popup scrolling issue that prevented iOS users from accessing bottom buttons

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17795

## **Manual testing steps**

1. Open MetaMask on an iOS device (physical device or simulator)
2. Clear the Solana feature modal storage flag to trigger the popup:
   - In developer tools, delete AsyncStorage key: `@MetaMask:solanaFeatureModalShownV2`
   - Or temporarily add `StorageWrapper.removeItem(SOLANA_FEATURE_MODAL_SHOWN)` to the component
3. Restart the app to see the Solana popup
4. Test with different scenarios:
   - **Short title (English)**: Verify normal display with buttons visible
   - **Long title (other languages)**: Change device language to German/Spanish/French or temporarily replace title with long text
5. When title spans 3+ lines:
   - Scroll down to reach the "Not now" button
   - Verify content stays scrolled and doesn't snap back to top
   - Verify both "Import your wallet" and "Not now" buttons are clickable
6. Test on both iPhone simulator and physical device for best coverage

## **Screenshots/Recordings**

### **Before**
- Recording in https://github.com/MetaMask/metamask-mobile/issues/17795
- Users reported scrolling down but screen automatically moving back up
- "Not now" button became inaccessible on longer text
- App effectively blocked for users with this popup

### **After**
https://www.loom.com/share/26aefcc54516462596e16fa0aa88e81d

- Smooth scrolling behavior without snap-back
- Bottom buttons remain accessible after scrolling
- Consistent experience across different text lengths and languages

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.