### PR TITLE
chore: unifying Keypad UI across mobile - part 2

### DIFF
--- a/app/components/Base/Keypad/Keypad.stories.tsx
+++ b/app/components/Base/Keypad/Keypad.stories.tsx
@@ -15,7 +15,7 @@ const DefaultKeypadStory = () => {
   };
 
   return (
-    <Box>
+    <Box twClassName="px-4">
       <Text variant={TextVariant.DisplayMd} twClassName="mb-4">
         Current Value: {value}
       </Text>

--- a/app/components/Base/Keypad/__snapshots__/Keypad.test.tsx.snap
+++ b/app/components/Base/Keypad/__snapshots__/Keypad.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`Keypad components components should render correctly and match snapshot
   style={
     [
       {
-        "paddingHorizontal": 25,
+        "display": "flex",
+        "gap": 12,
       },
       undefined,
     ]
@@ -13,768 +14,677 @@ exports[`Keypad components components should render correctly and match snapshot
 >
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      onPress={[MockFunction]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        1
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          1
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        2
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          2
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        3
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          3
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      onPress={[MockFunction]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        4
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          4
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        5
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          5
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        6
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          6
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      onPress={[MockFunction]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        7
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          7
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        8
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          8
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        9
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          9
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      onPress={[MockFunction]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="none"
+          style={
             [
               {
                 "color": "#121314",
-                "fontSize": 30,
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
                 "textAlign": "center",
               },
               undefined,
-            ],
-          ]
-        }
-      >
-        .
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+            ]
+          }
+        >
+          .
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="none"
+          style={
             [
               {
                 "color": "#121314",
-                "fontSize": 30,
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
                 "textAlign": "center",
               },
               undefined,
-            ],
-          ]
-        }
-      >
-        0
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      onPress={[MockFunction]}
+            ]
+          }
+        >
+          0
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[MockFunction]}
         style={
           [
             {
-              "color": undefined,
-              "fontSize": 12,
+              "alignItems": "center",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              {
-                "fontSize": 25,
-                "marginTop": 5,
-              },
-            ],
-            {
-              "fontFamily": "Ionicons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            {},
+            undefined,
           ]
         }
       >
-        
-      </Text>
-    </TouchableOpacity>
+        <SvgMock
+          fill="currentColor"
+          name="Backspace"
+          style={
+            [
+              {
+                "color": "#121314",
+                "height": 32,
+                "width": 32,
+              },
+              undefined,
+            ]
+          }
+        />
+      </TouchableOpacity>
+    </View>
   </View>
 </View>
 `;
@@ -784,7 +694,8 @@ exports[`Keypad should render correctly and match snapshot 1`] = `
   style={
     [
       {
-        "paddingHorizontal": 25,
+        "display": "flex",
+        "gap": 12,
       },
       undefined,
     ]
@@ -792,791 +703,682 @@ exports[`Keypad should render correctly and match snapshot 1`] = `
 >
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        1
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          1
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        2
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          2
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        3
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          3
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        4
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          4
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        5
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          5
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        6
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          6
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        7
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          7
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        8
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          8
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            [
-              {
-                "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
-              },
-              undefined,
-            ],
           ]
         }
       >
-        9
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
+                "textAlign": "center",
+              },
+              undefined,
+            ]
+          }
+        >
+          9
+        </Text>
+      </TouchableOpacity>
+    </View>
   </View>
   <View
     style={
-      {
-        "flexDirection": "row",
-        "justifyContent": "space-around",
-      }
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
-    <TouchableOpacity
-      onPress={[Function]}
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+            {
+              "backgroundColor": "transparent",
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="none"
+          style={
             [
               {
                 "color": "#121314",
-                "fontSize": 30,
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
                 "textAlign": "center",
               },
               undefined,
-            ],
-          ]
-        }
-      >
-        .
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      onPress={[Function]}
+            ]
+          }
+        >
+          .
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
     >
-      <Text
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        onPress={[Function]}
         style={
           [
             {
-              "color": "#121314",
-              "fontFamily": "CentraNo1-Book",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "marginVertical": 2,
+              "alignItems": "center",
+              "backgroundColor": "#3c4d9d0f",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
             undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityRole="none"
+          style={
             [
               {
                 "color": "#121314",
-                "fontSize": 30,
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "fontWeight": "500",
+                "letterSpacing": 0,
+                "lineHeight": 40,
                 "textAlign": "center",
               },
               undefined,
-            ],
-          ]
-        }
-      >
-        0
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      delayLongPress={500}
-      onLongPress={[Function]}
-      onPress={[Function]}
+            ]
+          }
+        >
+          0
+        </Text>
+      </TouchableOpacity>
+    </View>
+    <View
       style={
         [
           {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 12,
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           undefined,
         ]
       }
-      testID="keypad-delete-button"
     >
-      <Text
-        allowFontScaling={false}
-        selectable={false}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        delayLongPress={500}
+        onLongPress={[Function]}
+        onPress={[Function]}
         style={
           [
             {
-              "color": undefined,
-              "fontSize": 12,
+              "alignItems": "center",
+              "borderRadius": 12,
+              "height": 40,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
             },
+            undefined,
+          ]
+        }
+        testID="keypad-delete-button"
+      >
+        <SvgMock
+          fill="currentColor"
+          name="Backspace"
+          style={
             [
               {
                 "color": "#121314",
-                "fontSize": 30,
-                "textAlign": "center",
+                "height": 32,
+                "width": 32,
               },
-              {
-                "fontSize": 25,
-                "marginTop": 5,
-              },
-            ],
-            {
-              "fontFamily": "Ionicons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            {},
-          ]
-        }
-      >
-        
-      </Text>
-    </TouchableOpacity>
+              undefined,
+            ]
+          }
+        />
+      </TouchableOpacity>
+    </View>
   </View>
 </View>
 `;

--- a/app/components/Base/Keypad/components.tsx
+++ b/app/components/Base/Keypad/components.tsx
@@ -1,126 +1,128 @@
 import React from 'react';
+import { StyleSheet, TouchableOpacity, ViewStyle } from 'react-native';
 import {
-  View,
-  StyleSheet,
-  TouchableOpacity,
-  ViewStyle,
-  TextStyle,
-  AccessibilityRole,
-} from 'react-native';
-import IonicIcon from 'react-native-vector-icons/Ionicons';
-import Device from '../../../util/device';
-import Text from '../Text';
+  Box,
+  BoxFlexDirection,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+  type BoxProps,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
 import { useTheme } from '../../../util/theme';
 import { Colors } from '../../../util/theme/models';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
-    keypad: {
-      paddingHorizontal: 25,
-    },
-    keypadRow: {
-      flexDirection: 'row',
-      justifyContent: 'space-around',
-    },
     keypadButton: {
-      paddingHorizontal: 20,
-      paddingVertical: Device.isMediumDevice()
-        ? Device.isIphone5()
-          ? 4
-          : 8
-        : 12,
-      flex: 1,
+      backgroundColor: colors.background.muted,
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      height: 40,
       justifyContent: 'center',
       alignItems: 'center',
     },
-    keypadButtonText: {
-      color: colors.text.default,
-      textAlign: 'center' as const,
-      fontSize: 30,
-    },
-    deleteIcon: {
-      fontSize: 25,
-      marginTop: 5,
+    keypadDeleteButton: {
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      height: 40,
+      justifyContent: 'center',
+      alignItems: 'center',
     },
   });
 
-interface KeypadContainerProps {
-  style?: ViewStyle | ViewStyle[];
+interface KeypadContainerProps extends BoxProps {
   children?: React.ReactNode;
 }
 
-const KeypadContainer: React.FC<KeypadContainerProps> = ({
-  style,
-  ...props
-}) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
-
-  return <View style={[styles.keypad, style]} {...props} />;
-};
+const KeypadContainer: React.FC<KeypadContainerProps> = (props) => (
+  <Box gap={3} {...props} />
+);
 
 interface KeypadRowProps {
   children?: React.ReactNode;
 }
 
-const KeypadRow: React.FC<KeypadRowProps> = (props) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
-
-  return <View style={styles.keypadRow} {...props} />;
-};
+const KeypadRow: React.FC<KeypadRowProps> = (props) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    justifyContent={BoxJustifyContent.Between}
+    gap={3}
+    {...props}
+  />
+);
 
 interface KeypadButtonProps {
   style?: ViewStyle | ViewStyle[];
-  textStyle?: TextStyle | TextStyle[];
   children?: React.ReactNode;
   onPress?: () => void;
-  accessibilityRole?: AccessibilityRole;
-  accessible?: boolean;
+  isDisabled?: boolean;
+  boxWrapperProps?: BoxProps;
 }
 
 const KeypadButton: React.FC<KeypadButtonProps> = ({
   style,
-  textStyle,
   children,
+  isDisabled,
+  boxWrapperProps,
   ...props
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
   return (
-    <TouchableOpacity style={[styles.keypadButton, style]} {...props}>
-      <Text style={[styles.keypadButtonText, textStyle]}>{children}</Text>
-    </TouchableOpacity>
+    // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
+    <Box twClassName="flex-1" {...boxWrapperProps}>
+      <TouchableOpacity
+        style={[styles.keypadButton, style]}
+        disabled={isDisabled}
+        accessibilityRole="button"
+        accessible
+        {...props}
+      >
+        <Text
+          twClassName="font-medium text-center"
+          variant={TextVariant.DisplayMd}
+          accessibilityRole="none"
+        >
+          {children}
+        </Text>
+      </TouchableOpacity>
+    </Box>
   );
 };
 
 interface KeypadDeleteButtonProps {
   style?: ViewStyle | ViewStyle[];
-  icon?: React.ReactNode;
   onPress?: () => void;
   onLongPress?: () => void;
   delayLongPress?: number;
   testID?: string;
+  boxWrapperProps?: BoxProps;
 }
 
 const KeypadDeleteButton: React.FC<KeypadDeleteButtonProps> = ({
   style,
-  icon,
+  boxWrapperProps,
   ...props
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
   return (
-    <TouchableOpacity style={[styles.keypadButton, style]} {...props}>
-      {icon || (
-        <IonicIcon
-          style={[styles.keypadButtonText, styles.deleteIcon]}
-          name="arrow-back"
-        />
-      )}
-    </TouchableOpacity>
+    // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
+    <Box twClassName="flex-1" {...boxWrapperProps}>
+      <TouchableOpacity
+        style={[styles.keypadDeleteButton, style]}
+        accessibilityRole="button"
+        accessible
+        {...props}
+      >
+        <Icon name={IconName.Backspace} size={IconSize.Xl} />
+      </TouchableOpacity>
+    </Box>
   );
 };
 
@@ -136,3 +138,8 @@ Keypad.Button = KeypadButton;
 Keypad.DeleteButton = KeypadDeleteButton;
 
 export default Keypad;
+export type {
+  KeypadContainerProps,
+  KeypadButtonProps,
+  KeypadDeleteButtonProps,
+};

--- a/app/components/Base/Keypad/index.tsx
+++ b/app/components/Base/Keypad/index.tsx
@@ -1,8 +1,19 @@
 import React, { useCallback } from 'react';
-import { ViewStyle, TextStyle } from 'react-native';
-import Keypad from './components';
+import { StyleSheet } from 'react-native';
+import Keypad, {
+  type KeypadButtonProps,
+  type KeypadContainerProps,
+  type KeypadDeleteButtonProps,
+} from './components';
 import { Keys } from './constants';
 import useCurrency from './useCurrency';
+import { colors } from '../../../styles/common';
+
+const styles = StyleSheet.create({
+  periodButton: {
+    backgroundColor: colors.transparent,
+  },
+});
 
 interface KeypadChangeData {
   value: string;
@@ -10,7 +21,7 @@ interface KeypadChangeData {
   pressedKey: Keys;
 }
 
-interface KeypadComponentProps {
+interface KeypadComponentProps extends Omit<KeypadContainerProps, 'children'> {
   /**
    * Function that will be called when a key is pressed with arguments `(value, key)`
    */
@@ -29,33 +40,13 @@ interface KeypadComponentProps {
    */
   value: string;
   /**
-   * Custom style for container
+   * Props for the period button
    */
-  style?: ViewStyle | ViewStyle[];
+  periodButtonProps?: Partial<KeypadButtonProps>;
   /**
-   * Custom style for digit buttons
+   * Props for the delete button
    */
-  digitButtonStyle?: ViewStyle | ViewStyle[];
-  /**
-   * Custom style for digit text
-   */
-  digitTextStyle?: TextStyle | TextStyle[];
-  /**
-   * Custom style for period button
-   */
-  periodButtonStyle?: ViewStyle | ViewStyle[];
-  /**
-   * Custom style for period text
-   */
-  periodTextStyle?: TextStyle | TextStyle[];
-  /**
-   * Custom style for delete button
-   */
-  deleteButtonStyle?: ViewStyle | ViewStyle[];
-  /**
-   * Custom icon for delete button
-   */
-  deleteIcon?: React.ReactNode;
+  deleteButtonProps?: Partial<KeypadDeleteButtonProps>;
 }
 
 function KeypadComponent({
@@ -63,13 +54,9 @@ function KeypadComponent({
   value,
   currency,
   decimals,
-  style,
-  digitButtonStyle,
-  digitTextStyle,
-  periodButtonStyle,
-  periodTextStyle,
-  deleteButtonStyle,
-  deleteIcon,
+  periodButtonProps,
+  deleteButtonProps,
+  ...props
 }: KeypadComponentProps): React.JSX.Element {
   const { handler, decimalSeparator } = useCurrency(currency, decimals);
 
@@ -143,118 +130,37 @@ function KeypadComponent({
   );
 
   return (
-    <Keypad style={style}>
+    <Keypad {...props}>
       <Keypad.Row>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress1}
-          accessibilityRole="button"
-          accessible
-        >
-          1
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress2}
-          accessibilityRole="button"
-          accessible
-        >
-          2
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress3}
-          accessibilityRole="button"
-          accessible
-        >
-          3
-        </Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress1}>1</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress2}>2</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress3}>3</Keypad.Button>
+      </Keypad.Row>
+      <Keypad.Row>
+        <Keypad.Button onPress={handleKeypadPress4}>4</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress5}>5</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress6}>6</Keypad.Button>
+      </Keypad.Row>
+      <Keypad.Row>
+        <Keypad.Button onPress={handleKeypadPress7}>7</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress8}>8</Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress9}>9</Keypad.Button>
       </Keypad.Row>
       <Keypad.Row>
         <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress4}
