### PR TITLE
feat: improve perps deposit totals

### DIFF
--- a/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.styles.ts
+++ b/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.styles.ts
@@ -3,7 +3,11 @@ import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (_params: { theme: Theme }) =>
   StyleSheet.create({
-    container: {},
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+    },
     text: {
       textAlign: 'center',
     },

--- a/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.test.tsx
+++ b/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.test.tsx
@@ -4,9 +4,16 @@ import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithB
 import { BridgeToken } from '../../../../UI/Bridge/types';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
 import { PayTokenBalance } from './pay-token-balance';
+import { View as MockView } from 'react-native';
 
 jest.mock('../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
+
+jest.mock('../../../../UI/AnimatedSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../../UI/AnimatedSpinner'),
+  default: () => <MockView testID="pay-token-spinner">{`Spinner`}</MockView>,
+}));
 
 const TOKEN_ADDRESS_MOCK = '0xabcd1234abcd1234abcd1234abcd1234abcd1234';
 const CHAIN_ID_MOCK = '0x123';
@@ -41,22 +48,22 @@ describe('PayTokenBalance', () => {
 
   it('renders pay token balance', () => {
     const { getByText } = render(<PayTokenBalance />);
-    expect(getByText(`Available: ${BALANCE_FIAT_MOCK}`)).toBeTruthy();
+    expect(getByText(`Available: ${BALANCE_FIAT_MOCK}`)).toBeDefined();
   });
 
-  it('renders nothing if no pay token selected', () => {
+  it('renders spinner if no pay token selected', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
     } as ReturnType<typeof useTransactionPayToken>);
 
-    const { queryByText } = render(<PayTokenBalance />);
-    expect(queryByText(`Available: ${BALANCE_FIAT_MOCK}`)).toBeNull();
+    const { getByTestId } = render(<PayTokenBalance />);
+    expect(getByTestId('pay-token-spinner')).toBeDefined();
   });
 
-  it('renders nothing if token not found', () => {
+  it('renders spinner if token not found', () => {
     useTokensWithBalanceMock.mockReturnValue([]);
 
-    const { queryByText } = render(<PayTokenBalance />);
-    expect(queryByText(`Available: ${BALANCE_FIAT_MOCK}`)).toBeNull();
+    const { getByTestId } = render(<PayTokenBalance />);
+    expect(getByTestId('pay-token-spinner')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.tsx
+++ b/app/components/Views/confirmations/components/pay-token-balance/pay-token-balance.tsx
@@ -8,6 +8,7 @@ import styleSheet from './pay-token-balance.styles';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
 import { strings } from '../../../../../../locales/i18n';
+import AnimatedSpinner, { SpinnerSize } from '../../../../UI/AnimatedSpinner';
 
 export function PayTokenBalance() {
   const { styles } = useStyles(styleSheet, {});
@@ -22,16 +23,17 @@ export function PayTokenBalance() {
       t.chainId === chainId,
   );
 
-  if (!token) {
-    return null;
-  }
+  const isLoading = !token || token.balanceFiat === 'tokenBalanceLoading';
 
   return (
     <View style={styles.container}>
-      <Text style={styles.text} color={TextColor.Alternative}>
-        {strings('confirm.available_balance')}
-        {token.balanceFiat}
-      </Text>
+      {isLoading && <AnimatedSpinner size={SpinnerSize.SM} />}
+      {!isLoading && (
+        <Text style={styles.text} color={TextColor.Alternative}>
+          {strings('confirm.available_balance')}
+          {token.balanceFiat}
+        </Text>
+      )}
     </View>
   );
 }

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -5,7 +5,7 @@ import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToke
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent } from '@testing-library/react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { Text as MockText } from 'react-native';
+import { Text as MockText, View as MockView } from 'react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { useTransactionRequiredFiat } from '../../../hooks/pay/useTransactionRequiredFiat';
@@ -23,6 +23,12 @@ jest.mock('../../token-pill/', () => ({
   TokenPill: (props: TokenPillProps) => (
     <MockText>{`${props.address} ${props.chainId}`}</MockText>
   ),
+}));
+
+jest.mock('../../../../../UI/AnimatedSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../../../UI/AnimatedSpinner'),
+  default: () => <MockView testID="pay-with-spinner">{`Spinner`}</MockView>,
 }));
 
 const ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
@@ -97,5 +103,19 @@ describe('PayWithRow', () => {
     expect(navigateMock).toHaveBeenCalledWith(expect.any(String), {
       minimumFiatBalance: TOTAL_FIAT_MOCK,
     });
+  });
+
+  it('renders spinner when no pay token selected', () => {
+    jest.mocked(useTransactionPayToken).mockReturnValue({
+      payToken: undefined,
+      balanceFiat: undefined,
+      balanceHuman: undefined,
+      decimals: undefined,
+      setPayToken: jest.fn(),
+    });
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('pay-with-spinner')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -8,6 +8,9 @@ import { strings } from '../../../../../../../locales/i18n';
 import { TouchableOpacity } from 'react-native';
 import { useTransactionBridgeQuotes } from '../../../hooks/pay/useTransactionBridgeQuotes';
 import { useTransactionRequiredFiat } from '../../../hooks/pay/useTransactionRequiredFiat';
+import AnimatedSpinner, {
+  SpinnerSize,
+} from '../../../../../UI/AnimatedSpinner';
 
 export function PayWithRow() {
   const navigation = useNavigation();
@@ -22,14 +25,14 @@ export function PayWithRow() {
     });
   }, [navigation, totalFiat]);
 
-  if (!payToken) {
-    return null;
-  }
-
   return (
     <InfoRow label={strings('confirm.label.pay_with')}>
       <TouchableOpacity onPress={handleClick}>
-        <TokenPill address={payToken.address} chainId={payToken.chainId} />
+        {!payToken ? (
+          <AnimatedSpinner size={SpinnerSize.SM} />
+        ) : (
+          <TokenPill address={payToken.address} chainId={payToken.chainId} />
+        )}
       </TouchableOpacity>
     </InfoRow>
   );

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -31,7 +31,11 @@ export function PayWithRow() {
         {!payToken ? (
           <AnimatedSpinner size={SpinnerSize.SM} />
         ) : (
-          <TokenPill address={payToken.address} chainId={payToken.chainId} />
+          <TokenPill
+            address={payToken.address}
+            chainId={payToken.chainId}
+            showArrow
+          />
         )}
       </TouchableOpacity>
     </InfoRow>

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -45,7 +45,7 @@ describe('TotalRow', () => {
     jest.clearAllMocks();
 
     useTransactionTotalFiatMock.mockReturnValue({
-      value: 123.456,
+      value: '123.456',
       formatted: TOTAL_FIAT_MOCK,
     });
   });

--- a/app/components/Views/confirmations/components/token-pill/token-pill.test.tsx
+++ b/app/components/Views/confirmations/components/token-pill/token-pill.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TokenPill } from './token-pill';
+import { TokenPill, TokenPillProps } from './token-pill';
 import { Hex } from '@metamask/utils';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
@@ -17,8 +17,8 @@ const STATE_MOCK = {
   },
 };
 
-function render({ address, chainId }: { address: Hex; chainId: Hex }) {
-  return renderWithProvider(<TokenPill address={address} chainId={chainId} />, {
+function render(props: TokenPillProps) {
+  return renderWithProvider(<TokenPill {...props} />, {
     state: STATE_MOCK,
   });
 }
@@ -73,5 +73,15 @@ describe('TokenPill', () => {
     });
 
     expect(queryByTestId('token-pill-symbol')).toBeNull();
+  });
+
+  it('renders arrow if showArrow is true', () => {
+    const { getByTestId } = render({
+      address: ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      showArrow: true,
+    });
+
+    expect(getByTestId('token-pill-arrow')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/token-pill/token-pill.tsx
+++ b/app/components/Views/confirmations/components/token-pill/token-pill.tsx
@@ -14,13 +14,22 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
 
 export interface TokenPillProps {
   address: Hex;
   chainId: Hex;
+  showArrow?: boolean;
 }
 
-export const TokenPill: React.FC<TokenPillProps> = ({ address, chainId }) => {
+export const TokenPill: React.FC<TokenPillProps> = ({
+  address,
+  chainId,
+  showArrow,
+}) => {
   const { styles } = useStyles(styleSheet, {});
   const tokens = useTokensWithBalance({ chainIds: [chainId] });
 
@@ -62,6 +71,7 @@ export const TokenPill: React.FC<TokenPillProps> = ({ address, chainId }) => {
         />
       </BadgeWrapper>
       <Text testID="token-pill-symbol">{token?.symbol}</Text>
+      {showArrow && <Icon name={IconName.ArrowDown} size={IconSize.Xs} />}
     </Box>
   );
 };

--- a/app/components/Views/confirmations/components/token-pill/token-pill.tsx
+++ b/app/components/Views/confirmations/components/token-pill/token-pill.tsx
@@ -71,7 +71,13 @@ export const TokenPill: React.FC<TokenPillProps> = ({
         />
       </BadgeWrapper>
       <Text testID="token-pill-symbol">{token?.symbol}</Text>
-      {showArrow && <Icon name={IconName.ArrowDown} size={IconSize.Xs} />}
+      {showArrow && (
+        <Icon
+          testID="token-pill-arrow"
+          name={IconName.ArrowDown}
+          size={IconSize.Xs}
+        />
+      )}
     </Box>
   );
 };

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
@@ -10,14 +10,14 @@ import { emptySignatureControllerMock } from '../../../../__mocks__/controllers/
 import { useGasFeeEstimates } from '../../../../hooks/gas/useGasFeeEstimates';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { useTransactionPayToken } from '../../../../hooks/pay/useTransactionPayToken';
-import { usePerpsDepositData } from '../../hooks/usePerpsDepositData';
+import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
 
 jest.mock('../../../../hooks/ui/useNavbar');
 jest.mock('../../../../../../UI/Bridge/hooks/useTokensWithBalance');
 jest.mock('../../../../hooks/gas/useGasFeeEstimates');
 jest.mock('../../../../hooks/pay/useAutomaticTransactionPayToken');
 jest.mock('../../../../hooks/pay/useTransactionPayToken');
-jest.mock('../../hooks/usePerpsDepositData');
+jest.mock('../../hooks/usePerpsDepositView');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -36,7 +36,7 @@ describe('PerpsDeposit', () => {
   const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
   const useGasFeeEstimatesMock = jest.mocked(useGasFeeEstimates);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const usePerpsDepositDataMock = jest.mocked(usePerpsDepositData);
+  const usePerpsDepositViewMock = jest.mocked(usePerpsDepositView);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -58,7 +58,7 @@ describe('PerpsDeposit', () => {
       setPayToken: noop,
     });
 
-    usePerpsDepositDataMock.mockReturnValue({
+    usePerpsDepositViewMock.mockReturnValue({
       isFullView: false,
     });
   });

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
@@ -9,14 +9,15 @@ import { useTokensWithBalance } from '../../../../../../UI/Bridge/hooks/useToken
 import { emptySignatureControllerMock } from '../../../../__mocks__/controllers/signature-controller-mock';
 import { useGasFeeEstimates } from '../../../../hooks/gas/useGasFeeEstimates';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
-import { act, fireEvent } from '@testing-library/react-native';
 import { useTransactionPayToken } from '../../../../hooks/pay/useTransactionPayToken';
+import { usePerpsDepositData } from '../../hooks/usePerpsDepositData';
 
 jest.mock('../../../../hooks/ui/useNavbar');
 jest.mock('../../../../../../UI/Bridge/hooks/useTokensWithBalance');
 jest.mock('../../../../hooks/gas/useGasFeeEstimates');
 jest.mock('../../../../hooks/pay/useAutomaticTransactionPayToken');
 jest.mock('../../../../hooks/pay/useTransactionPayToken');
+jest.mock('../../hooks/usePerpsDepositData');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -35,6 +36,7 @@ describe('PerpsDeposit', () => {
   const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
   const useGasFeeEstimatesMock = jest.mocked(useGasFeeEstimates);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const usePerpsDepositDataMock = jest.mocked(usePerpsDepositData);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -55,6 +57,10 @@ describe('PerpsDeposit', () => {
       },
       setPayToken: noop,
     });
+
+    usePerpsDepositDataMock.mockReturnValue({
+      isFullView: false,
+    });
   });
 
   it('renders pay token', () => {
@@ -69,8 +75,8 @@ describe('PerpsDeposit', () => {
     expect(getByText('Pay with')).toBeDefined();
   });
 
-  it('hides total while keyboard visible', async () => {
-    const { queryByTestId, getByTestId, getByText } = renderWithProvider(
+  it('hides total', async () => {
+    const { queryByTestId } = renderWithProvider(
       <PerpsDeposit />,
       {
         state: STATE_MOCK,
@@ -79,16 +85,10 @@ describe('PerpsDeposit', () => {
     );
 
     expect(queryByTestId('total-row')).toBeNull();
-
-    await act(async () => {
-      fireEvent.press(getByText('Done'));
-    });
-
-    expect(getByTestId('total-row')).toBeDefined();
   });
 
-  it('hides gas fee while keyboard visible', async () => {
-    const { queryByTestId, getByTestId, getByText } = renderWithProvider(
+  it('hides gas fee', async () => {
+    const { queryByTestId } = renderWithProvider(
       <PerpsDeposit />,
       {
         state: STATE_MOCK,
@@ -99,13 +99,5 @@ describe('PerpsDeposit', () => {
     expect(
       queryByTestId(ConfirmationRowComponentIDs.GAS_FEES_DETAILS),
     ).toBeNull();
-
-    await act(async () => {
-      fireEvent.press(getByText('Done'));
-    });
-
-    expect(
-      getByTestId(ConfirmationRowComponentIDs.GAS_FEES_DETAILS),
-    ).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -21,7 +21,10 @@ const AMOUNT_PREFIX = '$';
 
 export function PerpsDeposit() {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
-  const { isFullView } = usePerpsDepositData({ isKeyboardVisible });
+
+  const { isFullView } = usePerpsDepositData({
+    isKeyboardVisible,
+  });
 
   const handleKeyboardShow = () => {
     setIsKeyboardVisible(true);

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -15,14 +15,14 @@ import AlertBanner from '../../../../components/alert-banner';
 import { Box } from '../../../../../../UI/Box/Box';
 import InfoRowDivider from '../../../../components/UI/info-row-divider';
 import { InfoRowDividerVariant } from '../../../../components/UI/info-row-divider/info-row-divider.styles';
-import { usePerpsDepositData } from '../../hooks/usePerpsDepositData';
+import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
 
 const AMOUNT_PREFIX = '$';
 
 export function PerpsDeposit() {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
-  const { isFullView } = usePerpsDepositData({
+  const { isFullView } = usePerpsDepositView({
     isKeyboardVisible,
   });
 

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -11,29 +11,17 @@ import { PayTokenBalance } from '../../../../components/pay-token-balance';
 import { BridgeTimeRow } from '../../../../components/rows/bridge-time-row';
 import { AlertMessage } from '../../../../components/alert-message';
 import { RowAlertKey } from '../../../../components/UI/info-row/alert-row/constants';
-import { useAutomaticTransactionPayToken } from '../../../../hooks/pay/useAutomaticTransactionPayToken';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 import AlertBanner from '../../../../components/alert-banner';
 import { Box } from '../../../../../../UI/Box/Box';
 import InfoRowDivider from '../../../../components/UI/info-row-divider';
 import { InfoRowDividerVariant } from '../../../../components/UI/info-row-divider/info-row-divider.styles';
+import { usePerpsDepositData } from '../../hooks/usePerpsDepositData';
 
 const AMOUNT_PREFIX = '$';
 
 export function PerpsDeposit() {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
-
-  useAutomaticTransactionPayToken({
-    balanceOverrides: [
-      {
-        address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as const,
-        balance: 10,
-        chainId: CHAIN_IDS.ARBITRUM,
-      },
-    ],
-  });
-
-  useNavbar(strings('confirm.title.perps_deposit'), false);
+  const { isFullView } = usePerpsDepositData({ isKeyboardVisible });
 
   const handleKeyboardShow = () => {
     setIsKeyboardVisible(true);
@@ -42,6 +30,8 @@ export function PerpsDeposit() {
   const handleKeyboardHide = () => {
     setIsKeyboardVisible(false);
   };
+
+  useNavbar(strings('confirm.title.perps_deposit'), false);
 
   return (
     <>
@@ -61,9 +51,9 @@ export function PerpsDeposit() {
         )}
         <InfoSection>
           <PayWithRow />
-          {!isKeyboardVisible && <BridgeTimeRow />}
+          {isFullView && <BridgeTimeRow />}
         </InfoSection>
-        {!isKeyboardVisible && (
+        {isFullView && (
           <InfoSection>
             <GasFeesDetailsRow disableUpdate hideSpeed fiatOnly noSection />
             <InfoRowDivider variant={InfoRowDividerVariant.Large} />

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -42,7 +42,7 @@ export function PerpsDeposit() {
         onKeyboardHide={handleKeyboardHide}
       >
         <Box gap={16}>
-          <PayTokenBalance />
+          {isKeyboardVisible && <PayTokenBalance />}
           <AlertMessage field={RowAlertKey.Amount} />
           <TokenAmountNative />
         </Box>

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositData.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositData.ts
@@ -1,0 +1,48 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../../../reducers';
+import {
+  selectIsTransactionBridgeQuotesLoadingById,
+  selectTransactionBridgeQuotesById,
+} from '../../../../../../core/redux/slices/confirmationMetrics';
+import { BigNumber } from 'bignumber.js';
+
+export function usePerpsDepositData({
+  isKeyboardVisible,
+}: {
+  isKeyboardVisible: boolean;
+}) {
+  const { id: transactionId } = useTransactionMetadataOrThrow();
+  const { amountUnformatted } = useTokenAmount();
+  const amountValue = new BigNumber(amountUnformatted ?? '0');
+
+  const quotes = useSelector((state: RootState) =>
+    selectTransactionBridgeQuotesById(state, transactionId),
+  );
+
+  const isQuotesLoading = useSelector((state: RootState) =>
+    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
+  );
+
+  const isFullView =
+    !isKeyboardVisible &&
+    !amountValue.isZero() &&
+    (isQuotesLoading || Boolean(quotes?.length));
+
+  useAutomaticTransactionPayToken({
+    balanceOverrides: [
+      {
+        address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as const,
+        balance: 10,
+        chainId: CHAIN_IDS.ARBITRUM,
+      },
+    ],
+  });
+
+  return {
+    isFullView,
+  };
+}

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositData.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositData.ts
@@ -9,12 +9,15 @@ import {
   selectTransactionBridgeQuotesById,
 } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { BigNumber } from 'bignumber.js';
+import { usePerpsDepositInit } from './usePerpsDepositInit';
 
 export function usePerpsDepositData({
   isKeyboardVisible,
 }: {
   isKeyboardVisible: boolean;
 }) {
+  usePerpsDepositInit();
+
   const { id: transactionId } = useTransactionMetadataOrThrow();
   const { amountUnformatted } = useTokenAmount();
   const amountValue = new BigNumber(amountUnformatted ?? '0');

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.test.ts
@@ -1,0 +1,75 @@
+import { Token } from '@metamask/assets-controllers';
+import Engine from '../../../../../../core/Engine';
+import { selectTokensByChainIdAndAddress } from '../../../../../../selectors/tokensController';
+import { renderHookWithProvider } from '../../../../../../util/test/renderWithProvider';
+import {
+  ARBITRUM_USDC_ADDRESS,
+  usePerpsDepositInit,
+} from './usePerpsDepositInit';
+import { act } from '@testing-library/react-native';
+
+const NETWORK_CLIENT_ID = 'mockNetworkClientId';
+
+jest.mock('../../../../../../selectors/tokensController');
+
+jest.mock('../../../../../../core/Engine', () => ({
+  context: {
+    NetworkController: {
+      findNetworkClientIdByChainId: jest.fn(),
+    },
+    TokensController: {
+      addToken: jest.fn(),
+    },
+  },
+}));
+
+async function runHook() {
+  const result = renderHookWithProvider(usePerpsDepositInit, {});
+
+  await act(async () => {
+    // Intentionally empty
+  });
+
+  return result;
+}
+
+describe('usePerpsDepositInit', () => {
+  const mockFindNetworkClientIdByChainId = jest.mocked(
+    Engine.context.NetworkController.findNetworkClientIdByChainId,
+  );
+  const mockAddToken = jest.mocked(Engine.context.TokensController.addToken);
+  const selectTokensByChainIdAndAddressMock = jest.mocked(
+    selectTokensByChainIdAndAddress,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFindNetworkClientIdByChainId.mockReturnValue(NETWORK_CLIENT_ID);
+    mockAddToken.mockResolvedValue([]);
+    selectTokensByChainIdAndAddressMock.mockReturnValue({});
+  });
+
+  it('adds token if not present', async () => {
+    await runHook();
+
+    expect(mockAddToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: ARBITRUM_USDC_ADDRESS,
+        networkClientId: NETWORK_CLIENT_ID,
+      }),
+    );
+  });
+
+  it('does not add token if already present', async () => {
+    selectTokensByChainIdAndAddressMock.mockReturnValue({
+      [ARBITRUM_USDC_ADDRESS]: {
+        address: ARBITRUM_USDC_ADDRESS,
+      } as Token,
+    });
+
+    await runHook();
+
+    expect(mockAddToken).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
@@ -6,6 +6,10 @@ import { HYPERLIQUID_ASSET_CONFIGS } from '../../../../../UI/Perps/constants/hyp
 import { Hex, parseCaipAssetId } from '@metamask/utils';
 import { useAsyncResult } from '../../../../../hooks/useAsyncResult';
 
+export const ARBITRUM_USDC_ADDRESS = parseCaipAssetId(
+  HYPERLIQUID_ASSET_CONFIGS.USDC.mainnet,
+).assetReference.toLowerCase() as Hex;
+
 const USDC_SYMBOL = 'USDC';
 const USDC_DECIMALS = 6;
 
@@ -16,15 +20,11 @@ export function usePerpsDepositInit() {
     selectTokensByChainIdAndAddress(state, CHAIN_IDS.ARBITRUM),
   );
 
-  const tokenAddress = parseCaipAssetId(
-    HYPERLIQUID_ASSET_CONFIGS.USDC.mainnet,
-  ).assetReference.toLowerCase() as Hex;
-
   const hasToken = Object.values(tokens).some(
-    (token) => token.address.toLowerCase() === tokenAddress,
+    (token) => token.address.toLowerCase() === ARBITRUM_USDC_ADDRESS,
   );
 
-  useAsyncResult(async () => {
+  const { error } = useAsyncResult(async () => {
     if (hasToken) {
       return;
     }
@@ -34,10 +34,14 @@ export function usePerpsDepositInit() {
     );
 
     await TokensController.addToken({
-      address: tokenAddress,
+      address: ARBITRUM_USDC_ADDRESS,
       symbol: USDC_SYMBOL,
       decimals: USDC_DECIMALS,
       networkClientId,
     });
-  }, [hasToken, tokenAddress]);
+  }, [hasToken]);
+
+  if (error) {
+    console.error('Error adding USDC token:', error);
+  }
 }

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
@@ -1,0 +1,43 @@
+import Engine from '../../../../../../core/Engine';
+import { useSelector } from 'react-redux';
+import { selectTokensByChainIdAndAddress } from '../../../../../../selectors/tokensController';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { HYPERLIQUID_ASSET_CONFIGS } from '../../../../../UI/Perps/constants/hyperLiquidConfig';
+import { Hex, parseCaipAssetId } from '@metamask/utils';
+import { useAsyncResult } from '../../../../../hooks/useAsyncResult';
+
+const USDC_SYMBOL = 'USDC';
+const USDC_DECIMALS = 6;
+
+export function usePerpsDepositInit() {
+  const { NetworkController, TokensController } = Engine.context;
+
+  const tokens = useSelector((state) =>
+    selectTokensByChainIdAndAddress(state, CHAIN_IDS.ARBITRUM),
+  );
+
+  const tokenAddress = parseCaipAssetId(
+    HYPERLIQUID_ASSET_CONFIGS.USDC.mainnet,
+  ).assetReference.toLowerCase() as Hex;
+
+  const hasToken = Object.values(tokens).some(
+    (token) => token.address.toLowerCase() === tokenAddress,
+  );
+
+  useAsyncResult(async () => {
+    if (hasToken) {
+      return;
+    }
+
+    const networkClientId = NetworkController.findNetworkClientIdByChainId(
+      CHAIN_IDS.ARBITRUM,
+    );
+
+    await TokensController.addToken({
+      address: tokenAddress,
+      symbol: USDC_SYMBOL,
+      decimals: USDC_DECIMALS,
+      networkClientId,
+    });
+  }, [hasToken, tokenAddress]);
+}

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
@@ -1,0 +1,112 @@
+import { merge } from 'lodash';
+import { renderHookWithProvider } from '../../../../../../util/test/renderWithProvider';
+import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../../__mocks__/controllers/transaction-controller-mock';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { usePerpsDepositView } from './usePerpsDepositView';
+
+jest.mock('./usePerpsDepositInit');
+jest.mock('../../../hooks/useTokenAmount');
+jest.mock('../../../hooks/pay/useAutomaticTransactionPayToken');
+
+function runHook(
+  props: Parameters<typeof usePerpsDepositView>[0],
+  {
+    isLoading,
+    hasQuotes,
+  }: {
+    isLoading?: boolean;
+    hasQuotes?: boolean;
+  } = {},
+) {
+  const state = merge(
+    {},
+    simpleSendTransactionControllerMock,
+    transactionApprovalControllerMock,
+    {
+      confirmationMetrics: {
+        transactionBridgeQuotesById: {
+          [transactionIdMock]: hasQuotes ? [{}] : undefined,
+        },
+        isTransactionBridgeQuotesLoadingById: {
+          [transactionIdMock]: isLoading,
+        },
+      },
+    },
+  );
+
+  return renderHookWithProvider(() => usePerpsDepositView(props), {
+    state,
+  });
+}
+
+describe('usePerpsDepositView', () => {
+  const useTokenAmountMock = jest.mocked(useTokenAmount);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '1',
+    } as ReturnType<typeof useTokenAmount>);
+  });
+
+  it('returns isFullView as true if keyboard hidden and amount is non-zero with quotes loading', () => {
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {
+        isLoading: true,
+      },
+    );
+
+    expect(result.current.isFullView).toBe(true);
+  });
+
+  it('returns isFullView as true if keyboard hidden and amount is non-zero with quotes', () => {
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {
+        hasQuotes: true,
+      },
+    );
+
+    expect(result.current.isFullView).toBe(true);
+  });
+
+  it('returns isFullView as false if keyboard visible', () => {
+    const { result } = runHook(
+      {
+        isKeyboardVisible: true,
+      },
+      {
+        hasQuotes: true,
+      },
+    );
+
+    expect(result.current.isFullView).toBe(false);
+  });
+
+  it('returns isFullView as false if amount is zero', () => {
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '0',
+    } as ReturnType<typeof useTokenAmount>);
+
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {
+        hasQuotes: true,
+      },
+    );
+
+    expect(result.current.isFullView).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -11,7 +11,7 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { usePerpsDepositInit } from './usePerpsDepositInit';
 
-export function usePerpsDepositData({
+export function usePerpsDepositView({
   isKeyboardVisible,
 }: {
   isKeyboardVisible: boolean;

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
@@ -20,9 +20,9 @@ describe('usePerpsDepositMinimumAlert', () => {
   });
 
   it('returns alert if token amount less than minimum', () => {
-    useTokenAmountMock.mockReturnValue({ usdValue: '9.99' } as ReturnType<
-      typeof useTokenAmount
-    >);
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '9.99',
+    } as ReturnType<typeof useTokenAmount>);
 
     const { result } = runHook();
 
@@ -38,9 +38,9 @@ describe('usePerpsDepositMinimumAlert', () => {
   });
 
   it('returns no alert if token amount greater than minimum', () => {
-    useTokenAmountMock.mockReturnValue({ usdValue: '10.01' } as ReturnType<
-      typeof useTokenAmount
-    >);
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '10.01',
+    } as ReturnType<typeof useTokenAmount>);
 
     const { result } = runHook();
 

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
@@ -9,10 +9,10 @@ import { strings } from '../../../../../../locales/i18n';
 export const MINIMUM_DEPOSIT_USD = 10;
 
 export function usePerpsDepositMinimumAlert(): Alert[] {
-  const { usdValue } = useTokenAmount();
+  const { amountUnformatted } = useTokenAmount();
 
   const underMinimum =
-    new BigNumber(usdValue ?? '0').isLessThan(MINIMUM_DEPOSIT_USD) &&
+    new BigNumber(amountUnformatted ?? '0').isLessThan(MINIMUM_DEPOSIT_USD) &&
     process.env.MM_CONFIRMATION_INTENTS === 'true';
 
   return useMemo(() => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -9,11 +9,14 @@ import { act } from '@testing-library/react-native';
 import * as confirmationReducer from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMetadataRequest';
 import { Hex } from '@metamask/utils';
+import { useAlerts } from '../../context/alert-system-context';
+import { AlertKeys } from '../../constants/alerts';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayTokenAmounts');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../../utils/bridge');
+jest.mock('../../context/alert-system-context');
 
 const TRANSACTION_ID_MOCK = '1234-5678';
 const CHAIN_ID_SOURCE_MOCK = '0x1';
@@ -37,6 +40,7 @@ function runHook() {
 describe('useTransactionBridgeQuotes', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const getBridgeQuotesMock = jest.mocked(getBridgeQuotes);
+  const useAlertsMock = jest.mocked(useAlerts);
 
   const useTransactionPayTokenAmountsMock = jest.mocked(
     useTransactionPayTokenAmounts,
@@ -82,6 +86,10 @@ describe('useTransactionBridgeQuotes', () => {
     } as ReturnType<typeof useTransactionPayTokenAmounts>);
 
     getBridgeQuotesMock.mockResolvedValue([QUOTE_MOCK, QUOTE_MOCK]);
+
+    useAlertsMock.mockReturnValue({
+      alerts: [],
+    } as unknown as ReturnType<typeof useAlerts>);
   });
 
   it('requests bridge quotes', () => {
@@ -135,7 +143,7 @@ describe('useTransactionBridgeQuotes', () => {
     });
   });
 
-  it('returns empty list if no selected pay token ', async () => {
+  it('returns empty list if no selected pay token', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
     } as unknown as ReturnType<typeof useTransactionPayToken>);
@@ -147,5 +155,43 @@ describe('useTransactionBridgeQuotes', () => {
     });
 
     expect(result.current.quotes).toStrictEqual([]);
+  });
+
+  it('returns empty list if blocking alert', async () => {
+    useAlertsMock.mockReturnValue({
+      alerts: [
+        {
+          key: 'alert-key',
+          isBlocking: true,
+        },
+      ],
+    } as unknown as ReturnType<typeof useAlerts>);
+
+    const result = runHook();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(result.current.quotes).toStrictEqual([]);
+  });
+
+  it('returns empty list if blocking alert unless no quotes alert', async () => {
+    useAlertsMock.mockReturnValue({
+      alerts: [
+        {
+          key: AlertKeys.NoPayTokenQuotes,
+          isBlocking: true,
+        },
+      ],
+    } as unknown as ReturnType<typeof useAlerts>);
+
+    const result = runHook();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(result.current.quotes).toStrictEqual([QUOTE_MOCK, QUOTE_MOCK]);
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
@@ -1,7 +1,7 @@
 import { useTransactionPayTokenAmounts } from './useTransactionPayTokenAmounts';
 import { useAsyncResult } from '../../../../hooks/useAsyncResult';
 import { BridgeQuoteRequest, getBridgeQuotes } from '../../utils/bridge';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useDispatch } from 'react-redux';
 import {
@@ -10,6 +10,7 @@ import {
 } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMetadataRequest';
 import { Hex, createProjectLogger } from '@metamask/utils';
+import { useDeepMemo } from '../useDeepMemo';
 
 const log = createProjectLogger('transaction-pay');
 
@@ -30,7 +31,7 @@ export function useTransactionBridgeQuotes() {
 
   const { amounts: sourceAmounts } = useTransactionPayTokenAmounts();
 
-  const requests: BridgeQuoteRequest[] = useMemo(() => {
+  const requests: BridgeQuoteRequest[] = useDeepMemo(() => {
     if (!sourceTokenAddress || !sourceChainId || !sourceAmounts) {
       return [];
     }

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
@@ -1,29 +1,34 @@
 import { merge } from 'lodash';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useTransactionTotalFiat } from './useTransactionTotalFiat';
-import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
 import { useTransactionMaxGasCost } from '../gas/useTransactionMaxGasCost';
 import { useTransactionRequiredFiat } from './useTransactionRequiredFiat';
-import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
-import { toHex } from '@metamask/controller-utils';
 import { TransactionBridgeQuote } from '../../utils/bridge';
 
 jest.mock('../gas/useTransactionMaxGasCost');
 jest.mock('./useTransactionRequiredFiat');
 jest.mock('./useTransactionRequiredTokens');
 
+const ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const ADDRESS_2_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12';
+
 function runHook({ quotes }: { quotes?: TransactionBridgeQuote[] } = {}) {
   return renderHookWithProvider(useTransactionTotalFiat, {
     state: merge(
+      {},
       simpleSendTransactionControllerMock,
       transactionApprovalControllerMock,
       otherControllersMock,
       {
         confirmationMetrics: {
           transactionBridgeQuotesById: {
-            '699ca2f0-e459-11ef-b6f6-d182277cf5e1': quotes ?? [],
+            [transactionIdMock]: quotes ?? [],
           },
         },
       },
@@ -33,10 +38,6 @@ function runHook({ quotes }: { quotes?: TransactionBridgeQuote[] } = {}) {
 
 describe('useTransactionTotalFiat', () => {
   const useTransactionMaxGasCostMock = jest.mocked(useTransactionMaxGasCost);
-
-  const useTransactionRequiredTokensMock = jest.mocked(
-    useTransactionRequiredTokens,
-  );
 
   const useTransactionRequiredFiatMock = jest.mocked(
     useTransactionRequiredFiat,
@@ -51,54 +52,102 @@ describe('useTransactionTotalFiat', () => {
       values: [],
       totalFiat: 0,
     });
-
-    useTransactionRequiredTokensMock.mockReturnValue([]);
-  });
-
-  it('includes gas cost', () => {
-    useTransactionMaxGasCostMock.mockReturnValue(toHex('12345600000000000'));
-
-    const { result } = runHook();
-
-    expect(result.current).toStrictEqual({
-      value: 123.456,
-      formatted: '$123.46',
-    });
   });
 
   it('includes quotes cost', () => {
-    useTransactionRequiredFiatMock.mockReturnValue({
-      values: [],
-      totalFiat: 456.123,
-    });
-
-    const { result } = runHook();
-
-    expect(result.current).toStrictEqual({
-      value: 456.123,
-      formatted: '$456.12',
-    });
-  });
-
-  it('includes quotes gas cost', () => {
     const { result } = runHook({
       quotes: [
         {
+          adjustedReturn: {
+            valueInCurrency: '12.34',
+          },
+          cost: {
+            valueInCurrency: '23.45',
+          },
           totalMaxNetworkFee: {
-            valueInCurrency: '123.456',
+            valueInCurrency: '34.56',
           },
         },
         {
+          adjustedReturn: {
+            valueInCurrency: '45.67',
+          },
+          cost: {
+            valueInCurrency: '56.78',
+          },
           totalMaxNetworkFee: {
-            valueInCurrency: '456.123',
+            valueInCurrency: '67.89',
           },
         },
       ] as TransactionBridgeQuote[],
     });
 
     expect(result.current).toStrictEqual({
-      value: 579.579,
-      formatted: '$579.58',
+      value: '240.69',
+      formatted: '$240.69',
+    });
+  });
+
+  it('includes balance cost', () => {
+    useTransactionRequiredFiatMock.mockReturnValue({
+      values: [
+        {
+          address: ADDRESS_MOCK,
+          amountFiat: 12.34,
+        },
+        {
+          address: ADDRESS_2_MOCK,
+          amountFiat: 23.45,
+        },
+      ],
+    } as unknown as ReturnType<typeof useTransactionRequiredFiat>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual({
+      value: '35.79',
+      formatted: '$35.79',
+    });
+  });
+
+  it('ignores balance cost if matching quote', () => {
+    useTransactionRequiredFiatMock.mockReturnValue({
+      values: [
+        {
+          address: ADDRESS_MOCK,
+          amountFiat: 1000,
+        },
+        {
+          address: ADDRESS_2_MOCK,
+          amountFiat: 20,
+        },
+      ],
+    } as unknown as ReturnType<typeof useTransactionRequiredFiat>);
+
+    const { result } = runHook({
+      quotes: [
+        {
+          adjustedReturn: {
+            valueInCurrency: '30',
+          },
+          cost: {
+            valueInCurrency: '40',
+          },
+          totalMaxNetworkFee: {
+            valueInCurrency: '50',
+          },
+          quote: {
+            destAsset: {
+              address: ADDRESS_MOCK,
+            },
+          },
+        },
+      ] as TransactionBridgeQuote[],
+    });
+
+    expect(result.current).toStrictEqual({
+      value: '140',
+      formatted: '$140',
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -1,9 +1,5 @@
 import { useSelector } from 'react-redux';
 import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMetadataRequest';
-import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
-import { selectConversionRateByChainId } from '../../../../../selectors/currencyRateController';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
-import { useTransactionMaxGasCost } from '../gas/useTransactionMaxGasCost';
 import { RootState } from '../../../../../reducers';
 import { selectTransactionBridgeQuotesById } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionRequiredFiat } from './useTransactionRequiredFiat';
@@ -11,27 +7,50 @@ import { BigNumber } from 'bignumber.js';
 import { createProjectLogger } from '@metamask/utils';
 import { useEffect } from 'react';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { TransactionBridgeQuote } from '../../utils/bridge';
 
 const log = createProjectLogger('transaction-pay');
 
 export function useTransactionTotalFiat() {
-  const gasCost = useGasCost();
-  const quotesGasCost = useQuotesGasCost();
   const fiatFormatter = useFiatFormatter();
-  const { totalFiat: quotesCost } = useTransactionRequiredFiat();
+  const { values: requiredFiat } = useTransactionRequiredFiat();
+  const { id: transactionId } = useTransactionMetadataOrThrow();
 
-  const value = gasCost + quotesGasCost + quotesCost;
-  const formatted = fiatFormatter(new BigNumber(value));
+  const quotes = useSelector((state: RootState) =>
+    selectTransactionBridgeQuotesById(state, transactionId),
+  );
+
+  const quotesCost = (quotes ?? []).reduce(
+    (acc, quote) => acc.plus(getQuoteCostFiat(quote)),
+    new BigNumber(0),
+  );
+
+  const balancesToUse = requiredFiat.filter(
+    (token) =>
+      !quotes?.some(
+        (quote) =>
+          quote.quote.destAsset.address.toLowerCase() ===
+          token.address.toLowerCase(),
+      ),
+  );
+
+  const balanceCost = balancesToUse.reduce(
+    (acc, token) => acc.plus(new BigNumber(token.amountFiat)),
+    new BigNumber(0),
+  );
+
+  const total = quotesCost.plus(balanceCost);
+  const value = total.toString(10);
+  const formatted = fiatFormatter(total);
 
   useEffect(() => {
     log('Total fiat', {
-      gasCost,
-      quotesGasCost,
-      quotesCost,
-      value,
+      balanceCost: balanceCost.toString(10),
+      quotesCost: quotesCost.toString(10),
       formatted,
+      value,
     });
-  }, [gasCost, quotesGasCost, quotesCost, value, formatted]);
+  }, [balanceCost, quotesCost, formatted, value]);
 
   return {
     value,
@@ -39,40 +58,10 @@ export function useTransactionTotalFiat() {
   };
 }
 
-function useQuotesGasCost() {
-  const { id: transactionId } = useTransactionMetadataOrThrow();
+function getQuoteCostFiat(quote: TransactionBridgeQuote): BigNumber {
+  const gasCost = new BigNumber(quote.totalMaxNetworkFee.valueInCurrency ?? 0);
+  const cost = new BigNumber(quote.cost.valueInCurrency ?? 0);
+  const amount = new BigNumber(quote.adjustedReturn.valueInCurrency ?? 0);
 
-  const quotes = useSelector((state: RootState) =>
-    selectTransactionBridgeQuotesById(state, transactionId),
-  );
-
-  return (quotes ?? []).reduce((acc, quote) => {
-    const value = new BigNumber(quote.totalMaxNetworkFee.valueInCurrency ?? 0);
-    return acc + (value.isNaN() ? 0 : value.toNumber());
-  }, 0);
-}
-
-function useGasCost() {
-  const tokens = useTransactionRequiredTokens();
-  const { chainId } = useTransactionMetadataOrThrow();
-
-  const conversionRate = useSelector((state: RootState) =>
-    selectConversionRateByChainId(state, chainId),
-  );
-
-  const nativeToken = tokens.find(
-    (token) =>
-      token.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase(),
-  );
-
-  const gasCost = useTransactionMaxGasCost() ?? '0x0';
-
-  if (nativeToken) {
-    return 0;
-  }
-
-  return new BigNumber(gasCost, 16)
-    .shiftedBy(-18)
-    .multipliedBy(new BigNumber(conversionRate ?? 1))
-    .toNumber();
+  return amount.plus(gasCost).plus(cost);
 }

--- a/app/components/Views/confirmations/utils/bridge.test.ts
+++ b/app/components/Views/confirmations/utils/bridge.test.ts
@@ -9,6 +9,7 @@ import { ExtendedControllerMessenger } from '../../../../core/ExtendedController
 import { BridgeQuoteRequest, getBridgeQuotes } from './bridge';
 import { selectBridgeQuotes } from '../../../../core/redux/slices/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
+import { GasFeeController } from '@metamask/gas-fee-controller';
 
 jest.mock('../../../../core/Engine');
 jest.mock('../../../../core/redux/slices/bridge');
@@ -54,6 +55,7 @@ describe('Confirmations Bridge Utils', () => {
   const engineMock = jest.mocked(Engine);
   let messengerMock: ExtendedControllerMessenger<never, BridgeControllerEvents>;
   let bridgeControllerMock: jest.Mocked<BridgeController>;
+  let gasFeeControllerMock: jest.Mocked<GasFeeController>;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -65,8 +67,13 @@ describe('Confirmations Bridge Utils', () => {
       updateBridgeQuoteRequestParams: jest.fn().mockResolvedValue({}),
     } as unknown as jest.Mocked<BridgeController>;
 
+    gasFeeControllerMock = {
+      fetchGasFeeEstimates: jest.fn(),
+    } as unknown as jest.Mocked<GasFeeController>;
+
     engineMock.controllerMessenger = messengerMock as never;
     engineMock.context.BridgeController = bridgeControllerMock as never;
+    engineMock.context.GasFeeController = gasFeeControllerMock as never;
 
     selectBridgeQuotesMock.mockImplementation(
       (state) =>
@@ -99,6 +106,23 @@ describe('Confirmations Bridge Utils', () => {
 
         return Promise.resolve();
       });
+
+    gasFeeControllerMock.fetchGasFeeEstimates.mockResolvedValue({
+      gasFeeEstimates: {
+        low: {
+          gasLimit: '21000',
+          gasPrice: '1000000000',
+        },
+        medium: {
+          gasLimit: '21000',
+          gasPrice: '2000000000',
+        },
+        high: {
+          gasLimit: '21000',
+          gasPrice: '3000000000',
+        },
+      },
+    } as never);
 
     selectShouldUseSmartTransactionMock.mockReturnValue(false);
   });

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^13.2.0",
     "@metamask/token-search-discovery-controller": "^3.1.0",
-    "@metamask/transaction-controller": "^59.0.0",
+    "@metamask/transaction-controller": "^59.2.0",
     "@metamask/utils": "^11.4.2",
     "@ngraveio/bc-ur": "^1.1.6",
     "@notifee/react-native": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,6 +4920,14 @@
     "@metamask/utils" "^11.2.0"
     immer "^9.0.6"
 
+"@metamask/base-controller@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/base-controller/-/base-controller-8.1.0.tgz#dd8746f8ec95fb564251c284f84e9264427816f1"
+  integrity sha512-pwWHTBntzPE6yBMH9qiXMaslQW2kS7Izw1g+4D8QhGIxNWBt1nz1uavTGcSBUFgO3eMDKe2QPU04xgThqCPv+g==
+  dependencies:
+    "@metamask/utils" "^11.4.2"
+    immer "^9.0.6"
+
 "@metamask/bitcoin-wallet-snap@^0.18.0":
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/@metamask/bitcoin-wallet-snap/-/bitcoin-wallet-snap-0.18.0.tgz#51b73f9132886c599b7e09fd5671a1dc7584836c"
@@ -6350,10 +6358,10 @@
     "@toruslabs/http-helpers" "^8.1.1"
     bn.js "^5.2.1"
 
-"@metamask/transaction-controller@^59.0.0":
-  version "59.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/transaction-controller/-/transaction-controller-59.0.0.tgz#8ef3fd64d70e8cb29a2da301a695bdf9a1e7ff6f"
-  integrity sha512-1qVvnoRJ220Bak4pqQ83Kq0528Xkl5DReV/WiZOWWN1Fna8lT1SJJX9bDVCYw2hAbzCmESSiZkSgvsYLKCOXrQ==
+"@metamask/transaction-controller@^59.2.0":
+  version "59.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/transaction-controller/-/transaction-controller-59.2.0.tgz#81b02318a3c4bf76eb06aa6ace833d4821ff3deb"
+  integrity sha512-b47gBy7v+Xp8PDM09uOR/dincsE0/sYjMVRxk1z+agcTtyXp8GvcqSTnkAlLWP1rLlAMxrj3FJu+QJaCXAR6bA==
   dependencies:
     "@ethereumjs/common" "^4.4.0"
     "@ethereumjs/tx" "^5.4.0"
@@ -6362,7 +6370,7 @@
     "@ethersproject/contracts" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"
     "@ethersproject/wallet" "^5.7.0"
-    "@metamask/base-controller" "^8.0.1"
+    "@metamask/base-controller" "^8.1.0"
     "@metamask/controller-utils" "^11.11.0"
     "@metamask/eth-query" "^4.0.0"
     "@metamask/metamask-eth-abis" "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,15 +4912,7 @@
     "@metamask/utils" "^11.0.1"
     immer "^9.0.6"
 
-"@metamask/base-controller@^8.0.0", "@metamask/base-controller@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/base-controller/-/base-controller-8.0.1.tgz#5ac066e101dcc2ea187900ce7c0b08b13c573fff"
-  integrity sha512-Yzf4Eipl7TIcS6PpDf+Fbb8Z1zMUEB0boMWJG0Jo2XhRM8Azb3yA1k5tashgEaacbl9Qs6HgGOe0P3eKzPzoJw==
-  dependencies:
-    "@metamask/utils" "^11.2.0"
-    immer "^9.0.6"
-
-"@metamask/base-controller@^8.1.0":
+"@metamask/base-controller@^8.0.0", "@metamask/base-controller@^8.0.1", "@metamask/base-controller@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@metamask/base-controller/-/base-controller-8.1.0.tgz#dd8746f8ec95fb564251c284f84e9264427816f1"
   integrity sha512-pwWHTBntzPE6yBMH9qiXMaslQW2kS7Izw1g+4D8QhGIxNWBt1nz1uavTGcSBUFgO3eMDKe2QPU04xgThqCPv+g==


### PR DESCRIPTION
## **Description**

Improve accuracy of the total in the Perps specific deposit transaction confirmation.

Specifically:

- Update `useTransactionTotalFiat` to calculate total from quotes themselves.
- Show spinner in `PayTokenBalance` if token balance not available.
- Show spinner in `PayWithRow` if no payment token selected.
- Add optional arrow to `TokenPill`.
- Move logic in `PerpsDeposit` component to new `usePerpsDepositView` hook.
- Add `usePerpsDepositInit` hook to automatically watch Arbitrum USDC token.
- Do not request quotes in `useTransactionBridgeQuotes` if blocking alerts found.
- Do not `waitForResult` on transaction approval if quotes found.
- Bump `transaction-controller` to `59.2.0`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
