### PR TITLE
fix: cp-7.51.4 wipe smart transactions on account reset

### DIFF
--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
@@ -7,6 +7,7 @@ import { ResetAccountModal } from './ResetAccountModal';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
 import { selectChainId } from '../../../../../selectors/networkController';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
+import { wipeSmartTransactions } from '../../../../../util/smart-transactions';
 import { wipeBridgeStatus } from '../../../../UI/Bridge/utils';
 
 jest.mock('../../../../../selectors/accountsController', () => {
@@ -33,6 +34,10 @@ jest.mock('../../../../../selectors/networkController', () => {
 
 jest.mock('../../../../../util/transaction-controller', () => ({
   wipeTransactions: jest.fn(),
+}));
+
+jest.mock('../../../../../util/smart-transactions', () => ({
+  wipeSmartTransactions: jest.fn(),
 }));
 
 jest.mock('../../../../UI/Bridge/utils', () => ({
@@ -73,7 +78,7 @@ describe('ResetAccountModal', () => {
     (selectChainId as unknown as jest.Mock).mockReturnValue('0x1');
   });
 
-  it('calls wipeBridgeStatus and wipeTransactions when reset button is pressed', () => {
+  it('calls wipeBridgeStatus, wipeTransactions, and wipeSmartTransactions when reset button is pressed', () => {
     const { getByText } = renderWithProvider(
       <ResetAccountModal {...defaultProps} />,
       { state: initialState },
@@ -89,6 +94,7 @@ describe('ResetAccountModal', () => {
       '0x1',
     );
     expect(wipeTransactions).toHaveBeenCalledWith();
+    expect(wipeSmartTransactions).toHaveBeenCalledWith('0x123456789abcdef123456789abcdef123456789a');
     expect(mockNavigate).toHaveBeenCalledWith('WalletView');
   });
 
@@ -109,6 +115,7 @@ describe('ResetAccountModal', () => {
 
     expect(wipeBridgeStatus).not.toHaveBeenCalled();
     expect(wipeTransactions).toHaveBeenCalledWith();
+    expect(wipeSmartTransactions).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('WalletView');
   });
 });

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
@@ -94,7 +94,9 @@ describe('ResetAccountModal', () => {
       '0x1',
     );
     expect(wipeTransactions).toHaveBeenCalledWith();
-    expect(wipeSmartTransactions).toHaveBeenCalledWith('0x123456789abcdef123456789abcdef123456789a');
+    expect(wipeSmartTransactions).toHaveBeenCalledWith(
+      '0x123456789abcdef123456789abcdef123456789a',
+    );
     expect(mockNavigate).toHaveBeenCalledWith('WalletView');
   });
 

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
@@ -6,6 +6,7 @@ import Text, {
 import { strings } from '../../../../../../locales/i18n';
 import ActionModal from '../../../../UI/ActionModal';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
+import { wipeSmartTransactions } from '../../../../../util/smart-transactions';
 import { wipeBridgeStatus } from '../../../../UI/Bridge/utils';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -31,6 +32,7 @@ export const ResetAccountModal = ({
   const resetAccount = () => {
     if (selectedAddress) {
       wipeBridgeStatus(selectedAddress, chainId);
+      wipeSmartTransactions(selectedAddress);
     }
     wipeTransactions();
     navigation.navigate('WalletView');

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -8,11 +8,21 @@ import {
   getGasIncludedTransactionFees,
   type GasIncludedQuote,
   getIsAllowedRpcUrlForSmartTransactions,
+  wipeSmartTransactions,
 } from './index';
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 // eslint-disable-next-line import/no-namespace
 import * as environment from '../environment';
 import type { BaseControllerMessenger } from '../../core/Engine';
+import Engine from '../../core/Engine';
+
+jest.mock('../../core/Engine', () => ({
+  context: {
+    SmartTransactionsController: {
+      wipeSmartTransactions: jest.fn(),
+    },
+  },
+}));
 
 describe('Smart Transactions utils', () => {
   describe('getTransactionType', () => {
@@ -708,6 +718,25 @@ describe('Smart Transactions utils', () => {
       isProductionMock.mockReturnValue(false);
       const result = getIsAllowedRpcUrlForSmartTransactions(undefined);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('wipeSmartTransactions', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call SmartTransactionsController.wipeSmartTransactions with address and ignoreNetwork flag', () => {
+      const mockWipeSmartTransactions = Engine.context.SmartTransactionsController.wipeSmartTransactions as jest.Mock;
+      const testAddress = '0x123456789abcdef123456789abcdef123456789a';
+
+      wipeSmartTransactions(testAddress);
+
+      expect(mockWipeSmartTransactions).toHaveBeenCalledTimes(1);
+      expect(mockWipeSmartTransactions).toHaveBeenCalledWith({ 
+        address: testAddress,
+        ignoreNetwork: true 
+      });
     });
   });
 });

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -727,15 +727,16 @@ describe('Smart Transactions utils', () => {
     });
 
     it('should call SmartTransactionsController.wipeSmartTransactions with address and ignoreNetwork flag', () => {
-      const mockWipeSmartTransactions = Engine.context.SmartTransactionsController.wipeSmartTransactions as jest.Mock;
+      const mockWipeSmartTransactions = Engine.context
+        .SmartTransactionsController.wipeSmartTransactions as jest.Mock;
       const testAddress = '0x123456789abcdef123456789abcdef123456789a';
 
       wipeSmartTransactions(testAddress);
 
       expect(mockWipeSmartTransactions).toHaveBeenCalledTimes(1);
-      expect(mockWipeSmartTransactions).toHaveBeenCalledWith({ 
+      expect(mockWipeSmartTransactions).toHaveBeenCalledWith({
         address: testAddress,
-        ignoreNetwork: true 
+        ignoreNetwork: true,
       });
     });
   });

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -13,8 +13,7 @@ import {
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 // eslint-disable-next-line import/no-namespace
 import * as environment from '../environment';
-import type { BaseControllerMessenger } from '../../core/Engine';
-import Engine from '../../core/Engine';
+import Engine, { type BaseControllerMessenger } from '../../core/Engine';
 
 jest.mock('../../core/Engine', () => ({
   context: {

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -175,5 +175,8 @@ export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
  */
 export function wipeSmartTransactions(address: string) {
   const { SmartTransactionsController } = Engine.context;
-  SmartTransactionsController.wipeSmartTransactions({ address, ignoreNetwork: true });
+  SmartTransactionsController.wipeSmartTransactions({
+    address,
+    ignoreNetwork: true,
+  });
 }

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -14,6 +14,7 @@ import {
 } from '@metamask/smart-transactions-controller/dist/types';
 import type { BaseControllerMessenger } from '../../core/Engine';
 import { isProduction } from '../environment';
+import Engine from '../../core/Engine';
 
 const TIMEOUT_FOR_SMART_TRANSACTION_CONFIRMATION_DONE_EVENT = 10000;
 
@@ -166,3 +167,13 @@ export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
     false
   );
 };
+
+/**
+ * Wipes smart transactions from the SmartTransactionsController state.
+ * This should be called when resetting an account to clear smart transaction history for a specific address.
+ * @param address - The address whose smart transactions should be wiped
+ */
+export function wipeSmartTransactions(address: string) {
+  const { SmartTransactionsController } = Engine.context;
+  SmartTransactionsController.wipeSmartTransactions({ address, ignoreNetwork: true });
+}

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -12,9 +12,8 @@ import {
   SmartTransaction,
   Fees,
 } from '@metamask/smart-transactions-controller/dist/types';
-import type { BaseControllerMessenger } from '../../core/Engine';
+import Engine, { type BaseControllerMessenger } from '../../core/Engine';
 import { isProduction } from '../environment';
-import Engine from '../../core/Engine';
 
 const TIMEOUT_FOR_SMART_TRANSACTION_CONFIRMATION_DONE_EVENT = 10000;
 
@@ -174,8 +173,8 @@ export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
  * @param address - The address whose smart transactions should be wiped
  */
 export function wipeSmartTransactions(address: string) {
-  const { SmartTransactionsController } = Engine.context;
-  SmartTransactionsController.wipeSmartTransactions({
+  const { SmartTransactionsController: controller } = Engine.context;
+  controller.wipeSmartTransactions({
     address,
     ignoreNetwork: true,
   });


### PR DESCRIPTION
## **Description**
It wipes smart transactions for a specific account on account reset (a button in Advanced settings).

## **Changelog**

CHANGELOG entry: Fixed wiping smart transactions on account reset.

## **Related issues**

Fixes: 

## **Manual testing steps**



## **Screenshots/Recordings**



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
