### PR TITLE
chore: confirmation keypad updates

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -121,6 +121,8 @@ const getStories = () => {
     "./app/components/Base/Keypad/Keypad.stories.tsx": require("../app/components/Base/Keypad/Keypad.stories.tsx"),
     "./app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx": require("../app/components/UI/Swaps/components/LoadingAnimation/ShapesBackgroundAnimation.stories.tsx"),
     "./app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories.tsx": require("../app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.stories.tsx"),
+    "./app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx": require("../app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx"),
+    "./app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx": require("../app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx"),
     "./app/components/Views/QRAccountDisplay/QRAccountDisplay.stories.tsx": require("../app/components/Views/QRAccountDisplay/QRAccountDisplay.stories.tsx"),
   };
 };

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { DepositKeyboard } from './deposit-keyboard';
+
+export default {
+  title: 'Views / Confirmations / Components / Deposit Keyboard',
+  component: DepositKeyboard,
+};
+
+const DefaultDepositKeyboardStory = () => {
+  const [value, setValue] = useState('0');
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+  };
+
+  const handlePercentagePress = (percentage: number) => {
+    console.log(`Percentage pressed: ${percentage}%`);
+  };
+
+  const handleDonePress = () => {
+    console.log('Done pressed');
+  };
+
+  return (
+    <DepositKeyboard
+      value={value}
+      onChange={handleChange}
+      onPercentagePress={handlePercentagePress}
+      onDonePress={handleDonePress}
+    />
+  );
+};
+
+export const Default = {
+  render: DefaultDepositKeyboardStory,
+};

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState } from 'react';
 import { DepositKeyboard } from './deposit-keyboard';
 

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.styles.ts
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.styles.ts
@@ -9,7 +9,7 @@ const styleSheet = (params: { theme: Theme }) =>
       height: 48,
       flexGrow: 1,
       fontSize: 20,
-      marginBottom: 5,
+      marginBottom: 12,
     },
   });
 

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.styles.ts
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.styles.ts
@@ -3,21 +3,9 @@ import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
-    container: {
-      paddingHorizontal: 0,
-      marginInline: -5,
-      justifyContent: 'center',
-    },
-    digitButton: {
-      borderRadius: 12,
-      backgroundColor: params.theme.colors.background.default,
-      paddingVertical: 6,
-      margin: 5,
-      padding: 0,
-    },
     percentageButton: {
       borderRadius: 12,
-      backgroundColor: params.theme.colors.background.default,
+      backgroundColor: params.theme.colors.background.muted,
       height: 48,
       flexGrow: 1,
       fontSize: 20,

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -63,8 +63,6 @@ export function DepositKeyboard({
       <KeypadComponent
         value={valueString}
         onChange={handleChange}
-        style={styles.container}
-        digitButtonStyle={styles.digitButton}
         currency="native"
       />
     </View>

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState } from 'react';
 import { EditAmountKeyboard } from './edit-amount-keyboard';
 

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { EditAmountKeyboard } from './edit-amount-keyboard';
+
+export default {
+  title: 'Views / Confirmations / Components / Edit Amount Keyboard',
+  component: EditAmountKeyboard,
+};
+
+const DefaultEditAmountKeyboardStory = () => {
+  const [value, setValue] = useState('0');
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+  };
+
+  const handlePercentagePress = (percentage: number) => {
+    console.log(`Percentage pressed: ${percentage}%`);
+  };
+
+  const handleDonePress = () => {
+    console.log('Done pressed');
+  };
+
+  return (
+    <EditAmountKeyboard
+      value={value}
+      onChange={handleChange}
+      onPercentagePress={handlePercentagePress}
+      onDonePress={handleDonePress}
+    />
+  );
+};
+
+export const Default = {
+  render: DefaultEditAmountKeyboardStory,
+};

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.styles.ts
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.styles.ts
@@ -4,7 +4,7 @@ import { Theme } from '../../../../../util/theme/models';
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
     additionalButtons: {
-      paddingBottom: 4,
+      paddingBottom: 12,
     },
     wrapper: {
       backgroundColor: params.theme.colors.background.alternative,

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.styles.ts
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.styles.ts
@@ -13,21 +13,6 @@ const styleSheet = (params: { theme: Theme }) =>
       padding: 12,
       paddingBottom: 20,
     },
-    container: {
-      display: 'flex',
-      justifyContent: 'space-evenly',
-      paddingHorizontal: 0,
-      marginInline: -5,
-      position: 'relative',
-      bottom: 0,
-    },
-    digitButton: {
-      borderRadius: 12,
-      backgroundColor: params.theme.colors.background.muted,
-      paddingVertical: 6,
-      margin: 5,
-      padding: 0,
-    },
     percentageButton: {
       borderRadius: 12,
       backgroundColor: params.theme.colors.background.muted,

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.tsx
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.tsx
@@ -76,8 +76,6 @@ export function EditAmountKeyboard({
       <KeypadComponent
         value={value}
         onChange={handleChange}
-        style={styles.container}
-        digitButtonStyle={styles.digitButton}
         currency="native"
       />
     </View>


### PR DESCRIPTION
## **Description**

This PR updates the `EditAmountKeyboard` and `DepositKeyboard` components in preparation for the Keypad unification effort outlined in [[Part 2](https://github.com/MetaMask/metamask-mobile/pull/18055)](https://github.com/MetaMask/metamask-mobile/pull/18055). [[Part 1](https://github.com/MetaMask/metamask-mobile/pull/17782)](https://github.com/MetaMask/metamask-mobile/pull/17782) was merged shortly after these components were introduced and did not include them in the unification work. Once Part 2 is merged, the Keypad UI will be fully updated and consistent across mobile.

***Reason for the change***
These components were created just before the unification work began and were missed during the initial refactor. This PR ensures they are aligned with the upcoming unified Keypad design.

***Improvements/solutions***

* Added complete Storybook stories for both `EditAmountKeyboard` and `DepositKeyboard`
* Removed unused styles that will be addressed in [[Part 2](https://github.com/MetaMask/metamask-mobile/pull/18055)](https://github.com/MetaMask/metamask-mobile/pull/18055)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A
Related: https://github.com/MetaMask/metamask-mobile/pull/18055

## **Manual testing steps**

```gherkin
Feature: Storybook stories for keypad components
  Scenario: developer views component documentation
    Given Storybook is running 
    When developer navigates to "Views / Confirmations / Components"
    Then they can see EditAmountKeyboard and DepositKeyboard stories
    And they can interact with different story variants
```

## **Screenshots/Recordings**

### **Before** (`main`)

Error message as `digitButtonStyle` was removed in part 1 of keypad unification PR https://github.com/MetaMask/metamask-mobile/pull/17782 

<img width="1106" height="396" alt="Screenshot 2025-08-09 at 9 01 22 AM" src="https://github.com/user-attachments/assets/c408850e-3184-4ab4-9719-eaf46fadd937" />

No stories exist but this is `main` with stories

https://github.com/user-attachments/assets/0703c54d-7cdd-43e0-93c9-1c7270caf5b8

### **After**

Added Storybook stories and removed some styles that will be added in https://github.com/MetaMask/metamask-mobile/pull/18055

https://github.com/user-attachments/assets/0b72b0c7-19e3-451f-9669-b8d6e249e74f

### **After** https://github.com/MetaMask/metamask-mobile/pull/18055

Confirmation keypads use styles from Base/Keypad

https://github.com/user-attachments/assets/166aba87-5681-455b-b4ef-419320f3832f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.ai/code)