### PR TITLE
fix: Market price should render market price, not liquidity price

### DIFF
--- a/app/components/UI/Perps/Views/PerpsPositionDetailsView/PerpsPositionDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionDetailsView/PerpsPositionDetailsView.tsx
@@ -163,6 +163,7 @@ const PerpsPositionDetailsView: React.FC = () => {
             position={position}
             onClose={handleCloseClick}
             onEdit={handleEditTPSL}
+            priceData={priceData}
           />
         </View>
       </ScrollView>

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -21,6 +21,7 @@ import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import type {
   PerpsNavigationParamList,
   Position,
+  PriceUpdate,
 } from '../../controllers/types';
 import {
   formatPercentage,
@@ -43,6 +44,7 @@ interface PerpsPositionCardProps {
   showIcon?: boolean;
   rightAccessory?: React.ReactNode;
   isInPerpsNavContext?: boolean; // NEW: Indicates if this is used within the Perps navigation stack
+  priceData?: PriceUpdate | null; // Current market price data
 }
 
 const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
@@ -54,6 +56,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
   showIcon = false, // Default to not showing icon
   rightAccessory,
   isInPerpsNavContext = true, // Default to true since most usage is within Perps stack
+  priceData,
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
@@ -236,7 +239,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 variant={TextVariant.BodySMMedium}
                 color={TextColor.Default}
               >
-                {formatPrice(position.liquidationPrice || position.entryPrice)}
+                {priceData?.price ? formatPrice(priceData.price) : ''}
               </Text>
             </View>
             <View style={styles.bodyItem}>


### PR DESCRIPTION
## **Description**

Fixes bug where perps position card was rendering liquidity price instead of market price of perp.

## **Changelog**

CHANGELOG entry: fixes bug on perps position detail card

## **Related issues**

Fixes:

## **Manual testing steps**

Market price should match the price of the perp in the header

## **Screenshots/Recordings**

<img width="403" height="690" alt="Screenshot 2025-08-07 at 12 43 12 PM" src="https://github.com/user-attachments/assets/5a30791f-6fba-453b-9211-37a5dbb13279" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