-          accessibilityRole="button"
-          accessible
-        >
-          4
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress5}
-          accessibilityRole="button"
-          accessible
-        >
-          5
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress6}
-          accessibilityRole="button"
-          accessible
-        >
-          6
-        </Keypad.Button>
-      </Keypad.Row>
-      <Keypad.Row>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress7}
-          accessibilityRole="button"
-          accessible
-        >
-          7
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress8}
-          accessibilityRole="button"
-          accessible
-        >
-          8
-        </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress9}
-          accessibilityRole="button"
-          accessible
-        >
-          9
-        </Keypad.Button>
-      </Keypad.Row>
-      <Keypad.Row>
-        <Keypad.Button
-          style={periodButtonStyle}
-          textStyle={periodTextStyle}
           onPress={handleKeypadPressPeriod}
+          style={styles.periodButton}
+          {...periodButtonProps}
         >
           {decimalSeparator}
         </Keypad.Button>
-        <Keypad.Button
-          style={digitButtonStyle}
-          textStyle={digitTextStyle}
-          onPress={handleKeypadPress0}
-          accessibilityRole="button"
-          accessible
-        >
-          0
-        </Keypad.Button>
+        <Keypad.Button onPress={handleKeypadPress0}>0</Keypad.Button>
         <Keypad.DeleteButton
           testID="keypad-delete-button"
