### PR TITLE
fix: Added ellipsis for long account names

### DIFF
--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
@@ -42,6 +42,10 @@ const styleSheet = (params: {
     dropDownIcon: {
       marginLeft: 8,
     },
+    accountName: {
+      flexShrink: 1,
+      maxWidth: '50%',
+    },
   });
 };
 

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -60,6 +60,9 @@ const PickerAccount: React.ForwardRefRenderFunction<
       <DSText
         variant={TextVariant.BodyMDMedium}
         testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        style={styles.accountName}
       >
         {accountName}
       </DSText>

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -10,6 +10,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Dimensions,
 } from 'react-native';
 import { colors as importedColors, fontStyles } from '../../../styles/common';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
@@ -967,6 +968,8 @@ export function getWalletNavbarOptions(
   readNotificationCount,
   isCardholder = false,
 ) {
+  const { width: WINDOW_WIDTH } = Dimensions.get('window');
+  const START_ACCESSORY_MAX_WIDTH = Math.floor(WINDOW_WIDTH * 0.5);
   const innerStyles = StyleSheet.create({
     headerContainer: {
       height: 72,
@@ -987,6 +990,11 @@ export function getWalletNavbarOptions(
     },
     startAccessoryContainer: {
       alignItems: 'flex-start',
+      flexShrink: 1,
+    },
+    accountPickerLeftStyle: {
+      width: START_ACCESSORY_MAX_WIDTH,
+      overflow: 'hidden',
     },
     endAccessoryContainer: {
       alignItems: 'flex-end',
@@ -1103,6 +1111,25 @@ export function getWalletNavbarOptions(
     />
   );
 
+  // Account picker variant for the left component (start accessory) with width constraint
+  const accountPickerLeft = (
+    <PickerAccount
+      ref={accountActionsRef}
+      accountName={accountName}
+      onPress={() => {
+        trace({
+          name: TraceName.AccountList,
+          tags: getTraceTags(store.getState()),
+          op: TraceOperation.AccountList,
+        });
+        navigation.navigate(...createAccountSelectorNavDetails({}));
+      }}
+      testID={WalletViewSelectorsIDs.ACCOUNT_ICON}
+      hitSlop={innerStyles.touchAreaSlop}
+      style={innerStyles.accountPickerLeftStyle}
+    />
+  );
+
   // Network picker component
   const networkPicker = (
     <PickerNetwork
@@ -1123,7 +1150,7 @@ export function getWalletNavbarOptions(
         style={innerStyles.headerContainer}
         startAccessory={
           <View style={innerStyles.startAccessoryContainer}>
-            {!isFeatureFlagEnabled ? networkPicker : accountPicker}
+            {!isFeatureFlagEnabled ? networkPicker : accountPickerLeft}
           </View>
         }
         endAccessory={


### PR DESCRIPTION
This PR ensures that for accounts with long names, it should ellipsify the names in app header

CHANGELOG entry:

## **Related issues**

Fixes:
[18191](https://github.com/MetaMask/metamask-mobile/issues/18191)
[18198](https://github.com/MetaMask/metamask-mobile/issues/18198)

## **Manual testing steps**

1. select an account with a longer name
2. Lock and unlock the wallet a couple of times
3. Notice the Copy address and Notifications buttons should appear

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/04702005-db7a-4d83-ac36-f671abdfda86


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
