### PR TITLE
fix: reorganize migration file cp-7.53.0

### DIFF
--- a/app/store/migrations/090.test.ts
+++ b/app/store/migrations/090.test.ts
@@ -1,295 +1,133 @@
-import migrate from './090';
-import { merge } from 'lodash';
 import { captureException } from '@sentry/react-native';
-import initialRootState from '../../util/test/initial-root-state';
-import { RootState } from '../../reducers';
+import { hasProperty } from '@metamask/utils';
+import { ensureValidState } from './util';
+import migrate from './090';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
 }));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+jest.mock('@metamask/utils', () => ({
+  hasProperty: jest.fn(),
+}));
+
 const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedHasProperty = jest.mocked(hasProperty);
 
-describe('Migration #90 - Replace BSC Network RPC URL', () => {
-  const BSC_CHAIN_ID = '0x38';
-  const OLD_RPC_URL = 'https://bsc-dataseed1.binance.org';
-  const NEW_RPC_URL = `https://bsc-mainnet.infura.io/v3/${
-    process.env.MM_INFURA_PROJECT_ID === 'null'
-      ? ''
-      : process.env.MM_INFURA_PROJECT_ID
-  }`;
-  const LINEA_CHAIN_ID = '0x1234';
-
+describe('Migration 090', () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
     jest.resetAllMocks();
   });
 
-  const invalidStates = [
-    {
-      state: null,
-      errorMessage: "FATAL ERROR: Migration 90: Invalid state error: 'object'",
-      scenario: 'state is invalid',
-    },
-    {
-      state: merge({}, initialRootState, {
-        engine: null,
-      }),
-      errorMessage:
-        "FATAL ERROR: Migration 90: Invalid engine state error: 'object'",
-      scenario: 'engine state is invalid',
-    },
-    {
-      state: merge({}, initialRootState, {
-        engine: {
-          backgroundState: null,
-        },
-      }),
-      errorMessage:
-        "FATAL ERROR: Migration 90: Invalid engine backgroundState error: 'object'",
-      scenario: 'backgroundState is invalid',
-    },
-  ];
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
 
-  for (const { errorMessage, scenario, state } of invalidStates) {
-    it(`should capture exception if ${scenario}`, async () => {
-      const newState = await migrate(state);
+    mockedEnsureValidState.mockReturnValue(false);
 
-      expect(newState).toStrictEqual(state);
-      expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-      expect(mockedCaptureException.mock.calls[0][0].message).toBe(
-        errorMessage,
-      );
-    });
-  }
+    const migratedState = migrate(state);
 
-  it('should replace the first occurrence of the BSC network RPC URL', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: OLD_RPC_URL },
-                  { url: 'https://another.rpc' },
-                ],
-              },
-            },
-          },
-        },
-      },
-    });
-
-    const expectedState = merge({}, oldState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: NEW_RPC_URL },
-                  { url: 'https://another.rpc' },
-                ],
-              },
-            },
-          },
-        },
-      },
-    });
-
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(expectedState);
+    expect(migratedState).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if the BSC network configuration is missing', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {},
-          },
-        },
+  it('removes alert state when it exists in the state', () => {
+    const state = {
+      alert: {
+        isVisible: true,
+        autodismiss: 1500,
+        content: 'clipboard-alert',
+        data: { msg: 'Public address copied to clipboard' },
       },
+      user: { existingUser: true },
+      settings: { theme: 'dark' },
+      engine: { backgroundState: {} },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedHasProperty.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toEqual({
+      user: { existingUser: true },
+      settings: { theme: 'dark' },
+      engine: { backgroundState: {} },
     });
 
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(oldState);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if the Base network RPC URL is not present', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: 'https://another.rpc' },
-                  { url: 'https://yet.another.rpc' },
-                ],
-              },
-            },
-          },
-        },
-      },
-    });
+  it('handles empty state object', () => {
+    const state = {};
 
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(oldState);
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedHasProperty.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should handle cases where rpcEndpoints is not an array', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: null,
-              },
-            },
-          },
-        },
-      },
+  it('handles state with null alert property', () => {
+    const state = {
+      alert: null,
+      user: { existingUser: true },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedHasProperty.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toEqual({
+      user: { existingUser: true },
     });
 
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(oldState);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if no networks use Infura RPC endpoints', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              '0x1': {
-                rpcEndpoints: [
-                  { url: 'https://non-infura.rpc' },
-                  { url: 'https://another-non-infura.rpc' },
-                ],
-                defaultRpcEndpointIndex: 0,
-              },
-            },
-          },
-        },
-      },
-    });
+  it('returns state unchanged when alert state does not exist', () => {
+    const state = {
+      user: { existingUser: true },
+      settings: { theme: 'dark' },
+      engine: { backgroundState: {} },
+    };
 
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(oldState);
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedHasProperty.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should proceed with migration if at least one network uses an Infura RPC endpoint', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              '0x1': {
-                rpcEndpoints: [
-                  { url: 'https://mainnet.infura.io/v3/some-key' },
-                  { url: 'https://non-infura.rpc' },
-                ],
-                defaultRpcEndpointIndex: 0,
-              },
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: OLD_RPC_URL },
-                  { url: 'https://another.rpc' },
-                ],
-              },
-            },
-          },
-        },
+  it('captures exception and returns original state when an error occurs', () => {
+    const state = {
+      alert: {
+        isVisible: true,
+        content: 'clipboard-alert',
       },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedHasProperty.mockImplementation(() => {
+      throw new Error('Unexpected error during property check');
     });
 
-    const expectedState = merge({}, oldState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: NEW_RPC_URL },
-                  { url: 'https://another.rpc' },
-                ],
-              },
-            },
-          },
-        },
-      },
-    });
+    const migratedState = migrate(state);
 