-          style={deleteButtonStyle}
-          icon={deleteIcon}
           onPress={handleKeypadPressBack}
           onLongPress={handleKeypadLongPressBack}
           delayLongPress={500}
+          {...deleteButtonProps}
         />
       </Keypad.Row>
     </Keypad>

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
@@ -62,7 +62,7 @@ export const createStyles = (params: { theme: Theme }) => {
       paddingBottom: 8,
     },
     keypad: {
-      paddingHorizontal: 4,
+      paddingHorizontal: 24,
     },
     destinationAccountSelectorContainer: {
       paddingBottom: 12,

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.styles.ts
@@ -34,7 +34,7 @@ const styleSheet = (params: { theme: Theme }) => {
       padding: 16,
     },
     keypad: {
-      paddingHorizontal: 24,
+      paddingHorizontal: 16,
     },
   });
 };

--- a/app/components/UI/Earn/Views/EarnInputView/__snapshots__/EarnInputView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnInputView/__snapshots__/EarnInputView.test.tsx.snap
@@ -841,801 +841,693 @@ exports[`EarnInputView render matches snapshot 1`] = `
                           style={
                             [
                               {
-                                "paddingHorizontal": 25,
+                                "display": "flex",
+                                "gap": 12,
                               },
                               {
-                                "paddingHorizontal": 24,
+                                "paddingHorizontal": 16,
                               },
                             ]
                           }
                         >
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                1
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  1
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                2
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  2
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                3
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  3
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                4
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  4
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                5
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  5
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                6
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  6
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                7
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  7
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                8
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  8
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                9
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  9
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                    {
+                                      "backgroundColor": "transparent",
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                .
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  .
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                0
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              delayLongPress={500}
-                              onLongPress={[Function]}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  0
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
-                              testID="keypad-delete-button"
                             >
-                              <Text
-                                allowFontScaling={false}
-                                selectable={false}
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                delayLongPress={500}
+                                onLongPress={[Function]}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": undefined,
-                                      "fontSize": 12,
+                                      "alignItems": "center",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
+                                    undefined,
+                                  ]
+                                }
+                                testID="keypad-delete-button"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Backspace"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
+                                        "height": 32,
+                                        "width": 32,
                                       },
-                                      {
-                                        "fontSize": 25,
-                                        "marginTop": 5,
-                                      },
-                                    ],
-                                    {
-                                      "fontFamily": "Ionicons",
-                                      "fontStyle": "normal",
-                                      "fontWeight": "normal",
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                
-                              </Text>
-                            </TouchableOpacity>
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </TouchableOpacity>
+                            </View>
                           </View>
                         </View>
                         <View
@@ -2540,801 +2432,693 @@ exports[`EarnInputView when values are entered in the keypad updates ETH and fia
                           style={
                             [
                               {
-                                "paddingHorizontal": 25,
+                                "display": "flex",
+                                "gap": 12,
                               },
                               {
-                                "paddingHorizontal": 24,
+                                "paddingHorizontal": 16,
                               },
                             ]
                           }
                         >
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                1
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  1
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                2
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  2
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                3
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  3
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                4
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  4
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                5
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  5
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                6
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  6
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                7
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  7
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                8
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  8
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                9
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  9
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                    {
+                                      "backgroundColor": "transparent",
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                .
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  .
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                0
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              delayLongPress={500}
-                              onLongPress={[Function]}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  0
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
-                              testID="keypad-delete-button"
                             >
-                              <Text
-                                allowFontScaling={false}
-                                selectable={false}
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                delayLongPress={500}
+                                onLongPress={[Function]}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": undefined,
-                                      "fontSize": 12,
+                                      "alignItems": "center",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
+                                    undefined,
+                                  ]
+                                }
+                                testID="keypad-delete-button"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Backspace"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
+                                        "height": 32,
+                                        "width": 32,
                                       },
