### PR TITLE
fix: cp-7.51.4 clean up existing smartTransactions state since we don't persist new ones anymore

### DIFF
--- a/app/store/migrations/092.test.ts
+++ b/app/store/migrations/092.test.ts
@@ -60,7 +60,7 @@ describe('Migration #92', () => {
   it('returns state unchanged when SmartTransactionsController is undefined (fresh install)', () => {
     const state = merge({}, initialRootState, {
       engine: {
-        backgroundState: { 
+        backgroundState: {
           SmartTransactionsController: undefined,
         },
       },
@@ -109,7 +109,10 @@ describe('Migration #92', () => {
     });
 
     const expectedState = merge({}, oldState);
-    (expectedState.engine.backgroundState.SmartTransactionsController.smartTransactionsState as any).smartTransactions = {};
+    (
+      expectedState.engine.backgroundState.SmartTransactionsController
+        .smartTransactionsState as any
+    ).smartTransactions = {};
 
     const newState = migrate(oldState);
 
@@ -138,7 +141,10 @@ describe('Migration #92', () => {
     });
 
     const expectedState = merge({}, oldState);
-    (expectedState.engine.backgroundState.SmartTransactionsController.smartTransactionsState as any).smartTransactions = {};
+    (
+      expectedState.engine.backgroundState.SmartTransactionsController
+        .smartTransactionsState as any
+    ).smartTransactions = {};
 
     const newState = migrate(oldState);
 
@@ -209,9 +215,10 @@ describe('Migration #92', () => {
     const newState = migrate(state);
 
     // State should remain unchanged but smartTransactions should still be an empty object
-    expect((newState as any).engine.backgroundState.SmartTransactionsController.smartTransactionsState.smartTransactions).toStrictEqual({});
+    expect(
+      (newState as any).engine.backgroundState.SmartTransactionsController
+        .smartTransactionsState.smartTransactions,
+    ).toStrictEqual({});
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
-
-
 });

--- a/app/store/migrations/092.test.ts
+++ b/app/store/migrations/092.test.ts
@@ -1,0 +1,217 @@
+import migrate from './092';
+import { merge } from 'lodash';
+import { captureException } from '@sentry/react-native';
+import initialRootState from '../../util/test/initial-root-state';
+import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+jest.mock('../../util/Logger');
+
+const mockedCaptureException = jest.mocked(captureException);
+
+describe('Migration #92', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const invalidStates = [
+    {
+      state: null,
+      errorMessage: "FATAL ERROR: Migration 92: Invalid state error: 'object'",
+      scenario: 'state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: null,
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 92: Invalid engine state error: 'object'",
+      scenario: 'engine state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: null,
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 92: Invalid engine backgroundState error: 'object'",
+      scenario: 'backgroundState is invalid',
+    },
+  ];
+
+  it.each(invalidStates)(
+    'captures exception if $scenario',
+    ({ errorMessage, state }) => {
+      const newState = migrate(state);
+
+      expect(newState).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockedCaptureException.mock.calls[0][0].message).toBe(
+        errorMessage,
+      );
+    },
+  );
+
+  it('returns state unchanged when SmartTransactionsController is undefined (fresh install)', () => {
+    const state = merge({}, initialRootState, {
+      engine: {
+        backgroundState: { 
+          SmartTransactionsController: undefined,
+        },
+      },
+    });
+
+    const newState = migrate(state);
+
+    expect(newState).toStrictEqual(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('wipes all smart transactions when they exist', () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          SmartTransactionsController: {
+            smartTransactionsState: {
+              smartTransactions: {
+                [CHAIN_IDS.MAINNET]: [
+                  {
+                    txHash: '0x123',
+                    status: SmartTransactionStatuses.SUCCESS,
+                  },
+                  {
+                    txHash: '0x456',
+                    status: SmartTransactionStatuses.PENDING,
+                  },
+                ],
+                [CHAIN_IDS.OPTIMISM]: [
+                  {
+                    txHash: '0x789',
+                    status: SmartTransactionStatuses.SUCCESS,
+                  },
+                ],
+                [CHAIN_IDS.POLYGON]: [
+                  {
+                    txHash: '0xabc',
+                    status: SmartTransactionStatuses.CANCELLED,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const expectedState = merge({}, oldState);
+    (expectedState.engine.backgroundState.SmartTransactionsController.smartTransactionsState as any).smartTransactions = {};
+
+    const newState = migrate(oldState);
+
+    expect(newState).toStrictEqual(expectedState);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('wipes smart transactions with minimal state', () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          SmartTransactionsController: {
+            smartTransactionsState: {
+              smartTransactions: {
+                [CHAIN_IDS.MAINNET]: [
+                  {
+                    txHash: '0x123',
+                    status: SmartTransactionStatuses.SUCCESS,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const expectedState = merge({}, oldState);
+    (expectedState.engine.backgroundState.SmartTransactionsController.smartTransactionsState as any).smartTransactions = {};
+
+    const newState = migrate(oldState);
+
+    expect(newState).toStrictEqual(expectedState);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('handles invalid SmartTransactionsController structure gracefully', () => {
+    const state = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          SmartTransactionsController: {
+            // Missing smartTransactionsState
+          },
+        },
+      },
+    });
+
+    const newState = migrate(state);
+
+    expect(newState).toStrictEqual(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('handles SmartTransactionsController as non-object', () => {
+    const state = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          SmartTransactionsController: 'invalid',
+        },
+      },
+    });
+
+    const newState = migrate(state);
+
+    expect(newState).toStrictEqual(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockedCaptureException.mock.calls[0][0].message).toBe(
+      "Migration 92: Invalid SmartTransactionsController state: 'string'",
+    );
+  });
+
+  it('handles empty smart transactions', () => {
+    const state = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          AccountsController: {
+            internalAccounts: {
+              accounts: {
+                'account-1': {
+                  id: 'account-1',
+                  address: '0x1234567890abcdef1234567890abcdef12345678',
+                  metadata: { name: 'Account 1' },
+                },
+              },
+              selectedAccount: 'account-1',
+            },
+          },
+          SmartTransactionsController: {
+            smartTransactionsState: {
+              smartTransactions: {},
+            },
+          },
+        },
+      },
+    });
+
+    const newState = migrate(state);
+
+    // State should remain unchanged but smartTransactions should still be an empty object
+    expect((newState as any).engine.backgroundState.SmartTransactionsController.smartTransactionsState.smartTransactions).toStrictEqual({});
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+
+});

--- a/app/store/migrations/092.ts
+++ b/app/store/migrations/092.ts
@@ -1,0 +1,50 @@
+import { isObject } from '@metamask/utils';
+import { captureException } from '@sentry/react-native';
+import { ensureValidState } from './util';
+import Logger from '../../util/Logger';
+
+const migrationVersion = 92;
+
+/**
+ * Migration 92 cleans up the smart transactions state by wiping all existing smart transactions
+ * for all accounts across all networks. We don't need it anymore since we don't persist new smart transactions.
+ */
+export default function migrate(state: unknown) {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  const smartTransactionsControllerState =
+    state.engine.backgroundState.SmartTransactionsController;
+
+  // If SmartTransactionsController doesn't exist (fresh install), skip migration
+  if (!smartTransactionsControllerState) {
+    return state;
+  }
+
+  if (!isObject(smartTransactionsControllerState)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid SmartTransactionsController state: '${typeof smartTransactionsControllerState}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (
+    !isObject(smartTransactionsControllerState.smartTransactionsState) ||
+    !isObject(smartTransactionsControllerState.smartTransactionsState.smartTransactions)
+  ) {
+    return state;
+  }
+
+  // Wipe smart transactions for all chains
+  // We're resetting the entire smartTransactions object to ensure complete cleanup
+  smartTransactionsControllerState.smartTransactionsState.smartTransactions = {};
+
+  Logger.log(
+    `Migration ${migrationVersion}: Wiped all smart transactions from state`,
+  );
+
+  return state;
+}

--- a/app/store/migrations/092.ts
+++ b/app/store/migrations/092.ts
@@ -33,14 +33,17 @@ export default function migrate(state: unknown) {
 
   if (
     !isObject(smartTransactionsControllerState.smartTransactionsState) ||
-    !isObject(smartTransactionsControllerState.smartTransactionsState.smartTransactions)
+    !isObject(
+      smartTransactionsControllerState.smartTransactionsState.smartTransactions,
+    )
   ) {
     return state;
   }
 
   // Wipe smart transactions for all chains
   // We're resetting the entire smartTransactions object to ensure complete cleanup
-  smartTransactionsControllerState.smartTransactionsState.smartTransactions = {};
+  smartTransactionsControllerState.smartTransactionsState.smartTransactions =
+    {};
 
   Logger.log(
     `Migration ${migrationVersion}: Wiped all smart transactions from state`,

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -92,6 +92,7 @@ import migration88 from './088';
 import migration89 from './089';
 import migration90 from './090';
 import migration91 from './091';
+import migration92 from './092';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';
@@ -200,6 +201,7 @@ export const migrationList: MigrationsList = {
   89: migration89,
   90: migration90,
   91: migration91,
+  92: migration92,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
## **Description**
With the following PR that was merged we will not persist new smart transactions in the STX controller: https://github.com/MetaMask/metamask-mobile/pull/18181 That was done previously for a long time and worked fine.

In this PR we have a migration script that cleans up existing smart transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
