### PR TITLE
chore: updating bottom sheet stories

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -47,6 +47,7 @@ const getStories = () => {
     "./app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories.tsx": require("../app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.stories.tsx"),
     "./app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx": require("../app/component-library/components-temp/KeyValueRow/KeyValueRow.stories.tsx"),
     "./app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories.tsx": require("../app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.stories.tsx"),
+    "./app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.stories.tsx": require("../app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.stories.tsx"),
     "./app/component-library/components-temp/MainActionButton/MainActionButton.stories.tsx": require("../app/component-library/components-temp/MainActionButton/MainActionButton.stories.tsx"),
     "./app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx": require("../app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx"),
     "./app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.stories.tsx": require("../app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.stories.tsx"),
@@ -125,7 +126,6 @@ const getStories = () => {
     "./app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx": require("../app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.stories.tsx"),
     "./app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx": require("../app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.stories.tsx"),
     "./app/components/Views/QRAccountDisplay/QRAccountDisplay.stories.tsx": require("../app/components/Views/QRAccountDisplay/QRAccountDisplay.stories.tsx"),
-    "./app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.stories.tsx": require("../app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.stories.tsx"),
   };
 };
 

--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.stories.tsx
@@ -1,19 +1,29 @@
 /* eslint-disable react-native/no-inline-styles */
 /* eslint-disable react/display-name */
 // Third party dependencies.
-import React, { useRef } from 'react';
-import { View } from 'react-native';
+import React, { useState } from 'react';
 
 // External dependencies.
-import Text, { TextVariant } from '../../Texts/Text';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  Text,
+  Button,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 
 // Internal dependencies.
-import { default as BottomSheetComponent } from './BottomSheet';
+import { default as BottomSheet } from './BottomSheet';
 import { BottomSheetProps, BottomSheetRef } from './BottomSheet.types';