-                                      {
-                                        "fontSize": 25,
-                                        "marginTop": 5,
-                                      },
-                                    ],
-                                    {
-                                      "fontFamily": "Ionicons",
-                                      "fontStyle": "normal",
-                                      "fontWeight": "normal",
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                
-                              </Text>
-                            </TouchableOpacity>
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </TouchableOpacity>
+                            </View>
                           </View>
                         </View>
                         <View

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.styles.ts
@@ -29,7 +29,7 @@ const styleSheet = (params: { theme: Theme }) => {
       padding: 16,
     },
     keypad: {
-      paddingHorizontal: 24,
+      paddingHorizontal: 16,
     },
     unstakeBanner: {
       marginHorizontal: 16,

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/__snapshots__/EarnWithdrawInputView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/__snapshots__/EarnWithdrawInputView.test.tsx.snap
@@ -727,801 +727,693 @@ exports[`EarnWithdrawInputView render matches snapshot 1`] = `
                           style={
                             [
                               {
-                                "paddingHorizontal": 25,
+                                "display": "flex",
+                                "gap": 12,
                               },
                               {
-                                "paddingHorizontal": 24,
+                                "paddingHorizontal": 16,
                               },
                             ]
                           }
                         >
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                1
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  1
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                2
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  2
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                3
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  3
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                4
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  4
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                5
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  5
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                6
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  6
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                7
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  7
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                8
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  8
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    [
-                                      {
-                                        "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
-                                      },
-                                      undefined,
-                                    ],
                                   ]
                                 }
                               >
-                                9
-                              </Text>
-                            </TouchableOpacity>
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  9
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
                           </View>
                           <View
                             style={
-                              {
-                                "flexDirection": "row",
-                                "justifyContent": "space-around",
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "gap": 12,
+                                  "justifyContent": "space-between",
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            <TouchableOpacity
-                              onPress={[Function]}
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                    {
+                                      "backgroundColor": "transparent",
+                                    },
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                .
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              accessibilityRole="button"
-                              accessible={true}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  .
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
                             >
-                              <Text
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": "#121314",
-                                      "fontFamily": "CentraNo1-Book",
-                                      "fontSize": 30,
-                                      "fontWeight": "400",
-                                      "marginVertical": 2,
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
                                     undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
+                                  ]
+                                }
+                              >
+                                <Text
+                                  accessibilityRole="none"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 32,
+                                        "fontWeight": "500",
+                                        "letterSpacing": 0,
+                                        "lineHeight": 40,
                                         "textAlign": "center",
                                       },
                                       undefined,
-                                    ],
-                                  ]
-                                }
-                              >
-                                0
-                              </Text>
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                              delayLongPress={500}
-                              onLongPress={[Function]}
-                              onPress={[Function]}
+                                    ]
+                                  }
+                                >
+                                  0
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                            <View
                               style={
                                 [
                                   {
-                                    "alignItems": "center",
-                                    "flex": 1,
-                                    "justifyContent": "center",
-                                    "paddingHorizontal": 20,
-                                    "paddingVertical": 12,
+                                    "display": "flex",
+                                    "flexBasis": "0%",
+                                    "flexGrow": 1,
+                                    "flexShrink": 1,
                                   },
                                   undefined,
                                 ]
                               }
-                              testID="keypad-delete-button"
                             >
-                              <Text
-                                allowFontScaling={false}
-                                selectable={false}
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                delayLongPress={500}
+                                onLongPress={[Function]}
+                                onPress={[Function]}
                                 style={
                                   [
                                     {
-                                      "color": undefined,
-                                      "fontSize": 12,
+                                      "alignItems": "center",
+                                      "borderRadius": 12,
+                                      "height": 40,
+                                      "justifyContent": "center",
+                                      "paddingHorizontal": 16,
                                     },
+                                    undefined,
+                                  ]
+                                }
+                                testID="keypad-delete-button"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Backspace"
+                                  style={
                                     [
                                       {
                                         "color": "#121314",
-                                        "fontSize": 30,
-                                        "textAlign": "center",
+                                        "height": 32,
+                                        "width": 32,
                                       },
-                                      {
-                                        "fontSize": 25,
-                                        "marginTop": 5,
-                                      },
-                                    ],
-                                    {
-                                      "fontFamily": "Ionicons",
-                                      "fontStyle": "normal",
-                                      "fontWeight": "normal",
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                
-                              </Text>
-                            </TouchableOpacity>
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </TouchableOpacity>
+                            </View>
                           </View>
                         </View>
                         <View

--- a/app/components/UI/Perps/Views/PerpsDepositAmountView/PerpsDepositAmountView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsDepositAmountView/PerpsDepositAmountView.styles.ts
@@ -99,9 +99,6 @@ const createStyles = ({ theme }: { theme: Theme }) => {
       flex: 1,
       height: 40,
     },
-    keypad: {
-      paddingHorizontal: 0,
-    },
     actionButton: {
       width: '100%',
     },

--- a/app/components/UI/Perps/Views/PerpsDepositAmountView/PerpsDepositAmountView.tsx
+++ b/app/components/UI/Perps/Views/PerpsDepositAmountView/PerpsDepositAmountView.tsx
@@ -644,7 +644,6 @@ const PerpsDepositAmountView: React.FC<PerpsDepositAmountViewProps> = () => {
             )}
 
             <Keypad
-              style={styles.keypad}
               value={sourceAmount || '0'}
               onChange={handleKeypadChange}
               currency={sourceToken?.symbol || USDC_SYMBOL}

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -490,9 +490,6 @@ const createStyles = (colors: Colors) =>
     percentageButton: {
       flex: 1,
     },
-    keypad: {
-      backgroundColor: colors.background.default,
-    },
     tooltipContent: {
       paddingBottom: 16,
     },

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -53,6 +53,7 @@ import {
   getNetworkImageSource,
 } from '../../../../../util/networks';
 import { useTheme } from '../../../../../util/theme';
+import Keypad from '../../../../Base/Keypad';
 import PerpsAmountDisplay from '../../components/PerpsAmountDisplay';
 import PerpsLeverageBottomSheet from '../../components/PerpsLeverageBottomSheet';
 import PerpsLimitPriceBottomSheet from '../../components/PerpsLimitPriceBottomSheet';
@@ -96,7 +97,6 @@ import createStyles from './PerpsOrderView.styles';
 import PerpsBottomSheetTooltip from '../../components/PerpsBottomSheetTooltip';
 import { PerpsTooltipContentKey } from '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
 import { PerpsOrderViewSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
-import Keypad from '../../../../Base/Keypad';
 import {
   PerpsOrderProvider,
   usePerpsOrderContext,
@@ -781,7 +781,6 @@ const PerpsOrderViewContent: React.FC = () => {
           </View>
 
           <Keypad
-            style={styles.keypad}
             value={orderForm.amount}
             onChange={handleKeypadChange}
             currency="USD"

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.styles.ts
@@ -96,9 +96,6 @@ const createStyles = ({ theme }: { theme: Theme }) => {
     percentageButton: {
       flex: 1,
     },
-    keypad: {
-      paddingHorizontal: 16,
-    },
     errorText: {
       marginBottom: 16,
       textAlign: 'center',

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -417,7 +417,6 @@ const PerpsWithdrawView: React.FC = () => {
             )}
 
             <Keypad
-              style={styles.keypad}
               value={withdrawAmount}
               onChange={handleKeypadChange}
               currency={USDC_SYMBOL}

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
@@ -68,11 +68,6 @@ export const createStyles = (colors: Theme['colors']) =>
     },
     keypadContainer: {
       marginBottom: 16,
-      padding: 0,
-    },
-    keypad: {
-      paddingHorizontal: 0,
-      marginHorizontal: -5,
     },
     footerContainer: {
       paddingHorizontal: 16,

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
@@ -239,7 +239,6 @@ jest.mock('./PerpsLimitPriceBottomSheet.styles', () => ({
       alignItems: 'center',
     },
     keypadContainer: { marginBottom: 16, padding: 0 },
-    keypad: { paddingHorizontal: 0 },
     footerContainer: { paddingHorizontal: 16, paddingBottom: 24 },
   }),
 }));

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -265,7 +265,6 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
             onChange={handleKeypadChange}
             currency="USD"
             decimals={2}
-            style={styles.keypad}
           />
         </View>
       </View>

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
@@ -25,6 +25,9 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingBottom: 50,
       backgroundColor: colors.background.alternative,
     },
+    keypad: {
+      paddingHorizontal: 16,
+    },
     cta: {
       paddingTop: 12,
     },

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -1036,6 +1036,7 @@ const BuildQuote = () => {
           amounts={quickAmounts}
         />
         <Keypad
+          style={styles.keypad}
           value={amount}
           onChange={handleKeypadChange}
           currency={

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -7118,799 +7118,693 @@ exports[`BuildQuote View Payment Method Data renders no icons if there are no pa
                             style={
                               [
                                 {
-                                  "paddingHorizontal": 25,
+                                  "display": "flex",
+                                  "gap": 12,
                                 },
-                                undefined,
+                                {
+                                  "paddingHorizontal": 16,
+                                },
                               ]
                             }
                           >
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  1
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    1
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  2
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    2
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  3
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    3
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  4
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    4
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  5
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    5
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  6
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    6
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  7
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    7
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  8
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    8
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  9
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    9
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                      {
+                                        "backgroundColor": "transparent",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  .
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    .
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  0
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                delayLongPress={500}
-                                onLongPress={[Function]}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    0
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
-                                testID="keypad-delete-button"
                               >
-                                <Text
-                                  allowFontScaling={false}
-                                  selectable={false}
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  delayLongPress={500}
+                                  onLongPress={[Function]}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": undefined,
-                                        "fontSize": 12,
+                                        "alignItems": "center",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
+                                      undefined,
+                                    ]
+                                  }
+                                  testID="keypad-delete-button"
+                                >
+                                  <SvgMock
+                                    fill="currentColor"
+                                    name="Backspace"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
+                                          "height": 32,
+                                          "width": 32,
                                         },
