### PR TITLE
fix: cp-7.53.0 Remove `assetId` when undefined

### DIFF
--- a/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
+++ b/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
@@ -26,7 +26,7 @@ export async function sendMultichainTransaction(
       params: {
         account,
         scope,
-        assetId,
+        ...(assetId ? { assetId } : {}),
       },
     },
   });

--- a/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
+++ b/app/core/SnapKeyring/utils/sendMultichainTransaction.ts
@@ -26,7 +26,7 @@ export async function sendMultichainTransaction(
       params: {
         account,
         scope,
-        ...(assetId ? { assetId } : {}),
+        ...(assetId !== undefined ? { assetId } : {}),
       },
     },
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove `assetId` when it is undefined to ensure it passes JSON-RPC validation. This fixes the Solana send flow not working on some screens.

## **Related issues**

Fixes: #17845 