### PR TITLE
feat: Add support for fiat conversion for non-evm send

### DIFF
--- a/app/components/Views/confirmations/__mocks__/send.mock.ts
+++ b/app/components/Views/confirmations/__mocks__/send.mock.ts
@@ -84,6 +84,14 @@ export const evmSendStateMock = {
           },
         },
       },
+      MultichainAssetsRatesController: {
+        conversionRates: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+            rate: '175',
+            conversionTime: 0,
+          },
+        },
+      },
     },
   },
 } as ProviderValues['state'];

--- a/app/components/Views/confirmations/components/send/amount/amount.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount.test.tsx
@@ -9,6 +9,7 @@ import renderWithProvider, {
 import { SendContextProvider } from '../../../context/send-context';
 import {
   ACCOUNT_ADDRESS_MOCK_1,
+  SOLANA_ASSET,
   TOKEN_ADDRESS_MOCK_1,
   evmSendStateMock,
 } from '../../../__mocks__/send.mock';
@@ -91,6 +92,22 @@ describe('Amount', () => {
     expect(getByText('Invalid amount')).toBeTruthy();
   });
 
+  it('pressing Max uses max balance of ERC20 token', () => {
+    (useRoute as jest.MockedFn<typeof useRoute>).mockReturnValue({
+      params: {
+        asset: {
+          address: TOKEN_ADDRESS_MOCK_1,
+          decimals: 2,
+        },
+      },
+    } as RouteProp<ParamListBase, string>);
+
+    const { getByText, getByTestId } = renderComponent();
+    expect(getByTestId('send_amount').props.value).toBe('');
+    fireEvent.press(getByText('Max'));
+    expect(getByTestId('send_amount').props.value).toBe('0.05');
+  });
+
   it('display error if amount is greater than balance for native token', async () => {
     (useRoute as jest.MockedFn<typeof useRoute>).mockReturnValue({
       params: {
@@ -134,23 +151,6 @@ describe('Amount', () => {
     expect(getByText(`Asset: ${TOKEN_ADDRESS_MOCK_1}`)).toBeTruthy();
   });
 
-  it('pressing Max uses max balance of ERC20 token', () => {
-    (useRoute as jest.MockedFn<typeof useRoute>).mockReturnValue({
-      params: {
-        asset: {
-          address: TOKEN_ADDRESS_MOCK_1,
-          decimals: 2,
-        },
-      },
-    } as RouteProp<ParamListBase, string>);
-
-    const { getByText, getByTestId } = renderComponent();
-    expect(getByTestId('send_amount').props.value).toBe('');
-    fireEvent.press(getByText('Max'));
-    expect(getByTestId('send_amount').props.value).toBe('0.05');
-    expect(getByText('$ 0.05')).toBeTruthy();
-  });
-
   it('pressing Max uses max balance minus gas for native token', () => {
     (useRoute as jest.MockedFn<typeof useRoute>).mockReturnValue({
       params: {
@@ -185,6 +185,18 @@ describe('Amount', () => {
     const { getByText, getByTestId } = renderComponent();
     fireEvent.changeText(getByTestId('send_amount'), '1');
     expect(getByText('$ 3890')).toBeTruthy();
+  });
+
+  it('display fiat conversion of amount entered for solana asset', async () => {
+    (useRoute as jest.MockedFn<typeof useRoute>).mockReturnValue({
+      params: {
+        asset: SOLANA_ASSET,
+      },
+    } as RouteProp<ParamListBase, string>);
+
+    const { getByText, getByTestId } = renderComponent();
+    fireEvent.changeText(getByTestId('send_amount'), '1');
+    expect(getByText('$ 175')).toBeTruthy();
   });
 
   it('if fiatmode is enabled display native conversion of amount entered', async () => {

--- a/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.test.ts
@@ -19,6 +19,9 @@ jest.mock('../../../../../../core/Engine', () => ({
     AssetsContractController: {
       getERC721AssetSymbol: Promise.resolve(undefined),
     },
+    NetworkController: {
+      findNetworkClientIdByChainId: () => 'mainnet',
+    },
   },
 }));
 
@@ -96,7 +99,7 @@ describe('shouldSkipValidation', () => {
 });
 
 describe('validateToAddress', () => {
-  it('returns warning if address is contract address on mainnet', async () => {
+  it('returns warning if address is contract address', async () => {
     Engine.context.AssetsContractController.getERC721AssetSymbol = () =>
       Promise.resolve('ABC');
     expect(

--- a/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.ts
@@ -12,7 +12,6 @@ import {
   isValidHexAddress,
   toChecksumAddress,
 } from '../../../../../../util/address';
-import { isMainnetByChainId } from '../../../../../../util/networks';
 import { doENSLookup } from '../../../../../../util/ENSUtils';
 import {
   collectConfusables,
@@ -69,24 +68,25 @@ const validateHexAddress = async (
 }> => {
   const checksummedAddress = toChecksumAddress(toAddress);
   if (chainId) {
-    const isMainnet = isMainnetByChainId(chainId);
-    const { AssetsContractController } = Engine.context;
-    // todo: This check should be done for all chains
-    if (isMainnet) {
-      try {
-        const symbol = await AssetsContractController.getERC721AssetSymbol(
-          checksummedAddress,
-        );
-        if (symbol) {
-          // todo: i18n to be implemented depending on the designs
-          return {
-            warning:
-              'This address is a token contract address. If you send tokens to this address, you will lose them.',
-          };
-        }
-      } catch (e) {
-        // Not a token address
+    const { AssetsContractController, NetworkController } = Engine.context;
+
+    try {
+      const networkClientId = NetworkController.findNetworkClientIdByChainId(
+        chainId as Hex,
+      );
+      const symbol = await AssetsContractController.getERC721AssetSymbol(
+        checksummedAddress,
+        networkClientId,
+      );
+      if (symbol) {
+        // todo: i18n to be implemented depending on the designs
+        return {
+          warning:
+            'This address is a token contract address. If you send tokens to this address, you will lose them.',
+        };
       }
+    } catch (e) {
+      // Not a token address
     }
   }
   return {};

--- a/app/components/Views/confirmations/hooks/send/useCurrencyConversions.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useCurrencyConversions.test.ts
@@ -26,9 +26,8 @@ describe('getFiatValueFn', () => {
   it('return fiat value for passed native value', () => {
     expect(
       getFiatValueFn({
-        asset: { address: TOKEN_ADDRESS_MOCK_1 } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         amount: '10',
         decimals: 2,
       }),
@@ -38,13 +37,23 @@ describe('getFiatValueFn', () => {
   it('return 0 if input is empty string', () => {
     expect(
       getFiatValueFn({
-        asset: { address: TOKEN_ADDRESS_MOCK_1 } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         amount: '',
         decimals: 2,
       }),
     ).toStrictEqual(0);
+  });
+
+  it('use conversionRate 1 if conversionRate is not passed', () => {
+    expect(
+      getFiatValueFn({
+        conversionRate: undefined as unknown as number,
+        exchangeRate: 3890.556,
+        amount: '10',
+        decimals: 2,
+      }),
+    ).toStrictEqual(38905.56);
   });
 });
 
@@ -52,13 +61,23 @@ describe('getFiatDisplayValueFn', () => {
   it('return fiat value with currency prefix for passed native value', () => {
     expect(
       getFiatDisplayValueFn({
-        asset: { address: TOKEN_ADDRESS_MOCK_1 } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         currentCurrency: 'usd',
         amount: '10',
       }),
     ).toStrictEqual('$ 38905.56');
+  });
+
+  it('return 0 if amount is not passed', () => {
+    expect(
+      getFiatDisplayValueFn({
+        conversionRate: 1,
+        exchangeRate: 3890.556,
+        currentCurrency: 'usd',
+        amount: '',
+      }),
+    ).toStrictEqual('$ 0');
   });
 });
 
@@ -66,9 +85,8 @@ describe('getNativeValueFn', () => {
   it('return native value for passed fiat value', () => {
     expect(
       getNativeValueFn({
-        asset: { address: TOKEN_ADDRESS_MOCK_1 } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         amount: '38905.56',
         decimals: 2,
       }),
@@ -78,10 +96,20 @@ describe('getNativeValueFn', () => {
   it('return 0 if input is empty string', () => {
     expect(
       getNativeValueFn({
-        asset: { address: TOKEN_ADDRESS_MOCK_1 } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         amount: '',
+        decimals: 2,
+      }),
+    ).toStrictEqual('0');
+  });
+
+  it('return 0 if input is invalid decimal', () => {
+    expect(
+      getNativeValueFn({
+        conversionRate: 1,
+        exchangeRate: 3890.556,
+        amount: 'abc',
         decimals: 2,
       }),
     ).toStrictEqual('0');
@@ -94,15 +122,26 @@ describe('getNativeDisplayValueFn', () => {
       getNativeDisplayValueFn({
         asset: { address: TOKEN_ADDRESS_MOCK_1, symbol: 'ETH' } as AssetType,
         conversionRate: 1,
-        contractExchangeRates: { [TOKEN_ADDRESS_MOCK_1]: { price: 3890.556 } },
+        exchangeRate: 3890.556,
         amount: '38905.56',
       }),
     ).toStrictEqual('ETH 10');
   });
+
+  it('return 0 if amount is not passed', () => {
+    expect(
+      getNativeDisplayValueFn({
+        asset: { address: TOKEN_ADDRESS_MOCK_1, symbol: 'ETH' } as AssetType,
+        conversionRate: 1,
+        exchangeRate: 3890.556,
+        amount: '',
+      }),
+    ).toStrictEqual('ETH 0');
+  });
 });
 
 describe('useCurrencyConversions', () => {
-  it('return function getMaxAmount', () => {
+  it('return conversion functions', () => {
     const { result } = renderHookWithProvider(
       () => useCurrencyConversions(),
       mockState,

--- a/app/components/Views/confirmations/utils/send.test.ts
+++ b/app/components/Views/confirmations/utils/send.test.ts
@@ -101,7 +101,7 @@ describe('submitEvmTransaction', () => {
     submitEvmTransaction({
       asset: { isNative: true } as AssetType,
       chainId: '0x1',
-      from: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
+      from: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
       to: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA967b',
       value: '10',
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add fiat conversion support for non-evm assets.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5487

## **Manual testing steps**

1. Enable send re-designs locally
2. Start send for solana asset
3. Check fiat mode toggling

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/a80dffab-3a82-4953-8419-05ad1a195cdf

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
