### PR TITLE
fix: cp-7.51.4 skip bridge and bridgeApproval tx types in STX

### DIFF
--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -253,6 +253,22 @@ describe('submitSmartTransactionHook', () => {
     });
   });
 
+  it('falls back to regular transaction submit if it is a bridge transaction', async () => {
+    withRequest(async ({ request }) => {
+      request.transactionMeta.type = TransactionType.bridge;
+      const result = await submitSmartTransactionHook(request);
+      expect(result).toEqual({ transactionHash: undefined });
+    });
+  });
+
+  it('falls back to regular transaction submit if it is a bridgeApproval transaction', async () => {
+    withRequest(async ({ request }) => {
+      request.transactionMeta.type = TransactionType.bridgeApproval;
+      const result = await submitSmartTransactionHook(request);
+      expect(result).toEqual({ transactionHash: undefined });
+    });
+  });
+
   it('returns a txHash asap if the feature flag requires it', async () => {
     withRequest(async ({ request }) => {
       request.featureFlags.smartTransactions.mobileReturnTxHashAsap = true;

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -2,6 +2,7 @@ import {
   TransactionParams,
   TransactionController,
   TransactionMeta,
+  TransactionType,
   type PublishBatchHookTransaction,
 } from '@metamask/transaction-controller';
 import SmartTransactionsController, {
@@ -180,7 +181,9 @@ class SmartTransactionHook {
     if (
       !this.#shouldUseSmartTransaction ||
       this.#transactionMeta.origin === RAMPS_SEND ||
-      isLegacyTransaction(this.#transactionMeta)
+      isLegacyTransaction(this.#transactionMeta) ||
+      this.#transactionMeta.type === TransactionType.bridge ||
+      this.#transactionMeta.type === TransactionType.bridgeApproval
     ) {
       return useRegularTransactionSubmit;
     }


### PR DESCRIPTION
## **Description**

Temporarily disable bridge transactions for STX.

## **Changelog**

CHANGELOG entry: Disable bridge transactions for STX

## **Related issues**

Fixes:

## **Manual testing steps**

This was failing before:
- BNB mainnet
- Click on "Bridge"
- BNB.USDC → Ethereum.ETH
- Very quickly send this tx while the first one is pending: BNB.BNB → Ethereum.ETH failed
- Send failed

Now it should succeed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
