### PR TITLE
chore: remove state 1 feature flag from `AccountTreeInitService`

### DIFF
--- a/app/multichain-accounts/AccountTreeInitService/index.ts
+++ b/app/multichain-accounts/AccountTreeInitService/index.ts
@@ -1,43 +1,12 @@
-import { Json } from '@metamask/utils';
-import {
-  assertMultichainAccountsFeatureFlagType,
-  isMultichainAccountsFeatureEnabled,
-  MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_1,
-  MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_2,
-  MultichainAccountsFeatureFlag,
-} from '../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
 import Engine from '../../core/Engine';
 
 export class AccountTreeInitService {
   initializeAccountTree = async (): Promise<void> => {
-    const {
-      AccountTreeController,
-      AccountsController,
-      RemoteFeatureFlagController,
-    } = Engine.context;
-    const { enableMultichainAccounts } =
-      RemoteFeatureFlagController.state.remoteFeatureFlags;
-    if (!assertMultichainAccountsFeatureFlagType(enableMultichainAccounts)) {
-      return;
-    }
-    const isMultichainAccountsEnabled =
-      this.isMultichainAccountsEnabledForState1(enableMultichainAccounts);
+    const { AccountTreeController, AccountsController } = Engine.context;
 
-    if (isMultichainAccountsEnabled) {
-      await AccountsController.updateAccounts();
-      AccountTreeController.init();
-    }
+    await AccountsController.updateAccounts();
+    AccountTreeController.init();
   };
-
-  private isMultichainAccountsEnabledForState1 = (
-    remoteFeatureFlags: Json & MultichainAccountsFeatureFlag,
-  ) =>
-    [
-      MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_1,
-      MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_2,
-    ].some((featureVersion) =>
-      isMultichainAccountsFeatureEnabled(remoteFeatureFlags, featureVersion),
-    );
 }
 
 export default new AccountTreeInitService();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Remove state 1 feature flag from `AccountTreeInitService`.

## **Changelog**

N/A

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
