### PR TITLE
feat: network enablement controller

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -102,6 +102,7 @@ describe('Engine', () => {
     expect(engine.context).toHaveProperty('EarnController');
     expect(engine.context).toHaveProperty('MultichainTransactionsController');
     expect(engine.context).toHaveProperty('DeFiPositionsController');
+    expect(engine.context).toHaveProperty('NetworkEnablementController');
     expect(engine.context).toHaveProperty('PerpsController');
   });
 

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -230,6 +230,7 @@ import {
 import { ErrorReportingService } from '@metamask/error-reporting-service';
 import { captureException } from '@sentry/react-native';
 import { WebSocketServiceInit } from './controllers/snaps/websocket-service-init';
+import { networkEnablementControllerInit } from './controllers/network-enablement-controller/network-enablement-controller-init';
 
 import { seedlessOnboardingControllerInit } from './controllers/seedless-onboarding-controller';
 import { perpsControllerInit } from './controllers/perps-controller';
@@ -1277,6 +1278,7 @@ export class Engine {
         MultichainAccountService: multichainAccountServiceInit,
         ///: END:ONLY_INCLUDE_IF
         SeedlessOnboardingController: seedlessOnboardingControllerInit,
+        NetworkEnablementController: networkEnablementControllerInit,
         PerpsController: perpsControllerInit,
       },
       persistedState: initialState as EngineState,
@@ -1340,6 +1342,9 @@ export class Engine {
       messenger: multichainRatesControllerMessenger,
       initialState: initialState.RatesController,
     });
+
+    const networkEnablementController =
+      controllersByName.NetworkEnablementController;
 
     // Set up currency rate sync
     setupCurrencyRateSync(
@@ -1656,6 +1661,7 @@ export class Engine {
       EarnController: earnController,
       DeFiPositionsController: controllersByName.DeFiPositionsController,
       SeedlessOnboardingController: seedlessOnboardingController,
+      NetworkEnablementController: networkEnablementController,
       PerpsController: perpsController,
     };
 
@@ -2380,6 +2386,7 @@ export default {
       PerpsController,
       DeFiPositionsController,
       SeedlessOnboardingController,
+      NetworkEnablementController,
     } = instance.datamodel.state;
 
     return {
@@ -2435,6 +2442,7 @@ export default {
       PerpsController,
       DeFiPositionsController,
       SeedlessOnboardingController,
+      NetworkEnablementController,
     };
   },
 

--- a/app/core/Engine/constants.ts
+++ b/app/core/Engine/constants.ts
@@ -75,6 +75,7 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   'PerpsController:stateChange',
   'DeFiPositionsController:stateChange',
   'SeedlessOnboardingController:stateChange',
+  'NetworkEnablementController:stateChange',
 ] as const;
 
 export const swapsSupportedChainIds = [

--- a/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.test.ts
@@ -1,0 +1,90 @@
+import {
+  NetworkEnablementController,
+  NetworkEnablementControllerMessenger,
+  NetworkEnablementControllerState,
+} from '@metamask/network-enablement-controller';
+import { ExtendedControllerMessenger } from '../../../ExtendedControllerMessenger';
+import { networkEnablementControllerInit } from './network-enablement-controller-init';
+import type { ControllerInitRequest } from '../../types';
+import { buildControllerInitRequestMock } from '../../utils/test-utils';
+import { KnownCaipNamespace } from '@metamask/utils';
+import { ChainId } from '@metamask/controller-utils';
+import { SolScope } from '@metamask/keyring-api';
+
+jest.mock('@metamask/network-enablement-controller');
+
+describe('networkEnablementControllerInit', () => {
+  const networkEnablementControllerClassMock = jest.mocked(
+    NetworkEnablementController,
+  );
+  let initRequestMock: ControllerInitRequest<NetworkEnablementControllerMessenger>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    const baseControllerMessenger = new ExtendedControllerMessenger();
+    initRequestMock = buildControllerInitRequestMock(baseControllerMessenger);
+  });
+
+  it('returns controller instance', () => {
+    const result = networkEnablementControllerInit(initRequestMock);
+
+    expect(result.controller).toBeInstanceOf(NetworkEnablementController);
+  });
+
+  it('initializes controller with messenger from request', () => {
+    networkEnablementControllerInit(initRequestMock);
+
+    const constructorCall =
+      networkEnablementControllerClassMock.mock.calls[0][0];
+    expect(constructorCall.messenger).toBe(initRequestMock.controllerMessenger);
+  });
+
+  it('uses default state when no initial state is provided', () => {
+    networkEnablementControllerInit(initRequestMock);
+
+    const constructorCall =
+      networkEnablementControllerClassMock.mock.calls[0][0];
+    expect(constructorCall.state).toBeUndefined();
+  });
+
+  it('uses persisted state when initial state is provided', () => {
+    const initialNetworkEnablementState: NetworkEnablementControllerState = {
+      enabledNetworkMap: {
+        [KnownCaipNamespace.Eip155]: {
+          [ChainId.mainnet]: true,
+          [ChainId.sepolia]: false,
+        },
+        [KnownCaipNamespace.Solana]: {
+          [SolScope.Mainnet]: true,
+        },
+      },
+    };
+
+    initRequestMock.persistedState = {
+      ...initRequestMock.persistedState,
+      NetworkEnablementController: initialNetworkEnablementState,
+    };
+
+    networkEnablementControllerInit(initRequestMock);
+
+    const constructorCall =
+      networkEnablementControllerClassMock.mock.calls[0][0];
+    expect(constructorCall.state).toEqual(initialNetworkEnablementState);
+  });
+
+  it('passes state as undefined when persisted state is not NetworkEnablementControllerState type', () => {
+    const invalidState = { invalidProperty: 'invalid' };
+    initRequestMock.persistedState = {
+      ...initRequestMock.persistedState,
+      NetworkEnablementController:
+        invalidState as unknown as NetworkEnablementControllerState,
+    };
+
+    networkEnablementControllerInit(initRequestMock);
+
+    const constructorCall =
+      networkEnablementControllerClassMock.mock.calls[0][0];
+    expect(constructorCall.state).toEqual(invalidState);
+  });
+});