-                                        {
-                                          "fontSize": 25,
-                                          "marginTop": 5,
-                                        },
-                                      ],
-                                      {
-                                        "fontFamily": "Ionicons",
-                                        "fontStyle": "normal",
-                                        "fontWeight": "normal",
-                                      },
-                                      {},
-                                    ]
-                                  }
-                                >
-                                  
-                                </Text>
-                              </TouchableOpacity>
+                                        undefined,
+                                      ]
+                                    }
+                                  />
+                                </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                           <View
@@ -12498,799 +12392,693 @@ exports[`BuildQuote View renders correctly 1`] = `
                             style={
                               [
                                 {
-                                  "paddingHorizontal": 25,
+                                  "display": "flex",
+                                  "gap": 12,
                                 },
-                                undefined,
+                                {
+                                  "paddingHorizontal": 16,
+                                },
                               ]
                             }
                           >
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  1
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    1
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  2
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    2
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  3
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    3
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  4
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    4
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  5
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    5
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  6
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    6
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  7
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    7
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  8
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    8
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  9
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    9
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                      {
+                                        "backgroundColor": "transparent",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  .
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    .
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  0
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                delayLongPress={500}
-                                onLongPress={[Function]}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    0
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
-                                testID="keypad-delete-button"
                               >
-                                <Text
-                                  allowFontScaling={false}
-                                  selectable={false}
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  delayLongPress={500}
+                                  onLongPress={[Function]}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": undefined,
-                                        "fontSize": 12,
+                                        "alignItems": "center",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
+                                      undefined,
+                                    ]
+                                  }
+                                  testID="keypad-delete-button"
+                                >
+                                  <SvgMock
+                                    fill="currentColor"
+                                    name="Backspace"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
+                                          "height": 32,
+                                          "width": 32,
                                         },
-                                        {
-                                          "fontSize": 25,
-                                          "marginTop": 5,
-                                        },
-                                      ],
-                                      {
-                                        "fontFamily": "Ionicons",
-                                        "fontStyle": "normal",
-                                        "fontWeight": "normal",
-                                      },
-                                      {},
-                                    ]
-                                  }
-                                >
-                                  
-                                </Text>
-                              </TouchableOpacity>
+                                        undefined,
+                                      ]
+                                    }
+                                  />
+                                </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                           <View
@@ -15311,799 +15099,693 @@ exports[`BuildQuote View renders correctly 2`] = `
                             style={
                               [
                                 {
-                                  "paddingHorizontal": 25,
+                                  "display": "flex",
+                                  "gap": 12,
                                 },
-                                undefined,
+                                {
+                                  "paddingHorizontal": 16,
+                                },
                               ]
                             }
                           >
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  1
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    1
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  2
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    2
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  3
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    3
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  4
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    4
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  5
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    5
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  6
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    6
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  7
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    7
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  8
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    8
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      [
-                                        {
-                                          "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
-                                        },
-                                        undefined,
-                                      ],
                                     ]
                                   }
                                 >
