### PR TITLE
fix: Tweak send max calculation to use max possible actual gas fees

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -26,6 +26,16 @@ jest.mock('../../hooks/useConfirmActions', () => ({
   }),
 }));
 
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
   openURL: jest.fn(),
   addEventListener: jest.fn(),

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Linking, View } from 'react-native';
 import { providerErrors } from '@metamask/rpc-errors';
+import { useNavigation } from '@react-navigation/native';
 
 import { ConfirmationFooterSelectorIDs } from '../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { strings } from '../../../../../../locales/i18n';
@@ -28,6 +29,7 @@ import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmat
 import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { isStakingConfirmation } from '../../utils/confirm';
 import styleSheet from './footer.styles';
+import Routes from '../../../../../constants/navigation/Routes';
 
 export const Footer = () => {
   const {
@@ -50,6 +52,7 @@ export const Footer = () => {
   );
   const { isFooterVisible, isTransactionValueUpdating } =
     useConfirmationContext();
+  const navigation = useNavigation();
 
   const [confirmAlertModalVisible, setConfirmAlertModalVisible] =
     useState(false);
@@ -69,8 +72,12 @@ export const Footer = () => {
 
   const onHandleConfirm = useCallback(async () => {
     hideConfirmAlertModal();
-    await onConfirm();
-  }, [hideConfirmAlertModal, onConfirm]);
+    try {
+      await onConfirm();
+    } catch (error) {
+      navigation.navigate(Routes.TRANSACTIONS_VIEW);
+    }
+  }, [hideConfirmAlertModal, onConfirm, navigation]);
 
   const onSignConfirm = useCallback(async () => {
     if (hasDangerAlerts) {

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -32,7 +32,9 @@ const EstimationInfo = ({
   fiatOnly,
 }: {
   hideFiatForTestnet: boolean;
-  feeCalculations: ReturnType<typeof useFeeCalculations>;
+  feeCalculations:
+    | ReturnType<typeof useFeeCalculations>
+    | ReturnType<typeof useFeeCalculationsTransactionBatch>;
   fiatOnly: boolean;
 }) => {
   const { styles } = useStyles(styleSheet, {});

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -1,5 +1,4 @@
 import { cloneDeep } from 'lodash';
-import { TransactionParams } from '@metamask/transaction-controller';
 
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { stakingDepositConfirmationState } from '../../../../../util/test/confirm-data-helpers';
@@ -38,30 +37,6 @@ describe('useFeeCalculations', () => {
   const transactionMeta =
     stakingDepositConfirmationState.engine.backgroundState.TransactionController
       .transactions[0];
-
-  it('returns no estimates for empty txParams', () => {
-    const clonedStateWithoutTxParams = cloneDeep(
-      stakingDepositConfirmationState,
-    );
-    clonedStateWithoutTxParams.engine.backgroundState.TransactionController.transactions[0].txParams =
-      undefined as unknown as TransactionParams;
-
-    const transactionMetaWithoutTxParams =
-      clonedStateWithoutTxParams.engine.backgroundState.TransactionController
-        .transactions[0];
-
-    const { result } = renderHookWithProvider(
-      () => useFeeCalculations(transactionMetaWithoutTxParams),
-      {
-        state: clonedStateWithoutTxParams,
-      },
-    );
-
-    expect(result.current.estimatedFeeFiat).toBe('< $0.01');
-    expect(result.current.estimatedFeeNative).toBe('0 ETH');
-    expect(result.current.preciseNativeFeeInHex).toBe('0x0');
-    expect(result.current.calculateGasEstimate).toBeDefined();
-  });
 
   it('returns fee calculations', () => {
     const { result } = renderHookWithProvider(

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -100,12 +100,16 @@ export const useFeeCalculations = (transactionMeta: TransactionMeta) => {
   );
 
   // Max fee
-  const maxFee = useMemo(() => multiplyHexes(
-      supportsEIP1559
-        ? (decimalToHex(maxFeePerGas) as Hex)
-        : (txParamsGasPrice as Hex),
-      gasLimitNoBuffer as Hex,
-    ), [supportsEIP1559, maxFeePerGas, txParamsGasPrice, gasLimitNoBuffer]);
+  const maxFee = useMemo(
+    () =>
+      multiplyHexes(
+        supportsEIP1559
+          ? (decimalToHex(maxFeePerGas) as Hex)
+          : (txParamsGasPrice as Hex),
+        gasLimitNoBuffer as Hex,
+      ),
+    [supportsEIP1559, maxFeePerGas, txParamsGasPrice, gasLimitNoBuffer],
+  );
 
   const {
     currentCurrencyFee: maxFeeFiat,

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -17,7 +17,35 @@ import { useGasFeeEstimates } from './useGasFeeEstimates';
 
 const HEX_ZERO = '0x0';
 
-export const useFeeCalculations = (transactionMeta: TransactionMeta) => {
+export const useFeeCalculations = (
+  transactionMeta: TransactionMeta,
+): {
+  estimatedFeeFiat: string | null;
+  estimatedFeeNative: string | null;
+  preciseNativeFeeInHex: string | null;
+  calculateGasEstimate: ({
+    feePerGas,
+    gasPrice,
+    gas,
+    shouldUseEIP1559FeeLogic,
+    priorityFeePerGas,
+  }: {
+    feePerGas: string;
+    gasPrice: string;
+    gas: string;
+    shouldUseEIP1559FeeLogic: boolean;
+    priorityFeePerGas: string;
+  }) => {
+    currentCurrencyFee: string | null;
+    nativeCurrencyFee: string | null;
+    preciseNativeCurrencyFee: string | null;
+    preciseNativeFeeInHex: string | null;
+  };
+  maxFeeFiat: string | null;
+  maxFeeNative: string | null;
+  maxFeeNativePrecise: string | null;
+  maxFeeNativeHex: string | null;
+} => {
   const { chainId, gasLimitNoBuffer, layer1GasFee, networkClientId } =
     transactionMeta;
 
@@ -106,9 +134,14 @@ export const useFeeCalculations = (transactionMeta: TransactionMeta) => {
         supportsEIP1559
           ? (decimalToHex(maxFeePerGas) as Hex)
           : (txParamsGasPrice as Hex),
-        gasLimitNoBuffer as Hex,
+        transactionMeta.txParams.gas,
       ),
-    [supportsEIP1559, maxFeePerGas, txParamsGasPrice, gasLimitNoBuffer],
+    [
+      supportsEIP1559,
+      maxFeePerGas,
+      txParamsGasPrice,
+      transactionMeta.txParams.gas,
+    ],
   );
 
   const {

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -10,6 +10,7 @@ import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
 import { isTestNet } from '../../../../../util/networks';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { calculateGasEstimate, getFeesFromHex } from '../../utils/gas';
+import { decimalToHex, multiplyHexes } from '../../../../../util/conversions';
 import { useSupportsEIP1559 } from '../transactions/useSupportsEIP1559';
 import { useEIP1559TxFees } from './useEIP1559TxFees';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
@@ -98,10 +99,29 @@ export const useFeeCalculations = (transactionMeta: TransactionMeta) => {
     ],
   );
 
+  // Max fee
+  const maxFee = useMemo(() => multiplyHexes(
+      supportsEIP1559
+        ? (decimalToHex(maxFeePerGas) as Hex)
+        : (txParamsGasPrice as Hex),
+      gasLimitNoBuffer as Hex,
+    ), [supportsEIP1559, maxFeePerGas, txParamsGasPrice, gasLimitNoBuffer]);
+
+  const {
+    currentCurrencyFee: maxFeeFiat,
+    nativeCurrencyFee: maxFeeNative,
+    preciseNativeCurrencyFee: maxFeeNativePrecise,
+    preciseNativeFeeInHex: maxFeeNativeHex,
+  } = getFeesFromHexCallback(maxFee);
+
   return {
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,
     estimatedFeeNative: estimatedFees.nativeCurrencyFee,
     preciseNativeFeeInHex: estimatedFees.preciseNativeFeeInHex,
     calculateGasEstimate: calculateGasEstimateCallback,
+    maxFeeFiat,
+    maxFeeNative,
+    maxFeeNativePrecise,
+    maxFeeNativeHex,
   };
 };

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
@@ -91,6 +91,10 @@ describe('useGasFeeToken', () => {
       preciseNativeFeeInHex: '0x1',
       estimatedFeeFiat: null,
       estimatedFeeNative: null,
+      maxFeeFiat: null,
+      maxFeeNative: null,
+      maxFeeNativePrecise: null,
+      maxFeeNativeHex: null,
       calculateGasEstimate: jest.fn(),
     } as ReturnType<typeof useFeeCalculations>);
   });

--- a/app/components/Views/confirmations/hooks/useApprovalRequest.ts
+++ b/app/components/Views/confirmations/hooks/useApprovalRequest.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { cloneDeep, isEqual } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { providerErrors } from '@metamask/rpc-errors';
-import { captureException } from '@sentry/react-native';
 import Engine from '../../../../core/Engine';
 import { selectPendingApprovals } from '../../../../selectors/approvalController';
 
@@ -30,15 +29,11 @@ const useApprovalRequest = () => {
       value?: Parameters<typeof Engine.acceptPendingApproval>[1],
     ) => {
       if (!approvalRequest) return;
-      try {
-        await Engine.acceptPendingApproval(
-          approvalRequest.id,
-          { ...approvalRequest.requestData, ...(value || {}) },
-          opts,
-        );
-      } catch (error: Error | unknown) {
-        captureException(error);
-      }
+      await Engine.acceptPendingApproval(
+        approvalRequest.id,
+        { ...approvalRequest.requestData, ...(value || {}) },
+        opts,
+      );
     },
     [approvalRequest],
   );

--- a/app/components/Views/confirmations/hooks/useApprovalRequest.ts
+++ b/app/components/Views/confirmations/hooks/useApprovalRequest.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { cloneDeep, isEqual } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { providerErrors } from '@metamask/rpc-errors';
+import { captureException } from '@sentry/react-native';
 import Engine from '../../../../core/Engine';
 import { selectPendingApprovals } from '../../../../selectors/approvalController';
 
@@ -29,12 +30,15 @@ const useApprovalRequest = () => {
       value?: Parameters<typeof Engine.acceptPendingApproval>[1],
     ) => {
       if (!approvalRequest) return;
-
-      await Engine.acceptPendingApproval(
-        approvalRequest.id,
-        { ...approvalRequest.requestData, ...(value || {}) },
-        opts,
-      );
+      try {
+        await Engine.acceptPendingApproval(
+          approvalRequest.id,
+          { ...approvalRequest.requestData, ...(value || {}) },
+          opts,
+        );
+      } catch (error: Error | unknown) {
+        captureException(error);
+      }
     },
     [approvalRequest],
   );

--- a/app/components/Views/confirmations/hooks/useMaxValueRefresher.test.ts
+++ b/app/components/Views/confirmations/hooks/useMaxValueRefresher.test.ts
@@ -52,7 +52,7 @@ describe('useMaxValueRefresher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseFeeCalculations.mockReturnValue({
-      preciseNativeFeeInHex: '0x5',
+      maxFeeNativeHex: '0x5',
     } as unknown as ReturnType<typeof useFeeCalculations>);
 
     mockUseSelector.mockImplementation(

--- a/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
+++ b/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
@@ -23,7 +23,7 @@ export function useMaxValueRefresher() {
   const transactionMetadata = useTransactionMetadataRequest();
   const { chainId, id, txParams, type } =
     transactionMetadata as TransactionMeta;
-  const { preciseNativeFeeInHex } = useFeeCalculations(
+  const { maxFeeNativeHex } = useFeeCalculations(
     transactionMetadata as TransactionMeta,
   );
   const { balanceWeiInHex } = useAccountNativeBalance(chainId, txParams.from);
@@ -35,8 +35,8 @@ export function useMaxValueRefresher() {
     }
 
     const balance = new BigNumber(balanceWeiInHex);
-    const fee = new BigNumber(preciseNativeFeeInHex as Hex);
-    const maxValue = balance.minus(fee);
+    const maxPossibleFee = new BigNumber(maxFeeNativeHex as Hex);
+    const maxValue = balance.minus(maxPossibleFee);
     const maxValueHex = add0x(maxValue.toString(16));
     const shouldUpdate = maxValueHex !== txParams.value;
 
@@ -51,7 +51,7 @@ export function useMaxValueRefresher() {
     balanceWeiInHex,
     id,
     maxValueMode,
-    preciseNativeFeeInHex,
+    maxFeeNativeHex,
     setIsTransactionValueUpdating,
     txParams,
     type,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The way we calculated the value to send all native asset funds of the wallet, subtracted the estimated gas fees to the balance. However, this may not always be sufficient given the gas fee market fluctuations. The estimated fee is not guaranteed to be enough for the transaction to be confirmed.

Where the estimated fee is calculated from the minimumFeePerGas * the gas limit (and the minimumFeePerGas is the minimum value between the maxFeePerGas and the sum of the estimatedBaseFee and maxPriorityFeePerGas), the max fee is calculated from the maxFeePerGas * the gas limit directly. This means that the maxFee is greater or equal than the estimated fee.

This PR implements the calculation of the max fee so we can use it to calculate the total to transfer, lowering the likelihood of failing transactions.

Something must have changed on the gas API last week, because this is a recent regression only now reported, and the client code hasn't changed. In fact, I tested that this regression is now happening on old client code, at least as old as [#15074](https://github.com/MetaMask/metamask-mobile/pull/15074).

[#17865](https://github.com/MetaMask/metamask-mobile/issues/17865) should not happen anymore with this fix, but a try catch was wrapped around `Engine.acceptPendingApproval` in any case, to prevent instances of a transaction failure error bubbling up to the navigation code again.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: [#17865](https://github.com/MetaMask/metamask-mobile/issues/17865) and [#17836](https://github.com/MetaMask/metamask-mobile/issues/17836)

## **Manual testing steps**

```gherkin
Feature: my feature name
  Scenario: user [verb for user action]
    Given [describe expected initial app state] 
    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
