### PR TITLE
fix: face id run twice during rehydration - cp-7.53.0

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -1144,8 +1144,9 @@ describe('Authentication', () => {
           type: SecretType.Mnemonic,
         },
       ]);
-      const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+      const newWalletVaultAndRestoreSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
 
       await Authentication.userEntryAuth(mockPassword, mockAuthData);
@@ -1157,13 +1158,12 @@ describe('Authentication', () => {
         mockSeedPhrase1,
         expect.any(Object),
       );
-      expect(newWalletAndRestoreSpy).toHaveBeenCalledWith(
+      expect(newWalletVaultAndRestoreSpy).toHaveBeenCalledWith(
         mockPassword,
-        mockAuthData,
         uint8ArrayToMnemonic(mockSeedPhrase1, []),
         false,
       );
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn, passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn, passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 
@@ -1197,8 +1197,9 @@ describe('Authentication', () => {
         getState: jest.fn(() => mockStateLocal),
       } as unknown as ReduxStore);
 
-      const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+      const newWalletVaultAndRestoreSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
       (
         Engine.context.KeyringController.addNewKeyring as jest.Mock
@@ -1215,9 +1216,8 @@ describe('Authentication', () => {
         mockSeedPhrase1,
         expect.any(Object),
       );
-      expect(newWalletAndRestoreSpy).toHaveBeenCalledWith(
+      expect(newWalletVaultAndRestoreSpy).toHaveBeenCalledWith(
         mockPassword,
-        mockAuthData,
         uint8ArrayToMnemonic(mockSeedPhrase1, []),
         false,
       );
@@ -1234,7 +1234,7 @@ describe('Authentication', () => {
         keyringId: 'new-keyring-id',
         type: 'mnemonic',
       });
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn, passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn, passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 
@@ -1252,8 +1252,9 @@ describe('Authentication', () => {
           type: SecretType.PrivateKey,
         },
       ]);
-      const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+      const newWalletVaultAndRestoreSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
       const importAccountFromPrivateKeySpy = jest
         .spyOn(Authentication, 'importAccountFromPrivateKey')
@@ -1264,9 +1265,8 @@ describe('Authentication', () => {
       expect(
         Engine.context.SeedlessOnboardingController.fetchAllSecretData,
       ).toHaveBeenCalledWith(mockPassword);
-      expect(newWalletAndRestoreSpy).toHaveBeenCalledWith(
+      expect(newWalletVaultAndRestoreSpy).toHaveBeenCalledWith(
         mockPassword,
-        mockAuthData,
         uint8ArrayToMnemonic(mockSeedPhrase1, []),
         false,
       );
@@ -1277,7 +1277,7 @@ describe('Authentication', () => {
           shouldSelectAccount: false,
         },
       );
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn and passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn and passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 
@@ -1296,14 +1296,15 @@ describe('Authentication', () => {
         },
       ]);
       const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
 
       await Authentication.userEntryAuth(mockPassword, mockAuthData);
 
       expect(newWalletAndRestoreSpy).toHaveBeenCalled();
       expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), 'unknown');
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn and passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn and passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 
@@ -1321,8 +1322,10 @@ describe('Authentication', () => {
           type: SecretType.PrivateKey,
         },
       ]);
-      const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+
+      const newWalletVaultAndRestoreSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
       const importError = new Error('Import failed');
       const importAccountFromPrivateKeySpy = jest
@@ -1331,10 +1334,10 @@ describe('Authentication', () => {
 
       await Authentication.userEntryAuth(mockPassword, mockAuthData);
 
-      expect(newWalletAndRestoreSpy).toHaveBeenCalled();
+      expect(newWalletVaultAndRestoreSpy).toHaveBeenCalled();
       expect(importAccountFromPrivateKeySpy).toHaveBeenCalled();
       expect(Logger.error).toHaveBeenCalledWith(importError);
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn and passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn and passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 
@@ -1373,8 +1376,9 @@ describe('Authentication', () => {
           type: SecretType.Mnemonic,
         },
       ]);
-      const newWalletAndRestoreSpy = jest
-        .spyOn(Authentication, 'newWalletAndRestore')
+      const newWalletVaultAndRestoreSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(Authentication as any, 'newWalletVaultAndRestore')
         .mockResolvedValueOnce(undefined);
       const error = new Error('Keyring add failed');
       (
@@ -1403,12 +1407,12 @@ describe('Authentication', () => {
       expect(
         Engine.context.KeyringController.addNewKeyring,
       ).toHaveBeenCalledTimes(1);
-      expect(newWalletAndRestoreSpy).toHaveBeenCalled();
+      expect(newWalletVaultAndRestoreSpy).toHaveBeenCalled();
       expect(
         Engine.context.SeedlessOnboardingController.updateBackupMetadataState,
       ).not.toHaveBeenCalled();
       expect(Logger.error).toHaveBeenCalledWith(error);
-      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(2); // logIn, passwordSet
+      expect(ReduxService.store.dispatch).toHaveBeenCalledTimes(3); // logIn, passwordSet, setExistingUser
       expect(OAuthService.resetOauthState).toHaveBeenCalled();
     });
 

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -1112,6 +1112,8 @@ describe('Authentication', () => {
         checkIsPasswordOutdated: jest.fn(),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
       Engine.context.KeyringController = {
+        setLocked: jest.fn(),
+        isUnlocked: jest.fn().mockResolvedValue(true),
         addNewKeyring: jest.fn(),
         createNewVaultAndRestore: jest.fn(),
         withKeyring: jest

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -1819,9 +1819,7 @@ describe('Authentication', () => {
       } as unknown as ReduxStore);
 
       await expect(
-        Authentication.syncPasswordAndUnlockWallet(mockGlobalPassword, {
-          currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
-        }),
+        Authentication.syncPasswordAndUnlockWallet(mockGlobalPassword),
       ).rejects.toThrow('change password failed');
 
       expect(Authentication.lockApp).toHaveBeenCalledWith({ locked: true });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -512,10 +512,10 @@ class AuthenticationService {
 
       if (authData.oauth2Login) {
         // if seedless flow - rehydrate
-        await this.rehydrateSeedPhrase(password, authData);
+        await this.rehydrateSeedPhrase(password);
       } else if (await this.checkIsSeedlessPasswordOutdated(false)) {
         // if seedless flow completed && seedless password is outdated, sync the password and unlock the wallet
-        await this.syncPasswordAndUnlockWallet(password, authData);
+        await this.syncPasswordAndUnlockWallet(password);
       } else {
         // else srp flow
         await this.loginVaultCreation(password);
@@ -902,10 +902,7 @@ class AuthenticationService {
     }
   };
 
-  rehydrateSeedPhrase = async (
-    password: string,
-    authData: AuthData,
-  ): Promise<void> => {
+  rehydrateSeedPhrase = async (password: string): Promise<void> => {
     try {
       const { SeedlessOnboardingController } = Engine.context;
       let allSRPs: Awaited<
@@ -949,7 +946,8 @@ class AuthenticationService {
         }
 
         const seedPhrase = uint8ArrayToMnemonic(firstSeedPhrase.data, wordlist);
-        await this.newWalletAndRestore(password, authData, seedPhrase, false);
+
+        await this.newWalletVaultAndRestore(password, seedPhrase, false);
         // add in more srps
         const keyringMetadataList: KeyringMetadata[] = [];
         if (restOfSeedPhrases.length > 0) {
@@ -980,6 +978,9 @@ class AuthenticationService {
         this.addMultichainAccounts(keyringMetadataList);
 
         this.dispatchOauthReset();
+
+        ReduxService.store.dispatch(setExistingUser(true));
+        await StorageWrapper.removeItem(SEED_PHRASE_HINTS);
       } else {
         throw new Error('No account data found');
       }
@@ -997,7 +998,6 @@ class AuthenticationService {
    */
   syncPasswordAndUnlockWallet = async (
     globalPassword: string,
-    authData: AuthData,
   ): Promise<void> => {
     const { SeedlessOnboardingController, KeyringController } = Engine.context;
 
@@ -1036,7 +1036,7 @@ class AuthenticationService {
 
         // rehydrate with social accounts if max keychain length exceeded
         await SeedlessOnboardingController.refreshAuthTokens();
-        await this.rehydrateSeedPhrase(globalPassword, authData);
+        await this.rehydrateSeedPhrase(globalPassword);
         // skip the rest of the flow ( change password and sync keyring encryption key)
         return;
       } else if (

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -985,6 +985,7 @@ class AuthenticationService {
         throw new Error('No account data found');
       }
     } catch (error) {
+      this.lockApp({ reset: false });
       Logger.error(error as Error);
       throw error;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Face Id (biometric) run twice during rehydration.
This PR reduce FaceId (biometric) run once during rehydration
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/18029

## **Manual testing steps**

1. Login with seedless flow ( social login) with existing account
2. Login with password and enable biometrics
3. Face ID should only prompt once

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f60448b0-e0ef-4c85-b664-ab0dccea4a69

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
