### PR TITLE
fix: cp-7.53.0 handle unrecognised Blockaid reasons in confirmation alerts

### DIFF
--- a/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.test.tsx
+++ b/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.test.tsx
@@ -10,6 +10,7 @@ import { deflate } from 'react-native-gzip';
 import { BLOCKAID_SUPPORTED_NETWORK_NAMES } from '../../../../../util/networks';
 import BlockaidVersionInfo from '../../../../../lib/ppom/blockaid-version';
 import { ResultType as BlockaidResultType } from '../../constants/signatures';
+import { strings } from '../../../../../../locales/i18n';
 
 jest.mock('react-native-gzip', () => ({
   deflate: jest.fn().mockResolvedValue('compressedData'),
@@ -160,5 +161,24 @@ describe('BlockaidAlertContent', () => {
     await waitFor(() => {
       expect(deflate).not.toHaveBeenCalled();
     });
+  });
+
+  it('renders generic reason message if reason not recognised', () => {
+    const mockSecurityAlertResponseWithUnknownReason: SecurityAlertResponse = {
+      ...mockSecurityAlertResponse,
+      reason: 'unknown_reason' as Reason,
+    };
+
+    const { getByText } = render(
+      <BlockaidAlertContent
+        alertDetails={ALERT_DETAILS_MOCK}
+        securityAlertResponse={mockSecurityAlertResponseWithUnknownReason}
+        onContactUsClicked={mockOnContactUsClicked}
+      />,
+    );
+
+    expect(
+      getByText(strings('blockaid_banner.other_description')),
+    ).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.tsx
+++ b/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.tsx
@@ -93,7 +93,7 @@ const BlockaidAlertContent: React.FC<BlockaidAlertContentProps> = ({
         {strings(
           REASON_DESCRIPTION_I18N_KEY_MAP[
             securityAlertResponse.reason as Reason
-          ],
+          ] ?? 'blockaid_banner.other_description',
         )}
       </Text>
       <Accordion


### PR DESCRIPTION
## **Description**

Handle unrecognised Blockaid reasons in confirmation alerts, by displaying a generic message as a fallback.

## **Changelog**

CHANGELOG entry: Fixed bug causing missing translation error in some Blockaid alerts

## **Related issues**

Fixes: #17823 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