-    const newState = await migrate(oldState);
-    expect(newState).toStrictEqual(expectedState);
-  });
-
-  it('should exclude LINEA_MAINNET from Infura RPC endpoint checks', async () => {
-    const oldState = merge({}, initialRootState, {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [LINEA_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: 'https://linea.infura.io/v3/some-key' },
-                  { url: 'https://another-linea.rpc' },
-                ],
-                defaultRpcEndpointIndex: 0,
-              },
-              [BSC_CHAIN_ID]: {
-                rpcEndpoints: [
-                  { url: OLD_RPC_URL },
-                  { url: 'https://another.rpc' },
-                ],
-              },
-            },
-          },
-        },
-      },
-    });
-
-    const newState = await migrate(oldState);
-
-    // The LINEA_MAINNET should not trigger migration; only BSC_CHAIN_ID is updated
-    expect(
-      (newState as RootState).engine.backgroundState.NetworkController
-        .networkConfigurationsByChainId[LINEA_CHAIN_ID],
-    ).toStrictEqual(
-      oldState.engine.backgroundState.NetworkController
-        .networkConfigurationsByChainId[LINEA_CHAIN_ID],
-    );
-    expect(
-      (newState as RootState).engine.backgroundState.NetworkController
-        .networkConfigurationsByChainId[BSC_CHAIN_ID].rpcEndpoints[0].url,
-    ).toBe(NEW_RPC_URL);
-  });
-
-  it('should capture exception when NetworkController structure is invalid', async () => {
-    const oldState = merge(
-      {},
-      {
-        engine: {
-          backgroundState: {
-            NetworkController: {
-              // Valid object but missing networkConfigurationsByChainId
-              selectedNetworkClientId: 'mainnet',
-              networksMetadata: {},
-              // networkConfigurationsByChainId is intentionally missing
-            },
-          },
-        },
-      },
-    );
-
-    const newState = await migrate(oldState);
-
-    expect(newState).toStrictEqual(oldState);
-    expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
-    expect(mockedCaptureException.mock.calls[0][0].message).toBe(
-      'Migration 90: NetworkController or networkConfigurationsByChainId not found in expected state structure. Skipping BSC RPC endpoint migration.',
+    expect(migratedState).toBe(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        'Migration 090: Failed to remove alert state from persisted data: Error: Unexpected error during property check',
+      ),
     );
   });
 });

--- a/app/store/migrations/090.ts
+++ b/app/store/migrations/090.ts
@@ -1,136 +1,36 @@
-import { hasProperty, isObject } from '@metamask/utils';
-import { ensureValidState } from './util';
-import Logger from '../../util/Logger';
+import { hasProperty } from '@metamask/utils';
 import { captureException } from '@sentry/react-native';
