### PR TITLE
chore: update eslint to ignore Text shadow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,13 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'error',
         // Under discussion
         '@typescript-eslint/no-duplicate-enum-values': 'off',
+        '@typescript-eslint/no-shadow': [
+          'warn',
+          {
+            builtinGlobals: true,
+            allow: ['Text'],
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
## **Description**
This PR updates our eslint configuration and the `@typescript-eslint/no-shadow` rule to allow for the `Text` component

### 1. What is the reason for the change?
The `@typescript-eslint/no-shadow` rule is currently flagging our `Text` component imports as linting errors because they shadow the built-in global `Text` constructor from React Native's global namespace. Throughout the codebase, we follow the pattern of importing the `Text` component from our design system rather than using React Native's default `Text`. This is intentional and ensures consistent typography and theming across the application. The ESLint rule was incorrectly flagging this standard practice as an error.

### 2. What is the improvement/solution?
This PR updates our ESLint configuration to:
- Enable checking for built-in global shadowing (`builtinGlobals: true`) to catch potential issues with shadowing native globals
- Add an explicit exception for `Text` in the `allow` list, since we intentionally import and use `Text` components from our design system libraries (`@metamask/design-system-react-native` `../../component-library/Texts/Text`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: ESLint no-shadow rule configuration

  Scenario: Developer writes code that shadows built-in globals
    Given the new ESLint configuration is in place
    
    When developer writes code that shadows a built-in global (e.g., const Array = [])
    Then ESLint shows a warning about variable shadowing
    
  Scenario: Developer imports Text component
    Given the new ESLint configuration is in place
    
    When developer imports Text from @metamask/design-system-react-native
    Then no ESLint warning is shown because Text is in the allow list
```

## **Screenshots/Recordings**

### **Before**
`@typescript-eslint/no-shadow` rule catches `Text` component as well as other globals

<img width="623" height="211" alt="Screenshot 2025-08-12 at 2 47 51 PM" src="https://github.com/user-attachments/assets/b4b16d59-5deb-4626-8230-9661766645f0" />

<img width="678" height="151" alt="Screenshot 2025-08-12 at 2 47 39 PM" src="https://github.com/user-attachments/assets/ee1f7f4c-53e1-4b35-80e5-1f33a3cb3554" />


### **After**
ESLint still warns about variable shadowing, while allowing `Text` component.

<img width="467" height="295" alt="Screenshot 2025-08-12 at 2 48 48 PM" src="https://github.com/user-attachments/assets/4afb0689-51c2-4b27-8be3-245d8a0314eb" />

<img width="598" height="147" alt="Screenshot 2025-08-12 at 2 46 33 PM" src="https://github.com/user-attachments/assets/32a1a756-2c8c-4ed2-aa22-6d751e5b8051" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.