### PR TITLE
chore: add QuickActionButtons component

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -56,6 +56,7 @@ const getStories = () => {
     "./app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.stories.tsx": require("../app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.stories.tsx"),
     "./app/component-library/components-temp/Price/PercentageChange/PercentageChange.stories.tsx": require("../app/component-library/components-temp/Price/PercentageChange/PercentageChange.stories.tsx"),
     "./app/component-library/components-temp/QuickActionButtons/QuickActionButton/QuickActionButton.stories.tsx": require("../app/component-library/components-temp/QuickActionButtons/QuickActionButton/QuickActionButton.stories.tsx"),
+    "./app/component-library/components-temp/QuickActionButtons/QuickActionButtons.stories.tsx": require("../app/component-library/components-temp/QuickActionButtons/QuickActionButtons.stories.tsx"),
     "./app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx": require("../app/component-library/components-temp/SegmentedControl/SegmentedControl.stories.tsx"),
     "./app/component-library/components-temp/TabBar/TabBar.stories.tsx": require("../app/component-library/components-temp/TabBar/TabBar.stories.tsx"),
     "./app/component-library/components-temp/TagColored/TagColored.stories.tsx": require("../app/component-library/components-temp/TagColored/TagColored.stories.tsx"),

--- a/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.stories.tsx
+++ b/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.stories.tsx
@@ -1,0 +1,195 @@
+/* eslint-disable no-console */
+// Third party dependencies
+import React, { useState } from 'react';
+
+// External dependencies
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+
+// Internal dependencies
+import QuickActionButtons, { QuickActionButton } from './QuickActionButtons';
+import Keypad from '../../../components/Base/Keypad';
+
+const QuickActionButtonsMeta = {
+  title: 'Components Temp / QuickActionButtons',
+  component: QuickActionButtons,
+  argTypes: {
+    buttonsPerRow: {
+      control: { type: 'number', min: 1, max: 6 },
+      description: 'Number of buttons per row',
+    },
+  },
+};
+
+export default QuickActionButtonsMeta;
+
+// Basic story with default props
+export const Default = {
+  render: function Render(args: { buttonsPerRow?: number }) {
+    return (
+      <QuickActionButtons {...args}>
+        <QuickActionButton onPress={() => console.log('10% pressed')}>
+          10%
+        </QuickActionButton>
+        <QuickActionButton onPress={() => console.log('25% pressed')}>
+          25%
+        </QuickActionButton>
+        <QuickActionButton onPress={() => console.log('50% pressed')}>
+          Max
+        </QuickActionButton>
+        <QuickActionButton onPress={() => console.log('Done pressed')}>
+          Done
+        </QuickActionButton>
+      </QuickActionButtons>
+    );
+  },
+  args: {
+    buttonsPerRow: 4,
+  },
+};
+
+// Different layouts
+export const ButtonsPerRow = {
+  render: function Render() {
+    return (
+      <Box padding={4} gap={6}>
+        <Box>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-2">
+            2 Buttons Per Row
+          </Text>
+          <QuickActionButtons buttonsPerRow={2}>
+            <QuickActionButton onPress={() => console.log('10% pressed')}>
+              10%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('25% pressed')}>
+              25%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('50% pressed')}>
+              50%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('75% pressed')}>
+              75%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('Max pressed')}>
+              Max
+            </QuickActionButton>
+          </QuickActionButtons>
+        </Box>
+        <Box>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-2">
+            3 Buttons Per Row
+          </Text>
+          <QuickActionButtons buttonsPerRow={3}>
+            <QuickActionButton onPress={() => console.log('10% pressed')}>
+              10%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('25% pressed')}>
+              25%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('50% pressed')}>
+              50%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('75% pressed')}>
+              75%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('Max pressed')}>
+              Max
+            </QuickActionButton>
+          </QuickActionButtons>
+        </Box>
+
+        <Box>
+          <Text variant={TextVariant.HeadingSm} twClassName="mb-2">
+            5 Buttons Per Row
+          </Text>
+          <QuickActionButtons buttonsPerRow={5}>
+            <QuickActionButton onPress={() => console.log('10% pressed')}>
+              10%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('25% pressed')}>
+              25%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('50% pressed')}>
+              50%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('75% pressed')}>
+              75%
+            </QuickActionButton>
+            <QuickActionButton onPress={() => console.log('Max pressed')}>
+              Max
+            </QuickActionButton>
+          </QuickActionButtons>
+        </Box>
+      </Box>
+    );
+  },
+};
+
+// Usage with actual Keypad component
+const WithKeypadComponent = () => {
+  const [amount, setAmount] = useState('0');
+  const maxBalance = 1000;
+
+  const handleKeypadChange = (data: {
+    value: string;
+    valueAsNumber: number;
+  }) => {
+    setAmount(data.value);
+  };
+
+  const handlePercentagePress = (percentage: number) => {
+    const calculatedAmount = (maxBalance * percentage) / 100;
+    setAmount(calculatedAmount.toFixed(2));
+  };
+
+  const handleMaxPress = () => {
+    setAmount(maxBalance.toFixed(2));
+  };
+
+  const handleMinPress = () => {
+    setAmount('0.01');
+  };
+
+  return (
+    <Box padding={4} gap={4}>
+      <Box twClassName="bg-default border border-muted rounded-lg p-4">
+        <Text variant={TextVariant.HeadingMd} twClassName="text-center">
+          ${amount}
+        </Text>
+      </Box>
+
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        twClassName="text-center"
+      >
+        Balance: ${maxBalance.toFixed(2)}
+      </Text>
+
+      <QuickActionButtons>
+        <QuickActionButton onPress={() => handlePercentagePress(10)}>
+          10%
+        </QuickActionButton>
+        <QuickActionButton onPress={() => handlePercentagePress(25)}>
+          25%
+        </QuickActionButton>
+        <QuickActionButton onPress={() => handleMaxPress()}>
+          Max
+        </QuickActionButton>
+        <QuickActionButton onPress={() => handleMinPress()}>
+          Done
+        </QuickActionButton>
+      </QuickActionButtons>
+
+      <Keypad currency="USD" value={amount} onChange={handleKeypadChange} />
+    </Box>
+  );
+};
+
+export const WithKeypad = {
+  render: () => <WithKeypadComponent />,
+};

