### PR TITLE
fix: cp-7.53.0 select non-evm transactions irrespective of account

### DIFF
--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -682,15 +682,12 @@ let cacheKey = null;
 const mapStateToProps = (state, { route }) => {
   const selectedInternalAccount = selectSelectedInternalAccount(state);
   const evmTransactions = selectTransactions(state);
+  const asset = route.params;
 
   let allTransactions = evmTransactions;
+
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  if (
-    selectedInternalAccount &&
-    !isEvmAccountType(selectedInternalAccount.type) &&
-    route.params?.chainId &&
-    isNonEvmChainId(route.params.chainId)
-  ) {
+  if (asset?.chainId && isNonEvmChainId(asset.chainId)) {
     const nonEvmTransactions = selectNonEvmTransactions(state);
     const txs = nonEvmTransactions?.transactions || [];
 


### PR DESCRIPTION
## **Description**

We currently alway fetch EVM transactions to only discard them if the account is a non EVM one and the asset is also a non EVM asset. Yet, when coming from the swaps view, the selected account can be an EVM account and the asset a non-EVM one, so we currently crash because we pass the EVM transactions to the non-EVM transaction list. To temporarily fix this, we should fetch non-EVM transactions depending on the asset, irrespective of the account being EVM or not.

This is only a temporary fix because the list of transactions will always be empty in this scenario since the account is not aligned with the asset. Only switching accounts will correctly display the transactions. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes App crashes when user clicks on the info CTA of a non-EVM asset on the swap asset picker

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/18053

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