-import { RpcEndpointType } from '@metamask/network-controller';
-import {
-  allowedInfuraHosts,
-  infuraChainIdsTestNets,
-} from '../../util/networks/customNetworks';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-
-const BSC_CHAIN_ID = '0x38';
-const INFURA_KEY = process.env.MM_INFURA_PROJECT_ID;
-const infuraProjectId = INFURA_KEY === 'null' ? '' : INFURA_KEY;
+import { ensureValidState } from './util';
 
 /**
- * Migration to update the BSC network configuration by replacing
- * "https://bsc-dataseed1.binance.org" with "https://bsc-mainnet.infura.io/v3/{infuraProjectId}".
+ * Migration 090: Remove alert state from persisted data
  *
- * This addresses potential compatibility issues caused by deprecated endpoints.
- *
- * @param state - The current MetaMask extension state.
- * @returns The updated state with the revised Infura endpoint for the BSC network.
+ * This migration fixes the issue where clipboard alerts persist across app restarts.
+ * Alert state should be ephemeral and not persisted. This removes any existing
+ * alert state that was incorrectly persisted in previous versions.
  */
-export default function migrate(state: unknown) {
-  // Ensure the state is valid for migration
+export default function migrate(state: unknown): unknown {
   if (!ensureValidState(state, 90)) {
     return state;
   }
 
-  // Locate the Base network configuration in the NetworkController
-  const { engine } = state;
-  if (
-    hasProperty(engine.backgroundState, 'NetworkController') &&
-    isObject(engine.backgroundState.NetworkController) &&
-    hasProperty(
-      engine.backgroundState.NetworkController,
-      'networkConfigurationsByChainId',
-    ) &&
-    isObject(
-      engine.backgroundState.NetworkController.networkConfigurationsByChainId,
-    )
-  ) {
-    const networkConfigurationsByChainId =
-      engine.backgroundState.NetworkController.networkConfigurationsByChainId;
-
-    // Check if at least one network uses an Infura RPC endpoint, excluding testnets
-    const usesInfura = Object.entries(networkConfigurationsByChainId)
-      .filter(
-        ([chainId]) =>
-          ![...infuraChainIdsTestNets, CHAIN_IDS.LINEA_MAINNET].includes(
-            chainId,
-          ),
-      ) // Exclude testnet chain IDs
-      .some(([, networkConfig]) => {
-        if (
-          !isObject(networkConfig) ||
-          !Array.isArray(networkConfig.rpcEndpoints) ||
-          typeof networkConfig.defaultRpcEndpointIndex !== 'number'
-        ) {
-          return false;
-        }
-
-        // Get the default RPC endpoint used by the network
-        const defaultRpcEndpoint =
-          networkConfig.rpcEndpoints?.[networkConfig.defaultRpcEndpointIndex];
-
-        if (
-          !isObject(defaultRpcEndpoint) ||
-          typeof defaultRpcEndpoint.url !== 'string'
-        ) {
-          return false;
-        }
-
-        try {
-          const urlHost = new URL(defaultRpcEndpoint.url).host;
-          return (
-            defaultRpcEndpoint.type === RpcEndpointType.Infura ||
-            allowedInfuraHosts.includes(urlHost)
-          );
-        } catch {
-          return false;
-        }
-      });
-
-    if (!usesInfura) {
-      // If no Infura endpoints are used, return the state unchanged
-      return state;
+  try {
+    if (hasProperty(state, 'alert')) {
+      const { alert: alertState, ...stateWithoutAlert } = state;
+      return stateWithoutAlert;
     }
 
-    const baseNetworkConfig = networkConfigurationsByChainId[BSC_CHAIN_ID];
-    if (
-      isObject(baseNetworkConfig) &&
-      hasProperty(baseNetworkConfig, 'rpcEndpoints')
-    ) {
-      const { rpcEndpoints } = baseNetworkConfig;
-
-      if (Array.isArray(rpcEndpoints)) {
-        const endpointIndex = rpcEndpoints.findIndex(
-          (endpoint) =>
-            isObject(endpoint) &&
-            endpoint.url === 'https://bsc-dataseed1.binance.org',
-        );
-
-        if (endpointIndex !== -1) {
-          Logger.log(
-            `Migration 90: Updating 'https://bsc-dataseed1.binance.org' to 'https://bsc-mainnet.infura.io/v3/${infuraProjectId}' in BSC network RPC endpoints.`,
-          );
-
-          // Update the first occurrence of the deprecated URL
-          rpcEndpoints[endpointIndex] = {
-            ...rpcEndpoints[endpointIndex],
-            url: `https://bsc-mainnet.infura.io/v3/${infuraProjectId}`,
-          };
-
-          // Apply the changes to the Base network configuration
-          networkConfigurationsByChainId[BSC_CHAIN_ID] = {
-            ...baseNetworkConfig,
-            rpcEndpoints,
-          };
-
-          engine.backgroundState.NetworkController.networkConfigurationsByChainId =
-            networkConfigurationsByChainId;
-        }
-      }
-    }
-  } else {
+    return state;
+  } catch (error) {
     captureException(
       new Error(
-        'Migration 90: NetworkController or networkConfigurationsByChainId not found in expected state structure. Skipping BSC RPC endpoint migration.',
+        `Migration 090: Failed to remove alert state from persisted data: ${String(
+          error,
+        )}`,
       ),
     );
-  }
 
-  return state;
+    // Return the original state if migration fails to avoid breaking the app
+    return state;
+  }
 }

--- a/app/store/migrations/093.test.ts
+++ b/app/store/migrations/093.test.ts
@@ -1,8 +1,9 @@
 import { captureException } from '@sentry/react-native';
-import { cloneDeep } from 'lodash';
-
 import { ensureValidState } from './util';
 import migrate from './093';
+import { EXISTING_USER } from '../../constants/storage';
+import StorageWrapper from '../storage-wrapper';
+import { userInitialState } from '../../reducers/user';
 
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
@@ -12,277 +13,326 @@ jest.mock('./util', () => ({
   ensureValidState: jest.fn(),
 }));
 
+jest.mock('../storage-wrapper', () => ({
+  getItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
 const mockedCaptureException = jest.mocked(captureException);
 const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedStorageWrapper = jest.mocked(StorageWrapper);
 
-describe('Migration 93: Update Sei Network name', () => {
+describe('Migration 093', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it('returns state unchanged if ensureValidState fails', () => {
+  it('returns state unchanged if ensureValidState fails', async () => {
     const state = { some: 'state' };
+
     mockedEnsureValidState.mockReturnValue(false);
 
-    const migratedState = migrate(state);
+    const migratedState = await migrate(state);
 
-    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(migratedState).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+    expect(mockedStorageWrapper.getItem).not.toHaveBeenCalled();
+    expect(mockedStorageWrapper.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('moves EXISTING_USER from MMKV to Redux state when value is "true"', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('true');
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: true,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      state: {
-        engine: {},
+  it('moves EXISTING_USER from MMKV to Redux state when value is "false"', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
       },
-      test: 'empty engine state',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {},
-        },
-      },
-      test: 'empty backgroundState',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {
-            NetworkController: 'invalid',
-          },
-        },
-      },
-      test: 'invalid NetworkController state',
-    },
-    {
-      state: {
-        engine: {
-          backgroundState: {
-            NetworkController: {
-              networkConfigurationsByChainId: 'invalid',
-            },
-          },
-        },
-      },
-      test: 'invalid networkConfigurationsByChainId state',
-    },
-  ])('does not modify state if the state is invalid - $test', ({ state }) => {
-    const orgState = cloneDeep(state);
+    };
+
     mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('false');
 
-    const migratedState = migrate(state);
+    const migratedState = await migrate(state);
 
-    // State should be unchanged
-    expect(migratedState).toStrictEqual(orgState);
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: false,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('does not update the SEI network name if it is not `Sei Network`', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            selectedNetworkClientId: 'mainnet',
-            networksMetadata: {},
-            networkConfigurationsByChainId: {
-              '0x1': {
-                chainId: '0x1',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'mainnet',
-                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://etherscan.io'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Ethereum Mainnet',
-                nativeCurrency: 'ETH',
-              },
-              '0x531': {
-                chainId: '0x531',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'sei-network',
-                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://seitrace.com'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Custom Sei Network',
-                nativeCurrency: 'SEI',
-              },
-            },
-          },
-        },
+  it('sets existingUser to false when MMKV value is null', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
       },
     };
 
     mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue(null);
 
-    const expectedState = cloneDeep(oldState);
+    const migratedState = await migrate(state);
 
-    const migratedState = await migrate(oldState);
-    expect(migratedState).toStrictEqual(expectedState);
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: false,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
-  it('does not update the PRC network name if it is not `Sei Network`', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            selectedNetworkClientId: 'mainnet',
-            networksMetadata: {},
-            networkConfigurationsByChainId: {
-              '0x1': {
-                chainId: '0x1',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'mainnet',
-                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://etherscan.io'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Ethereum Mainnet',
-                nativeCurrency: 'ETH',
-              },
-              '0x531': {
-                chainId: '0x531',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'sei-network',
-                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                    name: 'My Custom Sei Network',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://seitrace.com'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Sei Network',
-                nativeCurrency: 'SEI',
-              },
-            },
-          },
-        },
-      },
-    };
+  it('captures exception when user state is missing, but continues migration', async () => {
+    const state = {};
 
     mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('true');
 
-    const expectedState = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            ...oldState.engine.backgroundState.NetworkController,
-            networkConfigurationsByChainId: {
-              ...oldState.engine.backgroundState.NetworkController
-                .networkConfigurationsByChainId,
-              '0x531': {
-                ...oldState.engine.backgroundState.NetworkController
-                  .networkConfigurationsByChainId['0x531'],
-                name: 'Sei Mainnet',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'sei-network',
-                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                    name: 'My Custom Sei Network',
-                  },
-                ],
-              },
-            },
-          },
-        },
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        ...userInitialState,
+        existingUser: true, // Should use the MMKV value, not default to false
       },
-    };
+    });
 