--- a/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.test.tsx
+++ b/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.test.tsx
@@ -1,0 +1,198 @@
+// Third party dependencies.
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Text } from '@metamask/design-system-react-native';
+
+// Internal dependencies.
+import QuickActionButtons from './QuickActionButtons';
+import QuickActionButton from './QuickActionButton/QuickActionButton';
+
+describe('QuickActionButtons', () => {
+  const mockOnPress1 = jest.fn();
+  const mockOnPress2 = jest.fn();
+  const mockOnPress3 = jest.fn();
+
+  beforeEach(() => {
+    mockOnPress1.mockClear();
+    mockOnPress2.mockClear();
+    mockOnPress3.mockClear();
+  });
+
+  it('renders correctly with default props', () => {
+    const { getByTestId, getByText } = render(
+      <QuickActionButtons testID="quick-action-buttons">
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Container should be rendered
+    expect(getByTestId('quick-action-buttons')).toBeTruthy();
+
+    // Both buttons should be visible
+    expect(getByText('Button 1')).toBeOnTheScreen();
+    expect(getByText('Button 2')).toBeOnTheScreen();
+  });
+
+  it('renders buttons in rows based on buttonsPerRow prop', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons
+        buttonsPerRow={2}
+        testID="quick-action-buttons"
+        rowWrapperProps={{ testID: 'row' }}
+      >
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress3}>Button 3</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have 2 row containers (3 buttons with 2 per row = 2 rows)
+    const rows = getAllByTestId('row');
+    expect(rows).toHaveLength(2);
+  });
+
+  it('adds spacers for incomplete rows', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons buttonsPerRow={4} spacerProps={{ testID: 'spacer' }}>
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have spacers to fill the row (2 buttons + 2 spacers = 4 total)
+    const spacers = getAllByTestId('spacer');
+    expect(spacers).toHaveLength(2);
+  });
+
+  it('handles empty children', () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <QuickActionButtons
+        testID="quick-action-buttons"
+        rowWrapperProps={{ testID: 'row' }}
+      >
+        {null}
+        {undefined}
+        {false}
+      </QuickActionButtons>,
+    );
+
+    // Container should exist but no rows or buttons
+    expect(getByTestId('quick-action-buttons')).toBeTruthy();
+    const rows = queryAllByTestId('row');
+    expect(rows).toHaveLength(0);
+  });
+
+  it('accepts custom components alongside QuickActionButton children', () => {
+    // When rendering QuickActionButtons with mixed children
+    const { getByText, getByTestId, getAllByTestId } = render(
+      <QuickActionButtons buttonWrapperProps={{ testID: 'button-wrapper' }}>
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <Text testID="custom-button">Custom Button</Text>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Then all components should be rendered
+    expect(getByText('Button 1')).toBeOnTheScreen();
+    expect(getByText('Custom Button')).toBeOnTheScreen();
+    expect(getByText('Button 2')).toBeOnTheScreen();
+    expect(getByTestId('custom-button')).toBeOnTheScreen();
+
+    // And each should be wrapped
+    const wrappers = getAllByTestId('button-wrapper');
+    expect(wrappers).toHaveLength(3);
+  });
+
+  it('handles single button per row', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons buttonsPerRow={1} rowWrapperProps={{ testID: 'row' }}>
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress3}>Button 3</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have 3 rows with 1 button each
+    const rows = getAllByTestId('row');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('handles many buttons per row', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons
+        buttonsPerRow={6}
+        rowWrapperProps={{ testID: 'row' }}
+        spacerProps={{ testID: 'spacer' }}
+      >
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress3}>Button 3</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have 1 row with all 3 buttons
+    const rows = getAllByTestId('row');
+    expect(rows).toHaveLength(1);
+
+    // Should have 3 spacers (6 per row - 3 buttons = 3 spacers)
+    const spacers = getAllByTestId('spacer');
+    expect(spacers).toHaveLength(3);
+  });
+
+  it('preserves button keys when provided', () => {
+    const { toJSON } = render(
+      <QuickActionButtons>
+        <QuickActionButton key="first" onPress={mockOnPress1}>
+          Button 1
+        </QuickActionButton>
+        <QuickActionButton key="second" onPress={mockOnPress2}>
+          Button 2
+        </QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('applies rowWrapperProps to row containers', () => {
+    const { getByTestId } = render(
+      <QuickActionButtons
+        buttonsPerRow={2}
+        rowWrapperProps={{ testID: 'custom-row' }}
+      >
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Row container should have the custom testID
+    expect(getByTestId('custom-row')).toBeTruthy();
+  });
+
+  it('applies buttonWrapperProps to button wrappers', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons buttonWrapperProps={{ testID: 'button-wrapper' }}>
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have 2 button wrappers
+    const wrappers = getAllByTestId('button-wrapper');
+    expect(wrappers).toHaveLength(2);
+  });
+
+  it('applies spacerProps to spacer elements', () => {
+    const { getAllByTestId } = render(
+      <QuickActionButtons buttonsPerRow={4} spacerProps={{ testID: 'spacer' }}>
+        <QuickActionButton onPress={mockOnPress1}>Button 1</QuickActionButton>
+        <QuickActionButton onPress={mockOnPress2}>Button 2</QuickActionButton>
+      </QuickActionButtons>,
+    );
+
+    // Should have 2 spacers (4 per row - 2 buttons = 2 spacers)
+    const spacers = getAllByTestId('spacer');
+    expect(spacers).toHaveLength(2);
+  });
+});

--- a/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.tsx
+++ b/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.tsx
@@ -1,0 +1,85 @@
+// Third party dependencies
+import React, { Children, ReactElement, cloneElement } from 'react';
+
+// External dependencies
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
+
+// Internal dependencies
+import QuickActionButton from './QuickActionButton';
+import { QuickActionButtonsProps } from './QuickActionButtons.types';
+
+export { QuickActionButton };
+
+/**
+ * Container component for QuickActionButton components
+ */
+const QuickActionButtons: React.FC<QuickActionButtonsProps> = ({
+  children,
+  buttonsPerRow = 4,
+  rowWrapperProps,
+  buttonWrapperProps,
+  spacerProps,
+  ...props
+}) => {
+  // Convert children to array and process them
+  const buttonElements = Children.toArray(children).filter(
+    (child): child is ReactElement => React.isValidElement(child),
+  );
+
+  // Process children and add default props if needed
+  const processedButtons = buttonElements.map((button, index) => {
+    // Add default props to QuickActionButton components
+    if (button.type === QuickActionButton) {
+      return cloneElement(button, {
+        key: button.key || `quick-action-button-${index}`,
+      });
+    }
+    return button;
+  });
+
+  // Group buttons into rows
+  const buttonRows: ReactElement[][] = [];
+  for (let i = 0; i < processedButtons.length; i += buttonsPerRow) {
+    buttonRows.push(processedButtons.slice(i, i + buttonsPerRow));
+  }
+
+  return (
+    <Box gap={3} {...props}>
+      {buttonRows.map((row, rowIndex) => (
+        <Box
+          key={`row-${rowIndex}`}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          gap={3}
+          {...rowWrapperProps}
+        >
+          {row.map((button, buttonIndex) => (
+            <Box
+              key={button.key || `button-${buttonIndex}`}
+              // Box wrapper with flex-1 is needed to ensure the QuickActionButton doesn't collapse
+              twClassName="flex-1"
+              {...buttonWrapperProps}
+            >
+              {button}
+            </Box>
+          ))}
+          {/* Add empty spacers if the last row is not full */}
+          {row.length < buttonsPerRow &&
+            Array.from({ length: buttonsPerRow - row.length }).map((_, i) => (
+              <Box
+                key={`spacer-${rowIndex}-${i}`}
+                twClassName="flex-1"
+                {...spacerProps}
+              />
+            ))}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default QuickActionButtons;

--- a/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.types.ts
+++ b/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.types.ts
@@ -30,11 +30,3 @@ export interface QuickActionButtonsProps extends BoxProps {
    */
   spacerProps?: BoxProps;
 }
-
-/**
- * Style sheet input parameters
- */
-export interface QuickActionButtonsStyleSheetVars {
-  style?: BoxProps['style'];
-  buttonsPerRow: number;
-}

--- a/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.types.ts
+++ b/app/component-library/components-temp/QuickActionButtons/QuickActionButtons.types.ts
@@ -1,0 +1,40 @@
+// Third party dependencies
+import { ReactNode } from 'react';
+
+// External dependencies
+import { BoxProps } from '@metamask/design-system-react-native';
+
+/**
+ * QuickActionButtons container component props
+ */
+export interface QuickActionButtonsProps extends BoxProps {
+  /**
+   * Child components to render (QuickActionButton or custom components)
+   */
+  children: ReactNode;
+  /**
+   * Number of buttons per row
+   * @default 4
+   */
+  buttonsPerRow?: number;
+  /**
+   * Props to apply to each row wrapper Box
+   */
+  rowWrapperProps?: BoxProps;
+  /**
+   * Props to apply to each button wrapper Box
+   */
+  buttonWrapperProps?: BoxProps;
+  /**
+   * Props to apply to spacer elements
+   */
+  spacerProps?: BoxProps;
+}
+
+/**
+ * Style sheet input parameters
+ */
+export interface QuickActionButtonsStyleSheetVars {
+  style?: BoxProps['style'];
+  buttonsPerRow: number;
+}

--- a/app/component-library/components-temp/QuickActionButtons/__snapshots__/QuickActionButtons.test.tsx.snap
+++ b/app/component-library/components-temp/QuickActionButtons/__snapshots__/QuickActionButtons.test.tsx.snap
@@ -1,0 +1,424 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuickActionButtons preserves button keys when provided 1`] = `
+<View
+  style={
+    [
+      {
+        "display": "flex",
+        "gap": 12,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "display": "flex",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+            {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityLabel="Button 1"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "#3c4d9d0f",
+                "borderColor": "transparent",
+                "borderRadius": 12,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "minWidth": 0,
+                "opacity": 1,
+                "overflow": "hidden",
+                "paddingLeft": 8,
+                "paddingRight": 8,
+                "width": "100%",
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "bottom": 0,
+                "display": "flex",
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+            testID="spinner-container"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                  },
+                  undefined,
+                ]
+              }
+              testID="spinner"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    },
+                  ]
+                }
+                testID="spinner-animated-view"
+              >
+                <SvgMock
+                  fill="currentColor"
+                  name="Loading"
+                  style={
+                    [
+                      {
+                        "color": "#121314",
+                        "height": 20,
+                        "width": 20,
+                      },
+                      undefined,
+                    ]
+                  }
+                  testID="spinner-icon"
+                />
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "columnGap": 8,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "opacity": 1,
+              }
+            }
+            testID="content-container"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#121314",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Button 1
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+            {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityLabel="Button 2"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "#3c4d9d0f",
+                "borderColor": "transparent",
+                "borderRadius": 12,
+                "borderWidth": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "minWidth": 0,
+                "opacity": 1,
+                "overflow": "hidden",
+                "paddingLeft": 8,
+                "paddingRight": 8,
+                "width": "100%",
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "bottom": 0,
+                "display": "flex",
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+            testID="spinner-container"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                  },
+                  undefined,
+                ]
+              }
+              testID="spinner"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    },
+                  ]
+                }
+                testID="spinner-animated-view"
+              >
+                <SvgMock
+                  fill="currentColor"
+                  name="Loading"
+                  style={
+                    [
+                      {
+                        "color": "#121314",
+                        "height": 20,
+                        "width": 20,
+                      },
+                      undefined,
+                    ]
+                  }
+                  testID="spinner-icon"
+                />
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "columnGap": 8,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "opacity": 1,
+              }
+            }
+            testID="content-container"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#121314",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Button 2
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/app/component-library/components-temp/QuickActionButtons/index.ts
+++ b/app/component-library/components-temp/QuickActionButtons/index.ts
@@ -1,0 +1,3 @@
+export { default, QuickActionButton } from './QuickActionButtons';
+export type { QuickActionButtonsProps } from './QuickActionButtons.types';
+export type { QuickActionButtonProps } from './QuickActionButton';