-                                  9
-                                </Text>
-                              </TouchableOpacity>
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    9
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
                             </View>
                             <View
                               style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "space-around",
-                                }
+                                [
+                                  {
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 12,
+                                    "justifyContent": "space-between",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
-                              <TouchableOpacity
-                                onPress={[Function]}
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                      {
+                                        "backgroundColor": "transparent",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  .
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                accessibilityRole="button"
-                                accessible={true}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    .
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
                               >
-                                <Text
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": "#121314",
-                                        "fontFamily": "CentraNo1-Book",
-                                        "fontSize": 30,
-                                        "fontWeight": "400",
-                                        "marginVertical": 2,
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3c4d9d0f",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
                                       undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="none"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
+                                          "fontFamily": "Geist Bold",
+                                          "fontSize": 32,
+                                          "fontWeight": "500",
+                                          "letterSpacing": 0,
+                                          "lineHeight": 40,
                                           "textAlign": "center",
                                         },
                                         undefined,
-                                      ],
-                                    ]
-                                  }
-                                >
-                                  0
-                                </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
-                                delayLongPress={500}
-                                onLongPress={[Function]}
-                                onPress={[Function]}
+                                      ]
+                                    }
+                                  >
+                                    0
+                                  </Text>
+                                </TouchableOpacity>
+                              </View>
+                              <View
                                 style={
                                   [
                                     {
-                                      "alignItems": "center",
-                                      "flex": 1,
-                                      "justifyContent": "center",
-                                      "paddingHorizontal": 20,
-                                      "paddingVertical": 12,
+                                      "display": "flex",
+                                      "flexBasis": "0%",
+                                      "flexGrow": 1,
+                                      "flexShrink": 1,
                                     },
                                     undefined,
                                   ]
                                 }
