### PR TITLE
feat: contextual network picker component

### DIFF
--- a/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.styles.ts
+++ b/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.styles.ts
@@ -1,0 +1,43 @@
+import { StyleSheet } from 'react-native';
+import type { ThemeColors } from '@metamask/design-tokens';
+
+const createStyles = (colors: ThemeColors, disabled: boolean) =>
+  StyleSheet.create({
+    base: {
+      flexDirection: 'row',
+      paddingVertical: 5,
+      paddingHorizontal: 16,
+      borderRadius: 24,
+      borderWidth: 1,
+      width: '100%',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      borderColor: disabled ? colors.border.muted : colors.border.default,
+    },
+    accountSelectorWrapper: {
+      height: 40,
+      backgroundColor: colors.background.default,
+      paddingHorizontal: 16,
+      flexDirection: 'row',
+      width: '100%',
+      marginBottom: 16,
+    },
+    avatarWrapper: {
+      marginRight: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    avatar: {
+      opacity: disabled ? 0.5 : 1,
+    },
+    networkName: {
+      opacity: disabled ? 0.5 : 1,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
+++ b/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
@@ -20,29 +20,9 @@ jest.mock('../../../util/theme', () => ({
   }),
 }));
 
-jest.mock('./ContextualNetworkPicker.styles', () => ({
-  __esModule: true,
-  default: () => ({
-    accountSelectorWrapper: {
-      marginHorizontal: 16,
-      marginVertical: 8,
-    },
-    base: {
-      padding: 12,
-    },
-    row: {
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
-    avatarWrapper: {
-      marginRight: 8,
-    },
-    avatar: {},
-    networkName: {
-      fontSize: 16,
-    },
-  }),
-}));
+// Import actual styles for testing
+import createStyles from './ContextualNetworkPicker.styles';
+import type { ThemeColors } from '@metamask/design-tokens';
 
 describe('ContextualNetworkPicker', () => {
   const defaultProps = {
@@ -319,6 +299,62 @@ describe('ContextualNetworkPicker', () => {
       expect(
         getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
       ).toBeTruthy();
+    });
+  });
+
+  describe('Styles', () => {
+    const mockColors = {
+      background: {
+        default: '#ffffff',
+        alternative: '#f2f3f4',
+      },
+      border: {
+        default: '#d6d9dc',
+        muted: '#bbc0c5',
+      },
+      text: {
+        default: '#24272a',
+        alternative: '#535a61',
+      },
+    } as unknown as ThemeColors;
+
+    it('should create styles with enabled state (disabled=false)', () => {
+      const styles = createStyles(mockColors, false);
+
+      expect(styles.base.borderColor).toBe(mockColors.border.default);
+      expect(styles.avatar.opacity).toBe(1);
+      expect(styles.networkName.opacity).toBe(1);
+    });
+
+    it('should create styles with disabled state (disabled=true)', () => {
+      const styles = createStyles(mockColors, true);
+
+      expect(styles.base.borderColor).toBe(mockColors.border.muted);
+      expect(styles.avatar.opacity).toBe(0.5);
+      expect(styles.networkName.opacity).toBe(0.5);
+    });
+
+    it('should create consistent static styles regardless of disabled state', () => {
+      const enabledStyles = createStyles(mockColors, false);
+      const disabledStyles = createStyles(mockColors, true);
+
+      // These styles should be identical regardless of disabled state
+      expect(enabledStyles.accountSelectorWrapper).toEqual(
+        disabledStyles.accountSelectorWrapper,
+      );
+      expect(enabledStyles.avatarWrapper).toEqual(disabledStyles.avatarWrapper);
+      expect(enabledStyles.row).toEqual(disabledStyles.row);
+    });
+
+    it('should return valid StyleSheet objects with all expected properties', () => {
+      const styles = createStyles(mockColors, false);
+
+      expect(styles).toHaveProperty('base');
+      expect(styles).toHaveProperty('accountSelectorWrapper');
+      expect(styles).toHaveProperty('avatarWrapper');
+      expect(styles).toHaveProperty('row');
+      expect(styles).toHaveProperty('avatar');
+      expect(styles).toHaveProperty('networkName');
     });
   });
 });

--- a/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
+++ b/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
-import renderWithProvider from '../../../util/test/renderWithProvider';
-import ContextualNetworkPicker from './ContextualNetworkPicker';
+import type { ThemeColors } from '@metamask/design-tokens';
 import { NETWORK_SELECTOR_TEST_IDS } from '../../../constants/networkSelector';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import createStyles from './ContextualNetworkPicker.styles';
+import ContextualNetworkPicker from './ContextualNetworkPicker';
 
 jest.mock('../../../util/theme', () => ({
   useTheme: () => ({
@@ -19,10 +21,6 @@ jest.mock('../../../util/theme', () => ({
     },
   }),
 }));
-
-// Import actual styles for testing
-import createStyles from './ContextualNetworkPicker.styles';
-import type { ThemeColors } from '@metamask/design-tokens';
 
 describe('ContextualNetworkPicker', () => {
   const defaultProps = {

--- a/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
+++ b/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.test.tsx
@@ -1,0 +1,324 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import ContextualNetworkPicker from './ContextualNetworkPicker';
+import { NETWORK_SELECTOR_TEST_IDS } from '../../../constants/networkSelector';
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: {
+        default: '#ffffff',
+      },
+      border: {
+        muted: '#cccccc',
+      },
+      text: {
+        default: '#000000',
+      },
+    },
+  }),
+}));
+
+jest.mock('./ContextualNetworkPicker.styles', () => ({
+  __esModule: true,
+  default: () => ({
+    accountSelectorWrapper: {
+      marginHorizontal: 16,
+      marginVertical: 8,
+    },
+    base: {
+      padding: 12,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    avatarWrapper: {
+      marginRight: 8,
+    },
+    avatar: {},
+    networkName: {
+      fontSize: 16,
+    },
+  }),
+}));
+
+describe('ContextualNetworkPicker', () => {
+  const defaultProps = {
+    onPress: jest.fn(),
+    networkName: 'Ethereum Mainnet',
+    networkImageSource: { uri: 'https://example.com/ethereum.png' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render correctly with required props', () => {
+      const { getByText, getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={defaultProps.networkName}
+        />,
+      );
+
+      expect(getByText('Ethereum Mainnet')).toBeTruthy();
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+
+    it('should render correctly with all props including networkImageSource', () => {
+      const { getByText, getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker {...defaultProps} />,
+      );
+
+      expect(getByText('Ethereum Mainnet')).toBeTruthy();
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+
+    it('should display the correct network name', () => {
+      const customNetworkName = 'Polygon Mainnet';
+      const { getByText } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={customNetworkName}
+        />,
+      );
+
+      expect(getByText(customNetworkName)).toBeTruthy();
+    });
+
+    it('should render Avatar with correct props', () => {
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker {...defaultProps} />,
+      );
+
+      const avatar = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      );
+      expect(avatar).toBeTruthy();
+      expect(avatar.props.accessibilityLabel).toBe(defaultProps.networkName);
+    });
+  });
+
+  describe('Interaction', () => {
+    it('should call onPress when pressed and not disabled', () => {
+      const mockOnPress = jest.fn();
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={mockOnPress}
+          networkName={defaultProps.networkName}
+        />,
+      );
+
+      const picker = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      ).parent?.parent;
+
+      if (picker) {
+        fireEvent.press(picker);
+        expect(mockOnPress).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('should not call onPress when disabled', () => {
+      const mockOnPress = jest.fn();
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={mockOnPress}
+          networkName={defaultProps.networkName}
+          disabled
+        />,
+      );
+
+      const picker = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      ).parent?.parent;
+
+      if (picker) {
+        fireEvent.press(picker);
+        expect(mockOnPress).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('should handle disabled prop correctly', () => {
+      const mockOnPress = jest.fn();
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={mockOnPress}
+          networkName={defaultProps.networkName}
+          disabled
+        />,
+      );
+
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER).props
+          .accessibilityLabel,
+      ).toBe(defaultProps.networkName);
+    });
+
+    it('should use noop function when disabled', () => {
+      const mockOnPress = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={mockOnPress}
+          networkName={defaultProps.networkName}
+          disabled
+        />,
+      );
+
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Props Validation', () => {
+    it('should handle missing networkImageSource gracefully', () => {
+      const { getByText, getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={defaultProps.networkName}
+        />,
+      );
+
+      expect(getByText(defaultProps.networkName)).toBeTruthy();
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+
+    it('should handle empty network name', () => {
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName=""
+        />,
+      );
+
+      const avatar = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      );
+      expect(avatar).toBeTruthy();
+      expect(avatar.props.accessibilityLabel).toBe('');
+    });
+
+    it('should default disabled to false when not provided', () => {
+      const mockOnPress = jest.fn();
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={mockOnPress}
+          networkName={defaultProps.networkName}
+        />,
+      );
+
+      const picker = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      ).parent?.parent;
+
+      if (picker) {
+        fireEvent.press(picker);
+        expect(mockOnPress).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('Network Image Handling', () => {
+    it('should handle URI-based image sources', () => {
+      const uriImageSource = { uri: 'https://example.com/network.png' };
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={defaultProps.networkName}
+          networkImageSource={uriImageSource}
+        />,
+      );
+
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+
+    it('should handle numeric image sources', () => {
+      const numericImageSource = 123; // Simulates require() numeric reference
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={defaultProps.networkName}
+          networkImageSource={numericImageSource}
+        />,
+      );
+
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper accessibility label', () => {
+      const networkName = 'Arbitrum One';
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={networkName}
+        />,
+      );
+
+      const avatar = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      );
+      expect(avatar.props.accessibilityLabel).toBe(networkName);
+    });
+
+    it('should maintain accessibility when disabled', () => {
+      const networkName = 'Base Mainnet';
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker
+          onPress={defaultProps.onPress}
+          networkName={networkName}
+          disabled
+        />,
+      );
+
+      const avatar = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      );
+      expect(avatar.props.accessibilityLabel).toBe(networkName);
+    });
+  });
+
+  describe('Component Structure', () => {
+    it('should render PickerBase with correct props', () => {
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker {...defaultProps} />,
+      );
+
+      const avatar = getByTestId(
+        NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER,
+      );
+      expect(avatar.parent?.parent?.parent).toBeTruthy();
+    });
+
+    it('should apply styles correctly', () => {
+      const { getByTestId } = renderWithProvider(
+        <ContextualNetworkPicker {...defaultProps} />,
+      );
+
+      expect(
+        getByTestId(NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.tsx
+++ b/app/components/UI/ContextualNetworkPicker/ContextualNetworkPicker.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { ImageSourcePropType, View } from 'react-native';
+import { useTheme } from '../../../util/theme';
+import createStyles from './ContextualNetworkPicker.styles';
+import PickerBase from '../../../component-library/components/Pickers/PickerBase/PickerBase';
+import Avatar, {
+  AvatarSize,
+  AvatarVariant,
+} from '../../../component-library/components/Avatars/Avatar';
+import { IconSize } from '../../../component-library/components/Icons/Icon';
+import Text from '../../../component-library/components/Texts/Text';
+import { NETWORK_SELECTOR_TEST_IDS } from '../../../constants/networkSelector';
+
+interface ContextualNetworkPickerProps {
+  onPress: () => void;
+  networkName: string;
+  networkImageSource?: ImageSourcePropType;
+  disabled?: boolean;
+}
+
+const ContextualNetworkPicker = ({
+  onPress,
+  networkName,
+  networkImageSource,
+  disabled = false,
+}: ContextualNetworkPickerProps) => {
+  const { colors } = useTheme();
+  const styles = createStyles(colors, disabled);
+  const noop = () => {
+    // eslint-disable-next-line no-empty-function
+  };
+  return (
+    <View style={styles.accountSelectorWrapper}>
+      <PickerBase
+        onPress={disabled ? noop : onPress}
+        iconSize={IconSize.Xs}
+        style={styles.base}
+      >
+        <View style={styles.row}>
+          <View style={styles.avatarWrapper}>
+            <Avatar
+              variant={AvatarVariant.Network}
+              size={AvatarSize.Xs}
+              name={networkName}
+              imageSource={networkImageSource}
+              testID={NETWORK_SELECTOR_TEST_IDS.CONTEXTUAL_NETWORK_PICKER}
+              accessibilityLabel={networkName}
+              style={styles.avatar}
+            />
+          </View>
+          <Text style={styles.networkName}>{networkName}</Text>
+        </View>
+      </PickerBase>
+    </View>
+  );
+};
+
+export default ContextualNetworkPicker;

--- a/app/components/UI/ContextualNetworkPicker/index.ts
+++ b/app/components/UI/ContextualNetworkPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ContextualNetworkPicker';

--- a/app/constants/networkSelector.ts
+++ b/app/constants/networkSelector.ts
@@ -1,0 +1,27 @@
+/**
+ * Constants for Network Selector sources
+ * These values are used to identify the source/context where the network selector was opened from
+ */
+export const NETWORK_SELECTOR_SOURCES = {
+  SEND_FLOW: 'SendFlow',
+} as const;
+
+/**
+ * Type for network selector source values
+ */
+export type NetworkSelectorSource =
+  (typeof NETWORK_SELECTOR_SOURCES)[keyof typeof NETWORK_SELECTOR_SOURCES];
+
+/**
+ * Array of all valid network selector sources for PropTypes validation
+ */
+export const NETWORK_SELECTOR_SOURCE_VALUES = Object.values(
+  NETWORK_SELECTOR_SOURCES,
+);
+
+/**
+ * Constants for Network Selector test IDs
+ */
+export const NETWORK_SELECTOR_TEST_IDS = {
+  CONTEXTUAL_NETWORK_PICKER: 'contextual-network-picker',
+} as const;


### PR DESCRIPTION
## **Description**

This is a part of a series of pull requests based off of this parent PR [Send Flow with Contextual Chain Id](https://github.com/MetaMask/metamask-mobile/pull/13938)

This PR introduces the contextual network picker for the send flow, its required to allow the user to select networks within the send flow, moving away from global network state dependency.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added new component for the contextual send flow

## **Related issues**

Contributes to: [#13674](https://github.com/MetaMask/MetaMask-planning/issues/4173)

## **Manual testing steps**

NA

## **Screenshots/Recordings**

This screen recording is from the [parent PR](https://github.com/MetaMask/metamask-mobile/pull/13938), this PR doesn't put it in use yet

https://github.com/user-attachments/assets/cb96d8a8-ed05-4e1e-96c6-c52b07b28327

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