### PR DESCRIPTION
## **Description**

This PR introduces the `QuickActionButtons` container component as part of the QuickActionButtons feature set. This is the second part of the implementation, following the individual `QuickActionButton` component that was added in PR #18324.

The `QuickActionButtons` component is a flexible container that manages the layout and organization of quick action buttons in a grid format. It builds upon the previously implemented `QuickActionButton` component to provide a complete solution for percentage selections and other quick actions when working with the Keypad component.

**Key Features:**
- Flexible grid layout with configurable buttons per row (default: 4)
- Automatic row management and spacing
- Support for incomplete rows with automatic spacer elements
- Accepts both `QuickActionButton` components and custom components
- Full TypeScript support with proper type definitions
- Customizable wrapper props for rows, buttons, and spacers
- Comprehensive test coverage with 11 test cases
- Storybook integration with interactive examples including Keypad integration

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [DSYS-106](https://consensyssoftware.atlassian.net/browse/DSYS-106)
Related to: #18324 (Part 1 - QuickActionButton component)

## **Manual testing steps**

- run [storybook](https://github.com/MetaMask/metamask-mobile/blob/main/docs/readme/storybook.md) and go to `QuickActionButtons` story

```gherkin
Feature: QuickActionButtons

  Scenario: User interacts with QuickActionButtons grid layout
    Given the QuickActionButtons component is rendered with multiple buttons
    
    When user views the button grid
    Then buttons are displayed in rows of 4 (default)
    And incomplete rows have proper spacing with invisible spacers
    
    When user clicks on any button
    Then the respective onPress callback is triggered

  Scenario: Different grid configurations
    Given QuickActionButtons with buttonsPerRow prop set to different values
    
    When buttonsPerRow is set to 2
    Then buttons display in rows of 2
    
    When buttonsPerRow is set to 3
    Then buttons display in rows of 3
    
    When buttonsPerRow is set to 6
    Then buttons display in rows of 6 with proper spacers for incomplete rows

  Scenario: Integration with Keypad component
    Given QuickActionButtons integrated with Keypad for amount selection
    
    When user clicks "10%" button
    Then the amount updates to 10% of max balance
    
    When user clicks "25%" button
    Then the amount updates to 25% of max balance
    
    When user clicks "Max" button
    Then the amount updates to full balance
    
    When user clicks "Done" button
    Then the minimum amount is set
```

## **Screenshots/Recordings**

### **Before**

N/A - This is a new component addition (Part 2 of QuickActionButtons feature)

### **After**

The component provides:
- Grid-based layout system for quick action buttons
- Automatic row management with configurable buttons per row
- Smart spacer system for incomplete rows maintaining alignment
- Support for mixed component types (QuickActionButton and custom components)
- Full integration with Keypad component for percentage-based selections
- Customizable styling through wrapper props (rowWrapperProps, buttonWrapperProps, spacerProps)
- Responsive layout that maintains button proportions

https://github.com/user-attachments/assets/7f5dedd3-1aa7-4652-ad99-17f95ce6a5f3

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[DSYS-106]: https://consensyssoftware.atlassian.net/browse/DSYS-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