-                                testID="keypad-delete-button"
                               >
-                                <Text
-                                  allowFontScaling={false}
-                                  selectable={false}
+                                <TouchableOpacity
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  delayLongPress={500}
+                                  onLongPress={[Function]}
+                                  onPress={[Function]}
                                   style={
                                     [
                                       {
-                                        "color": undefined,
-                                        "fontSize": 12,
+                                        "alignItems": "center",
+                                        "borderRadius": 12,
+                                        "height": 40,
+                                        "justifyContent": "center",
+                                        "paddingHorizontal": 16,
                                       },
+                                      undefined,
+                                    ]
+                                  }
+                                  testID="keypad-delete-button"
+                                >
+                                  <SvgMock
+                                    fill="currentColor"
+                                    name="Backspace"
+                                    style={
                                       [
                                         {
                                           "color": "#121314",
-                                          "fontSize": 30,
-                                          "textAlign": "center",
+                                          "height": 32,
+                                          "width": 32,
                                         },
-                                        {
-                                          "fontSize": 25,
-                                          "marginTop": 5,
-                                        },
-                                      ],
-                                      {
-                                        "fontFamily": "Ionicons",
-                                        "fontStyle": "normal",
-                                        "fontWeight": "normal",
-                                      },
-                                      {},
-                                    ]
-                                  }
-                                >
-                                  
-                                </Text>
-                              </TouchableOpacity>
+                                        undefined,
+                                      ]
+                                    }
+                                  />
+                                </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                           <View

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.styles.ts
@@ -73,9 +73,7 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 12,
       borderWidth: 1,
       borderColor: theme.colors.border.muted,