-    const migratedState = await migrate(oldState);
-    expect(migratedState).toStrictEqual(expectedState);
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Migration 93: User state is missing or invalid. Expected object, got: undefined',
+      }),
+    );
   });
 
-  it('updates the SEI network name and RRC name from `Sei Network` to `Sei Mainnet`', async () => {
-    const oldState = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            selectedNetworkClientId: 'mainnet',
-            networksMetadata: {},
-            networkConfigurationsByChainId: {
-              '0x1': {
-                chainId: '0x1',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'mainnet',
-                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://etherscan.io'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Ethereum Mainnet',
-                nativeCurrency: 'ETH',
-              },
-              '0x531': {
-                chainId: '0x531',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'sei-network',
-                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                    name: 'Sei Network',
-                  },
-                ],
-                defaultRpcEndpointIndex: 0,
-                blockExplorerUrls: ['https://seitrace.com'],
-                defaultBlockExplorerUrlIndex: 0,
-                name: 'Sei Network',
-                nativeCurrency: 'SEI',
-              },
-            },
-          },
-        },
+  it('captures exception when user state is not an object, but continues migration', async () => {
+    const state = {
+      user: 'not an object',
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('true');
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        ...userInitialState,
+        existingUser: true, // Should use the MMKV value, not default to false
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Migration 93: User state is missing or invalid. Expected object, got: string',
+      }),
+    );
+  });
+
+  it('uses MMKV value of false when user state is corrupted', async () => {
+    const state = {
+      user: 'not an object',
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('false');
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        ...userInitialState,
+        existingUser: false, // Should use the MMKV value of false
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Migration 93: User state is missing or invalid. Expected object, got: string',
+      }),
+    );
+  });
+
+  it('handles StorageWrapper.getItem throwing an error', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
+      },
+    };
+
+    const error = new Error('Storage error');
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockRejectedValue(error);
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: false,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(mockedCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it('handles StorageWrapper.removeItem throwing an error', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
+      },
+    };
+
+    const error = new Error('Remove error');
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('true');
+    mockedStorageWrapper.removeItem.mockRejectedValue(error);
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: true,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it('initializes with full userInitialState when user state is missing and error occurs', async () => {
+    const state = {};
+
+    const error = new Error('Storage error');
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockRejectedValue(error);
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        ...userInitialState,
+        existingUser: false, // Default to false for safety
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(mockedCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it('preserves existing existingUser value in Redux if already set', async () => {
+    const state = {
+      user: {
+        existingUser: true,
+        someOtherField: 'value',
       },
     };
 
     mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('false');
 
-    const expectedData = {
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            ...oldState.engine.backgroundState.NetworkController,
-            networkConfigurationsByChainId: {
-              ...oldState.engine.backgroundState.NetworkController
-                .networkConfigurationsByChainId,
-              '0x531': {
-                ...oldState.engine.backgroundState.NetworkController
-                  .networkConfigurationsByChainId['0x531'],
-                name: 'Sei Mainnet',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'sei-network',
-                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
-                    type: 'infura',
-                    name: 'Sei Mainnet',
-                  },
-                ],
-              },
-            },
-          },
-        },
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        existingUser: false, // Should be overwritten by MMKV value
+        someOtherField: 'value',
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not remove from MMKV if value was null', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
       },
     };
 
