### PR TITLE
fix: throw on response not ok - cp-7.53.0

### DIFF
--- a/app/core/OAuthService/AuthTokenHandler.test.ts
+++ b/app/core/OAuthService/AuthTokenHandler.test.ts
@@ -57,6 +57,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -103,6 +104,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -160,6 +162,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: jest.fn().mockResolvedValueOnce(true),
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -186,6 +189,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: jest.fn().mockResolvedValueOnce(true),
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -226,6 +230,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -281,6 +286,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -302,6 +308,7 @@ describe('AuthTokenHandler', () => {
     it('handles JSON parsing errors in refreshJWTToken', async () => {
       // Arrange
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
       });
 
@@ -317,6 +324,7 @@ describe('AuthTokenHandler', () => {
     it('handles JSON parsing errors in revokeRefreshToken', async () => {
       // Arrange
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
       });
 
@@ -343,6 +351,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValueOnce({
+        ok: true,
         json: jest.fn().mockResolvedValueOnce(mockResponse),
       });
 
@@ -373,6 +382,7 @@ describe('AuthTokenHandler', () => {
       };
 
       fetchSpy.mockResolvedValue({
+        ok: true,
         json: jest.fn().mockResolvedValue(mockResponse),
       });
 

--- a/app/core/OAuthService/AuthTokenHandler.ts
+++ b/app/core/OAuthService/AuthTokenHandler.ts
@@ -36,6 +36,10 @@ class AuthTokenHandler {
       },
     );
 
+    if (!response.ok) {
+      throw new Error('Failed to refresh JWT token');
+    }
+
     const refreshTokenData = await response.json();
     const idToken = refreshTokenData.id_token;
 
@@ -67,6 +71,10 @@ class AuthTokenHandler {
         body: JSON.stringify(requestData),
       },
     );
+
+    if (!response.ok) {
+      throw new Error('Failed to revoke refresh token');
+    }
 
     const responseData = await response.json();
     return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Seedless onboarding might updated with undefined token when response is not ok
This PR throw when the response is not ok so that seedlessonboarding do not have opportunity to update seedlesscontroller with undefined 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/17594

## **Manual testing steps**

```gherkin
Feature: my feature name
  Scenario: user [verb for user action]
    Given [describe expected initial app state] 
    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
