### PR TITLE
fix: optinmetric screen show up even metric accepted - cp-7.53.0

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -70,6 +70,14 @@ jest.mock('../../../../app/core/WalletConnect/WalletConnectV2', () => ({
   },
 }));
 
+jest.mock('../../hooks/useMetrics/useMetrics', () => ({
+    __esModule: true,
+    default: () => ({
+      isEnabled: jest.fn().mockReturnValue(false),
+      getMetaMetricsId: jest.fn(),
+    }),
+  }));
+
 import WC2ManagerMock from '../../../../app/core/WalletConnect/WalletConnectV2';
 import { DevLogger as DevLoggerMock } from '../../../../app/core/SDKConnect/utils/DevLogger';
 

--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -71,12 +71,12 @@ jest.mock('../../../../app/core/WalletConnect/WalletConnectV2', () => ({
 }));
 
 jest.mock('../../hooks/useMetrics/useMetrics', () => ({
-    __esModule: true,
-    default: () => ({
-      isEnabled: jest.fn().mockReturnValue(false),
-      getMetaMetricsId: jest.fn(),
-    }),
-  }));
+  __esModule: true,
+  default: () => ({
+    isEnabled: jest.fn().mockReturnValue(false),
+    getMetaMetricsId: jest.fn(),
+  }),
+}));
 
 import WC2ManagerMock from '../../../../app/core/WalletConnect/WalletConnectV2';
 import { DevLogger as DevLoggerMock } from '../../../../app/core/SDKConnect/utils/DevLogger';

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -161,6 +161,7 @@ import { SmartAccountUpdateModal } from '../../Views/confirmations/components/sm
 import PrivacyOverlay from '../../Views/PrivacyOverlay';
 import { PayWithModal } from '../../Views/confirmations/components/modals/pay-with-modal/pay-with-modal';
 import { PayWithNetworkModal } from '../../Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal';
+import { useMetrics } from '../../hooks/useMetrics';
 
 const clearStackNavigatorOptions = {
   headerShown: false,
@@ -922,6 +923,8 @@ const App: React.FC = () => {
   const sdkInit = useRef<boolean | undefined>(undefined);
   const isFirstRender = useRef(true);
 
+  const { isEnabled: isMetricsEnabled } = useMetrics();
+
   const isSeedlessOnboardingLoginFlow = useSelector(
     selectSeedlessOnboardingLoginFlow,
   );
@@ -988,7 +991,7 @@ const App: React.FC = () => {
             OPTIN_META_METRICS_UI_SEEN,
           );
 
-          if (!isOptinMetaMetricsUISeen) {
+          if (!isOptinMetaMetricsUISeen && !isMetricsEnabled()) {
             const resetParams = {
               routes: [
                 {

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -923,7 +923,7 @@ const App: React.FC = () => {
   const sdkInit = useRef<boolean | undefined>(undefined);
   const isFirstRender = useRef(true);
 
-  const { isEnabled: isMetricsEnabled } = useMetrics();
+  const { isEnabled: checkMetricsEnabled } = useMetrics();
 
   const isSeedlessOnboardingLoginFlow = useSelector(
     selectSeedlessOnboardingLoginFlow,
@@ -991,7 +991,7 @@ const App: React.FC = () => {
             OPTIN_META_METRICS_UI_SEEN,
           );
 
-          if (!isOptinMetaMetricsUISeen && !isMetricsEnabled()) {
+          if (!isOptinMetaMetricsUISeen && !checkMetricsEnabled()) {
             const resetParams = {
               routes: [
                 {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
OptinMetric show up for user that accepted metric collection after new update MM

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/18033

## **Manual testing steps**

```gherkin
Feature: option metric screen bug
  Scenario: user agreed optin metric then reset the app and login again
    Given user agreed option metrics in the first time
    When user reset the app and login again with password and biometric enabled
    Then metric optin will not shown
    When user close the app and reopen the app
    Then biometric auto login and redirect user to option metric page
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/296709d1-5140-4bdf-90cb-f8832169b9fb

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/09b61503-51f2-4270-a3ee-b656d0453b07

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