-    const migratedState = await migrate(oldState);
-    expect(migratedState).toStrictEqual(expectedData);
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue(null);
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: false,
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).not.toHaveBeenCalled();
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('handles edge case with empty string value', async () => {
+    const state = {
+      user: {
+        someOtherField: 'value',
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+    mockedStorageWrapper.getItem.mockResolvedValue('');
+
+    const migratedState = await migrate(state);
+
+    expect(migratedState).toEqual({
+      user: {
+        someOtherField: 'value',
+        existingUser: false, // Empty string !== 'true'
+      },
+    });
+
+    expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/app/store/migrations/093.ts
+++ b/app/store/migrations/093.ts
@@ -1,103 +1,76 @@
-import { hasProperty, isObject } from '@metamask/utils';
+import { EXISTING_USER } from '../../constants/storage';
+import { ensureValidState, ValidState } from './util';
 import { captureException } from '@sentry/react-native';
-import { ensureValidState } from './util';
-import { NetworkConfiguration } from '@metamask/network-controller';
-import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
+import StorageWrapper from '../storage-wrapper';
+import { cloneDeep } from 'lodash';
+import { isObject } from '@metamask/utils';
+
+// Import the user initial state
+import { userInitialState } from '../../reducers/user';
+
+// Extend ValidState to include the user state
+interface ValidStateWithUser extends ValidState {
+  user?: {
+    existingUser?: boolean;
+    [key: string]: unknown;
+  };
+}
 
 /**
- * Migration 093: Update Sei Network Name
+ * Migration 093: Move EXISTING_USER flag from MMKV to Redux state
+ * This unifies user state management and fixes iCloud backup inconsistencies
  *
- * This migration updates:
- * - the SEI network name from `Sei Network` to `Sei Mainnet`.
- * - the SEI RPC name from `Sei Network` to `Sei Mainnet`.
+ * IMPORTANT: After iCloud restore, we should default to existingUser: false
+ * because keychain credentials are not backed up, even if MMKV data is restored
  */
-export default function migrate(state: unknown): unknown {
-  const migrationVersion = 93;
-  const fromName = 'Sei Network';
-  const toName = 'Sei Mainnet';
-  const seiChainId = NETWORK_CHAIN_ID.SEI_MAINNET;
-
-  if (!ensureValidState(state, migrationVersion)) {
+const migration = async (state: unknown): Promise<unknown> => {
+  if (!ensureValidState(state, 93)) {
     return state;
   }
+
+  const newState = cloneDeep(state) as ValidStateWithUser;
 
   try {
-    // We only update the network name if it exists in the state
-    // and matches the expected chain ID and name.
-    if (
-      hasProperty(state, 'engine') &&
-      hasProperty(state.engine, 'backgroundState') &&
-      hasProperty(state.engine.backgroundState, 'NetworkController') &&
-      isObject(state.engine.backgroundState.NetworkController) &&
-      isObject(
-        state.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId,
-      ) &&
-      hasProperty(
-        state.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId,
-        seiChainId,
-      ) &&
-      isObject(
-        state.engine.backgroundState.NetworkController
-          .networkConfigurationsByChainId[seiChainId],
-      )
-    ) {
-      // Update the network name if it matches the expected name
-      if (
-        hasProperty(
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration,
-          'name',
-        ) &&
-        (
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
-        ).name === fromName
-      ) {
-        (
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
-        ).name = toName;
-      }
+    const existingUser = await StorageWrapper.getItem(EXISTING_USER);
+    const existingUserValue = existingUser === 'true';
 
-      // Update the RPC Name if it matches the expected name
-      if (
-        hasProperty(
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration,
-          'rpcEndpoints',
-        ) &&
-        Array.isArray(
-          (
-            state.engine.backgroundState.NetworkController
-              .networkConfigurationsByChainId[
-              seiChainId
-            ] as NetworkConfiguration
-          ).rpcEndpoints,
-        )
-      ) {
-        const rpcEndpoints = (
-          state.engine.backgroundState.NetworkController
-            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
-        ).rpcEndpoints;
-        rpcEndpoints.forEach((endpoint) => {
-          if (endpoint.name === fromName) {
-            endpoint.name = toName;
-          }
-        });
+    if (!isObject(newState.user)) {
+      const error = new Error(
+        `Migration 93: User state is missing or invalid. Expected object, got: ${typeof newState.user}`,
+      );
+      captureException(error);
+
+      newState.user = {
+        ...userInitialState,
+        existingUser: existingUserValue,
+      };
+    } else {
+      newState.user.existingUser = existingUserValue;
+    }
+
+    if (existingUser !== null) {
+      try {
+        await StorageWrapper.removeItem(EXISTING_USER);
+      } catch (removeError) {
+        // If removeItem fails, capture the error but don't change the existingUser value
+        // since we successfully retrieved it from MMKV
+        captureException(removeError as Error);
       }
     }
-    return state;
   } catch (error) {
-    captureException(
-      new Error(
-        `Migration ${migrationVersion}: Failed to update Sei network name: ${String(
-          error,
-        )}`,
-      ),
-    );
-    // Return the original state if migration fails to avoid breaking the app
-    return state;
+    captureException(error as Error);
+
+    if (!isObject(newState.user)) {
+      newState.user = {
+        ...userInitialState,
+        existingUser: false, // Default to false only if we can't read from MMKV
+      };
+    } else {
+      newState.user.existingUser = false;
+    }
   }
-}
+
+  return newState;
+};
+
+export default migration;

--- a/app/store/migrations/094.test.ts
+++ b/app/store/migrations/094.test.ts
@@ -1,0 +1,288 @@
+import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+import migrate from './094';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+describe('Migration 94: Update Sei Network name', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual({ some: 'state' });
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      state: {
+        engine: {},
+      },
+      test: 'empty engine state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      test: 'empty backgroundState',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      test: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      test: 'invalid networkConfigurationsByChainId state',
+    },
+  ])('does not modify state if the state is invalid - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    // State should be unchanged
+    expect(migratedState).toStrictEqual(orgState);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not update the SEI network name if it is not `Sei Network`', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              '0x1': {
+                chainId: '0x1',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'mainnet',
+                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://etherscan.io'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Ethereum Mainnet',
+                nativeCurrency: 'ETH',
+              },
+              '0x531': {
+                chainId: '0x531',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'sei-network',
+                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://seitrace.com'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Custom Sei Network',
+                nativeCurrency: 'SEI',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedState = cloneDeep(oldState);
+
+    const migratedState = await migrate(oldState);
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('does not update the PRC network name if it is not `Sei Network`', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              '0x1': {
+                chainId: '0x1',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'mainnet',
+                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://etherscan.io'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Ethereum Mainnet',
+                nativeCurrency: 'ETH',
+              },
+              '0x531': {
+                chainId: '0x531',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'sei-network',
+                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                    name: 'My Custom Sei Network',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://seitrace.com'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Sei Network',
+                nativeCurrency: 'SEI',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              '0x531': {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x531'],
+                name: 'Sei Mainnet',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'sei-network',
+                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                    name: 'My Custom Sei Network',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = await migrate(oldState);
+    expect(migratedState).toStrictEqual(expectedState);
+  });
+
+  it('updates the SEI network name and RRC name from `Sei Network` to `Sei Mainnet`', async () => {
+    const oldState = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {},
+            networkConfigurationsByChainId: {
+              '0x1': {
+                chainId: '0x1',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'mainnet',
+                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://etherscan.io'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Ethereum Mainnet',
+                nativeCurrency: 'ETH',
+              },
+              '0x531': {
+                chainId: '0x531',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'sei-network',
+                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                    name: 'Sei Network',
+                  },
+                ],
+                defaultRpcEndpointIndex: 0,
+                blockExplorerUrls: ['https://seitrace.com'],
+                defaultBlockExplorerUrlIndex: 0,
+                name: 'Sei Network',
+                nativeCurrency: 'SEI',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              '0x531': {
+                ...oldState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x531'],
+                name: 'Sei Mainnet',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'sei-network',
+                    url: 'https://sei-mainnet.infura.io/v3/{infuraProjectId}',
+                    type: 'infura',
+                    name: 'Sei Mainnet',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = await migrate(oldState);
+    expect(migratedState).toStrictEqual(expectedData);
+  });
+});

--- a/app/store/migrations/094.ts
+++ b/app/store/migrations/094.ts
@@ -1,0 +1,103 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { captureException } from '@sentry/react-native';
+import { ensureValidState } from './util';
+import { NetworkConfiguration } from '@metamask/network-controller';
+import { NETWORK_CHAIN_ID } from '../../util/networks/customNetworks';
+
+/**
+ * Migration 094: Update Sei Network Name
+ *
+ * This migration updates:
+ * - the SEI network name from `Sei Network` to `Sei Mainnet`.
+ * - the SEI RPC name from `Sei Network` to `Sei Mainnet`.
+ */
+export default function migrate(state: unknown): unknown {
+  const migrationVersion = 94;
+  const fromName = 'Sei Network';
+  const toName = 'Sei Mainnet';
+  const seiChainId = NETWORK_CHAIN_ID.SEI_MAINNET;
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    // We only update the network name if it exists in the state
+    // and matches the expected chain ID and name.
+    if (
+      hasProperty(state, 'engine') &&
+      hasProperty(state.engine, 'backgroundState') &&
+      hasProperty(state.engine.backgroundState, 'NetworkController') &&
+      isObject(state.engine.backgroundState.NetworkController) &&
+      isObject(
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId,
+      ) &&
+      hasProperty(
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId,
+        seiChainId,
+      ) &&
+      isObject(
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId[seiChainId],
+      )
+    ) {
+      // Update the network name if it matches the expected name
+      if (
+        hasProperty(
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration,
+          'name',
+        ) &&
+        (
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
+        ).name === fromName
+      ) {
+        (
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
+        ).name = toName;
+      }
+
+      // Update the RPC Name if it matches the expected name
+      if (
+        hasProperty(
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration,
+          'rpcEndpoints',
+        ) &&
+        Array.isArray(
+          (
+            state.engine.backgroundState.NetworkController
+              .networkConfigurationsByChainId[
+              seiChainId
+            ] as NetworkConfiguration
+          ).rpcEndpoints,
+        )
+      ) {
+        const rpcEndpoints = (
+          state.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId[seiChainId] as NetworkConfiguration
+        ).rpcEndpoints;
+        rpcEndpoints.forEach((endpoint) => {
+          if (endpoint.name === fromName) {
+            endpoint.name = toName;
+          }
+        });
+      }
+    }
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to update Sei network name: ${String(
+          error,
+        )}`,
+      ),
+    );
+    // Return the original state if migration fails to avoid breaking the app
+    return state;
+  }
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -94,6 +94,7 @@ import migration90 from './090';
 import migration91 from './091';
 import migration92 from './092';
 import migration93 from './093';
+import migration94 from './094';
 
 // Add migrations above this line
 import { validatePostMigrationState } from '../validateMigration/validateMigration';
@@ -204,6 +205,7 @@ export const migrationList: MigrationsList = {
   91: migration91,
   92: migration92,
   93: migration93,
+  94: migration94,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

port migration files from 7.51.4


migration diff

In 7.51.4
089 - Migration to update the BSC network configuration
090 - Remove alert state
091 - Remove alert state
092 - Migration 92 cleans up the smart transactions state by wiping all

7.51.4 have duplicated migration (090 and 091)


Current Main
089 - Migration 89: Move EXISTING_USER flag
090 - Migration to update the BSC network configuration
091 - Remove alert state
092 - Migration 92 cleans up the smart transactions state by wiping all
093 - Update Sei Network Name 

I am planning to fix it like below
In main
089 - Migration to update the BSC network configuration
090 - Remove alert state
091 - Remove alert state
092 - Migration 92 cleans up the smart transactions state by wiping all
093 - Migration 89: Move EXISTING_USER flag
094 - Update Sei Network Name 


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/18135

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
