### PR TITLE
fix: cp-7.53.0 Properly stop Snaps when clearing state

### DIFF
--- a/patches/@metamask+snaps-controllers+14.1.0.patch
+++ b/patches/@metamask+snaps-controllers+14.1.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@metamask/snaps-controllers/dist/snaps/SnapController.cjs b/node_modules/@metamask/snaps-controllers/dist/snaps/SnapController.cjs
+index 908f4e7..8f66c3f 100644
+--- a/node_modules/@metamask/snaps-controllers/dist/snaps/SnapController.cjs
++++ b/node_modules/@metamask/snaps-controllers/dist/snaps/SnapController.cjs
+@@ -963,12 +963,7 @@ class SnapController extends base_controller_1.BaseController {
+      */
+     async clearState() {
+         const snapIds = Object.keys(this.state.snaps);
+-        if (this.#closeAllConnections) {
+-            snapIds.forEach((snapId) => {
+-                this.#closeAllConnections?.(snapId);
+-            });
+-        }
+-        await this.messagingSystem.call('ExecutionService:terminateAllSnaps');
++        await this.stopAllSnaps();
+         snapIds.forEach((snapId) => this.#revokeAllSnapPermissions(snapId));
+         this.update((state) => {
+             state.snaps = {};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Properly stop Snaps when clearing state. Patching in a fix from https://github.com/MetaMask/snaps/pull/3552 because mobile is a few versions behind on `snaps-controllers`.
