### PR TITLE
chore: Fix selector & key prop warnings on home page

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -277,11 +277,14 @@ const WalletTokensTabView = React.memo(
           renderTabBar={renderTabBar}
           onChangeTab={onChangeTab}
         >
-          <Tokens {...tokensTabProps} />
+          <Tokens {...tokensTabProps} key={tokensTabProps.key} />
           {isPerpsEnabled && <PerpsTabView {...perpsTabProps} />}
           {defiEnabled && <DeFiPositionsList {...defiPositionsTabProps} />}
           {collectiblesEnabled && (
-            <CollectibleContracts {...collectibleContractsTabProps} />
+            <CollectibleContracts
+              {...collectibleContractsTabProps}
+              key={collectibleContractsTabProps.key}
+            />
           )}
         </ScrollableTabView>
       </View>

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -278,8 +278,15 @@ const WalletTokensTabView = React.memo(
           onChangeTab={onChangeTab}
         >
           <Tokens {...tokensTabProps} key={tokensTabProps.key} />
-          {isPerpsEnabled && <PerpsTabView {...perpsTabProps} />}
-          {defiEnabled && <DeFiPositionsList {...defiPositionsTabProps} />}
+          {isPerpsEnabled && (
+            <PerpsTabView {...perpsTabProps} key={perpsTabProps.key} />
+          )}
+          {defiEnabled && (
+            <DeFiPositionsList
+              {...defiPositionsTabProps}
+              key={defiPositionsTabProps.key}
+            />
+          )}
           {collectiblesEnabled && (
             <CollectibleContracts
               {...collectibleContractsTabProps}

--- a/app/selectors/banner.ts
+++ b/app/selectors/banner.ts
@@ -1,9 +1,4 @@
 import { RootState } from '../reducers';
-import { createSelector } from 'reselect';
 
-const selectBannersState = (state: RootState) => state.banners.dismissedBanners;
-
-export const selectDismissedBanners = createSelector(
-  selectBannersState,
-  (dismissedBanners) => dismissedBanners,
-);
+export const selectDismissedBanners = (state: RootState) =>
+  state.banners.dismissedBanners;

--- a/app/selectors/currencyRateController.ts
+++ b/app/selectors/currencyRateController.ts
@@ -42,15 +42,15 @@ export const selectCurrencyRates = createSelector(
 
 export const selectCurrencyRateForChainId = createSelector(
   [
-    (state, chainId: Hex) => {
-      const currencyRates = selectCurrencyRates(state);
-      const networkConfig = selectNetworkConfigurationByChainId(state, chainId);
-      const conversionRate =
-        currencyRates?.[networkConfig?.nativeCurrency]?.conversionRate || 0;
-      return conversionRate;
-    },
+    selectCurrencyRates,
+    (_state: RootState, chainId: Hex) => chainId,
+    (state: RootState, chainId: Hex) =>
+      selectNetworkConfigurationByChainId(state, chainId),
   ],
-  (conversionRate): number => conversionRate,
+  (currencyRates, _chainId, networkConfig): number =>
+    (networkConfig?.nativeCurrency &&
+      currencyRates?.[networkConfig.nativeCurrency]?.conversionRate) ||
+    0,
   {
     memoize: weakMapMemoize,
     argsMemoize: weakMapMemoize,

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -185,12 +185,14 @@ export function selectMultichainAssetsMetadata(state: RootState) {
 }
 
 function selectMultichainAssetsRatesState(state: RootState) {
-  return state.engine.backgroundState.MultichainAssetsRatesController;
+  return state.engine.backgroundState.MultichainAssetsRatesController
+    .conversionRates;
 }
 
 export const selectMultichainAssetsRates = createDeepEqualSelector(
   selectMultichainAssetsRatesState,
-  (multichainAssetRates) => multichainAssetRates.conversionRates,
+  (conversionRates) => conversionRates,
+  { devModeChecks: { identityFunctionCheck: 'never' } },
 );
 
 export function selectMultichainHistoricalPrices(state: RootState) {

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -184,14 +184,13 @@ export function selectMultichainAssetsMetadata(state: RootState) {
   return state.engine.backgroundState.MultichainAssetsController.assetsMetadata;
 }
 
-export function selectMultichainAssetsRatesState(state: RootState) {
-  return state.engine.backgroundState.MultichainAssetsRatesController
-    .conversionRates;
+function selectMultichainAssetsRatesState(state: RootState) {
+  return state.engine.backgroundState.MultichainAssetsRatesController;
 }
 
 export const selectMultichainAssetsRates = createDeepEqualSelector(
   selectMultichainAssetsRatesState,
-  (conversionRates) => conversionRates,
+  (multichainAssetRates) => multichainAssetRates.conversionRates,
 );
 
 export function selectMultichainHistoricalPrices(state: RootState) {

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -6,23 +6,18 @@ import { selectPendingSmartTransactionsBySender } from './smartTransactionsContr
 const selectTransactionControllerState = (state: RootState) =>
   state.engine.backgroundState.TransactionController;
 
-const selectTransactionsStrict = createSelector(
-  selectTransactionControllerState,
-  (transactionControllerState) => transactionControllerState.transactions,
-);
-
 const selectTransactionBatchesStrict = createSelector(
   selectTransactionControllerState,
   (transactionControllerState) => transactionControllerState.transactionBatches,
 );
 
 export const selectTransactions = createDeepEqualSelector(
-  selectTransactionsStrict,
-  (transactions) => transactions,
+  selectTransactionControllerState,
+  (transactionControllerState) => transactionControllerState.transactions,
 );
 
 export const selectNonReplacedTransactions = createDeepEqualSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (transactions) =>
     transactions.filter(
       ({ replacedBy, replacedById, hash }) =>
@@ -46,7 +41,7 @@ export const selectSwapsTransactions = createSelector(
 );
 
 export const selectTransactionMetadataById = createDeepEqualSelector(
-  selectTransactionsStrict,
+  selectTransactions,
   (_: RootState, id: string) => id,
   (transactions, id) => transactions.find((tx) => tx.id === id),
 );

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -6,18 +6,28 @@ import { selectPendingSmartTransactionsBySender } from './smartTransactionsContr
 const selectTransactionControllerState = (state: RootState) =>
   state.engine.backgroundState.TransactionController;
 
+const selectTransactionsStrict = createSelector(
+  selectTransactionControllerState,
+  (transactionControllerState) => transactionControllerState.transactions,
+);
+
 const selectTransactionBatchesStrict = createSelector(
   selectTransactionControllerState,
   (transactionControllerState) => transactionControllerState.transactionBatches,
 );
 
 export const selectTransactions = createDeepEqualSelector(
-  selectTransactionControllerState,
-  (transactionControllerState) => transactionControllerState.transactions,
+  selectTransactionsStrict,
+  (transactions) => transactions,
+  {
+    devModeChecks: {
+      identityFunctionCheck: 'never',
+    },
+  },
 );
 
 export const selectNonReplacedTransactions = createDeepEqualSelector(
-  selectTransactions,
+  selectTransactionsStrict,
   (transactions) =>
     transactions.filter(
       ({ replacedBy, replacedById, hash }) =>
@@ -41,7 +51,7 @@ export const selectSwapsTransactions = createSelector(
 );
 
 export const selectTransactionMetadataById = createDeepEqualSelector(
-  selectTransactions,
+  selectTransactionsStrict,
   (_: RootState, id: string) => id,
   (transactions, id) => transactions.find((tx) => tx.id === id),
 );

--- a/app/selectors/util.ts
+++ b/app/selectors/util.ts
@@ -1,6 +1,32 @@
 import { deepEqual } from 'fast-equals';
 import { createSelectorCreator, lruMemoize } from 'reselect';
 
+/**
+ * Creates a selector with deep equality checking for input comparisons.
+ *
+ * Uses deep equality instead of reference equality to prevent unnecessary
+ * recalculations when input selectors return identical objects with different references.
+ *
+ * @example
+ * ```typescript
+ * const selectUserPreferences = createDeepEqualSelector(
+ *   selectUserPreferencesState,
+ *   (preferences) => preferences
+ * );
+ *
+ * const selectFilteredItems = createDeepEqualSelector(
+ *   [selectItems, selectComplexFilterConfig],
+ *   (items, filterConfig) => items.filter(item => matchesFilter(item, filterConfig))
+ * );
+ * ```
+ *
+ * **When to use:**
+ * - Input selectors return complex objects that should be compared by value
+ * - Result function returns identity/passthrough (acceptable here)
+ *
+ * **Avoid when:**
+ * - Working with primitives or when deep equality checks would be expensive
+ */
 export const createDeepEqualSelector = createSelectorCreator(
   lruMemoize,
   deepEqual,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


1. What is the reason for the change?
Remove the following warnings from the login/home page:

```
index.ts:63 The result function returned its own inputs without modification. e.g
`createSelector([state => state.todos], todos => todos)`
This could lead to inefficient memoization and unnecessary re-renders.
Ensure transformation logic is in the result function, and extraction logic is in the input selectors. 
```

```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, tabLabel: ..., navigation: ...};
  <Tokens {...props} />
```

```
index.tsx:274 Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, tabLabel: ..., navigation: ...};
  <Connect(CollectibleContracts) {...props} />
```

2. What is the improvement/solution?
-  explicitly apply the key prop in the Tokens list and the CollectibleContracts
- Remove "wrapper" selectors that simply return the the result of their input

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="970" height="895" alt="Screenshot 2025-08-10 at 4 25 36 PM" src="https://github.com/user-attachments/assets/265d6f47-d5a0-4287-9624-e6c6804095fe" />

<img width="977" height="893" alt="Screenshot 2025-08-10 at 4 27 36 PM" src="https://github.com/user-attachments/assets/f1c23f7b-9022-4651-874e-5ff980bec3da" />

<img width="987" height="909" alt="Screenshot 2025-08-10 at 4 28 04 PM" src="https://github.com/user-attachments/assets/4e208564-7e94-4035-818a-54e9d476cdc4" />

<img width="975" height="903" alt="Screenshot 2025-08-10 at 4 28 27 PM" src="https://github.com/user-attachments/assets/e54ac089-f69b-47bb-ab68-1827528a63b0" />

<img width="983" height="904" alt="Screenshot 2025-08-10 at 4 29 04 PM" src="https://github.com/user-attachments/assets/05044d4c-d803-4206-abeb-a9b138bd8c66" />

<img width="982" height="906" alt="Screenshot 2025-08-10 at 4 30 14 PM" src="https://github.com/user-attachments/assets/53927073-f6fb-4167-9d2f-c1d6bf508c49" />

### **After**
(There are still warnings but they are not related to selectors or keys. the remaining warnings seem to be bugs in some of the packages that we are using)

https://github.com/user-attachments/assets/d8c64a6b-5ed3-422b-97f8-d462dbda82ee


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
