### PR TITLE
chore: add predictEnabled feature flag

### DIFF
--- a/app/selectors/featureFlagController/predict/index.test.ts
+++ b/app/selectors/featureFlagController/predict/index.test.ts
@@ -1,12 +1,19 @@
-import { selectPredictEnabledFlag } from '.';
-import { selectRemoteFeatureFlags } from '..';
+import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+import { selectPredictEnabledFlag, FEATURE_FLAG_NAME } from './';
 
 describe('selectPredictEnabledFlag', () => {
-  type RemoteFlags = ReturnType<typeof selectRemoteFeatureFlags> & {
-    predictEnabled?: boolean;
-  };
+  const createMockState = (remoteFlags: FeatureFlags = {}) => ({
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: remoteFlags,
+          cacheTimestamp: 0,
+        },
+      },
+    },
+  });
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
@@ -15,10 +22,10 @@ describe('selectPredictEnabledFlag', () => {
     { flag: false, expected: false },
   ])('returns $expected when predictEnabled is $flag', ({ flag, expected }) => {
     // Arrange
-    const remoteFlags: RemoteFlags = { predictEnabled: flag };
+    const mockState = createMockState({ [FEATURE_FLAG_NAME]: flag });
 
     // Act
-    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
+    const result = selectPredictEnabledFlag(mockState);
 
     // Assert
     expect(result).toBe(expected);
@@ -26,21 +33,10 @@ describe('selectPredictEnabledFlag', () => {
 
   it('returns false when predictEnabled is not present', () => {
     // Arrange
-    const remoteFlags: RemoteFlags = {};
+    const mockState = createMockState({});
 
     // Act
-    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
-
-    // Assert
-    expect(result).toBe(false);
-  });
-
-  it('returns false when remote flags are undefined', () => {
-    // Arrange
-    const remoteFlags = undefined as unknown as RemoteFlags;
-
-    // Act
-    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
+    const result = selectPredictEnabledFlag(mockState);
 
     // Assert
     expect(result).toBe(false);

--- a/app/selectors/featureFlagController/predict/index.test.ts
+++ b/app/selectors/featureFlagController/predict/index.test.ts
@@ -1,0 +1,48 @@
+import { selectPredictEnabledFlag } from '.';
+import { selectRemoteFeatureFlags } from '..';
+
+describe('selectPredictEnabledFlag', () => {
+  type RemoteFlags = ReturnType<typeof selectRemoteFeatureFlags> & {
+    predictEnabled?: boolean;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    { flag: true, expected: true },
+    { flag: false, expected: false },
+  ])('returns $expected when predictEnabled is $flag', ({ flag, expected }) => {
+    // Arrange
+    const remoteFlags: RemoteFlags = { predictEnabled: flag };
+
+    // Act
+    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it('returns false when predictEnabled is not present', () => {
+    // Arrange
+    const remoteFlags: RemoteFlags = {};
+
+    // Act
+    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('returns false when remote flags are undefined', () => {
+    // Arrange
+    const remoteFlags = undefined as unknown as RemoteFlags;
+
+    // Act
+    const result = selectPredictEnabledFlag.resultFunc(remoteFlags);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/predict/index.ts
+++ b/app/selectors/featureFlagController/predict/index.ts
@@ -1,0 +1,7 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+
+export const selectPredictEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFlags): boolean => Boolean(remoteFlags?.predictEnabled),
+);

--- a/app/selectors/featureFlagController/predict/index.ts
+++ b/app/selectors/featureFlagController/predict/index.ts
@@ -1,7 +1,14 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import { hasProperty } from '@metamask/utils';
+
+const DEFAULT_PREDICT_ENABLED = false;
+export const FEATURE_FLAG_NAME = 'predictEnabled';
 
 export const selectPredictEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFlags): boolean => Boolean(remoteFlags?.predictEnabled),
+  (remoteFlags) =>
+    hasProperty(remoteFlags, FEATURE_FLAG_NAME)
+      ? (remoteFlags[FEATURE_FLAG_NAME] as boolean)
+      : DEFAULT_PREDICT_ENABLED,
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds a new feature flag for predict

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: [PRED-17](https://consensyssoftware.atlassian.net/browse/PRED-17?atlOrigin=eyJpIjoiYzMyOTA5OGVlZTk5NGUyNzhlNTgxMzhlNzNmMWQ1MWEiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Go to a top app component
2. Add `const isPredictEnabled = useSelector(selectPredictEnabledFlag)` to the top of your component
3. Log result to confirm flag is working as expected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-17]: https://consensyssoftware.atlassian.net/browse/PRED-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