-    },
-    keypad: {
-      paddingHorizontal: 0,
+      marginBottom: 16,
     },
     errorText: {
       textAlign: 'center',

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -604,11 +604,13 @@ const BuildQuote = () => {
           </TouchableOpacity>
 
           <Keypad
-            style={styles.keypad}
             value={amount}
             onChange={handleKeypadChange}
             currency={fiatCurrency.symbol}
             decimals={0}
+            periodButtonProps={{
+              isDisabled: true,
+            }}
           />
         </ScreenLayout.Content>
       </ScreenLayout.Body>

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -914,6 +914,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -1071,799 +1072,690 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -2849,6 +2741,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -3006,799 +2899,690 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -4784,6 +4568,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -4941,799 +4726,690 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -6695,6 +6371,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -6852,799 +6529,690 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -8606,6 +8174,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -8763,799 +8332,690 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -10516,6 +9976,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -10673,799 +10134,690 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -12427,6 +11779,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -12584,799 +11937,690 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>
@@ -14338,6 +13582,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                   "borderColor": "#b7bbc866",
                                   "borderRadius": 12,
                                   "borderWidth": 1,
+                                  "marginBottom": 16,
                                 }
                               }
                             >
@@ -14495,799 +13740,690 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                               style={
                                 [
                                   {
-                                    "paddingHorizontal": 25,
+                                    "display": "flex",
+                                    "gap": 12,
                                   },
-                                  {
-                                    "paddingHorizontal": 0,
-                                  },
+                                  undefined,
                                 ]
                               }
                             >
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    1
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    2
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    3
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    4
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    5
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    6
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    7
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    8
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
                                         undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    9
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                               <View
                                 style={
-                                  {
-                                    "flexDirection": "row",
-                                    "justifyContent": "space-around",
-                                  }
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
                                 >
-                                  <Text
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
-                                      ]
-                                    }
-                                  />
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  onPress={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
-                                >
-                                  <Text
-                                    style={
-                                      [
                                         {
-                                          "color": "#121314",
-                                          "fontFamily": "CentraNo1-Book",
-                                          "fontSize": 30,
-                                          "fontWeight": "400",
-                                          "marginVertical": 2,
+                                          "backgroundColor": "transparent",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          undefined,
-                                        ],
                                       ]
                                     }
                                   >
-                                    0
-                                  </Text>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  delayLongPress={500}
-                                  onLongPress={[Function]}
-                                  onPress={[Function]}
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                                <View
                                   style={
                                     [
                                       {
-                                        "alignItems": "center",
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                        "paddingHorizontal": 20,
-                                        "paddingVertical": 12,
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
                                       },
                                       undefined,
                                     ]
                                   }
-                                  testID="keypad-delete-button"
                                 >
-                                  <Text
-                                    allowFontScaling={false}
-                                    selectable={false}
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
                                     style={
                                       [
                                         {
-                                          "color": undefined,
-                                          "fontSize": 12,
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
                                         },
-                                        [
-                                          {
-                                            "color": "#121314",
-                                            "fontSize": 30,
-                                            "textAlign": "center",
-                                          },
-                                          {
-                                            "fontSize": 25,
-                                            "marginTop": 5,
-                                          },
-                                        ],
-                                        {
-                                          "fontFamily": "Ionicons",
-                                          "fontStyle": "normal",
-                                          "fontWeight": "normal",
-                                        },
-                                        {},
+                                        undefined,
                                       ]
                                     }
                                   >
-                                    
-                                  </Text>
-                                </TouchableOpacity>
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -112,6 +112,7 @@ const createStyles = (colors) =>
     keypad: {
       flexGrow: 1,
       justifyContent: 'space-around',
+      paddingHorizontal: 16,
     },
     tokenButtonContainer: {
       flexDirection: 'row',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR represents Part 2 of the Keypad UI component refactoring. This iteration takes a more conservative approach by reducing the usage of design system components compared to the initial implementation, serving as a middle ground solution to address failing e2e tests encountered in the previous version.

The changes consolidate the Keypad component from multiple locations (previously in `Ramp/Aggregator`) into a single, reusable component in `app/components/Base/Keypad/`, while maintaining a balance between design system adoption and stability.

Key improvements:

1. Unified Keypad component location - moved from `Ramp/Aggregator` to `Base` directory
2. Partial adoption of design system components (Box, Text, Icon) while keeping TouchableOpacity for button interactions
3. Added configurable props for period and delete buttons to support different use cases
4. Maintained backward compatibility with existing implementations

## **Changelog**

CHANGELOG entry: Refactored Keypad component to use partial design system components and consolidated into a single reusable component

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-25

## **Manual testing steps**

```gherkin
Feature: Keypad Component Functionality

  Scenario: User enters numeric values using the keypad
    Given the user is on a screen with the Keypad component (e.g., Bridge, Earn, Perps, or Ramp screens)

    When user taps numeric buttons on the keypad
    Then the input field should display the entered numbers correctly
    And the decimal separator should work according to the currency settings

  Scenario: User deletes characters using the keypad
    Given the user has entered some numeric values

    When user taps the delete button
    Then the last character should be removed from the input

  Scenario: Decimal input is disabled when configured
    Given the user is on BuildQuote screen in Ramp

    When user attempts to tap the period button
    Then the period button should be disabled (grayed out)
    And no decimal point should be added to the input
```

## **Screenshots/Recordings**

### **Before**

- Keypad components were duplicated in multiple locations (`Ramp/Aggregator`)
- Inconsistent styling across different implementations
- No design system component usage

### **After**

- Single, unified Keypad component in `Base` directory
- Consistent styling using partial design system components
- Configurable button props for different use cases
- Improved maintainability

https://github.com/user-attachments/assets/fed60b35-ad8f-4ba0-a7a1-c31bd3f37571

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