--- a/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.ts
+++ b/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.ts
@@ -1,0 +1,29 @@
+import {
+  NetworkEnablementController,
+  type NetworkEnablementControllerMessenger,
+  NetworkEnablementControllerState,
+} from '@metamask/network-enablement-controller';
+import type { ControllerInitFunction } from '../../types';
+
+/**
+ * Initialize the NetworkEnablementController.
+ *
+ * @param request - The request object.
+ * @returns The NetworkEnablementController.
+ */
+export const networkEnablementControllerInit: ControllerInitFunction<
+  NetworkEnablementController,
+  NetworkEnablementControllerMessenger
+> = (request) => {
+  const { controllerMessenger, persistedState } = request;
+
+  const networkEnablementControllerState =
+    persistedState.NetworkEnablementController as NetworkEnablementControllerState;
+
+  const controller = new NetworkEnablementController({
+    messenger: controllerMessenger,
+    state: networkEnablementControllerState,
+  });
+
+  return { controller };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -141,6 +141,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   NetworkEnablementController: {
     getMessenger: getNetworkEnablementControllerMessenger,
+    getInitMessenger: noop,
   },
   PerpsController: {
     getMessenger: getPerpsControllerMessenger,

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -2,6 +2,7 @@ import { noop } from 'lodash';
 import { getAccountsControllerMessenger } from './accounts-controller-messenger';
 import { getAccountTreeControllerMessenger } from '../../../multichain-accounts/messengers/account-tree-controller-messenger';
 import { getMultichainNetworkControllerMessenger } from './multichain-network-controller-messenger/multichain-network-controller-messenger';
+import { getNetworkEnablementControllerMessenger } from './network-enablement-controller-messenger/network-enablement-controller-messenger';
 import { getCurrencyRateControllerMessenger } from './currency-rate-controller-messenger/currency-rate-controller-messenger';
 import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 import {
@@ -137,6 +138,9 @@ export const CONTROLLER_MESSENGERS = {
   SeedlessOnboardingController: {
     getMessenger: getSeedlessOnboardingControllerMessenger,
     getInitMessenger: noop,
+  },
+  NetworkEnablementController: {
+    getMessenger: getNetworkEnablementControllerMessenger,
   },
   PerpsController: {
     getMessenger: getPerpsControllerMessenger,

--- a/app/core/Engine/messengers/network-enablement-controller-messenger/network-enablement-controller-messenger.ts
+++ b/app/core/Engine/messengers/network-enablement-controller-messenger/network-enablement-controller-messenger.ts
@@ -1,0 +1,24 @@
+import type { NetworkEnablementControllerMessenger } from '@metamask/network-enablement-controller';
+import type { BaseControllerMessenger } from '../../types';
+
+/**
+ * Get the messenger for the NetworkEnablementController.
+ *
+ * @param baseControllerMessenger - The base controller messenger.
+ * @returns The restricted messenger for the NetworkEnablementController.
+ */
+export const getNetworkEnablementControllerMessenger = (
+  baseControllerMessenger: BaseControllerMessenger,
+): NetworkEnablementControllerMessenger =>
+  baseControllerMessenger.getRestricted({
+    name: 'NetworkEnablementController',
+    allowedActions: [
+      'NetworkController:getState',
+      'MultichainNetworkController:getState',
+    ],
+    allowedEvents: [
+      'NetworkController:networkAdded',
+      'NetworkController:networkRemoved',
+      'NetworkController:stateChange',
+    ],
+  });

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -89,6 +89,12 @@ import {
   NetworkState,
 } from '@metamask/network-controller';
 import {
+  NetworkEnablementController,
+  NetworkEnablementControllerActions,
+  NetworkEnablementControllerEvents,
+  NetworkEnablementControllerState,
+} from '@metamask/network-enablement-controller';
+import {
   PhishingController,
   PhishingControllerActions,
   PhishingControllerEvents,
@@ -344,6 +350,7 @@ type GlobalActions =
   | GasFeeControllerActions
   | KeyringControllerActions
   | NetworkControllerActions
+  | NetworkEnablementControllerActions
   | PermissionControllerActions
   | SignatureControllerActions
   | LoggingControllerActions
@@ -401,6 +408,7 @@ type GlobalEvents =
   | GasFeeControllerEvents
   | KeyringControllerEvents
   | NetworkControllerEvents
+  | NetworkEnablementControllerEvents
   | PermissionControllerEvents
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   | SnapsGlobalEvents
@@ -475,6 +483,7 @@ export type Controllers = {
   KeyringController: KeyringController;
   LoggingController: LoggingController;
   NetworkController: NetworkController;
+  NetworkEnablementController: NetworkEnablementController;
   NftController: NftController;
   NftDetectionController: NftDetectionController;
   // TODO: Fix permission types
@@ -547,6 +556,7 @@ export type EngineState = {
   CurrencyRateController: CurrencyRateState;
   KeyringController: KeyringControllerState;
   NetworkController: NetworkState;
+  NetworkEnablementController: NetworkEnablementControllerState;
   PreferencesController: PreferencesState;
   RemoteFeatureFlagController: RemoteFeatureFlagControllerState;
   PhishingController: PhishingControllerState;
@@ -650,6 +660,7 @@ export type ControllersToInitialize =
   | 'SignatureController'
   | 'SeedlessOnboardingController'
   | 'TransactionController'
+  | 'NetworkEnablementController'
   | 'PerpsController';
 
 /**

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -59,6 +59,7 @@ import { accountTreeControllerInit } from '../../../multichain-accounts/controll
 import { WebSocketServiceInit } from '../controllers/snaps/websocket-service-init';
 import { perpsControllerInit } from '../controllers/perps-controller';
 import { multichainAccountServiceInit } from '../controllers/multichain-account-service/multichain-account-service-init';
+import { networkEnablementControllerInit } from '../controllers/network-enablement-controller/network-enablement-controller-init';
 
 jest.mock('../controllers/accounts-controller');
 jest.mock('../controllers/app-metadata-controller');
@@ -144,6 +145,9 @@ describe('initModularizedControllers', () => {
   const mockMultichainAccountServiceInit = jest.mocked(
     multichainAccountServiceInit,
   );
+  const mockNetworkEnablementControllerInit = jest.mocked(
+    networkEnablementControllerInit,
+  );
 
   function buildModularizedControllerRequest(
     overrides?: Record<string, unknown>,
@@ -168,6 +172,7 @@ describe('initModularizedControllers', () => {
             mockMultichainAssetsRatesControllerInit,
           MultichainBalancesController: mockMultichainBalancesControllerInit,
           MultichainAccountService: mockMultichainAccountServiceInit,
+          NetworkEnablementController: mockNetworkEnablementControllerInit,
           NotificationServicesController:
             mockNotificationServicesControllerInit,
           NotificationServicesPushController:

--- a/app/selectors/networkEnablementController/index.test.ts
+++ b/app/selectors/networkEnablementController/index.test.ts
@@ -1,0 +1,119 @@
+import { selectNetworkEnablementControllerState } from './index';
+import { RootState } from '../../reducers';
+
+describe('NetworkEnablementController Selectors', () => {
+  const mockState = {
+    engine: {
+      backgroundState: {
+        NetworkEnablementController: {
+          enabledNetworkMap: {
+            eip155: {
+              '0x1': true,
+              '0x2105': true,
+              '0xe708': true,
+            },
+            solana: {
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': true,
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RootState;
+
+  describe('selectNetworkEnablementControllerState', () => {
+    it('should return the network enablement controller state', () => {
+      // Arrange - mockState is already set up
+
+      // Act
+      const result = selectNetworkEnablementControllerState(mockState);
+
+      // Assert
+      expect(result).toBe(
+        mockState.engine.backgroundState.NetworkEnablementController,
+      );
+      expect(result).toEqual({
+        enabledNetworkMap: {
+          eip155: {
+            '0x1': true,
+            '0x2105': true,
+            '0xe708': true,
+          },
+          solana: {
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': true,
+          },
+        },
+      });
+    });
+
+    it('should return undefined when NetworkEnablementController state does not exist', () => {
+      // Arrange
+      const stateWithoutNetworkEnablement = {
+        engine: {
+          backgroundState: {
+            // NetworkEnablementController is missing
+          },
+        },
+      } as unknown as RootState;
+
+      // Act
+      const result = selectNetworkEnablementControllerState(
+        stateWithoutNetworkEnablement,
+      );
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when backgroundState does not exist', () => {
+      // Arrange
+      const stateWithoutBackgroundState = {
+        engine: {
+          // backgroundState is missing
+        },
+      } as unknown as RootState;
+
+      // Act
+      const result = selectNetworkEnablementControllerState(
+        stateWithoutBackgroundState,
+      );
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when engine state does not exist', () => {
+      // Arrange
+      const stateWithoutEngine = {
+        // engine is missing
+      } as unknown as RootState;
+
+      // Act
+      const result = selectNetworkEnablementControllerState(stateWithoutEngine);
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle empty enabledNetworkMap', () => {
+      // Arrange
+      const stateWithEmptyMap = {
+        engine: {
+          backgroundState: {
+            NetworkEnablementController: {
+              enabledNetworkMap: {},
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      // Act
+      const result = selectNetworkEnablementControllerState(stateWithEmptyMap);
+
+      // Assert
+      expect(result).toEqual({
+        enabledNetworkMap: {},
+      });
+    });
+  });
+});

--- a/app/selectors/networkEnablementController/index.ts
+++ b/app/selectors/networkEnablementController/index.ts
@@ -1,0 +1,23 @@
+import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
+import { CaipChainId } from '@metamask/utils';
+import { RootState } from '../../reducers';
+import { createDeepEqualSelector } from '../util';
+
+export const selectNetworkEnablementControllerState = (state: RootState) =>
+  state.engine?.backgroundState?.NetworkEnablementController;
+
+export const selectEnabledNetworksByNamespace = createDeepEqualSelector(
+  selectNetworkEnablementControllerState,
+  (networkEnablementControllerState: NetworkEnablementControllerState) =>
+    networkEnablementControllerState?.enabledNetworkMap,
+);
+
+export const selectEVMEnabledNetworks = createDeepEqualSelector(
+  selectEnabledNetworksByNamespace,
+  (
+    enabledNetworksByNamespace: NetworkEnablementControllerState['enabledNetworkMap'],
+  ) =>
+    Object.keys(enabledNetworksByNamespace?.eip155 ?? {}).filter(
+      (chainId) => enabledNetworksByNamespace?.eip155?.[chainId as CaipChainId],
+    ),
+);

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -318,6 +318,18 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         },
         "selectedNetworkClientId": "mainnet",
       },
+      "NetworkEnablementController": {
+        "enabledNetworkMap": {
+          "eip155": {
+            "0x1": true,
+            "0x2105": true,
+            "0xe708": true,
+          },
+          "solana": {
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": true,
+          },
+        },
+      },
       "NotificationServicesController": {
         "isCheckingAccountsPresence": false,
         "isFeatureAnnouncementsEnabled": false,

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -166,6 +166,18 @@
       }
     }
   },
+  "NetworkEnablementController": {
+    "enabledNetworkMap": {
+      "eip155": {
+        "0x1": true,
+        "0x2105": true,
+        "0xe708": true
+      },
+      "solana": {
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": true
+      }
+    }
+  },
   "PhishingController": {
     "c2DomainBlocklistLastFetched": 0,
     "phishingLists": [],

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "@metamask/multichain-network-controller": "^0.10.0",
     "@metamask/multichain-transactions-controller": "^2.0.0",
     "@metamask/network-controller": "^24.0.0",
+    "@metamask/network-enablement-controller": "^0.1.0",
     "@metamask/notification-services-controller": "^11.0.0",
     "@metamask/permission-controller": "^11.0.6",
     "@metamask/phishing-controller": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5691,6 +5691,16 @@
     uri-js "^4.4.1"
     uuid "^8.3.2"
 
+"@metamask/network-enablement-controller@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/network-enablement-controller/-/network-enablement-controller-0.1.0.tgz#b2ed26ae562069387393c12adc21d8717a201a28"
+  integrity sha512-z/Jr9MiANc8sZ9tzNQZIdb+DpjbSceekgUUDf/Y2XJ74CElhR8DuvdwxzlzFrADmljST67YwTb5c7r8bR0fQgQ==
+  dependencies:
+    "@metamask/base-controller" "^8.0.1"
+    "@metamask/controller-utils" "^11.11.0"
+    "@metamask/utils" "^11.4.2"
+    reselect "^5.1.1"
+
 "@metamask/nonce-tracker@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/nonce-tracker/-/nonce-tracker-6.0.0.tgz#ada64bdfd469acac5f5f83b914b470025c065ae3"


### PR DESCRIPTION
## **Description**

This PR is part of a series of PRs that breaks down this larger PR for the [Network Manager](https://github.com/MetaMask/metamask-mobile/pull/16642). **No migration is needed until the feature in the parent branch is merged**

This PR integrates the new Network Enablement Controller, eventually replacing the legacy network filter system with a robust Network Manager that gives users granular control over which networks are enabled. This is a foundational change that will determine asset visibility and dapp connectivity based on user-enabled networks.

###  Key Features
**Selective Network Control**: Users can now add and enable networks through the new Network Manager

**Smart Asset Display**: 
- Custom Networks and Solana show assets only for the selected network
- Default networks (Ethereum, Arbitrum) display assets across all enabled networks

**Seamless Dapp Integration:** 
- Dapp network requests automatically switch to and enable the requested network 
- New network additions via dapp connections are auto-enabled

**Enhanced UX**: Replaces legacy network filtering with a more intuitive and powerful network management system

### Core Controller Integration
- Added `@metamask/network-enablement-controller@^0.1.0` as a new dependency
- Engine Integration: Fully integrated the controller into the Engine system with proper initialization and state management
- Messenger Configuration: Set up controller communication with `NetworkController`
- Type Safety: Complete TypeScript integration with proper type definitions

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: [5083](https://github.com/MetaMask/MetaMask-planning/issues/5083)

## **Manual testing steps**

```gherkin
Scenario: Network Enablement Controller initializes successfully
    Given the MetaMask app is launched
    When the Engine initializes all controllers
    Then the NetworkEnablementController should be properly instantiated
    And the controller state should be accessible via Redux selectors

  Scenario: Developer can verify enabled networks state via console logs
    Given the NetworkEnablementController is initialized
    And developer has added console.log statements to Wallet/index.tsx
    When user navigates to the Wallet view
    Then console should display "evm enabled networks" with current enabled network IDs
    And console should display "enabled networks by namespace" with network mapping

  Scenario: Controller state is properly persisted and restored
    Given the app has been previously used with network configurations
    When the app is closed and reopened
    Then the NetworkEnablementController should restore its previous state
    And the persisted enabled networks should be accessible via selectors

  Scenario: Selectors return expected data structure
    Given the NetworkEnablementController is initialized with network data
    When developers access the selectEVMEnabledNetworks selector
    Then it should return an array of enabled EVM network chain IDs
    When developers access the selectEnabledNetworksByNamespace selector
    Then it should return a mapping object with eip155 namespace containing network states

  Scenario: Controller messenger communicates with Network Controllers
    Given the NetworkEnablementController is initialized
    When NetworkController state changes (network added/removed)
    Then the NetworkEnablementController should receive the state change events
    And the controller should have access to NetworkController and MultichainNetworkController state
```

## **Screenshots/Recordings**

Showing new state via console logs. Logs are not in this PR

<img width="987" height="1055" alt="Screenshot 2025-08-06 at 1 11 14 PM" src="https://github.com/user-attachments/assets/3aba6ef1-1bb9-469d-91f0-d8ac0d5de24b" />

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
