### PR TITLE
chore: add `selectSelectedAccountGroup` selector

### DIFF
--- a/app/selectors/multichainAccounts/accounts.test.ts
+++ b/app/selectors/multichainAccounts/accounts.test.ts
@@ -10,6 +10,7 @@ import {
   createMockSnapInternalAccount,
 } from '../../util/test/accountsControllerTestUtils';
 import {
+  selectSelectedAccountGroup,
   getWalletIdFromAccountGroup,
   selectSelectedInternalAccountByScope,
   selectInternalAccountByAccountGroupAndScope,
@@ -921,6 +922,44 @@ describe('accounts selectors', () => {
         const secondBtcResult = selector(BITCOIN_SCOPE, secondEntropyGroup);
         expect(secondBtcResult).toEqual(secondBtcAccount);
       });
+    });
+  });
+
+  describe('selectSelectedAccountGroup', () => {
+    it('returns undefined when AccountTreeController is undefined', () => {
+      const mockState = createMockState(undefined);
+      const result = selectSelectedAccountGroup(mockState);
+      expect(result).toBe(null);
+    });
+
+    it('returns undefined when selectedAccountGroup is undefined', () => {
+      const mockState = createMockState({
+        accountTree: {
+          selectedAccountGroup: undefined,
+          wallets: {},
+        },
+      });
+
+      const result = selectSelectedAccountGroup(mockState);
+      expect(result).toBe(null);
+    });
+
+    it('returns selected account group ID', () => {
+      const mockState = createMockState({
+        accountTree: {
+          selectedAccountGroup: ACCOUNT_GROUP_ID_1,
+          wallets: {
+            [WALLET_ID_1]: {
+              id: WALLET_ID_1,
+              metadata: { name: 'Wallet 1' },
+              groups: {},
+            },
+          },
+        },
+      });
+
+      const result = selectSelectedAccountGroup(mockState);
+      expect(result).toBe(ACCOUNT_GROUP_ID_1);
     });
   });
 });

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -116,6 +116,19 @@ const findInternalAccountByScope = (
 };
 
 /**
+ * Selector to get the currently selected account group from the AccountTreeController state.
+ * This selector retrieves the selected account group ID from the account tree state.
+ *
+ * @param state - The Redux root state
+ * @returns The currently selected account group ID or null if none is found
+ */
+export const selectSelectedAccountGroup = createDeepEqualSelector(
+  [selectAccountTreeControllerState],
+  (accountTreeState: AccountTreeControllerState) =>
+    accountTreeState?.accountTree?.selectedAccountGroup || null,
+);
+
+/**
  * Selector to get an internal account by scope from the currently selected account group.
  *
  * This selector finds an account that matches the given scope within the currently


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds a new redux selector to access the `selectedAccountGroup` from the `AccountTreeController` state.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: None

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
