### PR TITLE
chore: deprecate reusable modal and suggest bottom sheet

### DIFF
--- a/app/components/UI/ReusableModal/index.tsx
+++ b/app/components/UI/ReusableModal/index.tsx
@@ -46,6 +46,14 @@ import {
 // Export to make compatible with components that use this file.
 export type { ReusableModalRef } from './ReusableModal.types';
 
+/**
+ * @deprecated The `<ReusableModal />` component has been deprecated in favor of the new `<BottomSheet>` component from the component-library.
+ * Please update your code to use the new `<BottomSheet>` component instead, which can be found at app/component-library/components/BottomSheets/BottomSheet/BottomSheet.tsx.
+ * You can find documentation for the new BottomSheet component in the README:
+ * {@link https://github.com/MetaMask/metamask-mobile/tree/main/app/component-library/components/BottomSheets/BottomSheet}
+ * If you would like to help with the replacement of the old ReusableModal component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-mobile/issues/12656}
+ */
 const ReusableModal = forwardRef<ReusableModalRef, ReusableModalProps>(
   (
     {


### PR DESCRIPTION
## **Description**

This PR adds a deprecation notice to the `ReusableModal` component to guide developers towards using the new `BottomSheet` component from the component-library. The deprecation notice includes JSDoc comments with links to the new component's documentation and the GitHub issue tracking the migration effort. This change helps maintain code consistency and encourages adoption of the newer, more maintainable component architecture.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: ReusableModal deprecation notice
  Scenario: Developer sees deprecation notice when using ReusableModal
    Given the codebase contains the ReusableModal component
    When a developer hovers over or uses the ReusableModal component in their IDE
    Then they see a deprecation notice with guidance to use BottomSheet instead
    And the notice includes links to documentation and the migration tracking issue
```

## **Screenshots/Recordings**

### **Before**

The ReusableModal component had no deprecation notice, leaving developers unaware of the preferred BottomSheet alternative.

<img width="457" height="241" alt="Screenshot 2025-08-18 at 11 16 36 AM" src="https://github.com/user-attachments/assets/b72438fc-eb75-44f3-b00b-30c00c0dc4ee" />

### **After**

The ReusableModal component now displays a clear deprecation notice in IDEs with:
- Explanation that the component is deprecated
- Direction to use the new BottomSheet component
- Path to the new component location
- Link to BottomSheet documentation
- Link to the GitHub issue for contributing to the migration effort

<img width="639" height="399" alt="Screenshot 2025-08-18 at 11 15 54 AM" src="https://github.com/user-attachments/assets/377a3a6f-0e04-4dbd-9f92-3baece217a7a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation change only)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.