+import BottomSheetHeader from '../BottomSheetHeader';
+import BottomSheetFooter from '../BottomSheetFooter';
+import { ButtonVariants } from '../../Buttons/Button';
 
 const BottomSheetMeta = {
-  title: 'Component Library / BottomSheets',
-  component: BottomSheetComponent,
+  title: 'Component Library / BottomSheets / BottomSheet',
+  component: BottomSheet,
   argTypes: {
     isInteractable: {
       control: { type: 'boolean' },
@@ -23,26 +33,66 @@ const BottomSheetMeta = {
 };
 export default BottomSheetMeta;
 
-export const BottomSheet = {
-  render: (
+export const Default = {
+  render: function Render(
     args: JSX.IntrinsicAttributes &
       BottomSheetProps &
       React.RefAttributes<BottomSheetRef>,
-  ) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const bottomSheetRef = useRef<BottomSheetRef | null>(null);
+  ) {
+    const [isVisible, setIsVisible] = useState(false);
+
+    const openBottomSheet = () => setIsVisible(true);
+    const closeBottomSheet = () => setIsVisible(false);
     return (
-      <BottomSheetComponent ref={bottomSheetRef} {...args}>
-        <View
-          style={{
-            height: 300,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+      <>
+        <Button
+          variant={ButtonVariant.Primary}
+          onPress={openBottomSheet}
+          twClassName="mb-4"
         >
-          <Text variant={TextVariant.BodySM}>{'Wrapped Content'}</Text>
-        </View>
-      </BottomSheetComponent>
+          Open BottomSheet
+        </Button>
+        {isVisible && (
+          <BottomSheet
+            {...args}
+            onClose={closeBottomSheet}
+            shouldNavigateBack={false}
+          >
+            <BottomSheetHeader
+              onClose={closeBottomSheet}
+              onBack={closeBottomSheet}
+            >
+              BottomSheetHeader
+            </BottomSheetHeader>
+            <Box
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              twClassName="h-20"
+            >
+              <Text>
+                BottomSheetContent: Lorem ipsum dolor sit amet, consectetur
+                adipiscing elit.
+              </Text>
+            </Box>
+            <BottomSheetFooter
+              buttonPropsArray={[
+                {
+                  label: 'Cancel',
+                  variant: ButtonVariants.Secondary,
+                  onPress: closeBottomSheet,
+                },
+                {
+                  label: 'Confirm',
+                  variant: ButtonVariants.Primary,
+                  onPress: closeBottomSheet,
+                },
+              ]}
+            />
+            {/* TODO: This is a hack to make the bottom sheet visible */}
+            <Box twClassName="h-35" />
+          </BottomSheet>
+        )}
+      </>
     );
   },
 };

--- a/app/component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.stories.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 
 // Internal dependencies.
-import { default as BottomSheetFooterComponent } from './BottomSheetFooter';
+import { default as BottomSheetFooter } from './BottomSheetFooter';
 import { SAMPLE_BOTTOMSHEETFOOTER_PROPS } from './BottomSheetFooter.constants';
 import { ButtonsAlignment } from './BottomSheetFooter.types';
 
 const BottomSheetFooterMeta = {
-  title: 'Component Library / BottomSheets',
-  component: BottomSheetFooterComponent,
+  title: 'Component Library / BottomSheets / BottomSheetFooter',
+  component: BottomSheetFooter,
   argTypes: {
     buttonsAlignment: {
       options: ButtonsAlignment,
@@ -22,11 +22,11 @@ const BottomSheetFooterMeta = {
 };
 export default BottomSheetFooterMeta;
 
-export const BottomSheetFooter = {
+export const Default = {
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   render: (args: any) => (
-    <BottomSheetFooterComponent
+    <BottomSheetFooter
       {...args}
       buttonPropsArray={SAMPLE_BOTTOMSHEETFOOTER_PROPS.buttonPropsArray}
     />

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
@@ -4,29 +4,33 @@
 import React from 'react';
 
 // Internal dependencies.
-import { default as BottomSheetHeaderComponent } from './BottomSheetHeader';
+import { default as BottomSheetHeader } from './BottomSheetHeader';
+import { BottomSheetHeaderProps } from './BottomSheetHeader.types';
 
 const BottomSheetHeaderMeta = {
-  title: 'Component Library / BottomSheets',
-  component: BottomSheetHeaderComponent,
+  title: 'Component Library / BottomSheets / BottomSheetHeader',
+  component: BottomSheetHeader,
 };
 export default BottomSheetHeaderMeta;
 
-export const BottomSheetHeader = {
+export const Default = {
   args: {
-    chidlren: 'Super Long BottomSheetHeader Title that may span 3 lines',
+    children: 'Super Long BottomSheetHeader Title that may span 3 lines',
   },
   // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: (args: any) => (
-    <BottomSheetHeaderComponent
-      {...args}
-      onBack={() => {
-        console.log('Back button clicked');
-      }}
-      onClose={() => {
-        console.log('Close button clicked');
-      }}
-    />
-  ),
+  render: function Render(args: BottomSheetHeaderProps) {
+    return (
+      <BottomSheetHeader
+        {...args}
+        onBack={() => {
+          console.log('Back button clicked');
+        }}
+        onClose={() => {
+          console.log('Close button clicked');
+        }}
+      >
+        {args.children}
+      </BottomSheetHeader>
+    );
+  },
 };


### PR DESCRIPTION
## **Description**

This PR refactors the BottomSheet component stories to follow MetaMask Mobile's design system guidelines and improve the Storybook organization. The changes include:

1. Migration from custom components to `@metamask/design-system-react-native` components
2. Improved story structure with proper naming conventions and organization
3. Replacement of inline styles with Tailwind classes using the `useTailwind` hook
4. Better component composition demonstrating real-world usage patterns

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: BottomSheet Component Stories

  Scenario: User views BottomSheet story in Storybook
    Given Storybook is running with the updated stories
    
    When user navigates to Component Library / BottomSheets / BottomSheet
    Then user sees a button labeled "Open BottomSheet"
    
    When user clicks "Open BottomSheet" button
    Then BottomSheet appears with header, content, and footer sections
    And BottomSheet displays "Cancel" and "Confirm" buttons
    
    When user clicks either "Cancel", "Confirm", or close button
    Then BottomSheet closes and returns to initial state

  Scenario: User views BottomSheetHeader story
    Given Storybook is running
    
    When user navigates to Component Library / BottomSheets / BottomSheetHeader
    Then user sees the header component with back and close buttons
    And header displays the provided title text

  Scenario: User views BottomSheetFooter story
    Given Storybook is running
    
    When user navigates to Component Library / BottomSheets / BottomSheetFooter
    Then user sees footer component with action buttons
    And buttons are properly aligned based on configuration
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

- BottomSheet story used raw React Native `View` component with inline styles
- Stories were all under single "Component Library / BottomSheets" path
- Used deprecated Text component from component-library
- No interactive example showing real usage

https://github.com/user-attachments/assets/f9579705-7f0f-49ee-8570-ed2b1d08705d

### **After**

- BottomSheet story uses design system `Box`, `Text`, and `Button` components
- Stories organized into separate paths for each component (BottomSheet, BottomSheetHeader, BottomSheetFooter)
- Interactive example with open/close functionality
- Proper Tailwind classes for styling (`twClassName`)
- Demonstrates complete BottomSheet composition with header, content, and footer
 
https://github.com/user-attachments/assets/d80ba92f-feb3-458d-a971-14877c9cabbc

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.